### PR TITLE
Pills & flags: restyle the chip system to Jac's locked design

### DIFF
--- a/docs/superpowers/specs/2026-06-15-pills-flags-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-15-pills-flags-redesign-design.md
@@ -1,0 +1,31 @@
+# Pills & Flags redesign — approved design (2026-06-15)
+
+Jac's locked per-element selection for the R-Rulebook chip system, chosen from the
+round-1→4 drafts. This is the build contract; implemented as an append-only block in
+`style.css` (no §5 builder or `data-r` changes, so the R0 lint stays intact), and it
+adapts to the active `[data-theme="yard"]` because every value is token-based.
+
+## The eight elements — chosen idiom each
+
+| Rule | Element | Chosen idiom | Treatment |
+|---|---|---|---|
+| **R1** | Gate pill | **Wells** | Raised steel key: status-tinted gradient face (derived from `currentColor`), top highlight + bottom shadow (reads pressable), Saira-caps label, chevron in a recessed dark "detent" well on the right. `:active` presses in; `:focus-visible` orange ring. |
+| **R2** | Linked pill | **mini-R10 chip** | Scaled-down R10 `.c-titlecard`: dark `--bg-2` plate, white bold name (Geist), plain orange leading destination icon, permanent orange border, optional unlink ✕, 8px radius. |
+| **R3** | Status badge | **Stamped** | Soft registry-tint pill, parent-card icon, **Saira Condensed uppercase** label, hover underline only. Flat — never raised, never pressable. |
+| **R3b** | Data chip | **Stamped** | Gray `--panel-2` plate, `--line` border, Saira-caps, no icon, no hover, `cursor:default`. The quietest chip. |
+| **R4** | Derived pill | **Current** | Unchanged: no bg/border, ink + icon only, sits right of its parent. |
+| **R4b** | Flashing pill | **Hazard cap** | Derived pill that grows a 2px **red hi-vis hazard tape** cap on its top edge, animated as a slow barber-pole (~1.4s); replaces the opacity pulse. |
+| **R9** | Title flags | **Stamped** | ≤2 stacked mini-flags, NO background, ink + small icon, **Saira micro-caps**, hover underline. |
+| **R9b** | Flashing flag | **Current** | Title flag, no background, Geist sentence-case, red ink + icon, gentle opacity pulse (existing `flagPulse`). |
+
+## Semantics preserved (unchanged)
+green = ready/good · yellow = waiting/caution · red = alert/needed · orange = linked record OR required gate · gray = plain fact. Action (R1) reads pressable; status (R3/R4/R9) reads NOT pressable; derived (R4) lighter/attached; flashing (R4b/R9b) pulls the eye without strobing.
+
+## Implementation
+Single append-only block in `style.css` (after the `.flag.alert, .pill.alert` rule),
+targeting `.pill.gate`, `.pill.ref.link`, `.pill[data-badge]`, `.pill[data-r="R3b"]`,
+`.pill.dvd.alert`, `.flag`, `.flag.alert`. No `app.js` edits. `rule-usage.js`
+regenerated (its catalog includes style.css). Quality floor: visible `:focus-visible`,
+`prefers-reduced-motion` freezes the hazard barber-pole. Gates: `node ci/smoke.mjs` ·
+`ci/logic-test.mjs` · `ci/gen-rule-usage.mjs --check`. Deploy: feature branch → PR →
+squash-merge to `main`.

