### PR TITLE
Wrangler fix: Cash/Check refunds reset balance instead of showing Refunded

### DIFF
--- a/app.js
+++ b/app.js
@@ -9654,10 +9654,29 @@ async function chargeInvoiceFlow(invoiceId) {
     fail(friendlyPayErr(r));
   } catch (e) { fail('Network error — try again.'); }
 }
-// Refund the captured amount back to the card (full). Reduces amountPaid; a full
-// refund flips the invoice to Refunded. The server is authoritative.
+// Refund the captured amount (full). Reduces amountPaid; a full refund flips the
+// invoice to Refunded. CASH/CHECK payments (#109) carry no Stripe charge, so their
+// refund is a bookkeeping record handled CLIENT-SIDE — exactly like recordManualPayment
+// recorded it — never through stripeRefundInvoice (no charge to reverse → the invoice
+// would just reset to "unpaid" with no Refunded status). CARD/bank refunds go through
+// the authoritative server.
 async function refundInvoiceFlow(invoiceId) {
   const o = state.overlay; if (!o || o.kind !== 'payment') return;
+  const inv = IDX.invoice.get(invoiceId); if (!inv) return;
+  if (/^(cash|check)/i.test(inv.paymentMethod || '')) {
+    const before = invoiceTotals(inv).status;
+    const refunded = Number(inv.amountPaid) || 0;
+    inv.amountPaid = 0;
+    inv.refunded = true;
+    inv.refundedAmount = refunded;
+    inv.allocations = {};   // a full refund releases every line assignment (§7.4)
+    o.confirmRefund = false; o.busy = false;
+    reindex('invoices', inv);
+    const after = invoiceTotals(inv).status;
+    logAction(inv, `Refunded ${money(refunded)} to ${inv.paymentMethod} — ${before} → ${after}`);
+    toast('Refunded ✓'); renderOverlay(); render();
+    return;
+  }
   const live = () => state.overlay === o;
   o.busy = true; o.error = ''; o.confirmRefund = false; renderOverlay();
   try {


### PR DESCRIPTION
## Report (#116)
Refunding a fully-paid **Cash** invoice (e.g. 05i17Ju26, $221.50) → "Confirm refund" just replenished the balance to $221.50 as if unpaid — no "Refunded" status, no refund record.

## Root cause — proven against the code
- Cash/Check payments (#109, commit 18715ae) are recorded **client-side** in `recordManualPayment` (`app.js:9693`) with **no Stripe charge** behind them.
- But `refundInvoiceFlow` (`app.js:9659`) *always* called the backend `stripeRefundInvoice` (`app.js:9664`), which only knows the §14/§19 Stripe card flow.
- With no charge to reverse, the server can't return a real refund → `applyPayment` never sets `inv.refunded` (`app.js:9679`) → `invoiceTotals` never flips status to `'Refunded'` (`app.js:910`) → the invoice shows `balance = total - 0` as if it was never paid. Exactly the reported symptom.

## Fix (minimal, logic-only)
Handle Cash/Check refunds **client-side**, mirroring how the payment was recorded: zero `amountPaid`, set `refunded` + `refundedAmount`, release line allocations (§7.4 full-refund-releases-all), and log a `Refunded` record. **Card/bank refunds still go through the authoritative server, untouched.** No UI elements added/changed, so `rule-usage.js` is unchanged.

## Money/auth note
This touches money logic but does **not weaken** it: it makes a cash refund a bookkeeping record exactly the way the cash *payment* already is (client-side, synced via `saveSoon`). The card refund path — the only one that moves real funds — is unchanged.

## Gates
- `node ci/smoke.mjs` ✅
- `node ci/logic-test.mjs` ✅ (48/48)
- `node ci/gen-rule-usage.mjs --check` ✅ (current)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)