### PR TITLE
Discuss-before-build: plan gate + mid-build "needs you" loop

### DIFF
--- a/.github/workflows/wrangler-fix.yml
+++ b/.github/workflows/wrangler-fix.yml
@@ -101,6 +101,13 @@ jobs:
                 approved) → fix it. If it's `wrangler-request` (a suggestion) → fix it ONLY
                 if you can PROVE it correct. A proven request is fixed RIGHT NOW — no
                 approval, it does not wait in the inbox.
+              • If the issue has an "### Approved plan (build to this)" section, Jac already
+                OK'd that plan in chat — build EXACTLY to it; do not redesign or second-guess it.
+              • If you hit a real decision you can't make safely mid-build (genuine ambiguity,
+                or it would touch money / card / auth / WO-completion), STOP — do NOT guess.
+                Post your ONE specific question as a comment and relabel the issue
+                `wrangler-needs-jac` (so it pings Jac in-app), then end. When Jac answers and it's
+                relabeled back to `wrangler-fix`, you'll resume from the full thread.
               • Proven → make the MINIMAL fix that satisfies the cited rule (match the code +
                 the design language). Run all 3 gates (node ci/smoke.mjs · node ci/logic-test.mjs
                 · node ci/gen-rule-usage.mjs --check; regenerate rule-usage.js if usage changed).

