### PR TITLE
Wrangler fix: drop per-render console.log perf spam

### DIFF
--- a/app.js
+++ b/app.js
@@ -7355,7 +7355,6 @@ function render() {
   const dt = performance.now() - t0;
   renderCount++;
   if (dt > CFG.PERF_BUDGET_MS) console.warn(`[perf] render ${renderCount} took ${dt.toFixed(1)}ms (budget ${CFG.PERF_BUDGET_MS}ms)`);
-  else console.log(`[perf] render ${renderCount}: ${dt.toFixed(1)}ms`);
 }
 /** Flag any element that's actually truncated with data-tip (full text) so the
  *  custom app-styled tooltip can show it on hover. Nothing lost to ellipsis. */


### PR DESCRIPTION
## The glitch
`render()`'s epilogue logged `[perf] render N: …ms` to the console on **every** happy-path render (`app.js` ~line 7358), spamming the production console on every interaction.

## The fix
Remove only the unconditional `else console.log(...)` branch. The `console.warn` budget guard — `if (dt > CFG.PERF_BUDGET_MS)` — is a useful over-budget alert and **stays**. One line deleted; no behavior change beyond silencing the happy-path log.

## Gates
- ✅ `node ci/smoke.mjs`
- ✅ `node ci/logic-test.mjs` (48/48)
- ✅ `node ci/gen-rule-usage.mjs --check` (no rule-usage change)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)