### PR TITLE
Graphs: interactive carousel above the list (Units slice)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1081,7 +1081,7 @@ function categoryStats(cat) {
    its own anchored main card + cascade. */
 function freshSession() {
   const cards = {};
-  for (const c of GRID_CARDS) cards[c.id] = { mode: 'list', recId: null, recType: null, search: '', filterTerms: [], historySearch: '', sort: loadSort(c.id), backStack: [], fwdStack: [], segment: c.id === 'shop' ? 'all' : null };
+  for (const c of GRID_CARDS) cards[c.id] = { mode: 'list', recId: null, recType: null, search: '', filterTerms: [], historySearch: '', sort: loadSort(c.id), backStack: [], fwdStack: [], segment: c.id === 'shop' ? 'all' : null, graphIdx: 0, graphSel: {} };   // §13.4 graphIdx = active carousel view; graphSel = remembered selection per view
   // 3-column layout: which member card is visible in each column (display-only;
   // rides inside the session so item-tabs / pause-resume restore it for free).
   const cols = {}; for (const col of COLUMNS) cols[col.id] = col.default;
@@ -1478,9 +1478,17 @@ function rowMatches(card, rec, query, terms) {
   }
   const q2 = (query || '').replace(/\b(?:un)?available\b/gi, '').replace(/\s+/g, ' ').trim();
   const terms2 = (terms || []).filter((t) => !/^(?:un)?available$/.test(t.t));
-  // A1 — col-scoped terms (from footer chips) do an EXACT column match so "Ready" can't also
-  // catch "Not Ready"; plain text terms fall through to the blob substring match.
-  for (const t of terms2) { if (!t.col) continue; const m = totColMatch(card, rec, t.col, t.value); if (t.neg ? m : !m) return false; }
+  // A1 — col-scoped terms (from footer chips / graph slices) do an EXACT column match so
+  // "Ready" can't also catch "Not Ready"; plain text terms fall to the blob substring match.
+  // §13.4 — a NOT term excludes on its own; positive terms of the SAME column OR together
+  // (toggle several graph slices = match any), while different columns still AND.
+  const byCol = {};
+  for (const t of terms2) {
+    if (!t.col) continue;
+    if (t.neg) { if (totColMatch(card, rec, t.col, t.value)) return false; }
+    else (byCol[t.col] = byCol[t.col] || []).push(t.value);
+  }
+  for (const col in byCol) { if (!byCol[col].some((v) => totColMatch(card, rec, col, v))) return false; }
   return blobMatches(IDX.search.get(card + ':' + idOf(card, rec)), q2, terms2.filter((t) => !t.col));
 }
 // A1 — exact match for a footer-chip's {col, value}, per record (mirrors applyTotalFilter).
@@ -1489,6 +1497,8 @@ function totColMatch(card, rec, col, value) {
   if (col === '__cond') return rec.inspectionStatus === value;
   if (col === '__svc') { const s = topServiceForUnit(rec); return !!rec.washRequested || !!(s && s.remaining < 0); }   // service-due: overdue service or wash requested
   if (col === '__fleet') { const [cat, status, kind] = String(value).split('|'); if (rec.categoryId !== cat) return false; return kind === 'rental' ? unitRentalBucket(rec) === status : rec.inspectionStatus === status; }   // A1 — fleet-bar segment = category + inspection/rental status
+  if (col === '__fc') return DATA.workOrders.some((w) => w.unitId === rec.unitId && w.woType === 'Field Call');   // §13.4 — unit has any Field Call WO
+  if (col === '__fcmonth') return DATA.workOrders.some((w) => w.unitId === rec.unitId && w.woType === 'Field Call' && (w.date || '').slice(0, 7) === value);   // §13.4 — Field Call in month YYYY-MM
   const c = cardColumns(card, activeSession()).find((x) => x.key === col);
   return c ? String(c.get(rec)) === String(value) : true;
 }
@@ -1517,6 +1527,8 @@ function colFilterLabel(card, col, value) {
   if (col === '__wo') return value === 'open' ? 'WOs Open' : 'Parts Ordered';
   if (col === '__svc') return 'Service Due';
   if (col === '__fleet') { const [cat, status] = String(value).split('|'); return `${status} · ${IDX.category.get(cat)?.name || 'category'}`; }
+  if (col === '__fc') return 'Field Calls';
+  if (col === '__fcmonth') { const d = parseISO(value + '-01'); return 'FC · ' + (d ? d.toLocaleString('en-US', { month: 'short' }) : value); }
   const c = cardColumns(card, activeSession()).find((x) => x.key === col);
   const m = (c && c.meta) ? c.meta(value) : null;
   return (m && m.label) || String(value);
@@ -4130,6 +4142,7 @@ function cardEl(cardDef, session) {
 function listView(cardDef, session) {
   const card = cardDef.id;
   const cs = session.cards[card];
+  gvSyncClosed(card, cs);   // §13.4 — graph closed but g-terms linger (record open / invoice surface) → save + drop them before the bar's pills render
   const wrap = el('div');
   // sort/search bar
   const sf = SORT_FIELDS[card];
@@ -4155,8 +4168,12 @@ function listView(cardDef, session) {
       <button class="dir js-sortdir" data-card="${card}"><span class="${cs.sort.dir === 'asc' ? 'on' : ''}">▲</span><span class="${cs.sort.dir === 'desc' ? 'on' : ''}">▼</span></button>
     </div>`;
   wrap.appendChild(bar);
-  // Phase 4 — Graph view is an IN-COLUMN toggle (sibling to the list), not a popup.
-  if (cs.graphView && !state.searchMode) { const g = el('div', 'gv-card'); g.innerHTML = cardGraphBody(card); wrap.appendChild(g); return wrap; }
+  // §13.4 — Graph carousel: an interactive panel ABOVE the list (the list renders below,
+  // filtered by the chart's g-tagged search terms). Legacy cards still full-replace the list.
+  if (cs.graphView && !state.searchMode) {
+    if (graphViewsFor(card)) { const g = el('div', 'gv-panel'); g.innerHTML = graphPanelHtml(card, cs); wrap.appendChild(g); }
+    else { const g = el('div', 'gv-card'); g.innerHTML = cardGraphBody(card); wrap.appendChild(g); return wrap; }
+  }
   // Phase 4 — Units narrowed to an invoice's linked units (Invoice +WO) → removable chip
   if (card === 'units' && state.unitPick) {
     const n = state.unitPick.ids.length;
@@ -5153,6 +5170,118 @@ function gvMonths6() {
   const out = [];
   for (let i = 5; i >= 0; i--) { const d = new Date(TODAY.getFullYear(), TODAY.getMonth() - i, 1); out.push({ key: d.toISOString().slice(0, 7), label: d.toLocaleString('en-US', { month: 'short' }) }); }
   return out;
+}
+/* ════════════════════════════════════════════════════════════════════════
+   §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of
+   INTERACTIVE views stacked ABOVE the list. Chevrons cycle the view; clicking a
+   slice / bar / row / number TOGGLES a search entry (the one filtering pathway),
+   so the chart drives the rows. Same-column toggles OR together. Each view
+   remembers its selection (cs.graphSel); first open of a pie/bars view defaults to
+   its smallest non-empty slice. Cards without a view set fall back to the legacy
+   cardGraphBody dashboard. ════════════════════════════════════════════════════ */
+const gvClampIdx = (idx, n) => (n ? ((((idx || 0) % n) + n) % n) : 0);
+const gvKey = (card, v) => card + ':' + v.key;
+const gvSegOn = (cs, col, value) => (cs.filterTerms || []).some((t) => t.g && t.col === col && String(t.value) === String(value));
+function gvSmallest(view) { const live = (view.segs || []).filter((s) => s.count > 0); return live.length ? live.reduce((a, b) => (b.count < a.count ? b : a)) : null; }
+// A graph view = { key, title, kind:'pie'|'bars'|'lead'|'nums', color?, segs:[{col,value,label,count,color}] }.
+// Each seg's {col,value} is exactly a filter term, so a click maps straight to the list.
+function graphViewsFor(card) {
+  if (card === 'units') {
+    const f = fleetInsp();
+    const insp = [['Ready', 'green'], ['Not Ready', 'yellow'], ['Failed', 'red']].map(([v, c]) => ({ col: 'inspection', value: v, label: v, count: f[v] || 0, color: c }));
+    const fleetN = {}; DATA.units.forEach((u) => { const s = u.fleetStatus || '—'; fleetN[s] = (fleetN[s] || 0) + 1; });
+    const fleet = Object.entries(fleetN).sort((a, b) => b[1] - a[1]).map(([s, n]) => ({ col: 'fleet', value: s, label: s, count: n, color: getStatus('unitFleetStatus', s).color || 'gray' }));
+    const openSet = new Set(DATA.workOrders.filter((w) => w.phase !== 'Complete' && !w.cancelled).map((w) => w.unitId));
+    const ordSet = new Set(DATA.workOrders.filter((w) => w.phase !== 'Complete' && !w.cancelled && (w.phase === 'Part Ordered' || (w.lineItems || []).some((l) => l.phase === 'Part Ordered'))).map((w) => w.unitId));
+    const nUnits = (set) => DATA.units.filter((u) => set.has(u.unitId)).length;
+    const shop = [{ col: '__wo', value: 'open', label: 'WOs Open', count: nUnits(openSet), color: 'red' }, { col: '__wo', value: 'ordered', label: 'Parts Ordered', count: nUnits(ordSet), color: 'yellow' }];
+    const fc = DATA.workOrders.filter((w) => w.woType === 'Field Call');
+    const fcMonth = gvMonths6().map((m) => ({ col: '__fcmonth', value: m.key, label: m.label, count: new Set(fc.filter((w) => (w.date || '').slice(0, 7) === m.key).map((w) => w.unitId)).size, color: 'red' }));
+    const fcByUnit = {}; fc.forEach((w) => { if (w.unitId) fcByUnit[w.unitId] = (fcByUnit[w.unitId] || 0) + 1; });
+    const fcLead = Object.entries(fcByUnit).map(([uid, n]) => ({ col: 'name', value: IDX.unit.get(uid)?.name || uid, label: IDX.unit.get(uid)?.name || uid, count: n, color: 'red' })).sort((a, b) => b.count - a.count).slice(0, 8);
+    const nums = [
+      { col: '__fc', value: '1', label: 'Field Calls', count: new Set(fc.map((w) => w.unitId)).size, color: 'red' },
+      { col: '__wo', value: 'open', label: 'Open WOs', count: nUnits(openSet), color: 'yellow' },
+      { col: '__wo', value: 'ordered', label: 'Parts Ordered', count: nUnits(ordSet), color: 'blue' },
+      { col: 'wash', value: 'Wash Requested', label: 'Wash', count: DATA.units.filter((u) => u.washRequested).length, color: 'blue' },
+      { col: 'fleet', value: 'For Sale', label: 'For Sale', count: fleetN['For Sale'] || 0, color: 'green' },
+    ];
+    return [
+      { key: 'inspection', title: 'Inspection', kind: 'pie', segs: insp },
+      { key: 'fleet', title: 'Fleet', kind: 'pie', segs: fleet },
+      { key: 'shop', title: 'Shop · Open WOs', kind: 'pie', segs: shop },
+      { key: 'fcmonth', title: 'Field Calls / Month', kind: 'bars', color: 'red', segs: fcMonth },
+      { key: 'fclead', title: 'Most Field Calls', kind: 'lead', segs: fcLead },
+      { key: 'nums', title: 'By the Numbers', kind: 'nums', segs: nums },
+    ];
+  }
+  return null;
+}
+// ── state transitions (the active view's selection lives in cs.filterTerms as g-tagged
+//    terms = visible search pills; inactive views are remembered in cs.graphSel) ──
+function gvSaveCurrent(card, cs) {
+  const views = graphViewsFor(card); if (!views) return;
+  const k = gvKey(card, views[gvClampIdx(cs.graphIdx, views.length)]);
+  cs.graphSel = cs.graphSel || {};
+  cs.graphSel[k] = (cs.filterTerms || []).filter((t) => t.g === k).map((t) => ({ col: t.col, value: t.value, t: t.t }));
+}
+const gvStripTerms = (cs) => { cs.filterTerms = (cs.filterTerms || []).filter((t) => !t.g); };
+function gvRestore(card, cs, idx) {
+  const views = graphViewsFor(card); if (!views) return;
+  gvStripTerms(cs);
+  cs.graphIdx = gvClampIdx(idx, views.length);
+  const nv = views[cs.graphIdx], k = gvKey(card, nv);
+  cs.graphSel = cs.graphSel || {};
+  let sel = cs.graphSel[k];
+  if (sel === undefined) { const sm = (nv.kind === 'pie' || nv.kind === 'bars') ? gvSmallest(nv) : null; sel = sm ? [{ col: sm.col, value: sm.value, t: sm.label }] : []; }   // first open of a slice view → smallest slice
+  cs.filterTerms = cs.filterTerms || [];
+  for (const s of sel) cs.filterTerms.push({ t: s.t, col: s.col, value: s.value, neg: false, g: k });
+}
+function gvOpen(card) { const cs = activeSession().cards[card]; cs.graphView = true; gvRestore(card, cs, cs.graphIdx || 0); cs.listLimit = undefined; render(); }
+function gvChevron(card, dir) { const cs = activeSession().cards[card]; gvSaveCurrent(card, cs); gvRestore(card, cs, (cs.graphIdx || 0) + dir); cs.listLimit = undefined; render(); }
+// Idempotent close-sync: any path that flips graphView off (record open, invoice surface)
+// leaves the g-terms behind — save them to memory + strip before the next list renders.
+function gvSyncClosed(card, cs) { if (cs.graphView) return; if (!graphViewsFor(card)) return; if (!(cs.filterTerms || []).some((t) => t.g)) return; gvSaveCurrent(card, cs); gvStripTerms(cs); }
+function toggleGraphSeg(card, col, value, label) {
+  const cs = activeSession().cards[card]; const views = graphViewsFor(card); if (!views) return;
+  const k = gvKey(card, views[gvClampIdx(cs.graphIdx, views.length)]);
+  const i = (cs.filterTerms || []).findIndex((t) => t.g === k && t.col === col && String(t.value) === String(value));
+  if (i >= 0) cs.filterTerms.splice(i, 1); else (cs.filterTerms = cs.filterTerms || []).push({ t: label, col, value, neg: false, g: k });
+  gvSaveCurrent(card, cs); cs.listLimit = undefined; render();
+}
+// ── renderers ──
+const GV_CHEV_L = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5l-7 7 7 7"/></svg>';
+const GV_CHEV_R = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M9 5l7 7-7 7"/></svg>';
+function gvSegBtn(cs, card, s, inner, cls) {
+  const on = gvSegOn(cs, s.col, s.value);
+  return `<button class="${cls} js-gv-seg${on ? ' on' : ''}" data-card="${card}" data-col="${esc(s.col)}" data-value="${esc(String(s.value))}" data-label="${esc(s.label)}" data-tip="${on ? 'Remove filter' : 'Filter to ' + esc(s.label)}">${inner}</button>`;
+}
+function gvRenderView(card, cs, v) {
+  if (v.kind === 'pie') {
+    const legend = v.segs.map((s) => gvSegBtn(cs, card, s, `<i style="background:var(--${s.color})"></i><span class="gl-lbl">${esc(s.label)}</span> <b>${s.count}</b>`, 'gv-leg')).join('');
+    return `<div class="gv-pie">${pieSVG(v.segs.map((s) => ({ label: s.label, value: s.count, color: s.color })), 116)}<div class="gv-legend gv-legend-click">${legend}</div></div>`;
+  }
+  if (v.kind === 'bars') {
+    const max = Math.max(1, ...v.segs.map((s) => s.count));
+    return `<div class="gv-bars">${v.segs.map((s) => gvSegBtn(cs, card, s, `<div class="gv-bar-n">${s.count || ''}</div><div class="gv-bar-track"><div class="gv-bar-fill" style="height:${Math.round((s.count / max) * 100)}%;background:var(--${s.color || v.color || 'accent'})"></div></div><div class="gv-bar-x">${esc(s.label)}</div>`, 'gv-barcol')).join('')}</div>`;
+  }
+  if (v.kind === 'lead') {
+    if (!v.segs.length) return '<div class="gv-empty">No data yet.</div>';
+    return `<div class="gv-lead-list">${v.segs.map((s, i) => gvSegBtn(cs, card, s, `<span class="gv-lead-n">${i + 1}</span><span class="gv-lead-name">${esc(s.label)}</span><span class="gv-lead-c">${s.count}</span>`, 'gv-lead-row')).join('')}</div>`;
+  }
+  if (v.kind === 'nums') return `<div class="gv-numrow">${v.segs.map((s) => gvSegBtn(cs, card, s, `<div class="gv-num-v">${esc(String(s.count))}</div><div class="gv-num-l">${esc(s.label)}</div>`, 'gv-numtile')).join('')}</div>`;
+  return '';
+}
+function graphPanelHtml(card, cs) {
+  const views = graphViewsFor(card); if (!views) return '';
+  const idx = gvClampIdx(cs.graphIdx, views.length), v = views[idx];
+  const dots = views.map((_, i) => `<i class="${i === idx ? 'on' : ''}"></i>`).join('');
+  return `<div class="gv-head">
+      <button class="gv-chev js-gv-chev" data-card="${card}" data-dir="-1" data-tip="Previous graph">${GV_CHEV_L}</button>
+      <div class="gv-head-mid"><div class="gv-title">${esc(v.title)}</div><div class="gv-dots">${dots}</div></div>
+      <button class="gv-chev js-gv-chev" data-card="${card}" data-dir="1" data-tip="Next graph">${GV_CHEV_R}</button>
+    </div>
+    <div class="gv-view gv-view-${v.kind}">${gvRenderView(card, cs, v)}</div>`;
 }
 function cardGraphBody(card) {
   if (card === 'units') {
@@ -7378,7 +7507,9 @@ function onClick(e) {
   if (closest('.js-ff-save')) { e.stopPropagation(); return saveFileForm(); }
   if (closest('.js-vendor-tax')) { e.stopPropagation(); const b = closest('.js-vendor-tax'); const v = recOf('vendors', b.dataset.rec); if (v) { const ex = b.dataset.val === '1'; if (!!v.salesTaxExempt !== ex) { v.salesTaxExempt = ex; reindex('vendors', v); logAction(v, `Sales tax → ${ex ? 'Exempt' : 'Taxed'}`); } if (state.overlay?.kind === 'board') renderOverlay(); render(); } return; }
   if (closest('.js-boardview')) { e.stopPropagation(); return openBoardView(closest('.js-boardview').dataset.card); }
-  if (closest('.js-cardgraph')) { e.stopPropagation(); const card = closest('.js-cardgraph').dataset.card; const cs = activeSession().cards[card]; cs.graphView = !cs.graphView; return render(); }   // Phase 4 per-card Graph view — in-column toggle (sibling to the list)
+  if (closest('.js-cardgraph')) { e.stopPropagation(); const card = closest('.js-cardgraph').dataset.card; const cs = activeSession().cards[card]; if (!cs.graphView) { if (graphViewsFor(card)) return gvOpen(card); cs.graphView = true; return render(); } cs.graphView = false; return render(); }   // §13.4 per-card Graph carousel toggle (legacy cards: dashboard)
+  if (closest('.js-gv-chev')) { e.stopPropagation(); const b = closest('.js-gv-chev'); return gvChevron(b.dataset.card, Number(b.dataset.dir)); }   // §13.4 cycle the active graph view
+  if (closest('.js-gv-seg')) { e.stopPropagation(); const b = closest('.js-gv-seg'); return toggleGraphSeg(b.dataset.card, b.dataset.col, b.dataset.value, b.dataset.label); }   // §13.4 toggle a slice/bar/row/number → search entry
   if (closest('.js-bv-sort') && !closest('.js-bv-inscol')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { const key = closest('.js-bv-sort').dataset.col; if (o.sort?.key === key) o.sort.dir = o.sort.dir === 'asc' ? 'desc' : 'asc'; else o.sort = { key, dir: 'asc' }; renderOverlay(); } return; }
   if (closest('.js-bv-addcol')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { o.colOrder = o.colOrder || []; o.colOrder.push({ kind: 'extra', id: 'xc' + (++o.seq), label: '' }); renderOverlay(); } return; }
   if (closest('.js-bv-inscol')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview' && o.colOrder) { const after = Number(closest('.js-bv-inscol').dataset.after); o.colOrder.splice(after + 1, 0, { kind: 'extra', id: 'xc' + (++o.seq), label: '' }); renderOverlay(); } return; }

--- a/style.css
+++ b/style.css
@@ -1173,6 +1173,53 @@ input { font-family: inherit; }
 .gv-soon-ic { display: inline-flex; width: 40px; height: 40px; color: var(--accent); opacity: .7; }
 .gv-soon p { margin-top: 12px; font-size: 14px; }
 @media (max-width: 720px) { .gv-grid { grid-template-columns: repeat(2, 1fr); } .gv-num, .gv-lead, .gv-pie, .gv-wide { grid-column: span 2; } }
+
+/* §13.4 — Graph CAROUSEL: an interactive panel above the list. Selected = orange
+   (the one allowed decorative orange: a selected control). Chart data stays on calm
+   status-colored fields; orange marks only what's toggled on. */
+.gv-panel { flex: 0 0 auto; padding: 8px 10px 10px; border-bottom: 1px solid var(--line); background: linear-gradient(180deg, var(--card-head), var(--card)); }
+.gv-head { display: flex; align-items: center; gap: 8px; }
+.gv-head-mid { flex: 1; min-width: 0; display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.gv-title { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 12px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.gv-dots { display: flex; gap: 4px; }
+.gv-dots i { width: 5px; height: 5px; border-radius: 50%; background: var(--line); }
+.gv-dots i.on { background: var(--accent); }
+.gv-chev { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; flex: 0 0 auto; border-radius: 8px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-2); cursor: pointer; }
+.gv-chev:hover { color: var(--txt); border-color: var(--accent-line); }
+.gv-chev:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.gv-view { margin-top: 8px; }
+.gv-empty { color: var(--txt-3); font-size: 12px; padding: 8px 2px; text-align: center; }
+/* clickable legend chips (pie) */
+.gv-legend-click { gap: 6px; }
+.gv-legend-click .gv-leg { cursor: pointer; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-2); font-size: 11px; }
+.gv-legend-click .gv-leg:hover { border-color: var(--accent-line); color: var(--txt); }
+.gv-legend-click .gv-leg.on { background: var(--accent); border-color: var(--accent); color: var(--on-orange); }
+.gv-legend-click .gv-leg.on b { color: var(--on-orange); }
+.gv-legend-click .gv-leg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+/* clickable bars */
+.gv-bars .gv-barcol { cursor: pointer; border: none; background: transparent; padding: 0; }
+.gv-bars .gv-barcol:hover .gv-bar-fill { filter: brightness(1.15); }
+.gv-bars .gv-barcol.on .gv-bar-fill { background: var(--accent) !important; }
+.gv-bars .gv-barcol.on .gv-bar-x { color: var(--accent); }
+.gv-bars .gv-barcol:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
+/* clickable leaderboard */
+.gv-lead-list { display: flex; flex-direction: column; }
+.gv-lead-list .gv-lead-row { grid-template-columns: 18px 1fr auto; width: 100%; cursor: pointer; border: none; border-bottom: 1px solid var(--line); background: transparent; color: var(--txt); text-align: left; font: inherit; }
+.gv-lead-list .gv-lead-row:hover { background: var(--panel); }
+.gv-lead-list .gv-lead-row.on { background: var(--accent-soft); }
+.gv-lead-list .gv-lead-row.on .gv-lead-name { color: var(--accent); }
+.gv-lead-list .gv-lead-row .gv-lead-c { color: var(--txt-2); }
+.gv-lead-list .gv-lead-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+/* clickable number tiles */
+.gv-numrow { display: flex; flex-wrap: wrap; gap: 8px; }
+.gv-numtile { flex: 1 1 78px; min-width: 78px; display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 9px 8px; border-radius: 10px; border: 1px solid var(--line); background: linear-gradient(180deg, var(--card-head), var(--card)); cursor: pointer; }
+.gv-numtile .gv-num-v { color: var(--txt); font-size: 26px; }
+.gv-numtile .gv-num-l { margin-top: 0; }
+.gv-numtile:hover { border-color: var(--accent-line); }
+.gv-numtile.on { border-color: var(--accent); background: var(--accent-soft); }
+.gv-numtile.on .gv-num-v { color: var(--accent); }
+.gv-numtile:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) { .gv-bars .gv-barcol:hover .gv-bar-fill { filter: none; } }
 .board-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .board-table th { position: sticky; top: 0; z-index: 1; text-align: left; padding: 10px 14px; background: var(--card-head); color: var(--txt-3); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; border-bottom: 1px solid var(--line); white-space: nowrap; }
 .board-table td { padding: 9px 14px; border-bottom: 1px solid var(--line-soft); color: var(--txt); vertical-align: middle; }


### PR DESCRIPTION
Reworks the per-card Graph into an interactive **carousel above the list** that drives the rows (Jac's design, 2026-06-16). **Units slice only** — the other cards still use the legacy dashboard until rollout.

**Workflow:** graph icon → panel drops down (pushes list down) → smallest slice auto-enters the search → click slices/bars/rows/numbers to toggle entries → chevrons cycle views, re-syncing the search.

- Chart selections flow through the existing `filterTerms` (one filtering pathway) → show as removable search pills.
- `rowMatches` now ORs same-column terms (toggle several slices = match any); different columns still AND; single-term groups unchanged.
- Per-view memory (`cs.graphSel`); pie/bars views default to smallest non-empty slice.
- New synthetic cols `__fc` / `__fcmonth`.

**Verified on #local (13/13):** panel-above-list, smallest-slice default (Not Ready, 2/11), OR toggle (2→9), chevron re-sync + memory restore, numbers tiles, close resets. smoke ✓, logic 42/42 ✓, rule-usage no real drift.

Styled via jactec-ui: tokens only, orange = selected control, Saira-stamped title, focus-visible, reduced-motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)