### PR TITLE
Phase 2b: right-click list rows (B1) + scope the complete-rental flash (B7)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1438,7 +1438,7 @@ function openCtxMenuAt(target, x, y) {
   const card = target.closest('.card'); if (!card && !target.closest('.overlay .popup')) return;
   // While the rental-window picker is open, keep right-click → BACK working; just suppress
   // the element context menu (it gets in the way of picking). (Jac B5, 2026-06-15)
-  const leaf = state.winpicker ? null : target.closest('.pill, .add-field, .flag, .linkname, .inv-line-link, .req, .seg, button, .inline-edit, .jnode, .x, a, .d-title, .derived');
+  const leaf = state.winpicker ? null : target.closest('.pill, .add-field, .flag, .linkname, .inv-line-link, .req, .seg, button, .inline-edit, .jnode, .x, a, .d-title, .r-title, .derived');
   const hit = leaf ? (ruleOf(leaf) || { r: null, el: leaf }) : null;
   if (hit) return openCtxMenu({ clientX: x, clientY: y }, hit);
   if (!card) return;
@@ -6608,7 +6608,7 @@ function onClick(e) {
     const b = closest('.js-complete-rental'); const r = IDX.rental.get(b.dataset.rec); if (!r) return;
     // Locked gates ALWAYS speak (Jac: "Complete Rental doesn't do anything") — the old
     // flashOr stayed silent whenever its on-screen target existed, so a locked click read as dead.
-    if (!rentalUnits(r).length) { attnFlash('[data-slot="unit"], .add-field'); return toast('🔒 No units on this rental — drag one on, or cancel the rental.'); }
+    if (!rentalUnits(r).length) { attnFlash('[data-slot="unit"]'); return toast('🔒 No units on this rental — drag one on, or cancel the rental.'); }
     if (!allUnitsTerminal(r)) { attnFlash(`.js-yard[data-cap="end"][data-rec="${r.rentalId}"]`); return toast('🔒 Return every unit first (or mark No Show / Cancel) to complete the rental.'); }
     r.completed = true; reindex('rentals', r); logAction(r, 'Rental completed'); toast('Rental completed ✓'); return reanchorRender();
   }


### PR DESCRIPTION
Third interaction batch.

- **B1** Right-clicking a **list-view row name** now opens the record's context menu (Comment / Ask Mr. Wrangler / Search / etc.) instead of navigating back — `.r-title` was missing from the context-menu leaf selector. (Verified: menu opens with the record actions.)
- **B7** The locked **Complete Rental** click used to flash *every* `.add-field` on the card (including +PO and +notes), which read as a confusing signal. Narrowed the flash to the unit slot (`[data-slot="unit"]`) so it points at the actual blocker (no units).

Gates green (smoke, logic 28/28, rule-usage).

**Deferred from Phase 2 (need more care, will tackle next):**
- **B3** (no hover preview on Investment-section badges) — the unit-name pills already carry `data-pill-card`, so the cause is narrower than expected (likely the status badge rendered with no `recId` when a unit has no active rental); needs a live repro.
- **B4** (drag a unit pill from Investment → Rental) — line 6008 deliberately excludes `.pill` from initiating drags (pills are click/navigate targets), so enabling this means changing core drag-arm behavior. Worth doing deliberately, not as a quick fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDZrXsrfWAYSyyKDzUXJKY)_