### PR TITLE
docs: HANDOFF for a local live-update session (+ SPEC logic-count fix)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -3,7 +3,69 @@
 > For the next Claude Code session (another machine, the web, or Jac's phone).
 > **Read this first.**
 
-## ▶▶▶ STATE AS OF 2026-06-14 (supersedes everything below)
+## ▶▶▶ STATE AS OF 2026-06-15 (pm — supersedes everything below)
+
+> Handoff for an incoming **local Claude Code session** doing live updates. `main` is moving
+> FAST today (parallel sessions + the wrangler-fix pipeline merged several PRs within minutes),
+> so always `git fetch origin && git log --oneline origin/main` for the TRUE tip — the SHAs
+> below are a snapshot.
+
+**Live `main` @ `445511b`** = app.jacrentals.com. All three gates green (smoke · logic
+**36/36** · `gen-rule-usage --check`). This session's branch `claude/exciting-goldberg-htri6w`
+is cut off `main` and is the live-update branch: develop here → push branch + draft PR →
+`git push origin HEAD:main` to ship to Pages.
+
+### What's LIVE now (built-state detail in `JacTec-handoff/JacTec-SPEC-v8.md` §v8.1–v8.4)
+- **v8.1** — §17 internal team chat dock + §M0–M3 mobile adaptive reflow.
+- **v8.2 (PR #7, now MERGED + LIVE)** — the UI overhaul + Jac's 6-phase dump (per-card hazard
+  stripes, KPI rework, Card Graph view, WO/Parts workflow, daily driver-timeline dispatch) +
+  the **Mr. Wrangler self-healing pipeline** (Track B: a `wrangler-fix`/`wrangler-request`
+  issue → coding agent grounds it in the canon, PROVES it, fixes if proven → 3 gates →
+  auto-merge → Pages).
+- **v8.3** — Mr. Wrangler **in-app Requests inbox** + **bottom-right FAB cluster**
+  (notification-bell stub over the inbox); chat image attach; the **`wrangler-fix` skill**
+  (prove-then-fix — proof replaces approval); backend `wranglerFile`/`Requests`/`Approve`/
+  `Dismiss` deployed via **clasp** (`@16`).
+- **#29** — Phase-6 **free-form route arrows** on the dispatch timeline + the
+  **For-Sale-in-availability** list fix + D/R icon legibility (the two scroll bugs were proven
+  already fixed by #16/#17).
+- **#31 / #32 (A1)** — the "Not Ready" tab chip and the Services (heart) tab no longer set a
+  stuck mode; each now drops a **removable search-bar pill** (Not Ready / Service Due).
+
+### Docs in flight + open PRs — coordinate, don't duplicate
+- **#36 (open)** — the **"SPEC v8.4"** delta records this evening's A1 / B-list / D-E-C-F-G-H
+  work + the two pending backend handlers. **It owns the SPEC v8.4 narrative — don't write a
+  second one.** (This branch's PR #33 only refreshes the HANDOFF, corrects the stale
+  logic-count, and fixes the backlog summary line.)
+- **#1 (open)** — CI bump checkout/setup-node v4→v5 (Node 24). ⏰ **GitHub forces Node-24 on
+  2026-06-16 (tomorrow)** — merge it.
+
+### START HERE (local session)
+1. **Gates — install Playwright first** (the repo ships no `node_modules`):
+   ```sh
+   npm install --no-save playwright@1.48.0 && npx playwright install chromium
+   node ci/smoke.mjs && node ci/logic-test.mjs && node ci/gen-rule-usage.mjs --check
+   ```
+   `logic-test` is now **36** checks. Regenerate `rule-usage.js` (drop `--check`) ONLY when
+   rule USAGE changes.
+2. **Live-update workflow:** develop on this branch → push branch + draft PR →
+   `git push origin HEAD:main` to deploy. Gates MUST pass before any push.
+3. **New/changed UI → run it through the `frontend` skill** in the yard data-plate language
+   (CLAUDE.md is binding); touch only what an edit already touches.
+4. **Backend `Code.gs` is gitignored but now deployable from a session via clasp**
+   (`clasp pull` → edit → `clasp push` → `clasp deploy -i <id>`; re-auth each session). Still
+   TODO there: **`uploadFile`** and **`saveSession`/`getSession`** handlers (per #36), the
+   Claude-API proxy for the AI surfaces, and the image-capable paste so chat image attachments
+   reach the model.
+5. **🔐 Security to-do (from §v8.3):** rotate the `GITHUB_TOKEN` that was pasted in chat —
+   minimal scope (Issues RW, this one repo).
+6. **Remaining product work:** SPEC §7 "Carry forward" (after #36 merges) — the backend
+   handlers, the Claude-API proxy, the Categories fleet-bar (A1's last sticky filter), and the
+   notification-bell → in-app feed.
+
+---
+
+## ▶▶▶ STATE AS OF 2026-06-14 (historical — superseded above)
 
 **Baseline (known-good):** branch `claude/handoff-continuation-q442qm` @ **`08f9da8`**
 (code + the SPEC v8.1 delta + the mobile spec + the build-list tracker); live **`main`**

--- a/JacTec-handoff/JacTec-SPEC-v8.md
+++ b/JacTec-handoff/JacTec-SPEC-v8.md
@@ -15,7 +15,7 @@ rule here was read out of `const RULE_META` (app.js:1344), `const CLASS_RULE`
 (app.js:1373), the R0 lint CSS (style.css:985), and the live `data-r` stamps —
 not from memory. Drift is guarded mechanically: `ci/gen-rule-usage.mjs --check`
 fails CI if a builder's call sites change but `rule-usage.js` (the per-rule field
-catalog) wasn't regenerated, and `ci/logic-test.mjs` (22 `ok()` checks via the
+catalog) wasn't regenerated, and `ci/logic-test.mjs` (36 `ok()` checks via the
 `#local`-only `window.__rw` seam) locks the money + multi-unit invariants as
 executable tests. **Commit this doc** so it travels with the repo — the whole
 reason v7 went stale is that it didn't. When the code changes a rule, change this
@@ -575,7 +575,7 @@ days + honors overbooking (bffde57, 54c9849).
 **KPI:** +X score pops (4d1ea19); Team KPI one-ring-per-role + Sulphur Team row
 (57cc5dd).
 
-**CI:** `ci/logic-test.mjs` (c62ff16, now 22 `ok()` checks); `ci/gen-rule-usage.mjs` +
+**CI:** `ci/logic-test.mjs` (c62ff16, now 36 `ok()` checks); `ci/gen-rule-usage.mjs` +
 `rule-usage.js` drift guard (fbb3ee7); boot smoke hardened (a5999da); `backend/`
 gitignored (f3215a9).
 
@@ -590,7 +590,7 @@ gitignored (f3215a9).
 2. **`rule-usage.js --check`** (`ci/gen-rule-usage.mjs`) fails CI if a builder's
    call sites changed but the per-rule field catalog wasn't regenerated — it is the
    mechanical drift alarm for the rulebook's CONTENTS.
-3. **`ci/logic-test.mjs`** (22 `ok()` checks via the `#local`-only `window.__rw` seam) is
+3. **`ci/logic-test.mjs`** (36 `ok()` checks via the `#local`-only `window.__rw` seam) is
    the executable spec for the money + multi-unit invariants (#13-#15 above).
    Treat those assertions as canonical behavior.
 4. **DUPLICATE rule-number guard — ✅ DONE (eaceeb5).** `ci/gen-rule-usage.mjs` now

--- a/docs/wrangler-backlog.md
+++ b/docs/wrangler-backlog.md
@@ -3,9 +3,11 @@
 Pinned backlog from the sticky-note photos, grouped into like-minded phases.
 (FC = Field Call. Crossed-out notes are parked at the bottom.)
 
-## ✅ Autonomous run summary (2026-06-15, on `claude/ui-overhaul-w55upw`)
+## ✅ Autonomous run summary (2026-06-15, started on `claude/ui-overhaul-w55upw`)
 Worked all 6 phases end-to-end. Every commit passed the 3 gates; each UI piece was
-screenshot-checked. **All on the branch (PR #7)** — nothing auto-shipped to live.
+screenshot-checked. **PR #7 is now MERGED + LIVE** (`main` @ `445511b`), followed by the
+v8.3 Requests-inbox/FAB work, #29 (route arrows + For-Sale fix + scroll-bug clearance), and
+the A1 tab→search-pill routing (#31/#32). Per-session SPEC narrative continues in PR #36.
 
 - **Phase 1 — bugs:** ✅ right-click-over-preview · Complete-Rental feedback · Bill/Don't-bill toggle · fleet-dropdown z-index · Cancel/Reopen WO · footers-no-longer-change-mode · ✅ **For-Sale-in-availability** (units list now hides non-Active fleet under an availability window). The 2 units-list scroll bugs: **proven resolved at HEAD** (Playwright repro — Back/right-click-back/jog all restore the saved scroll; fresh opens land at top) — fixed by the Phase 2a/2b interaction work (#16/#17).
 - **Phase 2 — chrome:** ✅ per-card striped-header colors · removed Dashboard · removed footer dashed line · Membership/Used-Sales swapped · +Unit pill hidden after first unit · Yard Mode already locked. (Graph icon delivered with Phase 4.)


### PR DESCRIPTION
Hands off to an incoming **local Claude Code session** that will do live updates (push to `main` → Pages). Rebased onto current `main` after it moved during the session.

### Context
`main` advanced fast while this was being written (`05b764a` → `445511b`): **PR #7 (v8.2) merged + live**, then **#29** (route arrows + For-Sale-in-availability fix + scroll-bug clearance) and **#31/#32** (A1 tab→search-pill routing). A parallel session's **PR #36** already owns the **SPEC v8.4** narrative, so this PR is deliberately scoped to **not duplicate it**.

### Changes (doc-only)
- **`HANDOFF.md`** — new top **"STATE AS OF 2026-06-15 (pm)"** section for the local session: live state (`main` @ `445511b`, moving fast — fetch for the true tip), what's live (v8.1–v8.3 + #29 + #31/#32), open PRs to coordinate (**#36** SPEC v8.4, **#1** Node-24 ⏰ forced 2026-06-16), gate steps (**install Playwright first**; logic is now **36** checks), the live-update + `frontend`-skill + **clasp**-backend workflow, and the 🔐 security to-do (rotate the pasted `GITHUB_TOKEN`). Old 2026-06-14 section demoted to historical.
- **`JacTec-handoff/JacTec-SPEC-v8.md`** — corrected the stale logic-suite count **22 → 36** in all three places. The v8.4 Built-State Delta is **left to PR #36** (no duplicate section).
- **`docs/wrangler-backlog.md`** — autonomous-run summary no longer says "nothing shipped to live".

### R-Rulebook
Unchanged — **no new rules**; `rule-usage.js` re-verified current (regeneration is a no-op); the §1 table still matches `RULE_META`.

### Gates
`node ci/smoke.mjs` ✅ · `node ci/logic-test.mjs` ✅ **36/36** · `node ci/gen-rule-usage.mjs --check` ✅
(Run locally — `ci.yml` runs `push` on `main` + `pull_request` to `main`; a PR opened via the API token doesn't trigger it, the documented `GITHUB_TOKEN` limitation.)

https://claude.ai/code/session_01TCRQbA3oYW1A9QmnCVjtpf