### PR TITLE
B4: drag a unit pill (e.g. from the Investment list) onto a rental to link it

### DIFF
--- a/app.js
+++ b/app.js
@@ -6025,7 +6025,10 @@ function dragDown(e) {
     if (arm.touch) arm.lp = armMenuTimer(arm);
     DRAG.armed = arm; return;
   }
-  if (e.target.closest('.inline-edit, .inline-input, input, textarea, select, button, .x, .pill, .seg, .add-field, .linkname, .flag, .jnode, .dropdown-menu, .overlay, .hover-preview, .winpicker-float, .ctx-menu')) return;
+  const bail = e.target.closest('.inline-edit, .inline-input, input, textarea, select, button, .x, .pill, .seg, .add-field, .linkname, .flag, .jnode, .dropdown-menu, .overlay, .hover-preview, .winpicker-float, .ctx-menu');
+  // …but a UNIT pill is itself a valid drag source — drag it (e.g. from a category's
+  // Investment list) onto a rental to link the unit. A click still navigates (6px threshold). (Jac B4)
+  if (bail && !(bail.classList && bail.classList.contains('pill') && bail.dataset.pillCard === 'units' && bail.dataset.pillRec)) return;
   const src = dragSourceAt(e.target);
   if (!src) return;
   DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;                    // seed the ghost/hit-test point — a touch long-press may fire with NO move first
@@ -6038,6 +6041,8 @@ function dragDown(e) {
    2. a list ROW of a draggable entity;
    3. empty space on a STANDARD-view card (Task 2) → that card's open record. */
 function dragSourceAt(target) {
+  const upill = target.closest('[data-pill-card="units"]');                  // a unit pill drags as that unit → link to a rental (Jac B4)
+  if (upill && upill.dataset.pillRec) return { card: 'units', rec: upill.dataset.pillRec };
   const woSect = target.closest('.section[data-wo]');
   if (woSect && woSect.dataset.wo) return { card: 'workOrders', rec: woSect.dataset.wo };
   const row = target.closest('.row');                                   // .rtl rentals rows still carry card/rec on the .row wrapper


### PR DESCRIPTION
Closes the last real deferred interaction bug.

**B4** — dragging a unit pill from the Categories → Investment list (or any unit pill) onto a rental didn't work because pills are globally excluded from initiating drags (`dragDown` bail). Now a **unit pill** is let through that bail and resolved in `dragSourceAt`, so it drags as that unit and drops onto a rental via the existing, proven `units>rentals` link handler. A plain click still navigates (6px drag threshold protects it).

Verified: drag starts (ghost appears mid-drag), releases cleanly, and a click leaves no stuck ghost. Gates green (smoke, logic 28/28, rule-usage).

**Also investigated and found NOT broken (no change needed):**
- **B3** — hovering the unit-name pill in the Investment section *does* show a preview (confirmed live). Only status badges with no associated record don't preview — correctly, there's nothing to preview.
- **C2** — there is no 2-entry cap; the global search pins 3+ terms fine (confirmed live), and the per-card path uses the same cap-less `addFilterTerm`. If Jac still sees it, I'll need the exact card + steps to repro.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDZrXsrfWAYSyyKDzUXJKY)_