### PR TITLE
docs: SPEC v8.4 delta + local-session handoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ JacTec-handoff/*
 !JacTec-handoff/JacTec-SPEC-v8.md
 !JacTec-handoff/DRAGDROP-DESIGN.md
 !JacTec-handoff/JAC-BUILD-LIST.md
+!JacTec-handoff/HANDOFF-*.md
 # REAL customer data (PII) — generated locally, pushed ONLY to the password-gated
 # backend, NEVER committed or served as a public static file.
 data.generated.js

--- a/JacTec-handoff/HANDOFF-2026-06-15-pm.md
+++ b/JacTec-handoff/HANDOFF-2026-06-15-pm.md
@@ -1,0 +1,91 @@
+# Handoff → local Claude Code session (2026-06-15, evening)
+
+Pick up here. Live is current; this is what shipped, what's open, and how to work safely.
+
+## Where things stand (live = `main` → app.jacrentals.com via Pages)
+
+Top of `main`: **#29** — *Phase 6 free-form route arrows + For-Sale availability fix; cleared the
+2 scroll bugs*. Squashed & merged, CI (`smoke`) green, deployed. Plus, from other sessions already
+on `main`: **#32** Services (heart) tab → Units 'Service Due' pill · **#31** 'Not Ready' tab → Units
+search · **#30** Mr. Wrangler merge · **#28** footer chips route into the card search bar · **#27**
+real session sharing via QR.
+
+What #29 actually did (all proven via the `wrangler-fix` prove-then-fix protocol — see that skill):
+- **Free-form route arrows** on the Calendar daily-driver timeline. Click a D/R/🏠 icon to arm a
+  leg, click another to draw a directional "from here → there" arrow. Per-day in `localStorage`
+  (`jactec.dispatchArrows`), drawn as an SVG overlay in the route's **left rail**. Re-draw/click a
+  leg to remove, "× N arrows" clears the day, Esc cancels. Keyboard + focus + reduced-motion.
+  Code: `dispatchArrowsLS`/`dispatchArrowClick`/`removeDispatchArrow` + `drawDispatchArrows()`
+  (called at the end of `render()`); transient `state.dispArm`.
+- **For-Sale-in-availability:** under an availability window (`availWin`) the Units list now shows
+  only the Active (rentable) fleet, matching the count. All-fleet/sold-inactive sorts still reveal
+  them; normal views untouched. (Units list build, ~the `unitsVisible` call site.)
+- **Two scroll bugs:** proven already fixed at HEAD (#16/#17) — no code change.
+- **D/R dispatch icon** letter was blue-on-blue → now white.
+
+Docs updated alongside: `JacTec-SPEC-v8.md` (**v8.4 delta**), `docs/wrangler-backlog.md` (4 pinned
+items marked resolved with the proofs).
+
+## Move forward — candidate next work
+
+1. **Notification bell → in-app feed (the pinned "few days" item).** The bottom-right bell is still
+   a **stub**. The intended payoff: surface the engine's *verdict + proof + "refresh to see it"*
+   issue comments back inside the app so the report→fix loop closes without anyone opening GitHub.
+   Backend already files/lists requests (`wranglerRequests`); the bell needs a feed that polls
+   the issue's closing comment (or a new backend action that returns it) and renders it in the
+   `notifications` overlay kind that's already stubbed in `app.js`.
+2. **Per-card Graph views beyond Units.** Phase 4 shipped Units first (`cardGraphBody`/`pieSVG`/
+   `gvBars`); Rentals/Customers/Categories/Invoices each still want their own charts behind the
+   same graph icon.
+3. **Route arrows — possible follow-ups if Jac wants them:** a printable/"driver sheet" export of a
+   day's legs, or auto-suggesting legs from the sequential order. Leave unless asked — current build
+   satisfies the pinned request.
+4. Work the rest of `docs/wrangler-backlog.md` / `JacTec-handoff/JAC-BUILD-LIST.md` (the master
+   build list) for anything still unchecked.
+
+## How to work here (gotchas that cost time)
+
+- **Design language:** every new/changed UI goes through the **yard data-plate** language (see
+  `CLAUDE.md` + the `frontend` skill): hazard stripes, rivets, Saira Condensed stamps, safety-orange
+  `--accent`, light ranch twist. Screenshot + self-critique before showing Jac.
+- **Gates (must pass before push):** `node ci/smoke.mjs` · `node ci/logic-test.mjs` ·
+  `node ci/gen-rule-usage.mjs --check`. Regenerate `rule-usage.js` (drop `--check`) only when
+  `data-r` usage actually changes.
+- **Deploy:** `git push origin HEAD:main` ships live; also open a **draft PR** for the record. `main`
+  is gate-protected (the `smoke` check) and PRs auto-merge on green via the Wrangler engine.
+- **Headless testing the real app:** boot offline with the `#local` hash (renders from `data.js`,
+  no backend) and drive it with Playwright. Serve over **HTTP** (e.g. `python3 -m http.server`) —
+  `file://` blocks the ES-module load via CORS. Launch with
+  `chromium.launch({args:['--ignore-certificate-errors']})` + `newContext({ignoreHTTPSErrors:true})`;
+  the font/Stripe cert warnings and the `dev-version.txt` 404 are environmental, not bugs.
+  `window.__rw` exposes a read-mostly logic API (and `DATA`/`IDX`) in `#local` only.
+- **Playwright vs clasp conflict:** they're installed `--no-save` and evict each other
+  (`npm install` for one prunes the other). Reinstall what you need + `npx playwright install chromium`.
+- **The R-Rulebook:** UI is stamped `data-r="Rxx"`; rules live in `RULE_META`/`CLASS_RULE` in
+  `app.js` and §1 of the SPEC. Bespoke timeline controls (the `disp-*` dispatch elements, incl. the
+  new route arrows) are intentionally **not** stamped.
+
+## Backend (Mr. Wrangler — Apps Script)
+
+- `backend/` is **gitignored and never served by Pages** — never commit it (it holds
+  `DEFAULT_CONFIG` with real passwords). It's present locally for clasp.
+- clasp is wired: `clasp pull` → edit → `clasp push` → `clasp deploy -i <deploymentId>` (keeps the
+  same `/exec` URL). Re-auth each session (`clasp login --no-localhost`) — creds are ephemeral.
+- Secrets (`STRIPE_SECRET`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`) live **only** in Script Properties.
+- Actions live: `wranglerFile`, `wranglerRequests`, `wranglerApprove`, `wranglerDismiss`,
+  `wranglerReply_` (accepts image content blocks + an allowlisted model). Deployed `@16`.
+
+## Security note (not blocking)
+
+The `GITHUB_TOKEN` that was pasted into chat earlier is a **known-leaked** credential (fine-grained
+PAT, scoped to this one repo: Contents/PRs/Issues RW). Nothing breaks if it isn't rotated — it's a
+hygiene call. To stop the churn for good: keep the token **out of chat** (paste it straight into the
+GitHub Actions secret `WRANGLER_PAT` and the Apps Script Script Property `GITHUB_TOKEN`), use a
+narrow long-expiry PAT, or run `/install-github-app` so the engine uses the Claude GitHub App token
+and there's no PAT to mint at all.
+
+## Don'ts (from CLAUDE.md)
+
+- Never put the model identifier, secrets, or `DEFAULT_CONFIG` passwords in the repo (it's public).
+- Changing a WO part/task line to Complete must **not** complete the work order — only the blue
+  **Complete WO** button does.

--- a/JacTec-handoff/JacTec-SPEC-v8.md
+++ b/JacTec-handoff/JacTec-SPEC-v8.md
@@ -171,6 +171,49 @@ one repo).
 
 ---
 
+## v8.4 — Built-State Delta (2026-06-15, evening · pinned-backlog cleanup, shipped live via #29)
+
+The four pinned Phase-1/Phase-6 items, each run through the `wrangler-fix` **prove-then-fix**
+protocol (proven against the canon before any code changed).
+
+**§2.3 Dispatch — free-form route arrows (Phase 6 completion).** The Calendar daily-driver
+timeline already had a sequential, drag-orderable run (🏠→stops→🏠). It now also supports
+**arbitrary directional route legs**: click any stop's D/R/🏠 icon to **arm** it, click a second
+icon to **draw** a "from here → there" arrow. Legs are kept **per-day in `localStorage`**
+(`jactec.dispatchArrows` = `{ [day]: [[fromNode, toNode], …] }`; node = a stop id or
+`home:in`/`home:out`) and painted as an **SVG overlay in the route's left rail** (transit-map
+style — never crosses the rows; bows scale with reach so stacked legs stay legible). Re-drawing a
+leg or clicking it **removes** it; the header **"× N arrows"** pill clears the day; **Esc** cancels
+a draw. Keyboard parity (Enter/Space arm/land, Esc cancel), visible focus, reduced-motion honored.
+New functions: `dispatchArrowsLS` / `dispatchArrowClick` / `removeDispatchArrow` (near the other
+`dispatch*` helpers) + `drawDispatchArrows()` (called at the end of `render()`, after the DOM
+lands, since it needs live geometry). State: transient `state.dispArm` (the armed node).
+
+**§10 Availability — For-Sale machines no longer leak into "Category Availability."** `§9` says
+non-Active units aren't rentable, and `isUnitAvailableFor`/`categoryAvailableCount` already drop
+**every** non-Active `fleetStatus`, so the availability *count* excluded a For-Sale machine — but
+`unitsVisible` only hid **Sold/Inactive**, so the unit still **listed** under an availability
+window while the count said it was gone. Fix (in the §13.2 Units list build): while an availability
+window is in scope (`availWin`), the Units list shows **only the Active (rentable) fleet**, matching
+the count. The **all-fleet / sold-inactive sorts still reveal them**, and normal management views
+(no window) are untouched.
+
+**Two scroll bugs — proven already fixed (no change).** "Units list scrolls to a different spot
+on Back" and "Unit opens scrolled all the way down" **could not be reproduced at HEAD** (Playwright
+on the real app: button-Back, right-click-Back, and the back/forward jog all restore the exact
+saved scroll; a fresh open lands at top). The Phase-2a/2b interaction rework (#16/#17) had already
+fixed them; shipping a speculative scroll edit would only risk the working path.
+
+**Legibility.** The dispatch **D/R icon letter** was blue-on-blue (the generic `.c-blue` text
+color out-specified `.disp-ico`) — now explicitly white on the colored disc.
+
+**R-Rulebook:** **unchanged.** The route-arrow icons are bespoke timeline controls, consistent
+with the rest of the unstamped `disp-*` elements (the dispatch grid is not part of the general
+pill/badge/add `data-r` system), so no new rule and `rule-usage.js` is undisturbed
+(`gen-rule-usage.mjs --check` stays green).
+
+---
+
 ## 0 · How to debug with this spec
 
 1. **The flash-lint (R0)** is the alarm. Toggle = the eye icon in the bottom bar


### PR DESCRIPTION
Docs-only follow-up to #29 (no code change).

- **`JacTec-SPEC-v8.md`** — adds the **v8.4 Built-State Delta** recording what shipped in #29: the free-form route arrows (§2.3), the For-Sale-in-availability fix (§10), the two scroll bugs proven already fixed at HEAD, and the D/R icon legibility fix. Notes the **R-Rulebook is unchanged** (the route-arrow icons are bespoke timeline controls, consistent with the rest of the unstamped `disp-*` elements).
- **`HANDOFF-2026-06-15-pm.md`** — handoff for a local Claude Code session: current live state, next candidates (notification-bell in-app feed, more per-card graphs), dev gotchas (gates, `#local` Playwright testing, playwright/clasp conflict, deploy flow), backend/clasp, and the non-blocking token-rotation note.
- **`.gitignore`** — track `HANDOFF-*.md` under the otherwise-ignored `JacTec-handoff/`.

Gates: `gen-rule-usage --check` + `smoke` green (docs-only).

https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZ1vwzhuosZHdYzZ85zTCg)_