### PR TITLE
A1: the "Not Ready" tab chip becomes a removable search pill (was a sticky mode)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6882,13 +6882,13 @@ function onClick(e) {
   // inspection gated flow (§9): Wash → Checklist → result
   if (closest('.js-open-insp')) { e.stopPropagation(); return openOverlay({ kind: 'inspection', recId: closest('.js-open-insp').dataset.rec }); }
   if (closest('[data-ctx]')) return runCtxAction(closest('[data-ctx]').dataset.ctx);   // R20 context menu
-  if (closest('.js-notready')) {   // the units "Not Ready" filter chip — it's just a filter
+  if (closest('.js-notready')) {   // the units "Not Ready" chip — A1: route into the Units search bar as a removable pill, not a sticky mode
     e.stopPropagation();
     const s = activeSession();
     if (s.cols && s.cols.left) s.cols.left = 'units';
-    s.cards.units.mode = 'list'; s.cards.units.recId = null;
-    s.cards.units.totalFilter = { col: '__cond', value: 'Not Ready' };
-    return render();
+    s.cards.units.mode = 'list'; s.cards.units.recId = null; s.cards.units.recType = null;
+    addColFilter('units', '__cond', 'Not Ready');
+    return;
   }
   // ── v2 build: condition/wash segs · yard captures · site popup · WO complete · history chips ──
   if (closest('.js-cond')) { const b = closest('.js-cond'); return setUnitCondition(b.dataset.rec, b.dataset.val); }


### PR DESCRIPTION
Per Jac's precise repro: clicking the **Not Ready chip** in the top tab row (the clipboard/inspections icon) set a sticky `cs.totalFilter` you couldn't clear from the search bar — "puts the list view in not ready mode." Now it adds a **removable, exact-match "Not Ready" pill** to the Units search bar (cleared from the search bar like any term, via the same A1 structured-term mechanism). Verified: shows exactly the 2 Not-Ready units, no over-match.

Gates green (smoke, logic 36/36, rule-usage). The "services" counterpart (the serviceOrders heart tab) is a navigation tab, not a sticky chip — confirming its exact desired behavior separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDZrXsrfWAYSyyKDzUXJKY)_