### PR TITLE
Dispatch cockpit UX: free the map, restore day-nav + rail layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -6887,6 +6887,7 @@ function dragDown(e) {
   if (DRAG.active || e.button !== 0) return;
   if (state.overlay) return;                                             // overlays own their clicks; the winpicker is non-modal (Task E — drag to select)
   if (e.target.closest('.tedit')) return;                                // the inline transport editor owns its pointers — let Google pan the map + drag the site pin (never arm an app/chat drag here)
+  if (e.target.closest('.dispm')) return;                                // §2.3 the dispatch cockpit map owns its pointers too — Google handles pan/zoom, never the app drag engine
   // §17 — a granular element marked [data-chat-el] (a pill/price/line/person) arms a
   // CHAT-TAG drag (tap still does its own thing; drag/long-press tags it into a chat).
   const chatEl = e.target.closest('[data-chat-el]');
@@ -7391,6 +7392,7 @@ function onClick(e) {
   if (closest('.js-disp-autoroute')) { e.stopPropagation(); return autoDispatchRoute(state.dispatchDay || TODAY_ISO); }
   if (closest('.js-disp-clearlegs')) { e.stopPropagation(); const all = dispatchArrowsLS(); delete all[state.dispatchDay || TODAY_ISO]; _lsSave('jactec.dispatchArrows', all); state.dispArm = null; return render(); }
   if (closest('.js-disp-stop') && !closest('.js-disp-time') && !closest('.disp-grip') && !closest('.js-site-go')) { e.stopPropagation(); return anchorRecord('rentals', closest('.js-disp-stop').dataset.rec); }
+  if (closest('.js-disp-tok') && !closest('.dt-time') && !closest('.dt-grip') && !closest('.js-site-go')) { e.stopPropagation(); return anchorRecord('rentals', closest('.js-disp-tok').dataset.rec); }   // §2.3 cockpit: tap a rail stop → open its rental (parity with the map pins)
   if (closest('.js-new-wo-unit')) { e.stopPropagation(); return startNewWorkOrder(closest('.js-new-wo-unit').dataset.rec); }
   if (closest('.js-newitem')) {
     const kind = closest('.js-newitem').dataset.new;

--- a/style.css
+++ b/style.css
@@ -473,8 +473,7 @@ input { font-family: inherit; }
 @media (prefers-reduced-motion: reduce) { .js-disp-arrowpt { transition: none; } .js-disp-arrowpt.armed { transform: none; } }
 /* ── §2.3 OFFICE COCKPIT (Phase 1): live map + welded time-rail ───────────────── */
 .disp-cockpit { flex: 1; min-height: 0; display: flex; flex-direction: column; }
-.dispm { flex: 0 0 46%; min-height: 200px; position: relative; border-bottom: 1px solid var(--line); background: var(--bg-2); }
-.js-dispmount { position: absolute; inset: 0; }
+.dispm { flex: 0 0 46%; min-height: 200px; position: relative; overflow: hidden; border-bottom: 1px solid var(--line); background: var(--bg-2); }
 .disprail { flex: 1; min-height: 0; overflow-y: auto; padding: 8px 10px 12px; }
 .disp-bookend { display: flex; align-items: center; gap: 7px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 10.5px; font-weight: 700; color: var(--txt-2); padding: 5px 9px; border-radius: 7px; background: var(--accent-soft); }
 .disp-bookend svg { width: 13px; height: 13px; color: var(--accent); flex: 0 0 auto; }


### PR DESCRIPTION
Fixes the three UX problems Jac hit using the live cockpit:

1. Map pan/zoom only worked in spots — the global drag-to-chat engine grabbed pointer events over the map. dragDown now bails on .dispm (same as the transport editor), so Google owns pan/zoom.
2. Day-nav and the hour rail were broken — the mount div carried both .dispm and .js-dispmount, and the .js-dispmount{position:absolute} rule made the whole map box absolute, overlaying the header and rail. Dropped that rule; the map is a normal 46% flex box, so the day-nav header sits on top and the rail below.
3. Tap a rail stop to open its rental (parity with the map pins).

Gates green: smoke, logic 42/42, rule-usage.