### PR TITLE
A1: the Services (heart) tab becomes a removable "Service Due" units filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -1352,6 +1352,7 @@ function rowMatches(card, rec, query, terms) {
 function totColMatch(card, rec, col, value) {
   if (col === '__wo') return DATA.workOrders.some((w) => w.unitId === rec.unitId && w.phase !== 'Complete' && !w.cancelled && (value === 'open' || w.phase === 'Part Ordered' || (w.lineItems || []).some((l) => l.phase === 'Part Ordered')));
   if (col === '__cond') return rec.inspectionStatus === value;
+  if (col === '__svc') { const s = topServiceForUnit(rec); return !!rec.washRequested || !!(s && s.remaining < 0); }   // service-due: overdue service or wash requested
   const c = cardColumns(card, activeSession()).find((x) => x.key === col);
   return c ? String(c.get(rec)) === String(value) : true;
 }
@@ -1378,6 +1379,7 @@ function addColFilter(scope, col, value) {
 }
 function colFilterLabel(card, col, value) {
   if (col === '__wo') return value === 'open' ? 'WOs Open' : 'Parts Ordered';
+  if (col === '__svc') return 'Service Due';
   const c = cardColumns(card, activeSession()).find((x) => x.key === col);
   const m = (c && c.meta) ? c.meta(value) : null;
   return (m && m.label) || String(value);
@@ -6785,7 +6787,13 @@ function onClick(e) {
   if (closest('.js-bv-customize')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { o.customize = !o.customize; renderOverlay(); } return; }
   if (closest('.js-bv-resetlayout')) { e.stopPropagation(); const card = closest('.js-bv-resetlayout').dataset.card; saveListLayout(card, null); saveListTotals(card, null); render(); renderOverlay(); return; }
   if (closest('.js-new-cust-search')) { e.stopPropagation(); const cs = activeSession().cards.customers; return startNewCustomer(parseCustomerSearch(cs.search)); }
-  if (closest('.js-coltab')) { const ct = closest('.js-coltab'); e.stopPropagation(); state.fleetFilter = null; const cs = activeSession(); if (cs.cols) cs.cols[ct.dataset.col] = ct.dataset.member; return render(); }
+  if (closest('.js-coltab')) {
+    const ct = closest('.js-coltab'); e.stopPropagation();
+    // A1 — the Services (heart) tab filters the Units list to service-due as a removable
+    // pill, instead of switching to a stuck Service view you can't clear. (Jac 2026-06-15)
+    if (ct.dataset.member === 'serviceOrders') { const s = activeSession(); if (s.cols) s.cols.left = 'units'; s.cards.units.mode = 'list'; s.cards.units.recId = null; s.cards.units.recType = null; addColFilter('units', '__svc', 'due'); return; }
+    state.fleetFilter = null; const cs = activeSession(); if (cs.cols) cs.cols[ct.dataset.col] = ct.dataset.member; return render();
+  }
   // §2.3 dispatch timeline — day nav + open a stop's rental (Phase 6)
   if (closest('.js-disp-day')) { e.stopPropagation(); state.dispatchDay = addDaysISO(state.dispatchDay || TODAY_ISO, Number(closest('.js-disp-day').dataset.dir)); return render(); }
   if (closest('.js-disp-today')) { e.stopPropagation(); state.dispatchDay = TODAY_ISO; return render(); }


### PR DESCRIPTION
The companion to the Not Ready fix. Clicking the **serviceOrders heart tab** switched the column to a stuck Service view you couldn't clear ("the same thing happens for services"). Now it switches to the **Units list** and adds a **removable "Service Due" pill** (units with overdue service or a wash requested) — the same search-bar pathway as the Not Ready chip, cleared from the search bar.

Service *detail* stays reachable via service pills, and completion still works from the unit rows. Verified: shows the service-due units (one Sold/Inactive correctly hidden).

Gates green (smoke, logic 36/36, rule-usage).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDZrXsrfWAYSyyKDzUXJKY)_