### PR TITLE
Mr. Wrangler: skill self-check + "the developer" voice + first-person fixes

### DIFF
--- a/.claude/skills/wrangler-fix/SKILL.md
+++ b/.claude/skills/wrangler-fix/SKILL.md
@@ -7,19 +7,19 @@ description: How the Wrangler auto-fix engine — and Claude triaging any in-app
 
 A reported glitch or suggestion is a *claim*. Don't implement it on faith and don't
 dismiss it on a hunch — **check it against the project's own canon, prove the verdict,
-and let the proof drive what you do.** Jac was right about the R5b buttons because the
-Rulebook said so; that's the bar.
+and let the proof drive what you do.** The reporter was right about the R5b buttons because
+the Rulebook said so; that's the bar.
 
 ## When to use
 - The auto-fix engine implementing a `wrangler-fix` issue (the issue body is the report).
 - Claude triaging any in-app report (bug or suggestion) before touching code.
 
 ## Two triggers, two starting points
-- **`wrangler-fix`** (a clear bug, or a request Jac already approved) → it's a **go**:
+- **`wrangler-fix`** (a clear bug, or a request the developer already approved) → it's a **go**:
   fix it.
 - **`wrangler-request`** (a suggestion / opinion) → it's a **claim to test**: PROVE it
   first. **If you prove it correct, fix it right then — no approval needed.** Only if
-  you *can't* prove it does it stay in Jac's inbox for his call.
+  you *can't* prove it does it stay in the developer's inbox for their call.
 
 ## Do it in this order
 
@@ -42,19 +42,19 @@ Rulebook said so; that's the bar.
    Never hand-wave. If you can't cite something, you haven't proven it.
 
 4. **Decide from the proof:**
-   - **Proven correct → fix it NOW. Proof replaces approval — do NOT wait for Jac.**
+   - **Proven correct → fix it NOW. Proof replaces approval — do NOT wait for the developer.**
      Implement the **minimal** fix that satisfies the cited rule (match the surrounding
      code + the design language), run all 3 gates (`node ci/smoke.mjs`,
      `node ci/logic-test.mjs`, `node ci/gen-rule-usage.mjs --check`), regenerate
      `rule-usage.js` if rule usage changed, and ship. This holds even for a
      `wrangler-request` — a proven request gets fixed immediately; it does NOT sit in the
      inbox.
-   - **Can't prove it (subjective, no rule backing) →** it needs Jac. If the issue is a
-     `wrangler-request`, leave it as-is (it stays in his inbox) and comment what you found
-     + what you'd need. If it's a `wrangler-fix`, relabel it `wrangler-request` to move it
-     into the inbox.
+   - **Can't prove it (subjective, no rule backing) →** it needs the developer. If the issue
+     is a `wrangler-request`, leave it as-is (it stays in their inbox) and comment what you
+     found + what you'd need. If it's a `wrangler-fix`, relabel it `wrangler-request` to move
+     it into the inbox.
    - **Contradicts the canon →** do NOT implement. Comment the conflict, cite the rule it
-     would break + the trade-off, move it to `wrangler-request` for Jac, and stop.
+     would break + the trade-off, move it to `wrangler-request` for the developer, and stop.
    - **Ambiguous / underspecified →** ask ONE specific question in a comment; don't guess.
    - **Touches money / card / auth / WO-completion →** extra caution; never weaken those;
      flag loudly in the PR if the fix genuinely must touch them.
@@ -72,9 +72,14 @@ Rulebook said so; that's the bar.
    goes live when CI is green.
 
 ## Guardrails
+- **Ask yourself first: "Should I use one of our skills for this?"** Reach for the fitting
+  skill before you freehand — `jactec-ui` for ANY UI element (screen, column, card, pill,
+  flag, button, field, popup, menu), the `mobile-*` skills for phone layout/touch/viewport,
+  `frontend` for new visual design, `webapp-testing` to verify in a real browser. Skip only
+  when none genuinely apply.
 - One report, one targeted fix — don't refactor adjacent code.
 - If the fix changes UI, run it through the design language (yard data-plate; the
   per-card stripe palette; Saira stamps; the light ranch twist) — see CLAUDE.md.
-- **Proof is the gate, not Jac's tap.** If you can cite the canon to prove a report
+- **Proof is the gate, not the developer's tap.** If you can cite the canon to prove a report
   correct, fix it immediately — the inbox is only for the things you genuinely *cannot*
-  prove and that need his judgment.
+  prove and that need their judgment.

