### PR TITLE
CI: bump checkout/setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 


### PR DESCRIPTION
Bumps `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` in the **CI — boot check** workflow.

**Why:** v4 of both actions runs on the deprecated Node 20 action runtime. GitHub will force these to Node 24 on **2026-06-16** and remove Node 20 entirely on **2026-09-16**, emitting a deprecation warning until then. v5 of both actions runs on Node 24, clearing the warning.

The project Node version for the smoke test (`node-version: 20`) is unchanged — it is independent of the action runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)