--- a/style.css
+++ b/style.css
@@ -1759,6 +1759,68 @@ body { font-variant-numeric: tabular-nums; }
    rental, pay status that isn't Paid/Current. Slow + gentle, not the lint alarm. */
 @keyframes flagPulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
 .flag.alert, .pill.alert { animation: flagPulse 1.6s ease-in-out infinite; }   /* R9b flashing flags · R4b flashing pills */
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PILLS & FLAGS REDESIGN — Jac's locked set, 2026-06-15
+   Spec: docs/superpowers/specs/2026-06-15-pills-flags-redesign-design.md
+   Append-only overrides (later source order wins). NO builder / data-r changes,
+   so the R0 flash-lint stays intact. Token-based → adapts to [data-theme="yard"].
+   R1 Wells gate · R2 mini-R10 link · R3/R3b/R9 stamped · R4b hazard cap · R4/R9b current.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* R1 — GATE PILL → "Wells": raised steel key, status-tinted face, chevron in a recessed well */
+.pill.gate {
+  height: 28px; padding: 0 6px 0 12px; border-radius: 10px;
+  font-family: "Saira Condensed", system-ui, sans-serif;
+  font-size: 11.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+  background: linear-gradient(180deg, color-mix(in srgb, currentColor 18%, var(--card)), color-mix(in srgb, currentColor 8%, var(--card)));
+  border: 1px solid color-mix(in srgb, currentColor 45%, var(--line));
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.10), 0 1px 0 rgba(0,0,0,.5), 0 2px 5px rgba(0,0,0,.4);
+  transition: transform .08s ease, filter .12s ease;
+}
+.pill.gate > svg {                 /* the chevron, seated in a milled detent well */
+  box-sizing: content-box; margin-left: 3px; padding: 3px; width: 11px; height: 11px;
+  color: var(--txt-2); background: var(--bg-2); border-radius: 5px;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.6), inset 0 0 0 1px rgba(255,255,255,.03);
+}
+.pill.gate:hover { filter: brightness(1.08); transform: translateY(-1px); }
+.pill.gate:active { transform: translateY(1px); box-shadow: inset 0 2px 4px rgba(0,0,0,.5); }
+.pill.gate:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.pill.gate.locked { background: var(--panel-2); border-color: var(--line); box-shadow: none; }
+.pill.gate.locked > svg { display: none; }
+
+/* R2 — LINKED PILL → mini-R10 chip: dark plate, white bold name, orange icon, permanent orange border */
+.pill.ref.link {
+  background: var(--bg-2); color: var(--txt);
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, transparent); border-radius: 8px;
+  font-weight: 800; font-size: 11px; letter-spacing: .2px; box-shadow: var(--chip-shadow);
+}
+.pill.ref.link > svg { color: var(--accent); }           /* leading destination-card icon = orange */
+.pill.ref.link:hover { border-color: var(--accent); filter: brightness(1.06); }
+
+/* R3 — STATUS BADGE → stamped: keep the registry tint, add the Saira-stamped voice */
+.pill[data-badge] { font-family: "Saira Condensed", system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; }
+
+/* R3b — DATA CHIP → stamped gray plate, no icon/hover */
+.pill[data-r="R3b"] {
+  font-family: "Saira Condensed", system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px;
+  background: var(--panel-2); color: var(--txt-2); border-color: var(--line);
+  cursor: default; box-shadow: none;
+}
+
+/* R9 — TITLE FLAGS → stamped caps (R9b drops back to the current Geist voice) */
+.flag { font-family: "Saira Condensed", system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; }
+.flag.alert { font-family: var(--font); text-transform: none; letter-spacing: .2px; font-weight: 800; }
+
+/* R4b — FLASHING PILL → hazard cap: a red hi-vis barber-pole on the top edge (replaces the opacity pulse) */
+.pill.dvd.alert { position: relative; padding: 3px 4px 0; animation: none; }
+.pill.dvd.alert::before {
+  content: ""; position: absolute; left: 0; right: 0; top: 0; height: 2px;
+  background: repeating-linear-gradient(135deg, var(--red) 0 13px, #1a0808 13px 26px);
+  background-size: 26px 100%; animation: hazRoll 1.4s linear infinite;
+}
+@keyframes hazRoll { to { background-position: 26px 0; } }
+@media (prefers-reduced-motion: reduce) { .pill.dvd.alert::before { animation: none; } }
 /* §12.1 rapid action entry: field left, R14 mode toggle right, under the active bar */
 .act-entry { display: flex; gap: 8px; align-items: center; }
 .act-entry .act-in { flex: 1; height: 28px; background: var(--bg-2); border: 1px solid var(--line);


### PR DESCRIPTION
## Pills & flags — chip system restyle (Jac's locked design)

Implements the approved per-element design from the round 1→4 drafts.

| Rule | Element | Idiom |
|---|---|---|
| R1 | Gate pill | **Wells** — raised steel, status-tinted face, chevron detent well |
| R2 | Linked pill | **mini-R10 chip** — dark plate, white name, orange icon + border |
| R3 | Status badge | **Stamped** (Saira caps, registry tint) |
| R3b | Data chip | **Stamped** gray plate |
| R4 | Derived pill | Current (unchanged) |
| R4b | Flashing pill | **Red hi-vis hazard cap** (barber-pole) |
| R9 | Title flags | **Stamped** caps |
| R9b | Flashing flag | Current (Geist, opacity pulse) |

**Implementation:** one append-only block in `style.css` + regenerated `rule-usage.js`. **No `app.js` / builder or `data-r` changes**, so the R0 flash-lint stays intact; all values are token-based so it adapts to the Yard theme automatically.

**Verified:** `ci/smoke.mjs` ✓ · `ci/logic-test.mjs` 42/42 ✓ · `ci/gen-rule-usage.mjs --check` ✓ — and rendered on real cards in the yard theme.

Spec: `docs/superpowers/specs/2026-06-15-pills-flags-redesign-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)