--- a/.github/workflows/wrangler-fix.yml
+++ b/.github/workflows/wrangler-fix.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   fix:
     # Fire for either Wrangler label, on either entry path. wrangler-fix = build it;
-    # wrangler-request = PROVE it first (fix if proven — no approval — else leave for Jac).
+    # wrangler-request = PROVE it first (fix if proven — no approval — else leave for the developer).
     if: >
       (github.event.action == 'labeled' && (github.event.label.name == 'wrangler-fix' || github.event.label.name == 'wrangler-request')) ||
       (github.event.action == 'opened' && (contains(github.event.issue.labels.*.name, 'wrangler-fix') || contains(github.event.issue.labels.*.name, 'wrangler-request')))
@@ -97,17 +97,24 @@ jobs:
                 (RULE_META/CLASS_RULE in app.js + §1 of JacTec-handoff/JacTec-SPEC-v8.md),
                 the SPEC, docs/, and the actual code. Then PROVE the report right or wrong
                 with SPECIFIC citations (rule number / SPEC section / code).
-              • If this issue is `wrangler-fix` (a confirmed bug, or a request Jac already
-                approved) → fix it. If it's `wrangler-request` (a suggestion) → fix it ONLY
-                if you can PROVE it correct. A proven request is fixed RIGHT NOW — no
+              • ALWAYS ask yourself first: "Should I use one of our skills for this?" Check the
+                available skills and reach for the one that fits BEFORE you freehand —
+                `jactec-ui` for ANY UI (a screen, column, card, pill, flag, button, field,
+                popup, menu); the `mobile-*` skills for phone layout / touch / viewport;
+                `frontend` for new visual design; `webapp-testing` to verify in a real browser.
+                Skip a skill only when none genuinely apply.
+              • If this issue is `wrangler-fix` (a confirmed bug, or a request the developer
+                already approved) → fix it. If it's `wrangler-request` (a suggestion) → fix it
+                ONLY if you can PROVE it correct. A proven request is fixed RIGHT NOW — no
                 approval, it does not wait in the inbox.
-              • If the issue has an "### Approved plan (build to this)" section, Jac already
-                OK'd that plan in chat — build EXACTLY to it; do not redesign or second-guess it.
+              • If the issue has an "### Approved plan (build to this)" section, the developer
+                already OK'd that plan in chat — build EXACTLY to it; do not redesign or second-guess it.
               • If you hit a real decision you can't make safely mid-build (genuine ambiguity,
                 or it would touch money / card / auth / WO-completion), STOP — do NOT guess.
                 Post your ONE specific question as a comment and relabel the issue
-                `wrangler-needs-jac` (so it pings Jac in-app), then end. When Jac answers and it's
-                relabeled back to `wrangler-fix`, you'll resume from the full thread.
+                `wrangler-needs-jac` (so it reaches the developer in-app), then end. When the
+                developer answers and it's relabeled back to `wrangler-fix`, you'll resume from
+                the full thread.
               • Proven → make the MINIMAL fix that satisfies the cited rule (match the code +
                 the design language). Run all 3 gates (node ci/smoke.mjs · node ci/logic-test.mjs
                 · node ci/gen-rule-usage.mjs --check; regenerate rule-usage.js if usage changed).
@@ -116,7 +123,7 @@ jobs:
               • Can't prove it / it contradicts the canon / it's ambiguous → do NOT ship.
                 Comment your verdict + why on #${{ github.event.issue.number }}; if it's a
                 `wrangler-fix` you couldn't justify, relabel it `wrangler-request` so it lands
-                in Jac's inbox for his call.
+                in the developer's inbox for their call.
               • ALWAYS leave a closing comment on the issue in Mr. Wrangler's voice: the
                 verdict + the proof, what changed, and "refresh the page to see it" once it ships.
               • NEVER weaken money / card / auth / WO-completion logic.

