### PR TITLE
Customers: add 'N/A' funnel stage as the default (reset existing 'Inbound Lead')

### DIFF
--- a/app.js
+++ b/app.js
@@ -107,6 +107,13 @@ function migrateCustomers() {
       }
       migrationDirty = true;
     }
+    // §7.1 'Inbound Lead' was the de-facto default for EVERY customer — reset those to the new
+    // 'N/A' default ONCE per customer (the flag keeps a deliberate future 'Inbound Lead' picked).
+    if (!c.funnelNAApplied) {
+      if (c.usedSalesStage === 'Inbound Lead') c.usedSalesStage = 'N/A';
+      if (c.membershipStage === 'Inbound Lead') c.membershipStage = 'N/A';
+      c.funnelNAApplied = true; migrationDirty = true;
+    }
   });
 }
 /* ── §20 multi-unit rentals — "a Rental is an EVENT" ──
@@ -3581,11 +3588,11 @@ const DETAIL = {
 
     const intCats = (c.interestedCategoryIds || []).map((id) => { const cat = IDX.category.get(id); return cat ? refPill('categories', id, cat.name, { x: 'intcat-remove', xData: id }) : ''; }).join('');
     const usedSales = `<div class="section"><h4>Used Sales</h4><div class="fieldstack centered">
-      ${kvPills(funnelPill(c.customerId, 'usedSales', c.usedSalesStage || 'Inbound Lead'))}
+      ${kvPills(funnelPill(c.customerId, 'usedSales', c.usedSalesStage || 'N/A'))}
       <div class="kv pillrow">${intCats}${addBtn('Category', { link: true, js: 'js-addcat', h: 26, data: { rec: c.customerId } })}</div>
     </div></div>`;
     const membership = `<div class="section"><h4>Membership</h4><div class="fieldstack centered">
-      ${kvPills(funnelPill(c.customerId, 'membership', c.membershipStage || 'Inbound Lead'))}
+      ${kvPills(funnelPill(c.customerId, 'membership', c.membershipStage || 'N/A'))}
       ${isMember && c.paidUntil ? kv(yr(c.paidUntil), { sfx: 'paid until' }) : ''}
       ${c.paidCadence ? kvPills(`${badge('Paid ' + c.paidCadence, 'green')}${c.unlimitedTransport ? badge('Unlimited Transport', 'purple') : ''}`) : ''}
       ${c.paidFees ? kv(money(c.paidFees), { sfx: 'paid fees' }) : ''}
@@ -4583,7 +4590,7 @@ function kpiFor(roleId) {
     const big = C.filter((c) => (c._digest?.totalPaid || 0) > 1999);
     const activeRate = pctOf(big.filter((c) => (c._digest?.activePct || 0) > 0).length, big.length);
     const members = C.filter((c) => /Member/.test(c.accountType || '') && c.accountType !== 'Member Incomplete').length;
-    const leads = C.filter((c) => c.usedSalesStage && c.usedSalesStage !== 'Inbound Lead').length;
+    const leads = C.filter((c) => c.usedSalesStage && c.usedSalesStage !== 'Inbound Lead' && c.usedSalesStage !== 'N/A').length;
     const pipeline = pctOf(members + leads, 10);
     return [revGoal, activeRate, pipeline];
   }
@@ -4629,7 +4636,7 @@ function kpiRaw(roleId) {
   if (roleId === 'sales') {
     const ym = TODAY_ISO.slice(0, 7);
     const rev = R.reduce((a, r) => ((r.startDate || '').slice(0, 7) !== ym ? a : a + ((rentalPrice(r) || {}).price || 0)), 0);
-    return [usd(rev), c(C.filter((x) => (x._digest?.totalPaid || 0) > 1999 && (x._digest?.activePct || 0) > 0).length), c(C.filter((x) => /Member/.test(x.accountType || '') && x.accountType !== 'Member Incomplete').length + C.filter((x) => x.usedSalesStage && x.usedSalesStage !== 'Inbound Lead').length)];
+    return [usd(rev), c(C.filter((x) => (x._digest?.totalPaid || 0) > 1999 && (x._digest?.activePct || 0) > 0).length), c(C.filter((x) => /Member/.test(x.accountType || '') && x.accountType !== 'Member Incomplete').length + C.filter((x) => x.usedSalesStage && x.usedSalesStage !== 'Inbound Lead' && x.usedSalesStage !== 'N/A').length)];
   }
   return [c(0), c(0), c(0)];
 }
@@ -8810,7 +8817,7 @@ function parseQuickCustomer(q) {
 function quickAddCustomerFromSearch(value) {
   const p = parseQuickCustomer(value); if (!p) return false;
   const id = nextCustomerId();
-  const c = { customerId: id, firstName: p.firstName, lastName: p.lastName, name: `${p.firstName} ${p.lastName}`.trim(), company: '', phone: p.phone, email: '', address: '', industry: '', accountType: 'Non-Business', payStatus: 'New Customer', requiresPO: false, accountNotes: '', stripeId: '', selfie: '', signature: '', agreementType: '', agreementSignedAt: '', interestedCategoryIds: [], activityLog: [], usedSalesStage: 'Inbound Lead', membershipStage: 'Inbound Lead', _digest: { activePct: 0, totalPaid: 0, visits: 0, years: 0, avgFrequencyDays: 0, firstInvoice: '', lastInvoice: '' } };
+  const c = { customerId: id, firstName: p.firstName, lastName: p.lastName, name: `${p.firstName} ${p.lastName}`.trim(), company: '', phone: p.phone, email: '', address: '', industry: '', accountType: 'Non-Business', payStatus: 'New Customer', requiresPO: false, accountNotes: '', stripeId: '', selfie: '', signature: '', agreementType: '', agreementSignedAt: '', interestedCategoryIds: [], activityLog: [], usedSalesStage: 'N/A', membershipStage: 'N/A', _digest: { activePct: 0, totalPaid: 0, visits: 0, years: 0, avgFrequencyDays: 0, firstInvoice: '', lastInvoice: '' } };
   DATA.customers.push(c); IDX.customer.set(id, c); reindex('customers', c);
   logAction(c, 'Customer quick-added');
   const s = activeSession();
@@ -8909,7 +8916,7 @@ function quickSaveCustomer(o) {
     industry: d.industry, accountType: d.accountType || 'Non-Business', payStatus: 'New Customer',
     requiresPO: false, accountNotes: d.accountNotes, stripeId: '', selfie: d.selfie || '', signature: d.signature || '',
     agreementType: d.agreementType || '', agreementSignedAt: d.agreementSignedAt || '',
-    interestedCategoryIds: [], activityLog: [], usedSalesStage: 'Inbound Lead', membershipStage: 'Inbound Lead',
+    interestedCategoryIds: [], activityLog: [], usedSalesStage: 'N/A', membershipStage: 'N/A',
     _digest: { activePct: 0, totalPaid: 0, visits: 0, years: 0, avgFrequencyDays: 0, firstInvoice: '', lastInvoice: '' },
   };
   DATA.customers.push(c); IDX.customer.set(id, c); reindex('customers', c);
@@ -8960,7 +8967,7 @@ function saveNewCustomer() {
     industry: d.industry, accountType: d.accountType || 'Non-Business', payStatus: 'New Customer',
     requiresPO: false, accountNotes: d.accountNotes, stripeId: '', selfie: d.selfie || '', signature: d.signature || '',
     agreementType: d.agreementType || '', agreementSignedAt: d.agreementSignedAt || '',
-    interestedCategoryIds: [], activityLog: [], usedSalesStage: 'Inbound Lead', membershipStage: 'Inbound Lead',
+    interestedCategoryIds: [], activityLog: [], usedSalesStage: 'N/A', membershipStage: 'N/A',
     _digest: { activePct: 0, totalPaid: 0, visits: 0, years: 0, avgFrequencyDays: 0, firstInvoice: '', lastInvoice: '' },
   };
   DATA.customers.push(c); IDX.customer.set(id, c); reindex('customers', c);

--- a/config.js
+++ b/config.js
@@ -132,6 +132,7 @@ const RAW_STATUS = {
     'No':    { label: 'Bill: No',    color: 'gray'   },
   },
   funnelStage: {
+    'N/A':               { label: 'N/A',               color: 'gray'   },
     'Inbound Lead':      { label: 'Inbound Lead',      color: 'blue'   },
     'Outbound Lead':     { label: 'Outbound Lead',     color: 'navy'   },
     "Don't Contact":     { label: "Don't Contact",     color: 'red'    },

--- a/data.js
+++ b/data.js
@@ -58,7 +58,7 @@ const units = [
 const customers = [
   m({ customerId: 'C0009', name: 'Devin Lyles (bayou games)', company: 'bayou games', phone: '(337) 214-5001', email: 'manager@bayougames.com', address: 'Lake Charles, LA, USA', accountType: 'Business', payStatus: 'Current', industry: 'Entertainment', requiresPO: false, accountNotes: 'Recurring event-equipment renter.', stripeId: 'cus_demo009', cards: [{ id: 'CARD-D009', stripePmId: 'pm_demo009', brand: 'visa', last4: '4242', expMonth: 8, expYear: 2031, nickname: '', notes: '', isDefault: true, status: 'active' }], cardBrand: 'visa', cardLast4: '4242', cardExpMonth: 8, cardExpYear: 2031, _digest: { totalPaid: 18400, visits: 14, years: 2, avgFrequencyDays: 26, activePct: 82, firstInvoice: '2024-05-10', lastInvoice: '2026-06-02' },
       usedSalesStage: 'Contacted', interestedCategoryIds: ['CAT001', 'CAT008'], salesAction: 'Send weekend light-tower package quote',
-      membershipStage: 'Inbound Lead',
+      membershipStage: 'N/A',
       activityLog: [ { when: '2026-05-20', text: 'Quoted weekend light-tower package' }, { when: '2026-04-02', text: 'Inbound lead via website form' } ] }),
   m({ customerId: 'C0016', name: 'Kaleb Guidry (Industrial Thermal Services)', company: 'Industrial Thermal Services', phone: '(337) 400-1121', email: 'gracie.manuel@its-thermal.com', address: 'Sulphur, LA, USA', accountType: 'Business Member', payStatus: 'Current', industry: 'Industrial', requiresPO: true, accountNotes: 'PO required on every invoice.', stripeId: 'cus_demo016', _digest: { totalPaid: 41250, visits: 22, years: 3, avgFrequencyDays: 19, activePct: 91, firstInvoice: '2023-09-01', lastInvoice: '2026-05-28' },
       usedSalesStage: 'Not A No!', interestedCategoryIds: ['CAT011'], salesAction: 'Pitch a second excavator for Q3',
@@ -66,7 +66,7 @@ const customers = [
       activityLog: [ { when: '2026-01-15', text: 'Membership renewed — Yearly, Unlimited Transport' }, { when: '2025-11-30', text: 'Payment discussed for renewal' } ] }),
   m({ customerId: 'C0033', name: 'matthew hazel (HD Services)', company: 'HD Services', phone: '(337) 304-0071', email: 'Hdservices2409@gmail.com', address: 'Sulphur, LA, USA', accountType: 'Business', payStatus: 'Partial', industry: 'Construction', requiresPO: true, accountNotes: '', stripeId: 'cus_demo033', _digest: { totalPaid: 7600, visits: 6, years: 1, avgFrequencyDays: 41, activePct: 58, firstInvoice: '2025-08-15', lastInvoice: '2026-06-07' },
       usedSalesStage: 'Payment Discussed', interestedCategoryIds: ['CAT008'], salesAction: 'Follow up on used skid-steer purchase',
-      membershipStage: 'Inbound Lead',
+      membershipStage: 'N/A',
       activityLog: [ { when: '2026-06-07', text: 'Discussed buying a used skid steer' } ] }),
   m({ customerId: 'C0008', name: 'Tucker Fontenot', company: '', phone: '(337) 905-2210', email: '', accountType: 'Non-Business', payStatus: 'Current', industry: '', requiresPO: false, accountNotes: '', stripeId: 'cus_demo008', _digest: { totalPaid: 2320, visits: 4, years: 1, avgFrequencyDays: 63, activePct: 34, firstInvoice: '2025-11-02', lastInvoice: '2026-02-20' } }),
   m({ customerId: 'C0007', name: 'Chaise Russell', company: '', phone: '(409) 781-3344', email: '', accountType: 'Non-Business', payStatus: 'Unpaid', industry: '', requiresPO: false, accountNotes: 'Outstanding balance on last delivery.', stripeId: '', _digest: { totalPaid: 990, visits: 2, years: 1, avgFrequencyDays: 88, activePct: 21, firstInvoice: '2026-01-12', lastInvoice: '2026-03-13' } }),


### PR DESCRIPTION
New customers + the display fallback defaulted to 'Inbound Lead' on BOTH funnels (Membership + Used Sales), so every account looked like a fresh inbound lead.

- config.js funnelStage: add 'N/A' (gray) at the top of the set.
- New-customer defaults + both display fallbacks -> 'N/A'.
- One-time, flag-guarded migration in migrateCustomers: existing 'Inbound Lead' customers reset to 'N/A' on both funnels (persisted via migrationDirty). The funnelNAApplied flag makes it run once per customer, so a deliberate future 'Inbound Lead' is never reverted.
- The 'leads' KPIs now also exclude 'N/A' so the new default doesn't inflate the count.

Syntax clean; relying on CI smoke (port 8000 is OS-reserved locally). Done in an isolated worktree off main, separate from the in-progress ACH branch.