--- a/app.js
+++ b/app.js
@@ -5303,11 +5303,16 @@ function renderOverlay() {
     const turns = o.messages.length
       ? o.messages.map((m, i) => {
           let act = '';
-          if (m.action) act = m.filed
-            ? `<span class="wr-actdone">✓ ${m.action.action === 'request' ? 'Filed for Jac’s OK' : 'Sent to the fixer'}${m.issue ? ` · #${m.issue}` : ''}</span>`
-            : m.filing
-              ? `<span class="wr-actdone" style="color:var(--txt-3)">…filing</span>`
-              : `<button class="wr-actbtn js-wr-act" data-mi="${i}">${m.action.action === 'request' ? '💡 File this for Jac’s OK' : '🔧 Send this to get fixed'}</button>`;
+          if (m.action) {
+            const ak = m.action.action;
+            const doneLbl = ak === 'plan' ? 'Building to your plan' : ak === 'request' ? 'Filed for Jac’s OK' : 'Sent to the fixer';
+            const btnLbl = ak === 'plan' ? '✓ Build this plan' : ak === 'request' ? '💡 File this for Jac’s OK' : '🔧 Send this to get fixed';
+            act = m.filed
+              ? `<span class="wr-actdone">✓ ${doneLbl}${m.issue ? ` · #${m.issue}` : ''}</span>`
+              : m.filing
+                ? `<span class="wr-actdone" style="color:var(--txt-3)">…filing</span>`
+                : `<button class="wr-actbtn${ak === 'plan' ? ' wr-actbtn-build' : ''} js-wr-act" data-mi="${i}">${btnLbl}</button>`;
+          }
           const imgs = (m.images && m.images.length) ? `<div class="wr-bub-imgs">${m.images.map((s) => `<img src="${esc(s)}" alt="attached image">`).join('')}</div>` : '';
           const txt = m.content ? `${esc(m.content).replace(/\n/g, '<br>')}` : '';
           return `<div class="wr-msg ${m.role}">${m.role === 'assistant' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub">${imgs}${txt}${act}</div></div>`;
@@ -5576,22 +5581,35 @@ function renderOverlay() {
     // §18e the in-app approval inbox for Mr. Wrangler's "Filed for Jac's OK" requests.
     const can = canApproveRequests();
     const list = wranglerRequests;
+    const reqState = (rq) => {
+      const labels = rq.labels || (rq.label ? [rq.label] : []);
+      if (labels.includes('wrangler-needs-jac')) return { key: 'needs', label: 'Needs your answer', color: 'red' };
+      if (labels.includes('wrangler-fix')) return { key: 'building', label: 'Building', color: 'blue' };
+      return { key: 'ok', label: 'Needs your OK', color: 'yellow' };
+    };
     const reqCard = (rq) => {
       const p = parseWranglerIssue(rq.body);
+      const st = reqState(rq);
       const report = p.report ? `<div class="req-text">${esc(p.report).replace(/\n+/g, '<br>')}</div>` : '';
       const photos = (rq.images && rq.images.length)
         ? `<div class="req-photos">${rq.images.map((s) => `<img class="req-photo" src="${esc(s)}" alt="attached photo" loading="lazy">`).join('')}</div>` : '';
       const convo = p.messages.length
         ? `<div class="req-convo">${p.messages.map((m) => `<div class="req-line ${m.role === 'user' ? 'them' : 'wr'}"><span class="req-who">${m.role === 'user' ? 'Reporter' : '🤠 Wrangler'}</span><span class="req-msg">${esc(m.content).replace(/\n/g, '<br>')}</span></div>`).join('')}</div>` : '';
-      return `<div class="req-card">
-        <div class="req-head"><span class="req-num">#${rq.number}</span><span class="req-title">${esc(rq.title)}</span></div>
+      const chatLbl = st.key === 'needs' ? '💬 Answer Mr. Wrangler' : st.key === 'building' ? '💬 Talk it over' : '💬 Talk to Mr. Wrangler';
+      const right = st.key === 'building'
+        ? '<span class="req-await">Building…</span>'
+        : (can
+            ? (st.key === 'needs'
+                ? `<button class="pill ghost js-req-dismiss" data-r="R18" data-n="${rq.number}">Dismiss</button>`
+                : `<button class="pill ghost js-req-dismiss" data-r="R18" data-n="${rq.number}">Dismiss</button><button class="pill c-commit js-req-approve" data-r="R17" data-n="${rq.number}">✓ Approve → build it</button>`)
+            : '<span class="req-await">Awaiting Jac’s OK</span>');
+      return `<div class="req-card req-${st.key}">
+        <div class="req-head"><span class="req-num">#${rq.number}</span><span class="req-title">${esc(rq.title)}</span><span class="spacer"></span><span class="pill c-${st.color} req-state" data-r="R3b">${st.label}</span></div>
         ${report}${photos}${convo}
         <div class="req-acts">
-          <button class="pill c-blue js-req-chat" data-r="R17" data-n="${rq.number}">💬 Talk to Mr. Wrangler</button>
+          <button class="pill ${st.key === 'needs' ? 'c-commit' : 'c-blue'} js-req-chat" data-r="R17" data-n="${rq.number}">${chatLbl}</button>
           <span class="spacer"></span>
-          ${can
-            ? `<button class="pill ghost js-req-dismiss" data-r="R18" data-n="${rq.number}">Dismiss</button><button class="pill c-commit js-req-approve" data-r="R17" data-n="${rq.number}">✓ Approve → build it</button>`
-            : '<span class="req-await">Awaiting Jac’s OK</span>'}
+          ${right}
           <a class="req-link" href="${esc(rq.url)}" target="_blank" rel="noopener">GitHub ↗</a>
         </div>
       </div>`;
@@ -5955,7 +5973,7 @@ async function sendFeedback() {
    (action 'wrangler'); Code.gs calls api.anthropic.com with the key from a Script
    Property. Carries a compact data digest + (when opened from a record) its detail.
    ════════════════════════════════════════════════════════════════════════ */
-const WRANGLER_SYSTEM = "You are Mr. Wrangler, the in-app AI for JacRentals — a heavy-equipment rental yard in Sulphur, Louisiana. You help the team make sense of their units, rentals, customers, invoices, work orders, and service, and you help triage bugs they report.\n\nSTYLE — keep it tight: answer in 1–3 sentences by default. Lead with the direct answer first; add at most one short supporting clause. Use a bullet list ONLY when enumerating multiple records, one line each. Don't restate the question, don't pad, and don't over-explain what you can't do — just answer.\n\nDATA — the snapshot below holds the LIVE records: every category with its rates, every fleet unit with its type and status, every rental with its date window and customer, customers with balances owed, and the open invoices and work orders. Reason over it directly. Only say a fact is missing if it truly isn't in the snapshot. Never invent records, names, or numbers.\n\nHELPING & FIXING — you're the assistant living inside the app (think Claude, but for this yard). The user might ask a question, describe a problem, or paste something — work out what they need and help. If they describe a BUG or glitch in the app itself (something not working, a dead control, a wrong layout or behavior), reproduce it in your head; if you're missing a detail, ask ONE quick follow-up (what they tapped + what they expected). Once you can state a clear repro, FILE A FIX by ending your reply with this exact fenced block:\n```wrangler-action\n{\"action\":\"fix\",\"title\":\"<short title>\",\"report\":\"<clear repro: steps, expected vs actual, any element involved>\"}\n```\nIf it's an IMPROVEMENT or change request rather than a bug, use \"action\":\"request\" (that routes to Jac for his OK instead of auto-shipping). Emit the block ONLY when you're actually ready to file — never while still gathering detail — and keep your visible words short and natural; never mention JSON, blocks, labels, or buttons.\n\nA light wrangler/ranch flavor in voice is welcome — never campy.";
+const WRANGLER_SYSTEM = "You are Mr. Wrangler, the in-app AI for JacRentals — a heavy-equipment rental yard in Sulphur, Louisiana. You help the team make sense of their units, rentals, customers, invoices, work orders, and service, and you help triage bugs they report.\n\nSTYLE — keep it tight: answer in 1–3 sentences by default. Lead with the direct answer first; add at most one short supporting clause. Use a bullet list ONLY when enumerating multiple records, one line each. Don't restate the question, don't pad, and don't over-explain what you can't do — just answer.\n\nDATA — the snapshot below holds the LIVE records: every category with its rates, every fleet unit with its type and status, every rental with its date window and customer, customers with balances owed, and the open invoices and work orders. Reason over it directly. Only say a fact is missing if it truly isn't in the snapshot. Never invent records, names, or numbers.\n\nHELPING & FIXING — you're the assistant living inside the app (think Claude, but for this yard). The user might ask a question, describe a problem, or paste something — work out what they need and help. If they describe a BUG or glitch in the app itself (something not working, a dead control, a wrong layout or behavior), reproduce it in your head; if you're missing a detail, ask ONE quick follow-up (what they tapped + what they expected). Once you can state a clear repro, FILE A FIX by ending your reply with this exact fenced block:\n```wrangler-action\n{\"action\":\"fix\",\"title\":\"<short title>\",\"report\":\"<clear repro: steps, expected vs actual, any element involved>\"}\n```\nThat auto-ships obvious bugs (a dead control, a typo, a plainly wrong value).\nBut if it's a CHANGE or improvement (not an obvious bug), do NOT file it blind — talk it through first: lay out a SHORT, concrete PLAN of exactly what you'd change and where, then ask if that's good or needs adjusting. When you put a concrete plan on the table, end with:\n```wrangler-action\n{\"action\":\"plan\",\"title\":\"<short title>\",\"plan\":\"<numbered steps: what changes, where, and the resulting UX>\"}\n```\nJac reviews that plan and taps Build only when it's right — so take his tweaks and re-propose the plan until he's happy. Emit a block ONLY when ready — a clear repro for a fix, or a concrete plan for a change — never while still gathering detail; keep your visible words short and natural and never mention JSON, blocks, labels, or buttons.\n\nA light wrangler/ranch flavor in voice is welcome — never campy.";
 // The digest is Mr. Wrangler's whole window into the yard, so it carries the ACTUAL
 // records (not just counts): category rates, each unit's type/status, each rental's
 // date window + customer, customer balances, and open invoices/WOs. Sections cap at
@@ -6073,7 +6091,7 @@ async function wranglerSend() {
 function parseWranglerAction(text) {
   const m = String(text || '').match(/```wrangler-action\s*([\s\S]*?)```/);
   if (!m) return null;
-  try { const j = JSON.parse(m[1].trim()); if (j && (j.action === 'fix' || j.action === 'request') && j.title) return j; } catch (e) {}
+  try { const j = JSON.parse(m[1].trim()); if (j && (j.action === 'fix' || j.action === 'request' || j.action === 'plan') && j.title) return j; } catch (e) {}
   return null;
 }
 const stripWranglerAction = (text) => String(text || '').replace(/```wrangler-action\s*[\s\S]*?```/g, '').trim();
@@ -6083,20 +6101,24 @@ const stripWranglerAction = (text) => String(text || '').replace(/```wrangler-ac
 function wranglerActionPacket(o, act) {
   const ctx = feedbackContext();
   const isReq = act.action === 'request';
+  const isPlan = act.action === 'plan';   // a change Jac OK'd in chat — build EXACTLY to this plan
   const transcript = (o.messages || [])
     .filter((m) => m.content)
     .map((m) => `${m.role === 'user' ? '**Reporter**' : '**Mr. Wrangler**'}: ${m.content}`)
     .join('\n\n') || '(no message)';
   const focus = (o.card && o.recId != null) ? `${entityCardOf(o.card, o.recType)}:${o.recId}` : '—';
   const errs = ERR_LOG.length ? ERR_LOG.slice(-12).join('\n') : '(none captured this session)';
-  const footer = isReq
-    ? '_A request for Jac\'s OK — NOT auto-implemented. Jac can add the `wrangler-fix` label to greenlight it._'
-    : '_A Claude agent will reproduce + patch this; the CI gates guard it before it ships to live._';
+  const footer = isPlan
+    ? '_Build EXACTLY to the Approved plan above — Jac OK\'d it in chat. A Claude agent implements it; the CI gates guard it before it ships to live._'
+    : isReq
+      ? '_A request for Jac\'s OK — NOT auto-implemented. Jac can add the `wrangler-fix` label to greenlight it._'
+      : '_A Claude agent will reproduce + patch this; the CI gates guard it before it ships to live._';
+  const heading = isPlan ? 'Approved plan (build to this)' : isReq ? 'Requested change' : 'The glitch';
   const body = [
     `_Filed by Mr. Wrangler from in-app chat._`,
     '',
-    `### ${isReq ? 'Requested change' : 'The glitch'} (Mr. Wrangler's write-up)`,
-    act.report || '(see conversation below)',
+    `### ${heading} (Mr. Wrangler's write-up)`,
+    (isPlan ? (act.plan || act.report) : act.report) || '(see conversation below)',
     '',
     '> 📎 You can paste or drag a screenshot right here before submitting.',
     '',
@@ -6127,21 +6149,25 @@ function wranglerActionPacket(o, act) {
 async function wranglerFileAction(mi) {
   const o = state.overlay; if (!o || o.kind !== 'wrangler') return;
   const m = o.messages[mi]; if (!m || !m.action || m.filed) return;
+  const isPlan = m.action.action === 'plan';
   const { title, body, label } = wranglerActionPacket(o, m.action);
   const images = []; (o.messages || []).forEach((mm) => (mm.images || []).forEach((s) => { if (images.length < 8) images.push(s); }));   // §18e carry the chat's photos onto the issue
+  const okToast = (n) => isPlan ? `Building to your plan — #${n}. 🤠` : label === 'wrangler-request' ? `Filed #${n} — in Jac’s queue for the OK. 🤠` : `Filed #${n} — Mr. Wrangler’s on it. 🤠`;
   if (typeof backendPassword !== 'undefined' && backendPassword) {
     m.filing = true; renderOverlay();
     try {
       const r = await backendCall('wranglerFile', { title, body, label, images });
-      if (r && r.ok && r.number) { m.filed = true; m.filing = false; m.issue = r.number; renderOverlay(); toast(label === 'wrangler-request' ? `Filed #${r.number} — in Jac’s queue for the OK. 🤠` : `Filed #${r.number} — Mr. Wrangler’s on it. 🤠`); return; }
+      if (r && r.ok && r.number) { m.filed = true; m.filing = false; m.issue = r.number; renderOverlay(); toast(okToast(r.number)); return; }
     } catch (e) {}
     m.filing = false;   // backend couldn't file (no GITHUB_TOKEN / offline) → pre-filled fallback
   }
   window.open(wranglerIssueUrl(title, body, label), '_blank', 'noopener');
   m.filed = true; renderOverlay();
-  toast(label === 'wrangler-request'
-    ? 'Opening a request — tap “Submit new issue” and it lands in Jac’s queue. 🤠'
-    : 'Opening a fix ticket — tap “Submit new issue” and Mr. Wrangler wrangles the rest. 🤠');
+  toast(isPlan
+    ? 'Opening the build ticket — tap “Submit new issue” and Mr. Wrangler builds to your plan. 🤠'
+    : label === 'wrangler-request'
+      ? 'Opening a request — tap “Submit new issue” and it lands in Jac’s queue. 🤠'
+      : 'Opening a fix ticket — tap “Submit new issue” and Mr. Wrangler wrangles the rest. 🤠');
 }
 /* §18e IN-APP REQUESTS INBOX — Mr. Wrangler's "Filed for Jac's OK" reviewed + approved
    IN THE APP (never GitHub). Approve flips the issue to wrangler-fix → the auto-fix
@@ -10053,6 +10079,7 @@ function seedDemoRequests() {
   const ph = (label, c) => `data:image/svg+xml;utf8,${encodeURIComponent(`<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><rect width='160' height='160' fill='${c}'/><rect x='14' y='14' width='132' height='30' rx='6' fill='rgba(255,255,255,.18)'/><rect x='14' y='58' width='96' height='14' rx='4' fill='rgba(255,255,255,.28)'/><rect x='14' y='80' width='120' height='14' rx='4' fill='rgba(255,255,255,.2)'/><text x='14' y='140' fill='rgba(255,255,255,.7)' font-family='sans-serif' font-size='13'>${label}</text></svg>`)}`;
   wranglerRequests.push({
     number: 41, url: '#', title: 'Inspection “Ready” pill clashes with “On Rent” green',
+    labels: ['wrangler-request'],   // Needs your OK
     images: [ph('screenshot.png', '#1f5f48'), ph('zoomed.png', '#2a4d6e')],
     body: [
       '_Filed by Mr. Wrangler from in-app chat._', '',
@@ -10064,6 +10091,21 @@ function seedDemoRequests() {
       '**Mr. Wrangler**: Good eye — “Ready” (inspection) and “On Rent” (rental) both come out green, so they run together. I’ll propose a distinct tone for inspection-Ready and keep On Rent as the rental green.', '',
       '### Repro context', '- **View:** list view', '- **Role:** Admin', '',
       "_A request for Jac's OK — NOT auto-implemented._",
+    ].join('\n'),
+  });
+  wranglerRequests.push({
+    number: 43, url: '#', title: 'Add a “snooze service” button on the unit card',
+    labels: ['wrangler-needs-jac'],   // build paused — Mr. Wrangler needs an answer
+    body: [
+      '_Filed by Mr. Wrangler from in-app chat._', '',
+      '### Approved plan (build to this) (Mr. Wrangler\'s write-up)',
+      '1. Add a “Snooze 7 days” button to the service-due banner on the unit card.\n2. Push the service countdown out by the snoozed days.\n3. Show a small “snoozed” note until the new date.', '',
+      '### Conversation',
+      '**Reporter**: Let’s let me snooze a service reminder for a week.', '',
+      '**Mr. Wrangler**: Here’s the plan — a “Snooze 7 days” button on the service banner that pushes the countdown out. Build it?', '',
+      '**Reporter**: Yes, build it.', '',
+      '**Mr. Wrangler**: One thing before I ship — should a snooze also pause the “Past Due” red flag, or keep the flag and just move the date? It changes how overdue units read on the board.', '',
+      '### Repro context', '- **View:** units', '- **Role:** Admin',
     ].join('\n'),
   });
   reqLoaded = true;

--- a/docs/superpowers/specs/2026-06-16-discuss-before-build-flow.md
+++ b/docs/superpowers/specs/2026-06-16-discuss-before-build-flow.md
@@ -1,0 +1,48 @@
+# Discuss-before-build + mid-build "needs you" — one flow
+
+**Date:** 2026-06-16 · **Approved by Jac (pop-ups):** balanced gate · build both as one flow.
+
+One conversation surface (the **Talk to Mr. Wrangler** chat) and one review surface
+(the **Requests inbox** + the **notification bell** as the alert) handle a change
+from idea → plan → build → (if needed) a mid-build question → resume → shipped.
+
+## Issue lifecycle (labels = state)
+
+- **`wrangler-fix`** — an obvious bug, or a plan Jac OK'd → the engine builds it.
+- **`wrangler-request`** — a change Mr. Wrangler proposed; **needs Jac's plan-OK**
+  (he reviews/refines in chat, then taps **Build this plan**).
+- **`wrangler-needs-jac`** (NEW) — the build **paused** on a real decision; **needs
+  Jac's answer**. Lights the inbox badge + bell. Jac answers in the same chat →
+  relabel back to `wrangler-fix` → the engine **resumes** (reads the full thread).
+
+## In-app (frontend — this repo)
+
+- **Plan gate (chat):** a *bug* still auto-files (`action:"fix"`). A *change* makes
+  Mr. Wrangler propose a concrete **plan** (`action:"plan"`) — the bubble shows a
+  **✓ Build this plan** button. Building files `wrangler-fix` with an
+  **"### Approved plan (build to this)"** section as the spec.
+- **Inbox states:** each request card is tagged **Needs your OK** (plan) /
+  **Needs your answer** (needs-jac) / **Building**, read from the issue label.
+  `needs-jac` cards lead with Mr. Wrangler's question + **Answer** (opens the chat).
+- **Bell:** a feed entry when something enters a "needs you" state (hooks the
+  existing bell feed). The inbox FAB badge already counts open items.
+- **Answering:** sending in the chat on a `needs-jac` request posts the answer to
+  the issue **and** resumes the build (relabel).
+
+## Engine (`.github/workflows/wrangler-fix.yml` — this repo)
+
+- If the issue has an **"### Approved plan"**, build **exactly** to it.
+- If genuinely blocked (an ambiguous decision, or it would touch
+  money/card/auth/WO-completion), **do not guess**: post the question as a comment,
+  relabel `wrangler-fix → wrangler-needs-jac`, and stop. A later answer +
+  relabel to `wrangler-fix` resumes it.
+
+## Backend (Code.gs — owner paste; documented, graceful without it)
+
+- `wranglerRequests` returns each issue's **label** (so the inbox can tag state +
+  the bell can alert).
+- Answering a `needs-jac` request (`wranglerComment`) also **relabels it to
+  `wrangler-fix`** to resume (or a `wranglerResume` action).
+- Everything degrades: with no backend changes, the chat plan-gate + inbox still
+  work; the state tags/auto-resume light up after the paste.
+</content>

--- a/docs/wrangler-inbox-backend.md
+++ b/docs/wrangler-inbox-backend.md
@@ -93,4 +93,25 @@ redeploy the web app, and the inbox is fully wired.
   can go back and forth live (the AI runs through your existing `wrangler` action).
 - **After the paste:** photos appear in the inbox + chat, and the back-and-forth
   is recorded on the GitHub issue (so it survives across sessions/devices).
-</content>
+
+## Discuss-before-build + mid-build "needs you" (2026-06-16)
+
+Three small deltas light up the lifecycle states (see
+`docs/superpowers/specs/2026-06-16-discuss-before-build-flow.md`). All optional —
+the chat plan-gate + inbox work without them.
+
+1. **Return each issue's labels** in `wranglerRequests` so the inbox can tag state
+   (`Needs your OK` = `wrangler-request`, `Needs your answer` = `wrangler-needs-jac`,
+   `Building` = `wrangler-fix`). Just add `labels: issue.labels.map(l => l.name)` to
+   each returned request.
+
+2. **Resume on answer.** When `wranglerComment` posts to an issue currently labelled
+   `wrangler-needs-jac`, also **relabel it `wrangler-fix`** (remove `wrangler-needs-jac`)
+   so the engine re-fires and resumes from the full thread. (The engine already
+   sets `wrangler-needs-jac` + posts its question when it pauses.)
+
+3. **Ring the bell.** Have `wranglerNotifications` also include open
+   `wrangler-needs-jac` issues (e.g. `{ kind: 'needs', number, title, question }`)
+   so the notification bell alerts when Mr. Wrangler is waiting on you — not just
+   the inbox badge.
+

--- a/style.css
+++ b/style.css
@@ -915,6 +915,7 @@ input { font-family: inherit; }
 .wr-actbtn:active { transform: translateY(1px); }
 .wr-actbtn:focus-visible { outline: 2px solid var(--accent-line, #ff7a1a); outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) { .wr-actbtn:active { transform: none; } }
+.wr-actbtn-build { background: linear-gradient(180deg, #43d07f, #2faa63); color: #04140c; }   /* the plan-OK "go build it" commit */
 .wr-actdone { display: inline-block; margin-top: 8px; font-size: 11.5px; font-weight: 600;
   color: var(--green, #46c46a); letter-spacing: .3px; }
 
@@ -949,6 +950,10 @@ input { font-family: inherit; }
 .wr-reqttl { font-size: 12px; color: var(--txt-2); font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wr-reqbar .spacer { flex: 1 1 auto; }
 .wr-reqbar .pill { height: 26px; font-size: 11.5px; }
+/* request lifecycle state (Needs your OK / Needs your answer / Building) */
+.req-head .spacer { flex: 1 1 auto; }
+.req-state { height: 20px; font-size: 9.5px; letter-spacing: .3px; flex: 0 0 auto; align-self: center; }
+.req-card.req-needs { border-color: var(--red); box-shadow: 0 0 0 1px rgba(255, 66, 66, .25); }
 
 /* §18e/f floating bottom-right cluster — notification bell + Requests inbox */
 .fab-stack { position: fixed; right: 16px; bottom: 16px; z-index: 70; display: flex; flex-direction: column; gap: 10px; }


### PR DESCRIPTION
Builds the **discuss-before-build** flow you asked for, plus the **mid-build "Claude needs you"** loop — one conversation surface, one inbox/bell surface.

## The flow
- **Plan gate (changes only):** a clear bug still auto-files. A *change* now makes Mr. Wrangler propose a concrete **plan** in chat (a **✓ Build this plan** button); building files the issue with an **"### Approved plan (build to this)"** spec. Nothing builds until you tap Build.
- **Mid-build "needs you":** if the engine hits a real decision it can't make safely, it **stops instead of guessing** — posts its question and flips the issue to **`wrangler-needs-jac`**, which surfaces in your inbox (and rings the bell). You answer in the same **Talk to Mr. Wrangler** chat; that resumes the build.
- **Inbox states:** every request is tagged **Needs your OK** / **Needs your answer** / **Building** from its label; needs-answer cards are red-emphasized with the question + an **Answer Mr. Wrangler** button. The FAB badge counts the needs-you items.

## Where it lives
- **In-app (this repo):** chat plan action + Build button, inbox state tags + needs-jac surface, demo seed showing both states.
- **Engine (`.github/workflows/wrangler-fix.yml`):** build exactly to an Approved plan; blocked → `wrangler-needs-jac` + question + stop; resume on relabel.
- **Backend (you paste, documented + graceful):** labels in `wranglerRequests`, resume-on-answer, bell ring — `docs/wrangler-inbox-backend.md` + spec `docs/superpowers/specs/2026-06-16-discuss-before-build-flow.md`.

## Verified (`#local`)
Inbox shows **#41 "Needs your OK"** and **#43 "Needs your answer"** (red, with the question + Answer button), no console errors. Merged latest `main` (dispatch cockpit, Blued Steel). Gates: `smoke` ✓ · `logic` 42/42 ✓ · `gen-rule-usage --check` ✓.

https://claude.ai/code/session_01Vjwrncp3yFrUHxhJxec4bo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vjwrncp3yFrUHxhJxec4bo)_