--- a/app.js
+++ b/app.js
@@ -4892,8 +4892,8 @@ function wranglerDockEl() {
             : `<div class="wr-apply"><div class="wr-apply-sum">Preview: ${esc(sum)}</div>${skip}${plan.ops.length ? `<button class="wr-actbtn wr-actbtn-build js-wr-apply" data-mi="${i}">✓ Apply these changes</button>` : '<span class="wr-apply-none">Nothing here I can safely apply.</span>'}</div>`;
         } else if (m.action) {
           const ak = m.action.action;
-          const doneLbl = ak === 'plan' ? 'Building to your plan' : ak === 'request' ? 'Filed for Jac’s OK' : 'Sent to the fixer';
-          const btnLbl = ak === 'plan' ? '✓ Build this plan' : ak === 'request' ? '💡 File this for Jac’s OK' : '🔧 Send this to get fixed';
+          const doneLbl = ak === 'plan' ? 'Building to your plan' : ak === 'request' ? 'Sent to the developer for OK' : 'Fixing now — I’ll let you know when it’s done';
+          const btnLbl = ak === 'plan' ? '✓ Build this plan' : ak === 'request' ? '💡 Send to the developer' : '🔧 Fix it now';
           act = m.filed
             ? `<span class="wr-actdone">✓ ${doneLbl}${m.issue ? ` · #${m.issue}` : ''}</span>`
             : m.filing
@@ -6039,7 +6039,7 @@ function renderOverlay() {
             ? (st.key === 'needs'
                 ? `<button class="pill ghost js-req-dismiss" data-r="R18" data-n="${rq.number}">Dismiss</button>`
                 : `<button class="pill ghost js-req-dismiss" data-r="R18" data-n="${rq.number}">Dismiss</button><button class="pill c-commit js-req-approve" data-r="R17" data-n="${rq.number}">✓ Approve → build it</button>`)
-            : '<span class="req-await">Awaiting Jac’s OK</span>');
+            : '<span class="req-await">Awaiting the developer’s OK</span>');
       return `<div class="req-card req-${st.key}">
         <div class="req-head"><span class="req-num">#${rq.number}</span><span class="req-title">${esc(rq.title)}</span><span class="spacer"></span><span class="pill c-${st.color} req-state" data-r="R3b">${st.label}</span></div>
         ${report}${photos}${convo}
@@ -6055,7 +6055,7 @@ function renderOverlay() {
       ? list.map(reqCard).join('')
       : (!backendPassword ? '<div class="req-empty">Sign in to review requests.</div>'
         : (!reqLoaded && reqLoading ? '<div class="req-empty">Loading…</div>'
-          : '<div class="req-empty"><span class="req-empty-ic">📭</span><p>No requests waiting.</p><span>When Mr. Wrangler files one “for Jac’s OK”, it lands here for you to review.</span></div>'));
+          : '<div class="req-empty"><span class="req-empty-ic">📭</span><p>No requests waiting.</p><span>When Mr. Wrangler sends one to the developer, it lands here for review.</span></div>'));
     const pop = el('div', 'popup'); pop.style.width = '480px';
     pop.innerHTML = `
       <div class="popup-head"><span class="mark" style="color:var(--accent);display:inline-flex">${I.inbox}</span><h3>Requests${list.length ? ` · ${list.length}` : ''}</h3><span class="spacer"></span><button class="iconbtn js-req-refresh" data-tip="Refresh">${I.refresh || '⟳'}</button><button class="x js-close">${I.x}</button></div>
