### PR TITLE
UI overhaul: "The Yard" — a parallel, selectable theme

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,56 @@
-# HANDOFF — continue here (`design-overhaul` branch)
+# HANDOFF — continue here
 
 > For the next Claude Code session (another machine, the web, or Jac's phone).
 > **Read this first.**
 
-## ▶▶ STATE AS OF 2026-06-12 EVENING (supersedes everything below)
+## ▶▶▶ STATE AS OF 2026-06-14 (supersedes everything below)
+
+**Baseline (known-good):** branch `claude/handoff-continuation-q442qm` @ **`08f9da8`**
+(code + the SPEC v8.1 delta + the mobile spec + the build-list tracker); live **`main`**
+@ **`d11e1e3`**. Working tree clean, everything pushed. Gates: `node ci/smoke.mjs`,
+`node ci/logic-test.mjs` (a long-standing 20/21 — pre-existing, unrelated), and
+`node ci/gen-rule-usage.mjs --check`.
+
+**Shipped this session (all LIVE, details in `JacTec-handoff/JacTec-SPEC-v8.md` §v8.1):**
+1. **§17 Internal team dock (Phase 7)** — color-flooded comment composer; headerless
+   floating chat dock (tagged-element pill rail · chat bubbles · role tab-bar); PERSISTENT
+   multi-chat (never lost, reopen via a tagged element, re-flash on unseen); drag-to-chat
+   via the bottom-right drop pad; all four granular element types + categories + services
+   stamped `[data-chat-el]`.
+2. **§M0–M3 Mobile adaptive reflow** — responsive 3→2→1 columns; swipe nav + per-column
+   bottom strips; touch drag edge-switch + bottom-edge chat; long-press = context menu.
+   Spec: `docs/superpowers/specs/2026-06-14-mobile-adaptive-design.md`. Desktop untouched.
+3. **Skills added** (`.claude/skills/`): `webapp-testing`, `mobile-viewport`,
+   `mobile-navigation`, `mobile-touch`.
+
+### ▶ START HERE — the UI DESIGN OVERHAUL (this is the next session's job)
+**Goal:** overhaul how the design ELEMENTS *look* — colors, surfaces, type, texture —
+**NOT the layout or where anything lives.** The 3-column structure, the M0–M3 mobile
+reflow, the drag engine, and the chat dock plumbing all STAY PUT. Restyle, don't relayout.
+
+**1. Branch from the known-good baseline:**
+```sh
+git fetch origin
+# branch tip has the code + these updated docs (SPEC v8.1, mobile spec, this handoff):
+git checkout -b claude/ui-overhaul origin/claude/handoff-continuation-q442qm
+# (or branch from origin/main for just the deployed code — docs are on the branch)
+```
+**2. Do it the REVERSIBLE way — build the new look as a PARALLEL THEME.** The app already
+has a dark/light toggle (`data-theme`); add the new look as another selectable theme / CSS
+token-set ALONGSIDE the current one. The current look stays one tap away, so "if I hate
+it" = flip the toggle back. Do NOT overwrite the existing tokens; do NOT merge to `main`
+until Jac signs off.
+**3. Tools:** run every visual change through the vendored **`frontend` skill** (CLAUDE.md
+requires it), working in the CSS **design-token layer** in `style.css` (`--accent`,
+`--panel`, the data-plate vars). Screenshot + self-critique before showing Jac.
+**4. Don't touch:** the column grid/reflow (§M0–M3), the drag/cancel-arc/drop-pad engine,
+the chat dock structure. Those are layout/behavior, not look.
+**5. Gates before any push** (same as above). Keep the R-rulebook `data-r` stamps intact;
+regenerate `rule-usage.js` (drop `--check`) only if rule USAGE changes.
+
+---
+
+## ▶▶ STATE AS OF 2026-06-12 EVENING (historical — superseded above)
 
 **Everything is LIVE on app.jacrentals.com** (main = design-overhaul; the standing
 rule: every VERIFIED batch merges → main → Pages, no per-merge ask).

--- a/JacTec-handoff/JAC-BUILD-LIST.md
+++ b/JacTec-handoff/JAC-BUILD-LIST.md
@@ -4,6 +4,14 @@ Master queue. Status flags: 🆕 new · 🔧 partial/refine (some shipped) ·
 ✅ shipped last session (verify, don't rebuild) · ❓ decision/define needed.
 We walk this **task by task via poll**; decisions get recorded inline.
 
+## 📱 MOBILE (adaptive reflow) — ✅ M0–M3 SHIPPED + LIVE (2026-06-14)
+Spec: `docs/superpowers/specs/2026-06-14-mobile-adaptive-design.md`. Field-ready goal; desktop untouched.
+- **M0** — responsive columns 3→2→1 by width; viewport meta → device-width; body never side-scrolls; `is-phone`/`is-narrow` classes.
+- **M1** — swipe between columns (scroll-snap) + 3-dot indicator; phone-only per-column bottom strips: Yard→internal chat · Rentals→tool bar · Customers→external-chats **shell** (awaits messaging backend).
+- **M2** — drag on touch: dwell at L/R edge switches columns mid-drag; **bottom edge = start-a-chat** drop zone (cancel-arc hidden on phone).
+- **M3** — touch gesture model: hold-still→context menu, horizontal→drag, vertical→scroll, tap→action (`openCtxMenuAt` shared mouse/touch). Desktop right-click unchanged.
+- ⬜ Optional follow-ups (not built, "functional" scope): touch haptics, per-screen polish passes, external-chat backend.
+
 ## Phase 0 — Carry-over ("cute items")
 - 🆕 **Ask Mr. Wrangler** — Claude-API proxy so the app can call Claude (e.g. auto-suggest WO parts; the "Mr. Wrangler will add the parts for you" hook is already wired in copy).
 - 🔧 **#9/#10 drag bugs** — awaiting Jac's repro (what was grabbed, where dropped, what happened). Overlaps Phase 3.

--- a/JacTec-handoff/JacTec-SPEC-v8.md
+++ b/JacTec-handoff/JacTec-SPEC-v8.md
@@ -23,6 +23,48 @@ file in the SAME commit.
 
 ---
 
+## v8.1 — Built-State Delta (2026-06-14 session · code is truth, this records what shipped)
+
+Branch `claude/handoff-continuation-q442qm` @ `08f9da8`; live `main` @ `d11e1e3`.
+
+**§17 Internal team dock (Phase 7) — LIVE.** A bottom-bar team chat built on the
+Phase-6 record comments.
+- **Comment composer** = a simple **color-flooded card**: three traffic-light dots pick
+  red/yellow/green, the whole card floods that color, the selected dot glows.
+- **Headerless floating dock** (bottom-right): a tagged-element **pill rail** on top,
+  **chat bubbles** (steel incoming w/ avatar+name, safety-orange "you"), flagged comments
+  threaded in, a **role participant tab-bar** at the bottom, compose.
+- **PERSISTENT multi-chat** (`state.chat.chats`): never deleted; "everyone leaves" → the
+  chat goes **dormant**; reopen it through a tagged element (**right-click → 🧵 Start
+  chat**) rejoining with your role. A tagged element **re-flashes** on unseen messages
+  (per-user `seen`).
+- **Drag-to-chat:** drop a record OR a granular element on the **bottom-right drop pad**
+  (a cancel-arc sibling) → new chat; drop into the dock → tag the active chat. Granular
+  sources are stamped `[data-chat-el]`: status badges (statusPill), people/links
+  (refPill/unitPill), prices (rate + invoice balance), line items, categories (dPill +
+  inline), services (serviceOrders resolved via the shop segment).
+
+**§M0–M3 Mobile adaptive reflow — LIVE.** Full spec:
+`docs/superpowers/specs/2026-06-14-mobile-adaptive-design.md`. Field-ready; desktop untouched.
+- **M0:** viewport meta → `device-width`; `.grid` reflows **3→2→1** by width (scroll-snap
+  track); the `body{min-width:1180}` floor drops ≤1024px; `is-phone`/`is-narrow` classes.
+- **M1:** **swipe** between columns + 3-dot indicator; phone-only **per-column bottom
+  strips** (Yard→internal chat · Rentals→tool bar · Customers→external-chats **shell**).
+- **M2:** touch drag dwells at the **L/R edge to switch columns**; the **bottom edge** is
+  the start-a-chat drop zone; cancel-arc hidden on phone.
+- **M3:** touch gesture model — **hold-still→context menu** (`openCtxMenuAt`, shared with
+  the mouse handler), **horizontal→drag, vertical→scroll, tap→action**. Mouse/desktop
+  right-click unchanged.
+
+**Skills added** (`.claude/skills/`): `webapp-testing` (vendored official, Apache-2.0),
+`mobile-viewport`, `mobile-navigation`, `mobile-touch`.
+
+**Caveats:** mobile verified via Playwright **synthetic touch**, not a physical device —
+do a real-device pass (iOS long-press/scroll, safe-area) before leaning on it. The
+external-chats strip is a **shell** pending the backend messaging integration.
+
+---
+
 ## 0 · How to debug with this spec
 
 1. **The flash-lint (R0)** is the alarm. Toggle = the eye icon in the bottom bar

--- a/app.js
+++ b/app.js
@@ -730,7 +730,7 @@ const entityCardOf = (card, recType) => (card === 'shop' ? recType : card);
 
 const state = {
   data: DATA,
-  theme: 'dark',
+  theme: (() => { try { const t = localStorage.getItem('jactec.theme'); return (t === 'light' || t === 'yard') ? t : 'dark'; } catch (e) { return 'dark'; } })(),   // dark | yard | light (per device)
   query: '',
   searchMode: false,
   tabs: [],            // [{ id, card, recId, label, sub, color, session }]
@@ -1149,6 +1149,7 @@ const I = {
   mark: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 17l5-12 4 8 3-5 6 9z"/></svg>',
   sun: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5 19 19M19 5l-1.5 1.5M6.5 17.5 5 19"/></svg>',
   moon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A8 8 0 1 1 11.2 3 6 6 0 0 0 21 12.8z"/></svg>',
+  hardhat: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"><path d="M3 18a9 9 0 0 1 18 0z"/><path d="M2 18h20"/><path d="M10 9V6a2 2 0 0 1 2-2 2 2 0 0 1 2 2v3"/><path d="M5 14V12M19 14V12"/></svg>',
   qr: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><path d="M14 14h3v3h-3zM20 14v7M14 20h7"/></svg>',
   mouse: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="2" width="14" height="20" rx="7"/><path d="M12 6v4"/></svg>',
   video: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="6" width="13" height="12" rx="2"/><path d="m15 10 6-3v10l-6-3z"/></svg>',
@@ -3860,6 +3861,13 @@ function headerEl() {
     </div>`;
   return h;
 }
+/* Theme cycle: dark → yard → light → dark. The bottom-bar button shows the icon
+   + tooltip of the theme you'll switch TO next (matching the old sun/moon convention). */
+const THEME_NEXT = {
+  dark:  { next: 'yard',  icon: I.hardhat, tip: 'Yard mode' },
+  yard:  { next: 'light', icon: I.sun,     tip: 'Light mode' },
+  light: { next: 'dark',  icon: I.moon,    tip: 'Dark mode' },
+};
 /** The action toolbar — moved to a fixed bottom bar (Dashboard / +New / tools). */
 function bottomBarInner() {
   // rules 5/6: LEFT = labeled actions (icon LEADS label, no "+"), Wash joins them;
@@ -3868,7 +3876,7 @@ function bottomBarInner() {
     <button class="iconbtn js-dashboard">${I.grid} Dashboard</button>
     <button class="iconbtn js-newitem" data-new="receipt">${CARD_ICON.expenses}Receipt</button>
     <span class="bb-sep"></span>
-    <button class="iconbtn js-theme" data-tip="${state.theme === 'dark' ? 'Light' : 'Dark'} mode">${state.theme === 'dark' ? I.sun : I.moon}</button>
+    <button class="iconbtn js-theme" data-tip="${THEME_NEXT[state.theme].tip}">${THEME_NEXT[state.theme].icon}</button>
     <button class="iconbtn js-qr" data-tip="Share session (QR)">${I.qr}</button>
     <button class="iconbtn${state.previewsOn ? '' : ' off'} js-previews" data-tip="${state.previewsOn ? 'Hover previews: on' : 'Hover previews: off'}">${state.previewsOn ? I.eye : I.eyeOff}</button>
     <button class="iconbtn js-feedback" data-tip="Report a bug or request">${I.feedback}</button>
@@ -5683,7 +5691,7 @@ function onClick(e) {
   if (closest('.js-unlock-invoice')) { e.stopPropagation(); return lockInvoiceFlow(closest('.js-unlock-invoice').dataset.rec, false); }
   if (closest('.js-ring')) return openOverlay({ kind: 'role', role: closest('.js-ring').dataset.role });
   if (closest('.js-close')) return closeOverlay();
-  if (closest('.js-theme')) { state.theme = state.theme === 'dark' ? 'light' : 'dark'; if (state.overlay && state.overlay.kind !== 'addCard') renderOverlay(); render(); return; }
+  if (closest('.js-theme')) { state.theme = (THEME_NEXT[state.theme] || THEME_NEXT.dark).next; try { localStorage.setItem('jactec.theme', state.theme); } catch (e) {} if (state.overlay && state.overlay.kind !== 'addCard') renderOverlay(); render(); return; }
   if (closest('.js-qr')) return openOverlay({ kind: 'qr' });
   if (closest('.js-previews') || closest('.js-roweye')) { e.stopPropagation(); state.previewsOn = !state.previewsOn; if (!state.previewsOn) hideHoverPreview(); try { localStorage.setItem('jactec.previewsOff', state.previewsOn ? '0' : '1'); } catch (e) {} toast(state.previewsOn ? 'Hover previews on.' : 'Hover previews off — every eye runs red.'); return render(); }
   if (closest('.js-hotkeys')) return openOverlay({ kind: 'hotkeys' });

--- a/style.css
+++ b/style.css
@@ -1594,3 +1594,91 @@ body.dragging .row.drop-ok { opacity: 1; }
 .row { touch-action: pan-y; }
 /* settings overlay — the Allow-overbooking R14 toggle rides the row's right edge */
 .set-row .seg { margin-left: auto; }
+
+/* ════════════════════════════════════════════════════════════════════════════
+   THEME — "THE YARD" (data-theme="yard")   ·  frontend-design pass, 2026-06-14
+   ────────────────────────────────────────────────────────────────────────────
+   A PARALLEL, opt-in theme alongside dark/light — the whole app reframed as
+   walking the JacRentals yard: each of the three columns becomes a rugged
+   equipment ID PLATE bolted to the steel wall — hi-vis HAZARD-STRIPE header
+   (the signature, carried over from the login plate), corner RIVETS, stamped
+   Saira-Condensed tabs/labels, ignition-orange active tab. A light wrangler
+   seasoning rides on top: a worn leather-tan SADDLE-STITCH divider under the
+   bottom bar. Industrial steel stays dominant; the ranch read stays a whisper.
+
+   REVERSIBLE BY DESIGN: every rule here is scoped under [data-theme="yard"] and
+   is purely ADDITIVE (token overrides + scoped surfaces + pseudo-elements that
+   never touch the .anchored/.search-glow border+ring). Flip the theme toggle
+   and the original look returns untouched — nothing above this line changed.
+   Layout, the M0–M3 reflow, the drag engine and the chat dock are NOT touched.
+   ════════════════════════════════════════════════════════════════════════════ */
+[data-theme="yard"] {
+  /* steel-yard core — gunmetal panels, deeper plate shadows */
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1d242d;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#717b89; --track:#232b35; --on-orange:#1a1205;
+  /* the brand orange is the ignition accent — earned, a hair punchier here */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.16); --accent-line:rgba(255,126,31,.55);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.16);
+  --anchor-section:#222932;
+  --radius:14px; --chip-radius:11px;
+  --shadow:0 24px 64px -30px rgba(0,0,0,.85); --chip-shadow:0 6px 16px -10px rgba(0,0,0,.78);
+  /* yard-only helpers (steel gradients + the wrangler leather-tan seasoning) */
+  --steel-1:#1b222c; --steel-2:#0d1116;
+  --rivet:#4a525e; --rivet-pit:#0b0f14;
+  --tan:#c2925a; --tan-deep:#8a5a2b;
+}
+/* the yard floor — faint orange dawn-glow + a brushed diagonal mill texture */
+[data-theme="yard"] body {
+  background:
+    radial-gradient(120% 80% at 50% -12%, rgba(255,122,26,.06), transparent 55%),
+    repeating-linear-gradient(135deg, rgba(255,255,255,.010) 0 2px, transparent 2px 11px),
+    var(--bg);
+}
+
+/* ── THE SIGNATURE — each column is an equipment ID plate ──────────────────── */
+/* background gradient + position only: never sets border/box-shadow, so the
+   .anchored neon ring and .search-glow keep working untouched. */
+[data-theme="yard"] .col > .card {
+  position: relative;
+  background: linear-gradient(180deg, var(--steel-1), var(--steel-2));
+}
+[data-theme="yard"] .col > .card::before {       /* hi-vis hazard stripe — the signature band */
+  content:''; position:absolute; top:0; left:0; right:0; height:6px; z-index:5;
+  background: repeating-linear-gradient(135deg, var(--yellow,#f5c542) 0 13px, #14181d 13px 26px);
+  border-bottom:1px solid rgba(0,0,0,.6); pointer-events:none;
+}
+[data-theme="yard"] .col > .card::after {        /* four corner rivets bolting the plate down */
+  content:''; position:absolute; inset:0; z-index:5; pointer-events:none; border-radius:inherit;
+  background:
+    radial-gradient(circle at 12px 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+    radial-gradient(circle at calc(100% - 12px) 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+    radial-gradient(circle at 12px calc(100% - 12px), var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+    radial-gradient(circle at calc(100% - 12px) calc(100% - 12px), var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px);
+}
+
+/* ── Stamped type — condensed steel labels on the plate ────────────────────── */
+[data-theme="yard"] .coltab {
+  font-family:'Saira Condensed', system-ui, sans-serif;
+  text-transform:uppercase; letter-spacing:1.1px; font-weight:700;
+}
+[data-theme="yard"] .coltab.on {                 /* the ignition tab — lit orange, dark ink */
+  background: linear-gradient(180deg, #ff9038, var(--accent));
+  box-shadow: 0 5px 14px -6px rgba(255,122,26,.6), inset 0 1px 0 rgba(255,255,255,.32);
+}
+[data-theme="yard"] .ring-label,
+[data-theme="yard"] .section > h4 {
+  font-family:'Saira Condensed', system-ui, sans-serif; letter-spacing:1.2px;
+}
+[data-theme="yard"] .c-titlecard .c-title {
+  font-family:'Saira Condensed', system-ui, sans-serif;
+  text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:14.5px;
+}
+
+/* ── The wrangler seasoning — a worn leather-tan saddle-stitch under the deck ─ */
+[data-theme="yard"] .bottombar {
+  border-top: 1.5px dashed var(--tan);
+  border-image: repeating-linear-gradient(90deg, var(--tan) 0 7px, transparent 7px 13px) 1;
+  margin-top: 2px;
+}


### PR DESCRIPTION
## The Yard — a new, opt-in theme

Kicks off the UI design overhaul (per `HANDOFF.md` → "START HERE"). The new look is added the **reversible way**: a third selectable theme `data-theme="yard"` **alongside** dark/light — *not* a rewrite of the existing tokens. The current look stays one tap away.

The app is reframed as walking the JacRentals yard: each of the three columns becomes a rugged **equipment ID plate** bolted to the steel wall.

### What's in the look (industrial steel core, faint wrangler seasoning)
- **Signature — the hi-vis hazard stripe** across the top of each column plate (carried over from the login redesign), plus **corner rivets** bolting each plate down.
- **Stamped Saira-Condensed** column tabs, KPI ring labels, section headers, and title chips.
- **Ignition-orange** active column tab (lit orange gradient, dark ink).
- Deeper gunmetal-steel surfaces + a faint diagonal mill texture on the yard floor.
- **Wrangler seasoning (subtle):** a worn **leather-tan saddle-stitch** divider under the bottom deck. Reads industrial first, ranch second — by design.

### Reversible & contained
- Every rule is scoped under `[data-theme="yard"]` and is **purely additive** — token overrides + pseudo-elements that **never touch** the `.anchored` neon ring or `.search-glow`. Dark and light render **byte-for-byte unchanged** (verified by before/after screenshots).
- **No relayout**: the 3-column grid, the M0–M3 mobile reflow, the drag/cancel-arc engine, and the chat dock are untouched. This is restyle-only.
- Theme toggle now cycles **dark → yard → light** and persists per-device (`jactec.theme`); a hard-hat icon marks the yard step.

### Files
- `style.css` — one self-contained `[data-theme="yard"]` block at the end (tokens + scoped surfaces).
- `app.js` — 3-way theme cycle + persistence, a hard-hat icon.

### Gates
- `node ci/smoke.mjs` ✓
- `node ci/gen-rule-usage.mjs --check` ✓ (no rule-usage change)
- `node ci/logic-test.mjs` → 20/21 (the long-standing `rentalLineItems` failure, pre-existing & unrelated).

### Notes for Jac
Don't merge to `main` until you've flipped through it and signed off — the toggle is bottom-bar (hard-hat icon). If you hate it, it's one tap back to dark. Open `#local` to preview.

🤠 Built through the `frontend` skill in the yard data-plate language per `CLAUDE.md`.

https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg)_