### PR TITLE
Footers: keep Refunded on the Invoices card

### DIFF
--- a/app.js
+++ b/app.js
@@ -2472,8 +2472,9 @@ function fmtAggValue(col, a, calc) {
 const FOOT_DROP_NUM = { units: ['service'], rentals: ['price'], customers: ['rentals'] };
 const footDropNum = (card, key) => (FOOT_DROP_NUM[card] || []).includes(key);
 const footDropBadge = (card, value) =>
-  (value === 'No Show' && card !== 'rentals') ||   // No Show = rental card only
-  value === 'Returned' || value === 'Refunded' || value === 'Card OK';
+  (value === 'No Show' && card !== 'rentals') ||      // No Show = rental card only
+  (value === 'Refunded' && card !== 'invoices') ||    // Refunded = invoice card only
+  value === 'Returned' || value === 'Card OK';
 /** The highlighted summary row beneath a card's List View: badge value-counts +
  *  numeric roll-ups (e.g. "6 Tomorrow · 900 HRS avg · 12 Part Needed"). */
 function listTotalsEl(card, rows, session) {


### PR DESCRIPTION
Follow-up to #75: keep the **Refunded** count chip on the **Invoices** card while still dropping it from the **Rentals** footer.

`footDropBadge` now drops Refunded only when `card !== 'invoices'`.

Verified on #local:
- Invoices card footer shows `Refunded` (kept) ✓
- Rentals footer drops Refunded even with a refunded linked invoice ✓
- Regression: all six other #75 prunes still hold; No Show still kept on Rentals ✓
- smoke ✓, logic 42/42 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)