@@ -6593,7 +6593,7 @@ async function wranglerSend() {
       const raw = (r.text || '').trim();
       const act = parseWranglerAction(raw);
       let shown = stripWranglerAction(raw);
-      if (!shown) shown = act ? (act.action === 'data' ? 'Here’s what I’ll change — preview it and hit apply when it looks right.' : act.action === 'request' ? 'Got it — I’ll file this as a request for Jac to OK.' : act.action === 'plan' ? 'Here’s the plan — tap Build when it’s right.' : 'On it — I’ll send this to get fixed.') : '(no answer)';
+      if (!shown) shown = act ? (act.action === 'data' ? 'Here’s what I’ll change — preview it and hit apply when it looks right.' : act.action === 'request' ? 'Got it — I’ll send this to the developer to OK.' : act.action === 'plan' ? 'Here’s the plan — tap Build when it’s right.' : 'On it — I’ll fix this right now and let you know when I’m done.') : '(no answer)';
       o.messages.push({ role: 'assistant', content: shown, action: act || null, filed: false });
       syncWranglerComment(o, 'assistant', shown);   // §18e mirror Mr. Wrangler's reply onto the issue thread
     } else {
@@ -6717,9 +6717,9 @@ function wranglerActionPacket(o, act) {
   const focus = (o.card && o.recId != null) ? `${entityCardOf(o.card, o.recType)}:${o.recId}` : '—';
   const errs = ERR_LOG.length ? ERR_LOG.slice(-12).join('\n') : '(none captured this session)';
   const footer = isPlan
-    ? '_Build EXACTLY to the Approved plan above — Jac OK\'d it in chat. A Claude agent implements it; the CI gates guard it before it ships to live._'
+    ? '_Build EXACTLY to the Approved plan above — the developer OK\'d it in chat. A Claude agent implements it; the CI gates guard it before it ships to live._'
     : isReq
-      ? '_A request for Jac\'s OK — NOT auto-implemented. Jac can add the `wrangler-fix` label to greenlight it._'
+      ? '_A request for the developer\'s OK — NOT auto-implemented. The developer can add the `wrangler-fix` label to greenlight it._'
       : '_A Claude agent will reproduce + patch this; the CI gates guard it before it ships to live._';
   const heading = isPlan ? 'Approved plan (build to this)' : isReq ? 'Requested change' : 'The glitch';
   const body = [
@@ -6760,7 +6760,7 @@ async function wranglerFileAction(mi) {
   const isPlan = m.action.action === 'plan';
   const { title, body, label } = wranglerActionPacket(o, m.action);
   const images = []; (o.messages || []).forEach((mm) => (mm.images || []).forEach((s) => { if (images.length < 8) images.push(s); }));   // §18e carry the chat’s photos onto the issue
-  const okToast = (n) => isPlan ? `Building to your plan — #${n}. 🤠` : label === 'wrangler-request' ? `Filed #${n} — in Jac’s queue for the OK. 🤠` : `Filed #${n} — Mr. Wrangler’s on it. 🤠`;
+  const okToast = (n) => isPlan ? `Building to your plan — #${n}. 🤠` : label === 'wrangler-request' ? `Sent #${n} to the developer for the OK. 🤠` : `Filed #${n} — Mr. Wrangler’s on it. 🤠`;
   if (typeof backendPassword !== 'undefined' && backendPassword) {
     m.filing = true; render();
     try {
@@ -6774,7 +6774,7 @@ async function wranglerFileAction(mi) {
   toast(isPlan
     ? 'Opening the build ticket — tap “Submit new issue” and Mr. Wrangler builds to your plan. 🤠'
     : label === 'wrangler-request'
-      ? 'Opening a request — tap “Submit new issue” and it lands in Jac’s queue. 🤠'
+      ? 'Opening a request — tap “Submit new issue” and it goes to the developer. 🤠'
       : 'Opening a fix ticket — tap “Submit new issue” and Mr. Wrangler wrangles the rest. 🤠');
 }
 /* §18e IN-APP REQUESTS INBOX — Mr. Wrangler's "Filed for Jac's OK" reviewed + approved
@@ -10932,7 +10932,7 @@ function seedDemoRequests() {
       '**Reporter**: The green Ready tag looks exactly like On Rent. Can we make them different so I can tell them apart?', '',
       '**Mr. Wrangler**: Good eye — “Ready” (inspection) and “On Rent” (rental) both come out green, so they run together. I’ll propose a distinct tone for inspection-Ready and keep On Rent as the rental green.', '',
       '### Repro context', '- **View:** list view', '- **Role:** Admin', '',
-      "_A request for Jac's OK — NOT auto-implemented._",
+      "_A request for the developer's OK — NOT auto-implemented._",
     ].join('\n'),
   });
   wranglerRequests.push({


### PR DESCRIPTION
Three operator-requested refinements to Mr. Wrangler's behavior + voice.

## Changes
1. **Skill self-check** — the engine prompt (`wrangler-fix.yml`) and the `wrangler-fix` SKILL.md now force the agent to ask *"Should I use one of our skills for this?"* before freehanding (`jactec-ui` for any UI, `mobile-*` for phones, `frontend` for new visual design, `webapp-testing` to verify).
2. **"the developer", not "Jac"** — all user-facing copy (in-app chat actions, the request button/messages, toasts, the §18e approval inbox) and the engine's GitHub-comment voice now say "the developer". 
3. **First-person fixes** — the "fix" action drops "the fixer" / "send to get fixed" for *"I'll fix this right now and let you know when I'm done"* / "🔧 Fix it now".

## Deliberately untouched
- The `wrangler-needs-jac` **label** is kept verbatim (the backend's in-app ping filters on it).
- Company name **"Jac Rentals"**, the **"Jac" yard node** (depot label), and all `// Jac 2026-..` **code-authorship comments** — left as-is.

## Gates
`node ci/smoke.mjs` ✓ · `node ci/logic-test.mjs` 48/48 ✓ · `node ci/gen-rule-usage.mjs --check` ✓ (run locally with Playwright/Chromium installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vjwrncp3yFrUHxhJxec4bo)_