### PR TITLE
Free the Wrangler fix engine's hands (tools + gh token)

### DIFF
--- a/.github/workflows/wrangler-fix.yml
+++ b/.github/workflows/wrangler-fix.yml
@@ -63,11 +63,19 @@ jobs:
 
       - name: Mr. Wrangler patches the glitch
         uses: anthropics/claude-code-action@v1
+        env:
+          # gh uses this for PR/comment/merge ops. The PAT (not GITHUB_TOKEN) means
+          # the PR it opens actually triggers CI, so auto-merge can go green.
+          GH_TOKEN: ${{ secrets.WRANGLER_PAT }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # PAT (not GITHUB_TOKEN) so the PR it opens actually triggers CI.
           github_token: ${{ secrets.WRANGLER_PAT }}
-          claude_args: "--max-turns 60"
+          # Autonomous CI agent needs its hands free: Bash (gates + git + gh) and
+          # file edits. Without this the action denies Bash and the agent can't run
+          # the gates, commit, or open a PR. The runner is ephemeral and main is
+          # gate-protected, so broad Bash here is safe — CI is the real backstop.
+          claude_args: "--max-turns 60 --allowedTools 'Bash,Edit,Write,Read,Glob,Grep'"
           prompt: |
             A glitch was reported in the Rental Wrangler app — GitHub issue
             #${{ github.event.issue.number }}.


### PR DESCRIPTION
The wiring test (issue #8) proved the trigger + secrets work, but the agent hit **13 permission denials** — `claude-code-action` blocks Bash by default, so it couldn't run the gates, use git/`gh`, or comment.

This grants the agent its tools and gives `gh` the PAT:
- `claude_args: --allowedTools 'Bash,Edit,Write,Read,Glob,Grep'`
- step `env: GH_TOKEN = WRANGLER_PAT` (so the PR it opens triggers CI → auto-merge can go green)

Workflow-only change; no app code touched. The ephemeral runner + gate-protected `main` keep broad Bash safe — CI remains the real backstop.

https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg)_