### PR TITLE
Dispatch cockpit: full-pane map + hover-expand schedule rail

### DIFF
--- a/app.js
+++ b/app.js
@@ -4902,11 +4902,12 @@ function dispatchTruckPos(stops) {   // v1 seam — swapped for live telematics 
 // "HH:MM" (24h) → minutes (blanks → null, sort last); + a friendly "9:00a" stamp.
 function timeToMin(t) { const m = /^(\d{1,2}):(\d{2})$/.exec((t || '').trim()); return m ? (+m[1]) * 60 + (+m[2]) : null; }
 function fmtClock(t) { const mn = timeToMin(t); if (mn == null) return '—:—'; let h = Math.floor(mn / 60); const m = mn % 60; const ap = h < 12 ? 'a' : 'p'; h = h % 12 || 12; return `${h}:${String(m).padStart(2, '0')}${ap}`; }
-/* §2.3 DISPATCH = the OFFICE COCKPIT (Phase 1, Jac 2026-06-15): a live map of the
-   day's run + a welded TIME-RAIL. Stops auto-fill from rentals; the rail places each
-   on a time axis (retime = reorder, Phase 1b drag); the map draws the route + truck.
-   Every stop reads its KIND (deliver=blue / recover=tan) and the NEXT stop is marked,
-   on BOTH the map and the rail. The board is live — no "send"; edits auto-notify. */
+/* §2.3 DISPATCH = the OFFICE COCKPIT (Phase 1, Jac): a FULL-PANE live map of the day's
+   run + a minimal schedule rail floating on the right that widens on hover/focus to
+   adjust the run ("No set time" pinned on top). Stops auto-fill from rentals; the map
+   draws the route + truck; every stop reads its KIND (deliver=blue / recover=brown) and
+   the NEXT stop is marked, on BOTH map + rail. Live board — no "send"; edits auto-notify.
+   Phase 1b: drag a token to retime (today it's type-the-time). */
 function dispatchGridBody() {
   const day = state.dispatchDay || TODAY_ISO;
   const stops = dispatchDayStops(day);
@@ -4922,33 +4923,29 @@ function dispatchGridBody() {
   if (!stops.length) return `${head}<div class="disp-empty">${I.truck}<p>No transports on this day.</p><span>Rentals with Delivery / Round-Trip / Recovery land here automatically — flip days with ‹ ›.</span></div>`;
 
   const nextId = dispatchNextId(stops);
-  // time window for the rail axis (pad 30m; floor of 2h so a one-stop day still spreads)
-  const mins = stops.map((s) => timeToMin(s.time)).filter((m) => m != null);
-  const winA = mins.length ? Math.min(...mins) - 30 : 7 * 60;
-  let winB = mins.length ? Math.max(...mins) + 30 : 15 * 60;
-  if (winB - winA < 120) winB = winA + 120;
-  const pctOf = (mn) => Math.max(3, Math.min(97, ((mn - winA) / (winB - winA)) * 100));
-  let ticks = '';
-  for (let h = Math.ceil(winA / 60); h * 60 <= winB; h++) { const ap = h < 12 ? 'a' : 'p'; const hh = h % 12 || 12; ticks += `<span class="disp-tick" style="top:${pctOf(h * 60)}%">${hh}${ap}</span>`; }
-
   const scheduled = stops.filter((s) => timeToMin(s.time) != null);
-  const unscheduled = stops.filter((s) => timeToMin(s.time) == null);
-  const tokenEl = (s, axis) => {
+  const unscheduled = stops.filter((s) => timeToMin(s.time) == null);   // §2.3 "No set time" pinned to the TOP of the rail (Jac)
+  const tokenEl = (s) => {
     const kind = dispatchKind(s);
     const done = stopDone(s), isNext = s.id === nextId;
-    const top = axis ? ` style="top:${pctOf(timeToMin(s.time))}%"` : '';
     const flag = done ? `<span class="dt-flag ok">✓ done</span>` : (isNext ? `<span class="dt-flag next">${I.truck} next</span>` : '');
-    return `<div class="disp-tok js-disp-tok${done ? ' done' : ''}${isNext ? ' next' : ''}${s.pin ? '' : ' nopin'}" data-id="${esc(s.id)}" data-rec="${esc(s.rentalId)}" data-unit="${esc(s.unitId || '')}"${top}>
-      <div class="dt-r1"><span class="dt-grip" data-tip="Type a time to retime/reorder this stop (drag coming soon)">⠿</span><input class="dt-time js-disp-time" data-id="${esc(s.id)}" value="${esc(s.time || '')}" placeholder="—:—" maxlength="5" aria-label="Stop time" data-tip="Set the stop time — reorders the run" /><span class="spacer"></span>${flag}</div>
-      <div class="dt-r2"><span class="dt-kind k-${kind}">${kind === 'deliver' ? '▾' : '▴'} ${kind}</span><span class="dt-who">${esc(s.cust)} · ${esc(s.unit)}</span></div>
-      ${s.addr ? `<div class="dt-addr js-site-go" data-rec="${esc(s.rentalId)}" data-unit="${esc(s.unitId || '')}" data-tip="Open the site / set the map pin">${s.pin ? '' : '⚠ '}${esc(s.addr)}</div>` : ''}
+    return `<div class="disp-tok js-disp-tok kind-${kind}${done ? ' done' : ''}${isNext ? ' next' : ''}${s.pin ? '' : ' nopin'}" data-id="${esc(s.id)}" data-rec="${esc(s.rentalId)}" data-unit="${esc(s.unitId || '')}">
+      <div class="dt-rail"><span class="dt-dot"></span><b class="dt-mini">${timeToMin(s.time) != null ? esc(fmtClock(s.time)) : '—'}</b></div>
+      <div class="dt-full">
+        <div class="dt-r1"><span class="dt-grip" data-tip="Type a time to retime/reorder (drag coming soon)">⠿</span><input class="dt-time js-disp-time" data-id="${esc(s.id)}" value="${esc(s.time || '')}" placeholder="—:—" maxlength="5" aria-label="Stop time" data-tip="Set the stop time — reorders the run" /><span class="spacer"></span>${flag}</div>
+        <div class="dt-r2"><span class="dt-kind k-${kind}">${kind === 'deliver' ? '▾' : '▴'} ${kind}</span><span class="dt-who">${esc(s.cust)} · ${esc(s.unit)}</span></div>
+        ${s.addr ? `<div class="dt-addr js-site-go" data-rec="${esc(s.rentalId)}" data-unit="${esc(s.unitId || '')}" data-tip="Open the site / set the map pin">${s.pin ? '' : '⚠ '}${esc(s.addr)}</div>` : ''}
+      </div>
     </div>`;
   };
-  const rail = `<div class="disprail js-disprail" data-day="${esc(day)}">
-    <div class="disp-bookend">${ICO_STORE} <span>Roll out</span></div>
-    <div class="disp-axis">${ticks}<span class="disp-axisline"></span>${scheduled.map((s) => tokenEl(s, true)).join('')}</div>
-    ${unscheduled.length ? `<div class="disp-tray"><div class="disp-tray-h">${unscheduled.length} no set time</div>${unscheduled.map((s) => tokenEl(s, false)).join('')}</div>` : ''}
-    <div class="disp-bookend">${ICO_STORE} <span>Return to yard</span></div>
+  const sec = (t) => `<div class="dr-sec">${t}</div>`;
+  const railRows = (unscheduled.length ? sec('No set time') + unscheduled.map(tokenEl).join('') : '')
+    + (scheduled.length ? (unscheduled.length ? sec('Scheduled') : '') + scheduled.map(tokenEl).join('') : '');
+  // The map is the full pane; the rail is a minimal time strip floating on the right that
+  // widens on hover/focus to let the office adjust the run. "No set time" sits up top.
+  const rail = `<div class="disprail js-disprail" data-day="${esc(day)}" tabindex="0" data-tip="Hover to adjust the run">
+    <div class="dr-head"><span class="dr-chev">‹</span><span class="dr-title">Run · ${stops.length} stop${stops.length === 1 ? '' : 's'}</span></div>
+    <div class="dr-list">${railRows}</div>
   </div>`;
   const foot = `<div class="disp-foot"><span class="disp-livedot"></span><span class="disp-live">Live · auto-notifies the driver on change</span></div>`;
   return `${head}<div class="disp-cockpit"><div class="dispm js-dispmount" data-day="${esc(day)}"></div>${rail}</div>${foot}`;

--- a/style.css
+++ b/style.css
@@ -471,21 +471,36 @@ input { font-family: inherit; }
 .disp-arrow-dot { fill: var(--accent); }
 .disp-arrow-hit { pointer-events: stroke; cursor: pointer; }
 @media (prefers-reduced-motion: reduce) { .js-disp-arrowpt { transition: none; } .js-disp-arrowpt.armed { transform: none; } }
-/* ── §2.3 OFFICE COCKPIT (Phase 1): live map + welded time-rail ───────────────── */
-.disp-cockpit { flex: 1; min-height: 0; display: flex; flex-direction: column; }
-.dispm { flex: 0 0 46%; min-height: 200px; position: relative; overflow: hidden; border-bottom: 1px solid var(--line); background: var(--bg-2); }
-.disprail { flex: 1; min-height: 0; overflow-y: auto; padding: 8px 10px 12px; }
-.disp-bookend { display: flex; align-items: center; gap: 7px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 10.5px; font-weight: 700; color: var(--txt-2); padding: 5px 9px; border-radius: 7px; background: var(--accent-soft); }
-.disp-bookend svg { width: 13px; height: 13px; color: var(--accent); flex: 0 0 auto; }
-.disp-axis { position: relative; min-height: 360px; margin: 10px 0 10px 32px; }
-.disp-axisline { position: absolute; left: -14px; top: 0; bottom: 0; width: 2px; background: var(--line); }
-.disp-tick { position: absolute; left: -32px; transform: translateY(-50%); font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 10px; letter-spacing: .5px; color: var(--txt-3); }
-.disp-tok { background: linear-gradient(180deg, var(--card-head), var(--card)); border: 1px solid var(--line); border-radius: 10px; padding: 6px 9px; cursor: grab; }
-.disp-axis .disp-tok { position: absolute; left: 0; right: 0; transform: translateY(-50%); }
-.disp-tok:hover { border-color: var(--accent-line); }
+/* ── §2.3 OFFICE COCKPIT (Phase 1): FULL-PANE map + hover-expand schedule rail ──── */
+.disp-cockpit { flex: 1; min-height: 0; position: relative; }
+.dispm { position: absolute; inset: 0; }                                   /* the map is the whole pane */
+/* the rail floats over the map's right edge: a minimal time strip that widens on hover/focus */
+.disprail { position: absolute; top: 8px; right: 8px; bottom: 8px; width: 90px; z-index: 3; display: flex; flex-direction: column;
+  background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; box-shadow: var(--chip-shadow); transition: width .16s ease, box-shadow .16s ease; }
+.disprail:hover, .disprail:focus-within { width: 256px; box-shadow: var(--shadow); }
+.dr-head { display: flex; align-items: center; gap: 6px; padding: 7px 9px; border-bottom: 1px solid var(--line); flex: 0 0 auto; }
+.dr-chev { color: var(--txt-3); font-size: 13px; flex: 0 0 auto; transition: transform .16s ease; }
+.disprail:hover .dr-chev, .disprail:focus-within .dr-chev { transform: rotate(180deg); }
+.dr-title { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 10.5px; font-weight: 700; color: var(--txt-2); white-space: nowrap; opacity: 0; transition: opacity .16s ease; }
+.disprail:hover .dr-title, .disprail:focus-within .dr-title { opacity: 1; }
+.dr-list { flex: 1; min-height: 0; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 5px; }
+.dr-sec { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-size: 9px; font-weight: 700; color: var(--txt-3); padding: 3px 2px 0; display: none; }
+.disprail:hover .dr-sec, .disprail:focus-within .dr-sec { display: block; }
+.disp-tok { border: 1px solid var(--line); border-left: 3px solid var(--gray); border-radius: 8px; background: linear-gradient(180deg, var(--card-head), var(--card)); cursor: pointer; overflow: hidden; }
+.disp-tok.kind-deliver { border-left-color: var(--blue); }
+.disp-tok.kind-recover { border-left-color: var(--brown); }
 .disp-tok.next { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
 .disp-tok.done { opacity: .82; }
 .disp-tok.nopin { border-style: dashed; }
+.dt-rail { display: flex; align-items: center; gap: 7px; padding: 6px 8px; }                 /* collapsed view: kind dot + time */
+.disprail:hover .dt-rail, .disprail:focus-within .dt-rail { display: none; }
+.dt-dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; flex: 0 0 auto; color: var(--gray); }
+.disp-tok.kind-deliver .dt-dot { color: var(--blue); }
+.disp-tok.kind-recover .dt-dot { color: var(--brown); }
+.disp-tok.next .dt-dot { color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.dt-mini { font-size: 11px; font-weight: 800; color: var(--txt); white-space: nowrap; }
+.dt-full { display: none; padding: 6px 8px; }                                                /* expanded view: editable detail */
+.disprail:hover .dt-full, .disprail:focus-within .dt-full { display: block; }
 .dt-r1 { display: flex; align-items: center; gap: 6px; }
 .dt-grip { color: var(--txt-3); cursor: grab; font-size: 12px; }
 .dt-time { width: 52px; flex: 0 0 auto; font-size: 13px; font-weight: 800; color: var(--txt); font-family: inherit; background: transparent; border: 1px solid transparent; border-radius: 6px; padding: 1px 4px; }
@@ -503,8 +518,6 @@ input { font-family: inherit; }
 .dt-who { font-size: 11.5px; color: var(--txt-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .dt-addr { font-size: 10.5px; color: var(--blue); cursor: pointer; margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .disp-tok.nopin .dt-addr { color: var(--yellow); }
-.disp-tray { margin: 10px 0; padding: 8px; border: 1px dashed var(--line); border-radius: 9px; display: flex; flex-direction: column; gap: 7px; }
-.disp-tray-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 9.5px; color: var(--txt-3); }
 .disp-foot { flex: 0 0 auto; display: flex; align-items: center; gap: 7px; padding: 7px 12px; border-top: 1px solid var(--line); font-size: 10.5px; color: var(--txt-3); }
 .disp-live { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; }
 .disp-livedot { width: 8px; height: 8px; border-radius: 50%; background: var(--green); box-shadow: 0 0 0 3px var(--green-bg); flex: 0 0 auto; }


### PR DESCRIPTION
Reworked the cockpit per Jac's direction: the map is now the FULL pane, and the schedule is a minimal strip floating on the right that widens on hover/focus to adjust the run.

- .dispm is absolute inset:0 (whole pane); .disprail is a right-edge overlay, 90px collapsed to 256px on hover/focus-within.
- Collapsed token = kind-colored dot + time (glanceable mini-list); expanded = full editable row (time input, kind tag, customer/unit, next/done, address).
- 'No set time' stops pinned to the TOP, then a Scheduled section.
- Dropped the old time-axis/hour-ticks/bookends/tray.

Gates green: smoke, logic 42/42, rule-usage.