### PR TITLE
Maps: fix the live map needing two opens to appear

### DIFF
--- a/app.js
+++ b/app.js
@@ -671,6 +671,12 @@ function mountTransportEditor() {
       _tePlaces = new google.maps.places.PlacesService(_teMap);   // resolve picks by place-id via Places (the key has Places, not Geocoding)
       _teDist = google.maps.DistanceMatrixService ? new google.maps.DistanceMatrixService() : null;   // DMS may lag the core lib — teFetchDistance lazily retries
       te.mapFailed = false;                                        // the live map is up — clear any stale offline-fallback flag
+      // First-open paint fix: the map div is created the same frame it's inserted, before the
+      // browser lays its box out, so Google paints it at 0×0 and it stays blank until the NEXT
+      // open ("appeared only after opening twice"). Nudge it once the box has real size — rAF for
+      // the common case, a short timeout as a backstop for the editor's slide-in.
+      const repaint = () => { try { google.maps.event.trigger(_teMap, 'resize'); _teMap.setCenter(center); } catch (e2) {} };
+      requestAnimationFrame(repaint); setTimeout(repaint, 250);
     } catch (e) { delete mapEl.dataset.mounted; te.mapFailed = true; mapEl.classList.add('ph'); }   // never strand the editor on a half-mount
   }
 }


### PR DESCRIPTION
The transport-editor map is created in the same frame its container is inserted into the DOM, before the browser lays the box out, so Google initializes it at 0x0 and it stays blank until the NEXT open finds the box already sized (Jac: 'appeared only after opening and closing twice').

Fix: after mounting, nudge the map (resize + recenter) once it has real dimensions, via requestAnimationFrame plus a 250ms timeout backstop for the editor's slide-in.

Diagnosed from the prod console: no key/referrer/API/quota error at all, only Google deprecation warnings (AutocompleteService / PlacesService / DistanceMatrix) which still work. Purely a first-paint timing bug; no Google Cloud change needed.

Gates green: smoke, logic 42/42, rule-usage.