### PR TITLE
Add the jactec-ui design skill (anti-AI-slop UI ruleset)

### DIFF
--- a/.claude/skills/jactec-ui/SKILL.md
+++ b/.claude/skills/jactec-ui/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: jactec-ui
+description: >-
+  Use whenever you build, reshape, or restyle ANY JacTec / Rental Wrangler UI — a
+  screen, column, card, section, pill, flag, button, field, popup, menu, date
+  picker, KPI ring, or any visible element in app.js / style.css. Governs the
+  "yard data-plate" design language (dark industrial steel, ONE safety-orange
+  accent, hi-vis hazard-stripe signature, stamped Saira Condensed labels, rivets,
+  a light wrangler/ranch seasoning) and its enforcement machinery (the §5
+  builders, the R0–R24 stamped rulebook, the R0 flash-lint, the CI gates). It
+  exists to keep new UI looking unmistakably like OURS and never like generic,
+  AI-detectable "slop." Triggers: "add a column to the units card", "restyle the
+  rentals popup", "make a new status pill", "run this through the design
+  language". Do NOT use for: marketing/landing pages, backend Apps Script
+  (Code.gs), or non-UI logic. Apply only to NEW or RESHAPED UI — never
+  retroactively restyle untouched parts unless Jac asks for a site-wide pass.
+---
+
+# JacTec UI — the yard data-plate design system
+
+JacTec is a **dense, dark, industrial equipment-rental operations app** — not a
+marketing site. Every screen should read like a steel **data-plate** bolted to a
+machine in the yard: quiet steel surfaces, one safety-orange ignition accent, the
+hi-vis hazard stripe as the signature, stamped condensed labels, a light wrangler
+twist in the copy. The whole system is already encoded in the codebase. **Your job
+is to EXTEND it, never to invent a parallel one.** When in doubt, match what's
+there and speak in rule numbers.
+
+> Load the right reference for depth: [`references/tokens.md`](references/tokens.md)
+> (every color/size literal, all themes) · [`references/rulebook.md`](references/rulebook.md)
+> (the full R0–R24 catalog) · [`references/signature-recipes.md`](references/signature-recipes.md)
+> (copy-paste hazard stripe / rivets / ignition / rings / focus / reduced-motion)
+> · [`references/anti-slop.md`](references/anti-slop.md) (the banned looks + tells)
+> · [`references/checklists.md`](references/checklists.md) (pre-ship gate).
+
+## Requirements — non-negotiable, read before touching any UI
+
+1. **Tokens are law.** Derive every color, size, radius, shadow, and font from the
+   CSS custom properties in `style.css` `:root`. **Never** hardcode a hex, px
+   shadow, or font-name in `app.js` markup or new CSS. Dark `:root` is the default;
+   `[data-theme="light"]` and `[data-theme="yard"]`/`[data-theme="ranch"]` override
+   the **same** token names — so a treatment expressed in tokens themes itself for
+   free. Mirror every new treatment across dark + light (+ the active yard theme)
+   and confirm parity. Literals live in `references/tokens.md`.
+2. **Emit from a §5 builder with a `data-r` stamp.** Any new/changed pill · flag ·
+   add · button · field · date picker · file-drop · close-✕ MUST be produced by a
+   §5 builder in `app.js` that outputs `data-r="Rxx"`. Never hand-roll a
+   `.pill`/`.flag`/`.add-field`/`.req`/`.linkname` inline — extend the matching
+   builder so the fix lands everywhere. **Build target = ZERO R0 flash-lint
+   violations** (the lint pulses any un-stamped lint-family element red).
+3. **One orange, one meaning.** `--accent #ff7a1a` (ink `--on-orange #1a1205`) is
+   reserved for exactly three things: the **selected tab**, the **ignition/primary
+   action**, and **linked-record** affordances (R2). Never decorative, never a
+   second status color, never a hero gradient. Selected = solid orange + dark ink;
+   armed = orange **outline**, not fill. Orange surfaces always carry dark ink,
+   never white.
+4. **Two type voices, strictly separated.** `Saira Condensed` (UPPERCASE,
+   ~1.4–2px tracking, 600–800) is the **stamped** voice — wordmarks, column/section
+   tabs, KPI/micro labels, section headers, ignition buttons ONLY. `Geist`
+   (`var(--font)`) is body for everything you **read**; record names are Geist
+   bold, not caps. `ui-monospace` is only for the Inspector tag + builder names.
+   Body in the condensed face reads shouty; a stamped label in a neutral sans reads
+   generic. (Under `[data-theme="ranch"]` the stamped voice swaps to `Zilla Slab`
+   via the theme block — don't fight it.)
+5. **Status registry + action-color law are fixed and separate.** Registry colors
+   carry one meaning everywhere: `--green` ready · `--yellow` caution · `--red`
+   danger · `--blue` link · `--purple` scheduled · `--gray` plain fact. Action
+   *intent* is separate: blue = commit/save, green = takes money, red =
+   destructive-confirm (R17). Never invent or repurpose a color.
+6. **Accessibility is a gate, not a nicety.** Meet WCAG AA — ≥4.5:1 text, ≥3:1
+   large/UI — in dark **and** light **and** ranch. Never encode meaning in color
+   alone (always color + label + parent-card icon). Every interactive element has a
+   visible `:focus-visible`. Every animation degrades to a steady state under
+   `prefers-reduced-motion`.
+7. **Keep the rulebook truthful.** When you add or change a rule or token, update
+   `RULE_META` + `RB_FOUNDATION` + `RB_TABS` in the **same edit**, and speak/debug
+   in rule language ("that violates R4 — fix `dPill`") — fix the one builder, never
+   patch a single instance.
+8. **Route native UI through the styled path.** No native `title=` (use R23
+   `data-tip`), no native date picker (R22 `dateField`), no `alert()`/raw error
+   text (R19 attention-flash that points at the on-screen fix). Reaching for a
+   browser default is a tell.
+
+## The element → builder → rule map (use the builder, never hand-roll)
+
+| You need… | Builder | Rule |
+|---|---|---|
+| Status DROPDOWN that advances a record (big shape + chevron) | `gatePill`/`gatePillRaw`/`funnelPill`/`masterGate`/`unitStatusGate` | **R1** |
+| LINKED record (orange-outline / R10-chip, opens a record, optional ✕) | `refPill` / `unitPill` | **R2** |
+| Informational STATUS badge (registry color, parent-card icon, never an action) | `statusPill` | **R3** |
+| Plain FACT chip (`480 HRS`, `No GPS` — gray, no icon, no hover) | `badge` | **R3b** |
+| DERIVED pill riding its parent (ink+icon only, right of parent) | `dPill` | **R4** · `dPill({alert})` → **R4b** (pulses) |
+| BLUE dashed `+Thing` (links/creates a record OR adds a line item) | `addBtn({link\|line\|anchor})` | **R5b** |
+| GRAY dashed `+Thing` (a normal empty field) | `addBtn()` | **R5c** |
+| Required-until-entered (white bg + dark ink, stays loud) | `reqBtn` | **R6** |
+| Hyperlink (blue · italic · not bold · permanent underline) | `linkName` | **R7** |
+| Derived/computed VALUE (italic — you didn't type it) | `kv({derived})` / `.derived` | **R8** |
+| Title mini-flags (≤2 stacked, no backgrounds) | `flagEl` / `flagsStack` | **R9** · `flagEl({alert})` → **R9b** (pulses) |
+| S1 title chip (dark chip · white bold · plain orange icon · orange border) | `.c-titlecard` (`cardEl`) | **R10** |
+| Section (centered header; header+border follow live status) | `.section` + `sec-green/yellow/red` | **R11** |
+| Notes line (boxless; filled→top, empty→bottom) | `notesSection` | **R12** |
+| History (count chips above an inline filter) | `historySection` | **R13** |
+| 3-state segmented toggle | `segCtl` | **R14** |
+| Journey (yard +Start/+FC/+End · transport) | `yardToolHtml` / `miniJourneyHtml` | **R15** |
+| Day timeline (window in day cells) | the rentals `timeline` | **R16** |
+| Forward-action button (blue commit / green money / red danger) | `actionPill` | **R17** |
+| The ONE quiet action (Cancel/Close/Exit/Clear) | `ghostPill` | **R18** |
+| Attention flash that points AT the fix (replaces an error toast) | `attnFlash` / `flashOr` | **R19** |
+| Right-click / long-press menu | `openCtxMenu` | **R20** |
+| Massive popup add-file zone | `fileDrop` | **R21** |
+| The ONE app-styled single date/time picker | `dateField` | **R22** |
+| Tooltip (NEVER native `title=`) | `data-tip` attribute | **R23** |
+| Deliberate close/remove ✕ (red circle, white ✕) | `closeX` | **R24** |
+
+Full one-liners + do/don't per rule: [`references/rulebook.md`](references/rulebook.md).
+If an element genuinely has no rule, that's a decision to make WITH a new builder +
+a new `RULE_META` row + a `data-r` stamp — not an excuse to drop raw markup.
+
+## The objective safe-rules layer (apply unless you state a reason to override)
+
+Anthony Hobday's near-always-safe visual rules, adapted for a dense dark ops UI.
+They sharpen the system; they don't replace it.
+
+- **Near-black, near-white, never pure.** `--bg #0b0c0f` / `--txt #e9edf4` already
+  satisfy this — never introduce `#000` or `#fff`. Reserve max contrast for orange.
+- **Saturate neutrals one temperature.** Keep new neutrals on the existing yard
+  cast; never drop a dead `#888` gray in, never mix warm + cool.
+- **High contrast only for what leads.** Lines, `--txt-3` micro-labels, and panel
+  edges stay low-contrast; spend high contrast on data values, status, and orange.
+  Avoid both the even-grey-soup and the low-contrast fad.
+- **Depth by lightness, not shadow, on dark.** Closer = lighter. Use only the two
+  defined elevations (`--shadow` floats cards/popups; `--chip-shadow` lifts
+  chips/rows) plus the orange halo ring on menus/pop-ups and the `#18b6ff` neon ring
+  for an anchored "you are here" record. **No new drop shadows on dark cards**;
+  don't mix shadow/border/flat across sibling panels. Delineate sections with
+  `--line` borders that contrast both surfaces, not big fills.
+- **One math spacing scale.** Pull every gap/pad from the rhythm (grid 12 · list 7
+  · section pad 12 · row pad 9–11; radius `--radius 14–16` / `--chip-radius 11–12` /
+  8–10 controls / 999 pills). No one-off 13px/7px values. **Outer padding ≥ inner.**
+- **Nest radii properly:** inner = outer − gap. **Dim icons** to match the text
+  weight beside them. **Collapse redundant dividers** — one divide per boundary.
+  **Optical-align** glyphs whose visual center ≠ geometric (chevron, ▸).
+- **Deliberate overrides, named.** We legitimately override Hobday's marketing-tuned
+  16px-body / ~70-char-line rules: a dense yard grid runs smaller, tighter type (the
+  28/15/13/12/11/10/9.5px scale, 11px badges) and narrow numeric columns on purpose.
+  Enforce a minimum **legible** size and split into more views rather than shrink
+  past it — never let density become cramped. This is the one place we deviate.
+
+## Accessibility & contrast (hard)
+
+- **Check ratios, don't eyeball.** AA in dark **and** light **and** ranch. Light
+  theme darkens status colors so pill TEXT reads on the soft `-bg` fills — preserve
+  that when adding/altering a status.
+- **Orange ink is fixed:** orange surfaces carry dark `--on-orange`, never `--txt`.
+- **Never color alone** — color + label + parent-card icon, always.
+- **Visible `:focus-visible`** on every interactive element (`outline: 2px solid
+  var(--accent); outline-offset: 2px`).
+- **Respect `prefers-reduced-motion`** — pulses/barber-poles freeze to steady.
+- **Don't rely on hover** for critical info; long-press (R20) + tap reach it too.
+
+## Layout — flexible grids, recognition over recall
+
+- **The yard grid is fixed 3-equal-column** (Units / Rentals / Customers), 12px gap,
+  with a desktop floor. Below the floor the page **pans** horizontally — it never
+  squishes the columns, and the body never scrolls vertically. Don't introduce a
+  vertical-scroll page.
+- **Modern layout only:** CSS Grid + container queries (`@container`) for anything
+  that adapts to its container — never a 12-col bootstrap clone. Section headers are
+  centered Saira caps with flags pinned absolutely so the title stays true-center.
+- **Recognition over recall.** Reuse established shapes so a status pill looks like
+  every status pill and an add like every add. Consistency *is* grouping: repeat the
+  exact treatment for related items rather than improvising a variant.
+- **Button order & flow.** Keep confirm/cancel in the established order/position;
+  the ignition/commit action gets the weight, the ghost (R18) stays quiet. Order by
+  visual weight, heaviest toward the outer edge. **Minimize clicks** — a one-gate
+  move should never become a multi-step dialog.
+
+## Signature, motion & the ranch seasoning
+
+- **Spend boldness in ONE place: the hi-vis hazard stripe** —
+  `repeating-linear-gradient(135deg, var(--yellow) 0 13px, #14181d 13px 26px)` (red
+  variant for danger/abort). Apply it as plate **chrome** — the card cap, the login
+  band, drop zones, the R4b hazard cap — and keep everything around it quiet. Stripes
+  + rivets are intentional "complex" texture: keep DATA and reading content on calm
+  fields (simple-on-complex), never behind text. Supporting devices: corner rivets,
+  recessed detent wells, stamped labels, the ignition button. Reference
+  implementations live in the `.login-*` and `.cancel-arc` blocks in `style.css` —
+  match them. Snippets: [`references/signature-recipes.md`](references/signature-recipes.md).
+- **Motion is fast + functional, one orchestrated moment.** .12s controls · .15s
+  surfaces · .5s rings/timeline. Use the named keyframes only (`attnGlow`, `plateIn`,
+  `flagPulse`, `rwLint`). **Forbidden:** generic `transition: all 0.2s ease`,
+  bouncy/overshoot easing, scattered ambient micro-interactions — those read
+  consumer-marketing. Default crisp ease-out; reserve the one beat (the attnGlow that
+  REPLACES an error by pointing at the fix).
+- **Ranch is a seasoning, never the meal.** Carry it mostly through VOICE/COPY in the
+  yard/wrangler register (Wrangle · Round up · Corral · Brand · Saddle up · Rein in).
+  Restrained visual cues only: worn leather-tan (`--tan`) for tiny touches +
+  saddle-stitch dashed dividers; a rare brand/star marker. **Litmus: if a glance
+  reads "western" before "industrial rental yard," dial it back.** Never add
+  wood/rope/saloon-serif as a dominant skin in the dark/light themes.
+- **Copy is design material.** Active voice; an action keeps its name through the
+  whole flow ("Release to cancel" → matching toast). Errors say what's wrong and how
+  to fix it in the interface's voice — never apologize, never vague. Empty states
+  invite action.
+
+## Workflow: structure → tidy → responsive → polish → self-critique
+
+0. **Plan tokens first** (vendored `frontend` skill). Name the surfaces, status
+   colors, type roles, layout concept, and where the ONE signature beat lands.
+   Confirm it dodges the three AI defaults (cream+serif+terracotta /
+   near-black+acid-green / broadsheet hairlines). If `brainstorming` is opted in, its
+   HARD-GATE forbids code before an approved design+spec. **Ask Jac any decision via
+   the AskUserQuestion popup, never inline** (CLAUDE.md rule).
+1. **Structure** — right builders, right stamped elements, correct rules + data.
+   Make it correct in rule language before styling.
+2. **Tidy** — one spacing scale, align everything to something, nested radii,
+   collapsed dividers, outer ≥ inner padding, weight ordering. Reason for every choice.
+3. **Responsive** — grid pans (never squishes); container queries where a piece
+   adapts; minimum-legible-size honored (split, don't shrink); touch reaches every action.
+4. **Polish** — dim icons, optical-align glyphs, tune the one motion moment, wire the
+   halo / anchored ring, mirror into light (+ ranch).
+5. **Self-critique before showing Jac** — screenshot and review against this skill
+   (a picture is worth 1000 tokens); "remove one accessory"; run the anti-slop
+   checklist; then the gates.
+
+## Anti-slop checklist (catch these before you ship)
+
+The three banned AI-default looks: ① cream `#F4F1EA` + high-contrast serif +
+terracotta · ② near-black + a single acid-green/vermilion accent · ③ broadsheet
+hairlines + zero radius + dense newspaper columns. We are none of them. Then:
+
+- [ ] Any pill/flag/add/button/field **without a `data-r` stamp** (#1 tell) → route through a §5 builder.
+- [ ] Pure `#000` surface or `#fff` text anywhere → use the near-black/near-white tokens.
+- [ ] Orange as decoration, a 2nd status color, or a hero gradient → accent = selected · ignition · linked only.
+- [ ] New drop shadow on a dark card, or mixed elevation across siblings → lightness + the two defined elevations.
+- [ ] A dead `#888` / off-temperature gray instead of a token.
+- [ ] Body set in Saira Condensed, or a label in a neutral/system sans → keep the two voices separate (Inter/Roboto/Arial/system/Space Grotesk are banned for labels).
+- [ ] Arbitrary one-off spacing instead of the scale; inner padding tighter than outer.
+- [ ] Mismatched nested radii; full-strength icon out-shouting its label; stacked redundant dividers; mathematically-centered chevron that looks off.
+- [ ] Native `title=` / native date picker / `alert()` → R23 / R22 / R19.
+- [ ] Generic `transition: all .2s`, bouncy easing, scattered micro-interactions, or the template hero / ornamental 01·02·03 markers.
+- [ ] Ranch reading western-first; a treatment shipped in one theme only; a new rule with no `RULE_META` entry; missing `:focus-visible`; contrast under AA; meaning in color alone.
+
+## Gates before push (push to `main` = live)
+
+`node ci/smoke.mjs` · `node ci/logic-test.mjs` · `node ci/gen-rule-usage.mjs --check`
+(regenerate without `--check` only when rule USAGE changed) · **zero R0 violations** ·
+a self-critique screenshot pass. Deploy = feature branch → PR → squash-merge (main is
+branch-protected). Never push a failing gate or a red lint; never put model ids /
+secrets / passwords in the repo (it's public via Pages). Full pre-ship list:
+[`references/checklists.md`](references/checklists.md).

--- a/.claude/skills/jactec-ui/references/anti-slop.md
+++ b/.claude/skills/jactec-ui/references/anti-slop.md
@@ -1,0 +1,70 @@
+# Anti-slop — how to not look AI-generated
+
+"AI slop" is UI anyone can tell was generated: generic defaults, no point of view,
+inconsistent details. Our defense is a strong, specific identity (the yard
+data-plate) plus the discipline below. The goal isn't novelty for its own sake — it's
+that every element is **deliberate** and **part of one system**.
+
+## The three banned AI-default looks
+
+Current generated design clusters around three looks. We are **none** of them:
+
+1. **Cream + serif + terracotta** — warm `#F4F1EA` background, high-contrast serif
+   display, terracotta accent. (We're dark steel + condensed sans + safety-orange.)
+2. **Near-black + one acid accent** — flat near-black with a single
+   acid-green/vermilion pop doing all the work. (We carry a full *semantic* status
+   registry; orange is reserved for selected/ignition/linked, not a lone neon.)
+3. **Broadsheet** — hairline rules, zero border-radius, dense newspaper columns.
+   (We use radii, soft fills, a tactile elevation language, and the hazard signature.)
+
+Where a brief explicitly asks for one of these, the brief wins. Ours never does.
+
+## The specific tells (and the fix)
+
+- **Unstamped lint-family element** — a pill/flag/add/button/field with no
+  `data-r`. The #1 tell it bypassed the builders; R0 pulses it red. → route through a `§5` builder.
+- **Pure `#000` / `#fff`** — the amateur/AI default. → near-black `--bg`, near-white
+  `--txt`; reserve max contrast for orange only.
+- **Dead `#888` greys / mixed-temperature neutrals** — generated palettes default to
+  hueless grey. → use the token neutrals (one temperature, faint cast).
+- **Drop shadows on dark cards / mixed elevation** — invisible-or-muddy on dark, and
+  alternating shadow/border/flat across siblings screams generic dashboard. → one
+  elevation language: lightness + the two defined shadows + the rings.
+- **Everything at medium contrast (grey soup)** — nothing leads. → spend high
+  contrast on data/status/accent; let structure recede. (And avoid the low-contrast fad.)
+- **Body in a condensed/stamped face, or labels in a system sans** — Inter / Roboto /
+  Arial / system-ui / Space Grotesk for labels is a tell. → two voices only: Saira
+  Condensed (stamped) vs Geist (read).
+- **Arbitrary spacing (13px, 7px) / inner padding tighter than outer** → one math
+  scale; outer ≥ inner.
+- **Mismatched nested radii · full-strength icon out-shouting its label · stacked
+  redundant dividers · mathematically-centered chevron that looks off** → inner =
+  outer − gap; dim icons to text weight; one divide per boundary; optical-align glyphs.
+- **Native `title=` / native date picker / `alert()` / raw error string** → R23
+  `data-tip` / R22 `dateField` / R19 attention-flash pointing at the fix.
+- **Generic motion** — `transition: all .2s ease`, bouncy/overshoot easing, scattered
+  ambient micro-interactions. → fast crisp ease-out, the named keyframes, ONE
+  orchestrated beat.
+- **Template tropes** — the hero "big number + small label + gradient accent",
+  ornamental `01 / 02 / 03` markers that don't encode a real sequence, decorative
+  glassmorphism/gradients. → cut them; structure must encode something true.
+- **Ranch reading western-first** — wood/rope/saloon-serif as a dominant skin. → keep
+  it copy + a little leather-tan; litmus: industrial-rental-yard before western.
+- **Shipped in one theme only** / **a new rule with no `RULE_META`** / **missing
+  `:focus-visible`** / **contrast under AA** / **meaning in color alone** → all
+  incomplete work.
+
+## Deviations we make ON PURPOSE (name them, don't drift into them)
+
+- **Density over Hobday's 16px-body / ~70-char-line.** A dense ops grid runs the
+  28/15/13/12/11/10/9.5px scale and narrow numeric columns deliberately. Enforce a
+  minimum *legible* size and **split into more views rather than shrink past it** —
+  density must never become cramped. This is the ONE place we deviate from the safe rules.
+
+## Process gates (from `brainstorming` + CLAUDE.md)
+
+- If `brainstorming` is opted in, its HARD-GATE forbids writing code before a design
+  + spec is presented, approved, and saved to `docs/superpowers/specs/`.
+- **Ask Jac any decision via the `AskUserQuestion` popup, never inline** (CLAUDE.md).
+- Plan the token system FIRST (vendored `frontend` skill), then build, then
+  **self-critique with a screenshot** and "remove one accessory" before showing Jac.

--- a/.claude/skills/jactec-ui/references/checklists.md
+++ b/.claude/skills/jactec-ui/references/checklists.md
@@ -1,0 +1,41 @@
+# Pre-ship checklist
+
+Run this before showing Jac and before any push. If a box can't be ticked, it's not done.
+
+## System fidelity
+- [ ] Every color/size/radius/shadow/font is a **token** — zero hardcoded hex / px-shadow / font-name.
+- [ ] Every lint-family element is emitted by a **§5 builder** and carries `data-r="Rxx"`.
+- [ ] **R0 flash-lint = ZERO** (toggle the bottom-bar eye; nothing pulses red).
+- [ ] Orange used ONLY for selected tab · ignition/primary · linked (R2). Dark `--on-orange` ink on every orange surface.
+- [ ] Two type voices kept separate: Saira Condensed (stamped labels) vs Geist (read). No system sans on labels.
+- [ ] Status color used per the fixed registry; action color per R17 (commit/money/danger). Nothing invented.
+- [ ] If a rule/token changed: `RULE_META` + `RB_FOUNDATION` + `RB_TABS` updated in the same edit.
+
+## Accessibility (verify, don't eyeball)
+- [ ] AA contrast (≥4.5:1 text, ≥3:1 large/UI) in **dark, light, and yard/ranch**.
+- [ ] Meaning never by color alone (color + label + icon).
+- [ ] Visible `:focus-visible` on every interactive element.
+- [ ] Every animation degrades to steady under `prefers-reduced-motion`.
+- [ ] Touch (long-press R20 + tap) reaches every action; nothing hover-only that matters.
+
+## Craft (the safe-rules layer)
+- [ ] No pure `#000`/`#fff`; no dead/off-temperature greys.
+- [ ] High contrast spent only on what leads; structure recedes.
+- [ ] Depth by lightness + the two defined elevations/rings; **no new drop shadow on dark**, no mixed elevation across siblings.
+- [ ] One spacing scale; outer padding ≥ inner; nested radii = outer − gap.
+- [ ] Icons dimmed to text weight; one divide per boundary; glyphs optically aligned.
+- [ ] Density honors a minimum legible size — split views rather than shrink past it.
+
+## Identity & motion
+- [ ] Boldness spent in ONE place (hazard stripe as chrome, not behind text).
+- [ ] Motion fast + crisp, named keyframes only; no `transition: all .2s`, no bounce, no scattered micro-interactions.
+- [ ] Ranch reads industrial-first (copy + a little tan); no western skin.
+- [ ] No template hero / ornamental 01·02·03 / decorative gradient-glass.
+- [ ] Treatment mirrored across themes (not shipped in one only).
+
+## Process & ship
+- [ ] Token plan made first; design approved (if `brainstorming` opted in, spec saved to `docs/superpowers/specs/`).
+- [ ] Decisions asked via `AskUserQuestion` popup, not inline.
+- [ ] Self-critique screenshot reviewed; "removed one accessory."
+- [ ] Gates green: `node ci/smoke.mjs` · `node ci/logic-test.mjs` · `node ci/gen-rule-usage.mjs --check` (regen without `--check` only if rule USAGE changed).
+- [ ] Ship via feature branch → PR → squash-merge to `main` (branch-protected; push = live). No model ids / secrets / passwords in the repo.

--- a/.claude/skills/jactec-ui/references/rulebook.md
+++ b/.claude/skills/jactec-ui/references/rulebook.md
@@ -1,0 +1,54 @@
+# The R0–R24 rulebook (mirror of `RULE_META`, SPEC v8)
+
+Every lint-family UI element is built by ONE `§5` builder in `app.js` that stamps
+`data-r="Rxx"`. Match intent → rule → builder here; extend the builder, never
+hand-roll the markup. The in-app Rulebook overlay + Design Inspector render from
+this same metadata, so keep `RULE_META` / `RB_FOUNDATION` / `RB_TABS` in sync when
+you change a rule. Debug in this language: "that pill violates R4 — fix `dPill`."
+
+| R | Name | Builder | What it is / the law |
+|---|------|---------|----------------------|
+| **R0** | Flash-lint | `body.rw-lint` CSS | Any un-stamped pill/add/flag/link/req/seg/file-drop/datefield (or a native `title`) pulses red. The alarm. **Build target = ZERO.** |
+| **R1** | Gate pill | `gatePill`/`gatePillRaw`/`funnelPill`/`masterGate`/`unitStatusGate` | A status DROPDOWN that moves the record forward — big shape + chevron. The only "pressable status." |
+| **R2** | Linked pill | `refPill` / `unitPill` | Opens another record. Orange outline + DESTINATION-card icon; optional ✕ to unlink. |
+| **R3** | Status badge | `statusPill` | Informational STATUS only: registry color + parent-card icon + hover underline. NEVER an action. |
+| **R3b** | Data chip | `badge` | A plain FACT (`480 HRS`, `No GPS`): gray, no icon, no hover. Independent of R3. |
+| **R4** | Derived pill | `dPill` | Rides another pill: no bg/border, ink + icon only; sits RIGHT of its parent (LEFT if the parent is right-aligned). |
+| **R4b** | Flashing pill | `dPill({alert})` | A derived pill that PULSES for attention (e.g. `Overbooked`). |
+| **R5** | _retired_ | — | RETIRED → record-linking adds now wear R5b. Nothing stamps `R5`. |
+| **R5b** | Blue add | `addBtn({link\|line\|anchor})` | BLUE dashed `+Thing` — links/creates a record OR adds a line item. One blue add language. |
+| **R5c** | Empty field | `addBtn()` | GRAY dashed `+Thing` — a normal empty field (`+Serial`, `+Email`, `+PO`). |
+| **R6** | Required | `reqBtn` / `.req` | White + dark ink until entered/captured — stays loud. |
+| **R7** | Hyperlink | `linkName` / `.inv-line-link` | Blue · italic · NOT bold · permanent underline. |
+| **R8** | Derived value | `kv({derived})` / `.derived` | Italic = the app computed it; you don't type it. |
+| **R9** | Title flags | `flagEl` / `flagsStack` | ≤2 stacked 14px mini-flags beside a title — no backgrounds. `alert` pulses; `sect` scrolls to a section. |
+| **R9b** | Flashing flag | `flagEl({alert})` | A title flag that PULSES (No Card, Overbooked, bad pay status). |
+| **R10** | S1 title chip | `.c-titlecard` (`cardEl`) | Dark chip · white bold label · plain orange icon · permanent orange border. |
+| **R11** | Section | `.section` + `sec-green/yellow/red` | Centered header; header + border follow the LIVE status. |
+| **R12** | Notes line | `notesSection` | Boxless, label-less; filled → top of the card, empty → bottom above history. |
+| **R13** | History | `historySection` | Count chips above the search bar filter inline; record-backed links only. |
+| **R14** | Seg toggle | `segCtl` | 3-state segmented control (condition · wash). |
+| **R15** | Journey | `yardToolHtml` / `miniJourneyHtml` | Yard +Start/+FC/+End + Jac─Site─Jac transport; white = video owed. Per-unit. |
+| **R16** | Day timeline | the rentals `timeline` | The rental window in day cells; centered gate + naked price·rate; cells tint by status. |
+| **R17** | Action pill | `actionPill` | commit = blue · money = green · danger = solid red; `.locked` = gated. |
+| **R18** | Ghost | `ghostPill` | The ONE quiet action — Cancel / Close / Exit / Clear. |
+| **R19** | Attention flash | `attnFlash(sel)` / `flashOr(sel,msg)` | A glow that points AT the on-screen fix instead of an error message. |
+| **R20** | Wrangler menu | `openCtxMenu` / `runCtxAction` | Right-click / long-press a REAL control → Cut/Copy/Paste/Clear/Search/Replace/Add Comment/Ask Mr. Wrangler. Never on bare `.row`/dead space. |
+| **R21** | File drop | `fileDrop` | The MASSIVE popup add-file zone — R5b blue dashed at full size. |
+| **R22** | Date picker | `dateField` | The ONE app-styled calendar for a single date/time (NOT the rental-window timeline). Native pickers are banned. |
+| **R23** | Tooltip | `data-tip` attribute | Every hover hint goes through `data-tip`; a native `title=` is an R0 violation. |
+| **R24** | Close ✕ | `closeX` | Red circle · white ✕ — the deliberate close/remove; hover-reveal variant on tabs. |
+
+**Placement laws:** derived pills sit right of their parent (R4; left when the parent
+is right-aligned) · left of a section = actions, right = derived · Section 0 = Notes ·
+Section 1(–2) = high-action zone, then Details, then Data · line-row pills share a
+min-width + centered label so the column edge aligns down a stack; everything else
+keeps intrinsic width (only height/font/padding/radius are uniform) · body-wide
+`tabular-nums`.
+
+**Foundations** (the `RB_FOUNDATION` tab — primitives, not `data-r` stamped): type
+(display/body/mono/scale/weight), color (accent/status/semantic/neutral/tan), form
+(radius/elevation/spacing/motion), surfaces (bg/panel/card/section/anchored/row),
+containers (section + popup headers, overlay, menu, grid), data-viz (KPI rings,
+activity gauge), behaviors (hover previews). These are the tokens + guidelines the
+rules are built FROM — see `tokens.md` + `signature-recipes.md`.

--- a/.claude/skills/jactec-ui/references/signature-recipes.md
+++ b/.claude/skills/jactec-ui/references/signature-recipes.md
@@ -1,0 +1,83 @@
+# Signature recipes — copy these, don't reinvent
+
+The canonical implementations live in `style.css` (the `.login-*` block, the
+`.cancel-arc` block, and the `[data-theme="yard"] .col > .card` block). Match them.
+Spend boldness in ONE place (the hazard stripe); keep everything else quiet.
+
+## Hi-vis hazard stripe (the signature)
+
+The one bold motif. Use as plate CHROME — never behind text.
+
+```css
+/* yellow caution band (default) */
+background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 13px, #14181d 13px 26px);
+/* red abort/danger variant */
+background: repeating-linear-gradient(135deg, var(--red, #ff4242) 0 13px, #1a0808 13px 26px);
+```
+Uses today: the card's top cap (`.col > .card::before`, ~5px tall), the login band,
+file drop zones, the R4b flashing-pill cap (2px, animated as a barber-pole via
+`background-position`). Keep DATA + reading content on calm fields beside it.
+
+## Corner rivets (bolt the plate down)
+
+```css
+.plate { position: relative; }
+.plate .rivet {
+  position: absolute; width: 6px; height: 6px; border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, var(--rivet, #6b7480), var(--rivet-pit, #191c22) 70%);
+  box-shadow: 0 0 0 1px rgba(0,0,0,.5), inset 0 0 1px rgba(255,255,255,.4);
+}
+.plate .rivet.tl{top:12px;left:12px} .rivet.tr{top:12px;right:12px}
+.plate .rivet.bl{bottom:12px;left:12px} .rivet.br{bottom:12px;right:12px}
+```
+
+## Ignition button (the ONE primary action)
+
+```css
+background: linear-gradient(180deg, #ff9038, var(--accent));
+color: var(--on-orange);              /* dark ink on orange, ALWAYS */
+box-shadow: 0 6px 16px -6px var(--accent), inset 0 1px 0 rgba(255,255,255,.4);
+font-family: 'Saira Condensed', system-ui, sans-serif;
+text-transform: uppercase; letter-spacing: 1px; font-weight: 800;
+```
+Armed/secondary state = orange OUTLINE (`border:1px solid var(--accent); color:var(--accent); background:transparent`), never a fill.
+
+## Elevation rings (depth on dark = light + ring, not shadow)
+
+```css
+/* pop-up / menu — orange halo */
+border: 1px solid var(--accent);
+box-shadow: 0 0 0 2px var(--accent-line), 0 0 20px -6px var(--accent);
+/* anchored "you are here" record — neon blue (distinct from orange selection) */
+box-shadow: 0 0 0 2px rgba(24,182,255,.55);   /* #18b6ff */
+```
+For cards/chips use only the defined `var(--shadow)` (float) and `var(--chip-shadow)`
+(lift). Do NOT add new drop shadows on dark — step lightness instead (closer = lighter).
+
+## Saddle-stitch divider (the ranch seasoning — restrained)
+
+```css
+border-top: 1px dashed var(--tan, #c2925a);   /* a quiet leather-stitch line */
+```
+Tan is for tiny touches + the occasional divider only. If a glance reads "western"
+before "industrial rental yard," remove it.
+
+## Accessibility patterns (required on everything interactive)
+
+```css
+.thing:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  /* every pulse/barber-pole freezes to a steady, still-meaningful state */
+  .flag.alert, .pill.alert { animation: none; }
+  .pill.dvd.alert::before { animation: none; }   /* hazard cap stays, stops sliding */
+}
+```
+
+## The named keyframes (use these, invent none)
+
+`attnGlow` — the R19 attention flash that REPLACES an error by glowing the on-screen
+fix · `plateIn` — the login plate entrance · `flagPulse` — R9b/R4b alert breathe ·
+`rwLint` — the R0 lint red pulse. Durations: **.12s** controls · **.15s** surfaces ·
+**.5s** rings/timeline. Crisp ease-out. FORBIDDEN: `transition: all .2s ease`,
+bouncy/overshoot easing, scattered ambient micro-interactions.

--- a/.claude/skills/jactec-ui/references/tokens.md
+++ b/.claude/skills/jactec-ui/references/tokens.md
@@ -1,0 +1,63 @@
+# Tokens — the only colors/sizes you may use
+
+Every value below is a CSS custom property defined in `style.css`. **Use the token,
+never the literal.** Dark `:root` is the default; `[data-theme="light"]` and
+`[data-theme="yard"]` override the SAME names, so token-based CSS themes itself.
+The literals are here only so you can reason about contrast/relationships — do not
+paste hexes into markup or new CSS.
+
+## Dark (`:root`, default)
+
+**Surfaces** — `--bg #0b0c0f` · `--bg-2 #101216` · `--panel #15171c` ·
+`--panel-2 #1b1e24` · `--card #14161b` · `--card-head #191c22`
+**Lines** — `--line #262a31` · `--line-soft #1f232a`
+**Text** — `--txt #e9edf4` · `--txt-2 #a7afbc` · `--txt-3 #6b7480` · `--track #22262e`
+**Accent** — `--accent #ff7a1a` · `--accent-soft rgba(255,122,26,.14)` ·
+`--accent-line rgba(255,122,26,.5)` · `--on-orange #1a1205` (ink on orange)
+**Status (base ink / `-bg` soft fill ~.14)** — `--green #34d399` · `--yellow #f5c542`
+· `--red #ff4242` (`-bg .18`) · `--blue #5b9dff` · `--navy #6f8bdb` · `--purple #b07cf5`
+· `--pink #f06fb0` · `--brown #c79366` · `--gray #8b94a3` · `--orange #ff7a1a`
+**Bold viz tones** — `--mix-green/-yellow/-red/-blue/-navy/-purple/-pink/-brown/-gray/-orange`
+(stronger than the soft `-bg`; for mix bars / proportional fills)
+**Form** — `--radius 16px` · `--chip-radius 12px` · `--shadow 0 18px 50px -24px rgba(0,0,0,.75)`
+· `--chip-shadow 0 6px 16px -10px rgba(0,0,0,.7)` · `--anchor-section #23272e`
+**Type** — `--font "Geist", -apple-system, "Segoe UI", sans-serif` (the only font
+custom-prop; Saira Condensed + ui-monospace are named directly in the few stamped/code spots)
+**Add-blue (neon)** — `#18b6ff` (R5b add ink + the anchored "you are here" ring)
+
+## Light (`[data-theme="light"]`)
+
+Surfaces flip bright: `--bg #eef1f6` · `--bg-2 #e6eaf1` · `--panel #ffffff` ·
+`--panel-2 #eef1f6` · `--card #ffffff` · `--card-head #eef1f6` · `--line #cfd6e1` ·
+`--line-soft #e1e6ee`. Text: `--txt #141821` · `--txt-2 #414b5a` · `--txt-3 #69727f`
+· `--on-orange #2a1400`. **Status colors are intentionally DARKER** so pill text
+reads on the soft fills: `--green #0c8f5f` · `--yellow #956f00` · `--red #d52a2a` ·
+`--blue #1864d6` · `--navy #2f4496` · `--purple #7a37c9` · `--pink #c5337c` ·
+`--brown #855526` · `--gray #566072` · `--orange #cf6000`. `--anchor-section #dde2ea`.
+→ When you add or retune a status, re-check AA in light too; preserve this darkening.
+
+## Yard (`[data-theme="yard"]`, the live look)
+
+Gunmetal + deeper plate shadows: `--bg #0a0d11` · `--bg-2 #0f1318` · `--panel #171d25`
+· `--panel-2 #1d242d` · `--card #12171e` · `--card-head #1a212b` · `--line #2c343f` ·
+`--line-soft #212834`. Text: `--txt #eef2f7` · `--txt-2 #aab4c1` · `--txt-3 #717b89`.
+Accent a hair punchier: `--accent #ff7e1f` · `--accent-soft rgba(255,126,31,.16)` ·
+`--accent-line rgba(255,126,31,.55)`. `--radius 14px` · `--chip-radius 11px`.
+**Yard-only helpers:** `--steel-1 #1b222c` · `--steel-2 #0d1116` (steel gradients) ·
+`--rivet #4a525e` · `--rivet-pit #0b0f14` (corner rivets) · `--tan #c2925a` ·
+`--tan-deep #8a5a2b` (the wrangler leather seasoning — saddle-stitch + tiny touches).
+Status colors are NOT redefined here → they inherit the dark base values.
+
+## Rules of use
+
+- Status separation: each status hue means ONE thing everywhere (see SKILL §
+  Requirements). Action intent (commit=blue · money=green · danger=red) is a
+  SEPARATE axis — don't blend it into the status registry.
+- Brightness discipline (dark): keep container-vs-background within ~12% lightness;
+  delineate with `--line` borders (which contrast both surfaces), not big fills.
+  Closer = lighter; no drop shadows on dark — use `--shadow`/`--chip-shadow` only
+  where defined, plus the orange halo ring (menus/pop-ups) and `#18b6ff` ring (anchored).
+- One spacing scale: grid 12 · list 7 · section pad 12 · row pad 9–11; radii from the
+  `--radius`/`--chip-radius`/8–10/999 ladder. Outer padding ≥ inner. No one-off px.
+- Type scale (px): 28 KPI/value · 15 popup title · 13 content · 12 fields · 11
+  stamped micro-label & every status badge · 10 · 9.5 finest. Two voices only.


### PR DESCRIPTION
Adds a new project skill: **`.claude/skills/jactec-ui`** — a cohesive UI design ruleset so every future UI edit stays on our "yard data-plate" system and never reads AI-generated.

Lean `SKILL.md` + 5 references (`tokens` · `rulebook` R0–R24 · `signature-recipes` · `anti-slop` · `checklists`). Synthesized from Anthony Hobday's safe rules, the official frontend-design skill, the frontend slides, Remotion's skills repo, SKILL.md conventions, and a deep read of our own R0–R24 system + tokens.

Enforces: tokens-are-law + builder/`data-r` stamps + zero R0 lint · one-orange/two-voices/fixed status+action color · AA a11y gate in all themes · the objective safe-rules layer (with our density deviation named) · the yard signature/motion/ranch discipline · structure→tidy→responsive→polish→self-critique + an anti-slop checklist.

**Docs/tooling only — no app or runtime change** (not served by Pages). Note: `gen-rule-usage --check` is pre-existing-stale on `main` (unrelated to this docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)