### PR TITLE
Blued Steel: apply app-wide

### DIFF
--- a/style.css
+++ b/style.css
@@ -2020,13 +2020,23 @@ body.dragging .row.drop-ok { opacity: 1; }
     repeating-linear-gradient(135deg, rgba(255,255,255,.010) 0 2px, transparent 2px 11px),
     var(--bg);
 }
-/* Column container = the flat-steel Yard plate (NOT blued — the blued lives on
-   the floating-card sections + rows below, per Jac). */
+/* APP-WIDE (Jac): the column container cards are blued plates too, and the list
+   rows sit on them as light regions (not opaque tiles). The anchored card below
+   is a touch stronger so it still stands out. */
 [data-theme="bluedsteel"] .col > .card {
   position: relative;
-  background: linear-gradient(180deg, var(--steel-1), var(--steel-2));
+  background:
+    linear-gradient(180deg, rgba(38,84,150,.50), rgba(10,22,42,.78)),
+    url('assets/tex-metal-blued.jpg');
+  background-size: cover, 340px;
+  background-repeat: no-repeat, repeat;
   --stripe: var(--yellow, #f5c542);
 }
+[data-theme="bluedsteel"] .row {
+  background: rgba(7,12,22,.40);
+  border-color: rgba(150,178,222,.16);
+}
+[data-theme="bluedsteel"] .row:hover { border-color: var(--accent-line); }
 [data-theme="bluedsteel"] .col > .card[data-card="customers"]  { --stripe: var(--blue,  #5b9dff); }
 [data-theme="bluedsteel"] .col > .card[data-card="rentals"]    { --stripe: #147a47; }
 [data-theme="bluedsteel"] .col > .card[data-card="units"]      { --stripe: var(--yellow,#f5c542); }


### PR DESCRIPTION
Apply Blued Steel app-wide: column container cards become blued plates, with list rows as light regions on them; anchored card stays a touch stronger. Toggling now re-skins the whole app, not just an open record. CSS-only, scoped under [data-theme=bluedsteel].