### PR TITLE
Phase 6 free-form route arrows + For-Sale availability fix; clear the 2 scroll bugs

### DIFF
--- a/JacTec-handoff/JacTec-SPEC-v8.md
+++ b/JacTec-handoff/JacTec-SPEC-v8.md
@@ -132,6 +132,45 @@ Phase-6 free-form "click-icon-to-icon" arrows (built as the sequential drag-orde
 
 ---
 
+## v8.3 — Built-State Delta (2026-06-15, later same day · the self-healing loop closes)
+
+Mr. Wrangler now runs the full **report → prove → fix → report-back** loop, with a human
+gate only where proof is impossible.
+
+**In-app Requests inbox + bottom-right cluster.**
+- The bug/request form is folded into the **one Mr. Wrangler chat**; you can **paste / attach /
+  drag images** (sent as Anthropic image content blocks; backend `@15`).
+- A floating **bottom-right FAB cluster**: a **notification bell** (stub — the future in-app
+  feed for engine updates) over the **Requests inbox** (pending-count badge). Hidden while the
+  team-chat dock owns that corner; lifts above the mobile dock on phones.
+- The inbox lists `wrangler-request` issues; Owner/Admin **Approve** (→ relabels `wrangler-fix`)
+  or **Dismiss** (→ closes). Other roles see "Awaiting Jac's OK".
+
+**The `wrangler-fix` skill (`.claude/skills/wrangler-fix/`) — proof replaces approval.**
+- The auto-fix engine (and Claude triaging) must **ground every report in the canon** — the
+  R-Rulebook (`RULE_META`/`CLASS_RULE` + §1 here), this SPEC, `docs/`, and the code — and
+  **PROVE it right or wrong with citations** before acting.
+- **Proven correct → fix it immediately, no approval** (even a suggestion). Can't prove /
+  contradicts the canon / ambiguous → don't ship; comment the verdict and kick it to the inbox
+  (`wrangler-request`) for Jac. Always report **verdict + proof + "refresh to see it"** on the issue.
+- The engine workflow now **triggers on both `wrangler-fix` and `wrangler-request`**, so
+  suggestions are proven (not parked); only the unprovable ones reach the inbox.
+
+**Backend (Apps Script, deployed via clasp — `@16`).** Three new actions, all via a
+`GITHUB_TOKEN` Script Property (Issues RW): `wranglerFile` (seamless no-tab filing),
+`wranglerRequests` (list), `wranglerApprove` (relabel→fix, admin), `wranglerDismiss` (close,
+admin). `wranglerReply_` upgraded to accept image content blocks + an allowlisted model.
+**clasp is wired** (`backend/` is gitignored; `clasp pull`→edit→`clasp push`→`clasp deploy -i`)
+so the backend can be deployed from a session — re-auth needed each session (ephemeral creds).
+
+**Next (the "few days" item):** the notification bell becomes the **in-app feed** that surfaces
+the engine's verdict/proof/"refresh" comments back to you — closing the loop without GitHub.
+
+**Security to-do:** rotate the `GITHUB_TOKEN` that was pasted in chat (minimal scope: Issues RW,
+one repo).
+
+---
+
 ## 0 · How to debug with this spec
 
 1. **The flash-lint (R0)** is the alarm. Toggle = the eye icon in the bottom bar

--- a/app.js
+++ b/app.js
@@ -3683,6 +3683,15 @@ function listView(cardDef, session) {
 
   let rows = listFor(card, session);
   if (card === 'units') rows = unitsVisible(rows, cs);   // hide Sold/Inactive (or show only them via the sort) (#2)
+  // §10 — under an availability window the Units list IS the rentable fleet, so it must
+  // match the availability COUNT, which already drops every non-Active unit (§9 via
+  // isUnitAvailableFor/categoryAvailableCount). Hide For-Sale/Sold/Inactive here too, or a
+  // For-Sale machine "shows up in Category Availability" while the count says it's gone (Jac).
+  // The all-fleet / sold-inactive sorts still reveal them as an escape hatch.
+  if (card === 'units' && availWin) {
+    const reveal = cs && cs.sort && (cs.sort.field === 'allFleet' || cs.sort.field === 'soldInactive');
+    if (!reveal) rows = rows.filter((u) => u.fleetStatus === 'Active');
+  }
   if (cs.search.trim() || (cs.filterTerms || []).length) { rows = rows.filter((rec) => rowMatches(card, rec, cs.search, cs.filterTerms)); }
   rows = sortRows(card, rows, cs.sort);
   // §10 — while a rental window is in scope, order Units: available+Ready, available+Not
@@ -4337,6 +4346,27 @@ const _lsJSON = (k) => { try { return JSON.parse(localStorage.getItem(k) || '{}'
 const _lsSave = (k, o) => { try { localStorage.setItem(k, JSON.stringify(o)); } catch (e) {} };
 const dispatchOrderLS = () => _lsJSON('jactec.dispatchOrder');
 const dispatchTimesLS = () => _lsJSON('jactec.dispatchTimes');
+// §2.3 free-form route arrows (Jac): the dispatcher can draw arbitrary directional
+// "from here → there" legs between any two stop icons, on TOP of the top-to-bottom run
+// order. Stored per-day as [fromNode, toNode] pairs (node = a stop id or 'home:in'/'home:out').
+const dispatchArrowsLS = () => _lsJSON('jactec.dispatchArrows');
+const HOME_IN = 'home:in', HOME_OUT = 'home:out';   // the yard, start-of-day and end-of-day nodes
+// Click an icon to arm it (the leg's "from"); click a second to draw the arrow; click the
+// same one again — or Esc — to cancel; re-drawing an existing leg removes it (toggle).
+function dispatchArrowClick(day, node) {
+  if (state.dispArm == null) { state.dispArm = node; return render(); }
+  if (state.dispArm === node) { state.dispArm = null; return render(); }      // tapped self → cancel
+  const all = dispatchArrowsLS(); const legs = all[day] || [];
+  const i = legs.findIndex(([a, b]) => a === state.dispArm && b === node);
+  if (i !== -1) legs.splice(i, 1); else legs.push([state.dispArm, node]);      // toggle the leg
+  all[day] = legs; _lsSave('jactec.dispatchArrows', all);
+  state.dispArm = null; render();
+}
+function removeDispatchArrow(day, from, to) {
+  const all = dispatchArrowsLS(); const legs = all[day] || [];
+  const i = legs.findIndex(([a, b]) => a === from && b === to); if (i === -1) return;
+  legs.splice(i, 1); all[day] = legs; _lsSave('jactec.dispatchArrows', all); render();
+}
 const addDaysISO = (iso, n) => { const d = parseISO(iso); d.setDate(d.getDate() + n); return d.toISOString().slice(0, 10); };
 const dispatchDayLabel = (iso) => { const d = parseISO(iso); return d ? d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }) : iso; };
 function dispatchDayStops(day) {
@@ -4354,15 +4384,22 @@ function dispatchGridBody() {
   const stops = dispatchDayStops(day);
   const isToday = day === TODAY_ISO;
   const allUpcoming = dispatchEvents().filter((e) => e.date >= TODAY_ISO).length;
+  const armed = state.dispArm != null;
+  const legCount = (dispatchArrowsLS()[day] || []).length;
   const head = `<div class="disp-head">
     <button class="disp-nav js-disp-day" data-dir="-1" data-tip="Previous day">‹</button>
     <div class="disp-date"><b>${esc(dispatchDayLabel(day))}</b>${isToday ? '<span class="disp-today">Today</span>' : '<button class="disp-jump js-disp-today">Today</button>'}</div>
     <button class="disp-nav js-disp-day" data-dir="1" data-tip="Next day">›</button>
     <span class="spacer"></span>
+    ${legCount ? `<button class="disp-clearleg js-disp-clearlegs" data-tip="Clear every route arrow on this day">${I.x} ${legCount} arrow${legCount === 1 ? '' : 's'}</button>` : ''}
     <span class="disp-count">${stops.length} stop${stops.length === 1 ? '' : 's'}${allUpcoming ? ` · ${allUpcoming} upcoming` : ''}</span>
   </div>`;
   if (!stops.length) return `${head}<div class="disp-empty">${I.truck}<p>No transports on this day.</p><span>Rentals with Delivery / Round-Trip / Recovery land here automatically — flip days with ‹ ›.</span></div>`;
-  const home = (sub) => `<div class="disp-stop disp-home"><span class="disp-ico home">🏠</span><div class="disp-bd"><div class="disp-unit">${DISPATCH_HOME}</div><div class="disp-sub">${esc(sub)}</div></div></div>`;
+  // Each icon is a route node: click one then another to draw a "from → there" leg.
+  const ico = (node, cls, body, tip) =>
+    `<span class="disp-ico js-disp-arrowpt ${cls}" data-node="${esc(node)}" data-tip="${esc(tip)}" role="button" tabindex="0" aria-label="${esc(tip)}">${body}</span>`;
+  const armTip = armed ? 'Click to draw the route leg to here (Esc cancels)' : 'Click to start a route arrow from here';
+  const home = (node, sub) => `<div class="disp-stop disp-home">${ico(node, 'home', '🏠', armTip)}<div class="disp-bd"><div class="disp-unit">${DISPATCH_HOME}</div><div class="disp-sub">${esc(sub)}</div></div></div>`;
   const rows = stops.map((ev, i) => {
     const deliver = ev.task === 'Deliver';
     const overdue = ev.date < TODAY_ISO, dueToday = ev.date === TODAY_ISO;
@@ -4370,7 +4407,7 @@ function dispatchGridBody() {
       <span class="disp-grip" data-tip="Drag to reorder the run">⠿</span>
       <span class="disp-seq">${i + 1}</span>
       <input class="disp-time js-disp-time" data-id="${esc(ev.id)}" value="${esc(ev.time || '')}" placeholder="—:—" maxlength="5" data-tip="Set the stop time" />
-      <span class="disp-ico c-${deliver ? 'blue' : 'brown'}" data-tip="${deliver ? 'Deliver' : 'Recover'}">${deliver ? 'D' : 'R'}</span>
+      ${ico(ev.id, 'c-' + (deliver ? 'blue' : 'brown'), deliver ? 'D' : 'R', armTip)}
       <div class="disp-bd">
         <div class="disp-unit">${esc(ev.unit)} <span class="disp-task">${deliver ? 'Deliver' : 'Recover'}</span></div>
         <div class="disp-sub">${esc(ev.cust)}${ev.addr ? ` · <span class="disp-addr js-site-go" data-rec="${esc(ev.rentalId)}">${esc(ev.addr)}</span>` : ''}</div>
@@ -4378,7 +4415,53 @@ function dispatchGridBody() {
       <span class="disp-deadline${overdue ? ' over' : dueToday ? ' today' : ''}">${esc(fmtShortDate(ev.date))}${overdue ? ' · LATE' : dueToday ? ' · TODAY' : ''}</span>
     </div>`;
   }).join('');
-  return `${head}<div class="disp-route js-disp-route" data-day="${esc(day)}">${home('Roll out')}${rows}${home('Return to yard')}</div>`;
+  const arm = armed ? `<div class="disp-arm" role="status">${I.truck} Drawing a route leg — click the next stop to land the arrow. <button class="disp-arm-x js-disp-arm-cancel">Cancel</button></div>` : '';
+  return `${head}${arm}<div class="disp-route js-disp-route${armed ? ' arming' : ''}" data-day="${esc(day)}">${home(HOME_IN, 'Roll out')}${rows}${home(HOME_OUT, 'Return to yard')}</div>`;
+}
+/* §2.3 — paint the free-form route legs as an SVG overlay in the route's left gutter,
+   AFTER the DOM lands (we need each icon's real geometry). Pure post-render decor: each
+   leg bows into the gutter so non-adjacent / backtracking legs stay legible, with an
+   arrowhead at the destination. The armed icon is highlighted via the .armed class. */
+function drawDispatchArrows() {
+  const route = document.querySelector('.js-disp-route'); if (!route) return;
+  route.querySelector('.disp-arrows')?.remove();
+  const day = route.dataset.day, arm = state.dispArm;
+  route.querySelectorAll('.js-disp-arrowpt').forEach((n) => n.classList.toggle('armed', arm != null && n.dataset.node === arm));
+  const legs = dispatchArrowsLS()[day] || [];
+  if (!legs.length) return;
+  const rr = route.getBoundingClientRect(), top = route.scrollTop;
+  const RAIL = 19;   // legs live in the route's left rail (its padding-left), clear of the rows
+  // node anchor = rail-x, aligned to the icon's vertical center (content coords so it scrolls)
+  const yOf = (node) => {
+    const i = route.querySelector(`.js-disp-arrowpt[data-node="${CSS.escape(node)}"]`); if (!i) return null;
+    const r = i.getBoundingClientRect(); return r.top - rr.top + top + r.height / 2;
+  };
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('class', 'disp-arrows');
+  svg.setAttribute('width', rr.width); svg.setAttribute('height', route.scrollHeight);
+  svg.setAttribute('viewBox', `0 0 ${rr.width} ${route.scrollHeight}`);
+  svg.innerHTML = `<defs><marker id="dispArrowHead" markerWidth="7" markerHeight="7" refX="5.2" refY="3" orient="auto-start-reverse"><path d="M0,0 L6,3 L0,6 Z" fill="var(--accent)"/></marker></defs>`;
+  legs.forEach(([a, b], idx) => {
+    const ya = yOf(a), yb = yOf(b); if (ya == null || yb == null) return;
+    // bow left within the rail, deeper for longer legs / stacked legs so they don't overlap
+    const bow = Math.min(13, 4 + Math.abs(yb - ya) * 0.03) + (idx % 3) * 2;
+    const cx = RAIL - bow;
+    const d = `M ${RAIL} ${ya.toFixed(1)} C ${cx.toFixed(1)} ${ya.toFixed(1)}, ${cx.toFixed(1)} ${yb.toFixed(1)}, ${RAIL} ${yb.toFixed(1)}`;
+    // a fat invisible hit-path makes the thin leg easy to click away
+    const hit = document.createElementNS(NS, 'path');
+    hit.setAttribute('d', d); hit.setAttribute('class', 'disp-arrow-hit js-disp-arrow');
+    hit.setAttribute('data-from', a); hit.setAttribute('data-to', b);
+    hit.setAttribute('fill', 'none'); hit.setAttribute('stroke', 'transparent'); hit.setAttribute('stroke-width', '13');
+    const line = document.createElementNS(NS, 'path');
+    line.setAttribute('d', d); line.setAttribute('class', 'disp-arrow-line');
+    line.setAttribute('fill', 'none'); line.setAttribute('marker-end', 'url(#dispArrowHead)');
+    const dot = document.createElementNS(NS, 'circle');   // the leg's origin
+    dot.setAttribute('cx', RAIL); dot.setAttribute('cy', ya.toFixed(1)); dot.setAttribute('r', '2.6');
+    dot.setAttribute('class', 'disp-arrow-dot');
+    svg.appendChild(hit); svg.appendChild(line); svg.appendChild(dot);
+  });
+  route.appendChild(svg);
 }
 /** The status badge shown on an item tab (replaces the old datapoint sub-text). */
 function tabBadge(card, rec) {
@@ -5856,6 +5939,7 @@ function render() {
   // Hidden while the team dock owns that corner (Jac 2026-06-15).
   if (!state.chat.open) $('#app').appendChild(fabStackEl());
   applyTitles();   // full text on hover wherever we truncate (custom ~0.5s tooltip)
+  drawDispatchArrows();   // §2.3 — paint free-form route legs over the dispatch run (needs live geometry)
   scoreTick();     // §11 gamification — pop +X over any ring whose metric just rose
   if (DRAG.active) reapplyDragDecor();   // §15c — re-stamp drop targets after ANY mid-drag rebuild (the card swap IS a render)
   const dt = performance.now() - t0;
@@ -6504,8 +6588,13 @@ function onClick(e) {
   if (closest('.js-new-cust-search')) { e.stopPropagation(); const cs = activeSession().cards.customers; return startNewCustomer(parseCustomerSearch(cs.search)); }
   if (closest('.js-coltab')) { const ct = closest('.js-coltab'); e.stopPropagation(); state.fleetFilter = null; const cs = activeSession(); if (cs.cols) cs.cols[ct.dataset.col] = ct.dataset.member; return render(); }
   // §2.3 dispatch timeline — day nav + open a stop's rental (Phase 6)
-  if (closest('.js-disp-day')) { e.stopPropagation(); state.dispatchDay = addDaysISO(state.dispatchDay || TODAY_ISO, Number(closest('.js-disp-day').dataset.dir)); return render(); }
-  if (closest('.js-disp-today')) { e.stopPropagation(); state.dispatchDay = TODAY_ISO; return render(); }
+  if (closest('.js-disp-day')) { e.stopPropagation(); state.dispArm = null; state.dispatchDay = addDaysISO(state.dispatchDay || TODAY_ISO, Number(closest('.js-disp-day').dataset.dir)); return render(); }
+  if (closest('.js-disp-today')) { e.stopPropagation(); state.dispArm = null; state.dispatchDay = TODAY_ISO; return render(); }
+  // §2.3 free-form route arrows — these win over the stop-open below (the icon lives inside the row)
+  if (closest('.js-disp-arrow')) { e.stopPropagation(); const a = closest('.js-disp-arrow'); return removeDispatchArrow(state.dispatchDay || TODAY_ISO, a.dataset.from, a.dataset.to); }
+  if (closest('.js-disp-arrowpt')) { e.stopPropagation(); const route = closest('.js-disp-route'); return dispatchArrowClick(route ? route.dataset.day : (state.dispatchDay || TODAY_ISO), closest('.js-disp-arrowpt').dataset.node); }
+  if (closest('.js-disp-arm-cancel')) { e.stopPropagation(); state.dispArm = null; return render(); }
+  if (closest('.js-disp-clearlegs')) { e.stopPropagation(); const all = dispatchArrowsLS(); delete all[state.dispatchDay || TODAY_ISO]; _lsSave('jactec.dispatchArrows', all); state.dispArm = null; return render(); }
   if (closest('.js-disp-stop') && !closest('.js-disp-time') && !closest('.disp-grip') && !closest('.js-site-go')) { e.stopPropagation(); return anchorRecord('rentals', closest('.js-disp-stop').dataset.rec); }
   if (closest('.js-new-wo-unit')) { e.stopPropagation(); return startNewWorkOrder(closest('.js-new-wo-unit').dataset.rec); }
   if (closest('.js-newitem')) {
@@ -8886,6 +8975,15 @@ function boot() {
     dispDragId = null; render();
   });
   document.addEventListener('dragend', () => { dispDragId = null; document.querySelectorAll('.disp-dragging').forEach((n) => n.classList.remove('disp-dragging')); });
+  // §2.3 route arrows — keyboard parity: Enter/Space arms or lands a leg; Escape cancels the draw.
+  document.addEventListener('keydown', (e) => {
+    const pt = e.target.closest && e.target.closest('.js-disp-arrowpt');
+    if (pt && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault(); const route = pt.closest('.js-disp-route');
+      return dispatchArrowClick(route ? route.dataset.day : (state.dispatchDay || TODAY_ISO), pt.dataset.node);
+    }
+    if (e.key === 'Escape' && state.dispArm != null) { e.preventDefault(); e.stopPropagation(); state.dispArm = null; render(); }
+  });
   document.addEventListener('mousemove', onInspectMove);   // Design Inspector hover tag (no-op unless state.inspect)
   // Board View formula cells: reveal the raw "=…" on focus, recompute on blur.
   document.addEventListener('focusin', (e) => {

--- a/docs/wrangler-backlog.md
+++ b/docs/wrangler-backlog.md
@@ -7,20 +7,20 @@ Pinned backlog from the sticky-note photos, grouped into like-minded phases.
 Worked all 6 phases end-to-end. Every commit passed the 3 gates; each UI piece was
 screenshot-checked. **All on the branch (PR #7)** — nothing auto-shipped to live.
 
-- **Phase 1 — bugs:** ✅ right-click-over-preview · Complete-Rental feedback · Bill/Don't-bill toggle · fleet-dropdown z-index · Cancel/Reopen WO · footers-no-longer-change-mode. 📌 3 still pinned (need live repro): the 2 units-list scroll bugs + For-Sale-in-availability.
+- **Phase 1 — bugs:** ✅ right-click-over-preview · Complete-Rental feedback · Bill/Don't-bill toggle · fleet-dropdown z-index · Cancel/Reopen WO · footers-no-longer-change-mode · ✅ **For-Sale-in-availability** (units list now hides non-Active fleet under an availability window). The 2 units-list scroll bugs: **proven resolved at HEAD** (Playwright repro — Back/right-click-back/jog all restore the saved scroll; fresh opens land at top) — fixed by the Phase 2a/2b interaction work (#16/#17).
 - **Phase 2 — chrome:** ✅ per-card striped-header colors · removed Dashboard · removed footer dashed line · Membership/Used-Sales swapped · +Unit pill hidden after first unit · Yard Mode already locked. (Graph icon delivered with Phase 4.)
 - **Phase 3 — KPIs:** ✅ all four (Healthy Fleet, Parts Breakeven, Ready-Rate denominator, WO-Rate 20%/30-day goal-ring).
 - **Phase 4 — graphs:** ✅ per-card Graph icon + the full Units graph (FC stats, leaderboard, FC-history bars, Inspection & Parts donuts, unit roster).
 - **Phase 5 — WO/parts:** ✅ Part-in-Stock status · Part/Task autofocus + Enter-to-add · WO→failed-inspection link · failed-unit re-inspection gated on the last blocking WO.
-- **Phase 6 — transport:** ✅ Calendar = daily driver timeline (D/R/🏠, times, deadlines, drag-reorder, route arrows, day nav). 📌 manual "click-icon-to-icon" arbitrary arrows interpreted as the sequential route order (drag to reorder) — revisit if you want free-form arrows.
+- **Phase 6 — transport:** ✅ Calendar = daily driver timeline (D/R/🏠, times, deadlines, drag-reorder, sequential route order, day nav). ✅ **free-form route arrows** — click any stop icon then another to draw an arbitrary directional "from here → there" leg (kept per-day in localStorage, drawn in the route's left rail; re-draw a leg or click it to remove, "× N arrows" clears the day, Esc cancels a draw).
 
 ## Phase 1 — Bugs / broken controls (auto-fixer candidates)
 > **Decision:** fix all on the feature branch (PR #7), batched with the redesign — not via the live engine (would collide with the branch).
 >
 > **Status (2026-06-15):** ✅ right-click-over-preview · ✅ Complete-Rental locked feedback · ✅ Bill/Don't-bill toggle · ✅ fleet dropdown z-index/preview · ✅ Cancel WO · ✅ footers no longer yank you out of Yard Mode.
-> **📌 PINNED — need live repro to fix safely (don't guess):**
-> - *Units list scrolls to a different spot on Back* + *Unit opens scrolled all the way down* — the per-view scroll-memo logic (render() ~L5600) already lands fresh opens at top; the bug is likely list-height change after back-nav or memo clobbering mid-render. Needs to be watched live to confirm the trigger.
-> - *For-Sale machines in Category Availability* — `isUnitAvailableFor`/`categoryAvailableCount` ALREADY exclude every non-Active fleetStatus (incl. For Sale), so the count is correct. Need to know exactly WHICH view still shows them (category roster list? a calendar? the availability search?) before filtering, so I don't hide units somewhere they should appear.
+> **✅ PINNED ITEMS — RESOLVED (2026-06-15, dogfooded the `wrangler-fix` prove-then-fix protocol):**
+> - *Units list scrolls to a different spot on Back* + *Unit opens scrolled all the way down* — **could not reproduce at HEAD.** Playwright repro on the real app: scroll the list, open a unit (lands at top — correct), then Back via the button, right-click, and the back/forward jog — every path restores the exact saved scroll (e.g. 229/200/150). The Phase 2a/2b interaction rework (#16/#17) fixed it. **No code change** — shipping a speculative scroll edit would risk the working path.
+> - *For-Sale machines in Category Availability* — **fixed.** Proof: §9 says non-Active units aren't rentable, and `isUnitAvailableFor`/`categoryAvailableCount` already drop *every* non-Active fleetStatus, so the count excludes them — but `unitsVisible` only hid Sold/Inactive, so a For-Sale machine still *listed* under an availability window while the count said it was gone. Fix: under an active availability window (`availWin`), the Units list shows only the Active (rentable) fleet — matching the count. The all-fleet / sold-inactive sorts still reveal them, and normal management views (no window) are untouched. (`app.js` §13.2 list build.)
 - [ ] Right-click not working
 - [ ] Right-click should win over the hover Preview
 - [ ] "Complete Rental" button does nothing

--- a/style.css
+++ b/style.css
@@ -424,7 +424,7 @@ input { font-family: inherit; }
 .disp-today { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .6px; color: var(--accent); background: var(--accent-soft); padding: 2px 7px; border-radius: 99px; }
 .disp-jump { font-size: 11px; color: var(--accent); background: none; border: none; cursor: pointer; text-decoration: underline; }
 .disp-count { font-size: 11px; color: var(--txt-3); white-space: nowrap; }
-.disp-route { padding: 6px 12px 18px; overflow-y: auto; }
+.disp-route { position: relative; padding: 6px 12px 18px 34px; overflow-y: auto; }
 .disp-stop { position: relative; display: flex; align-items: center; gap: 9px; }
 .js-disp-stop { background: linear-gradient(180deg, var(--card-head), var(--card)); border: 1px solid var(--line); border-radius: 11px; padding: 9px 11px; margin: 7px 0; cursor: pointer; }
 .js-disp-stop:hover { border-color: var(--accent-line); }
@@ -436,7 +436,8 @@ input { font-family: inherit; }
 .disp-time { width: 50px; flex: 0 0 auto; height: 28px; text-align: center; border: 1px solid var(--line); border-radius: 7px; background: var(--bg-2, var(--panel)); color: var(--txt); font: inherit; font-size: 12px; font-weight: 700; }
 .disp-time:focus { border-color: var(--accent-line); outline: none; }
 .disp-ico { width: 30px; height: 30px; flex: 0 0 auto; border-radius: 50%; display: grid; place-items: center; font-weight: 800; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 14px; color: #fff; }
-.disp-ico.c-blue { background: var(--blue); } .disp-ico.c-brown { background: var(--brown, #9a6a3a); }
+/* the D/R letter must stay white on the colored disc — beat the generic .c-blue/.c-brown text color (style.css §pills) */
+.disp-ico.c-blue { background: var(--blue); color: #fff; } .disp-ico.c-brown { background: var(--brown, #9a6a3a); color: #fff; }
 .disp-ico.home { background: var(--bg-2, var(--panel)); border: 1px solid var(--line); font-size: 15px; }
 .disp-bd { flex: 1; min-width: 0; }
 .disp-unit { font-weight: 700; font-size: 13.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -453,6 +454,25 @@ input { font-family: inherit; }
 .disp-empty svg { width: 30px; height: 30px; opacity: .5; }
 .disp-empty p { font-size: 14px; color: var(--txt-2); margin: 10px 0 4px; }
 .disp-empty span { font-size: 12px; }
+/* ── §2.3 free-form route arrows: click an icon to start a leg, click another to land it ── */
+.js-disp-arrowpt { cursor: pointer; transition: box-shadow .12s, transform .12s; }
+.js-disp-arrowpt:hover { box-shadow: 0 0 0 2px var(--accent-line); }
+.js-disp-arrowpt:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.disp-route.arming .js-disp-arrowpt { box-shadow: 0 0 0 1px var(--accent-line); }   /* every icon is a target while drawing */
+.js-disp-arrowpt.armed { box-shadow: 0 0 0 2px var(--accent), 0 0 9px var(--accent); transform: scale(1.06); }
+.disp-arm { display: flex; align-items: center; gap: 7px; margin: 0 12px 4px; padding: 7px 10px; font-size: 11.5px; color: var(--accent);
+  background: var(--accent-soft); border: 1px solid var(--accent-line); border-radius: 9px; }
+.disp-arm svg { width: 15px; height: 15px; flex: 0 0 auto; }
+.disp-arm-x { margin-left: auto; font-size: 11px; font-weight: 700; color: var(--txt-2); background: none; border: none; cursor: pointer; text-decoration: underline; }
+.disp-clearleg { display: inline-flex; align-items: center; gap: 3px; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px;
+  color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-line); border-radius: 99px; padding: 2px 8px; cursor: pointer; white-space: nowrap; }
+.disp-clearleg svg { width: 11px; height: 11px; }
+.disp-clearleg:hover { border-color: var(--accent); }
+.disp-arrows { position: absolute; top: 0; left: 0; pointer-events: none; z-index: 2; }
+.disp-arrow-line { stroke: var(--accent); stroke-width: 2; stroke-linecap: round; vector-effect: non-scaling-stroke; }
+.disp-arrow-dot { fill: var(--accent); }
+.disp-arrow-hit { pointer-events: stroke; cursor: pointer; }
+@media (prefers-reduced-motion: reduce) { .js-disp-arrowpt { transition: none; } .js-disp-arrowpt.armed { transform: none; } }
 
 /* ── Card (each is the detail view; scrolls internally) ──────────────────── */
 .card {


### PR DESCRIPTION
Clears the four pinned backlog items. Each was run through the `wrangler-fix` **prove-then-fix** protocol — proven against the canon before any code changed.

### 1. Free-form route arrows (Phase 6) — built
Click a stop icon to arm a leg, click another to draw a directional **"from here → there"** arrow on top of the top-to-bottom run order. Legs persist per-day in `localStorage` and render as an SVG overlay in the route's **left rail** (transit-map style, never crossing the rows). Re-draw a leg or click it to remove; **"× N arrows"** clears the day; **Esc** cancels a draw. Keyboard parity (Enter/Space/Esc), visible focus, reduced-motion respected. Styled in the yard data-plate language (safety-orange route/ignition accent).

### 2. For-Sale machines in Category Availability — fixed
**Proof:** §9 — non-Active units aren't rentable; `isUnitAvailableFor`/`categoryAvailableCount` already drop **every** non-Active `fleetStatus`, so the availability *count* excludes a For-Sale machine. But `unitsVisible` only hid Sold/Inactive, so the unit still **listed** under an availability window while the count said it was gone. **Fix:** under an active availability window (`availWin`), the Units list shows only the Active (rentable) fleet — consistent with the count. The all-fleet / sold-inactive sorts still reveal them; normal management views (no window) are untouched.

### 3. The two units-list scroll bugs — could not reproduce at HEAD
Playwright repro on the real app: scroll the list → open a unit (lands at top, correct) → Back via the button, right-click, and the back/forward jog — **every path restores the exact saved scroll** (229 / 200 / 150). Already fixed by the Phase 2a/2b interaction rework (#16/#17). **No speculative change** — editing the working scroll path would only risk a regression.

### Bonus legibility fix
The D/R dispatch icon letter was blue-on-blue (the generic `.c-blue` text color beat `.disp-ico`) — now white on the colored disc.

### Gates
`node ci/smoke.mjs` · `node ci/logic-test.mjs` (28/28) · `node ci/gen-rule-usage.mjs --check` — all green.

https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg)_