### PR TITLE
Darken the rentals hazard-stripe green (#26)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1878,7 +1878,7 @@ body.dragging .row.drop-ok { opacity: 1; }
 }
 /* Each card type stamps its own hazard color, always paired with black. */
 [data-theme="yard"] .col > .card[data-card="customers"]  { --stripe: var(--blue,  #5b9dff); }
-[data-theme="yard"] .col > .card[data-card="rentals"]    { --stripe: var(--green, #34d399); }
+[data-theme="yard"] .col > .card[data-card="rentals"]    { --stripe: #147a47; }   /* deep green (darkened from the bright #34d399 per #26) */
 [data-theme="yard"] .col > .card[data-card="units"]      { --stripe: var(--yellow,#f5c542); }
 [data-theme="yard"] .col > .card[data-card="categories"] { --stripe: var(--accent,#ff7a1a); }
 [data-theme="yard"] .col > .card[data-card="invoices"]   { --stripe: var(--red,   #ff4242); }


### PR DESCRIPTION
Closes #26.

The rentals card's top **hazard stripe** rendered as a bright mint green (`#34d399`); the reporter asked for a darker green. Darkened it to a deep green (`#147a47`), scoped to the rentals card's `--stripe` only — the global `--green` status token (pills, etc.) is unchanged.

Note: the design canon (CLAUDE.md) specs the hazard stripe as caution-yellow; the rentals card is an existing per-card green override (style.css:1881). Per Jac's call, keeping it green but darker (not reconciling to yellow).

Gates: smoke ✓ · logic 36/36 ✓ · gen-rule-usage ✓.

https://claude.ai/code/session_01Vjwrncp3yFrUHxhJxec4bo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vjwrncp3yFrUHxhJxec4bo)_