### PR TITLE
Blued Steel: subtle tone, app-wide

### DIFF
--- a/style.css
+++ b/style.css
@@ -2026,14 +2026,14 @@ body.dragging .row.drop-ok { opacity: 1; }
 [data-theme="bluedsteel"] .col > .card {
   position: relative;
   background:
-    linear-gradient(180deg, rgba(38,84,150,.50), rgba(10,22,42,.78)),
+    linear-gradient(180deg, rgba(52,72,108,.26), rgba(8,11,18,.66)),
     url('assets/tex-metal-blued.jpg');
   background-size: cover, 340px;
   background-repeat: no-repeat, repeat;
   --stripe: var(--yellow, #f5c542);
 }
 [data-theme="bluedsteel"] .row {
-  background: rgba(7,12,22,.40);
+  background: rgba(7,12,22,.30);
   border-color: rgba(150,178,222,.16);
 }
 [data-theme="bluedsteel"] .row:hover { border-color: var(--accent-line); }
@@ -2062,7 +2062,7 @@ body.dragging .row.drop-ok { opacity: 1; }
    + .detail are transparent, so the plate reads straight through to the sections. */
 [data-theme="bluedsteel"] .col > .card.anchored {
   background:
-    linear-gradient(180deg, rgba(44,98,175,.62), rgba(11,26,50,.82)),
+    linear-gradient(180deg, rgba(58,80,118,.34), rgba(8,11,18,.68)),
     url('assets/tex-metal-blued.jpg');
   background-size: cover, 340px;
   background-repeat: no-repeat, repeat;
@@ -2071,8 +2071,8 @@ body.dragging .row.drop-ok { opacity: 1; }
    cool inset highlight + lift shadow) so they read distinctly against the now
    strongly-blue plate; their header + status accent carry the rest. */
 [data-theme="bluedsteel"] .col > .card.anchored .section {
-  background: rgba(7,12,22,.46);
-  box-shadow: inset 0 1px 0 rgba(160,195,240,.16), 0 2px 9px -3px rgba(0,0,0,.6);
+  background: rgba(11,15,24,.36);
+  box-shadow: inset 0 1px 0 rgba(150,178,222,.12), 0 2px 8px -3px rgba(0,0,0,.55);
 }
 
 [data-theme="bluedsteel"] .coltab {               /* same stamped type as Yard */


### PR DESCRIPTION
Dial Blued Steel back to the subtle/tasteful tone (the previous app-wide version was too blue). Columns 26%, anchored 34%, recessed sections; still app-wide so it's visible everywhere but not garish. CSS-only.