### PR TITLE
Wrangler fix: Cash/Check refunds mark invoice Refunded (not unpaid)

### DIFF
--- a/app.js
+++ b/app.js
@@ -9654,10 +9654,22 @@ async function chargeInvoiceFlow(invoiceId) {
     fail(friendlyPayErr(r));
   } catch (e) { fail('Network error — try again.'); }
 }
+// A manual (#109) payment is one recorded by hand — Cash or Check — with no Stripe charge.
+const isManualMethod = (m) => m === 'Cash' || /^Check\b/.test(m || '');
 // Refund the captured amount back to the card (full). Reduces amountPaid; a full
 // refund flips the invoice to Refunded. The server is authoritative.
 async function refundInvoiceFlow(invoiceId) {
   const o = state.overlay; if (!o || o.kind !== 'payment') return;
+  // Cash / Check (#109) never hit Stripe, so there's nothing for stripeRefundInvoice to
+  // reverse — apply the full refund locally through the SAME applyPayment path a card
+  // refund uses, so the invoice flips to Refunded with a refund record (#117).
+  const minv = IDX.invoice.get(invoiceId);
+  if (minv && isManualMethod(minv.paymentMethod)) {
+    const paid = invoiceTotals(minv).paid;
+    o.confirmRefund = false;
+    applyPayment(invoiceId, { amountPaid: 0, refunded: true, refundedAmount: paid, refundedCents: Math.round(paid * 100) });
+    toast('Refunded ✓'); renderOverlay(); return;
+  }
   const live = () => state.overlay === o;
   o.busy = true; o.error = ''; o.confirmRefund = false; renderOverlay();
   try {
@@ -10964,7 +10976,7 @@ function exposeTestApi() {
       rentalAllocated, unitRentalPrice, rentalDisplayName, setWoLinePhase, setWoPhase, woBottleneck,
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
-      wrValidatePlan, applyWranglerData, wrFunnel };
+      wrValidatePlan, applyWranglerData, wrFunnel, isManualMethod, applyPayment };
   } catch (e) { /* no window (non-browser) */ }
 }
 

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -210,6 +210,16 @@ try {
     ok(T.IDX.unit.get('U003').notes === 'WR test note' && T.IDX.unit.get('U003').currentHours === hoursBefore, 'applied the safe note, did NOT write the money/ops field');
     T.DATA.customers.length = custBefore; u3.notes = noteBefore;   // restore
 
+    // #117 — a Cash/Check refund must flip the invoice to Refunded locally (no Stripe),
+    // not just reverse amountPaid and leave it looking unpaid.
+    ok(T.isManualMethod('Cash') && T.isManualMethod('Check #1042') && !T.isManualMethod('Visa ••4242') && !T.isManualMethod(''), 'isManualMethod: Cash/Check yes, card/empty no');
+    const invR = { invoiceId: 'I-REFUNDTEST', customerId: 'C0009', rentalIds: [], date: T.TODAY_ISO, dueDate: T.TODAY_ISO, po: '', lineItems: [{ kind: 'custom', lid: 'RFL', ref: null, amount: 100 }], amountPaid: 110.75, paymentMethod: 'Cash', mock: true };
+    T.DATA.invoices.push(invR); T.IDX.invoice.set(invR.invoiceId, invR);
+    const paidR = T.invoiceTotals(invR).paid;
+    T.applyPayment(invR.invoiceId, { amountPaid: 0, refunded: true, refundedAmount: paidR, refundedCents: Math.round(paidR * 100) });
+    ok(T.invoiceTotals(invR).status === 'Refunded' && invR.refunded === true && Number(invR.refundedAmount) === paidR, 'Cash refund → status Refunded with a refund record (not Unpaid)');
+    T.DATA.invoices.pop(); T.IDX.invoice.delete(invR.invoiceId);   // restore
+
     return out;
   });
 


### PR DESCRIPTION
## Report
[#117](../../issues/117) — *Refund confirmation resets balance instead of marking invoice as refunded.* Refunding invoice `05I17JU26` (paid in **Cash**) reversed the balance to \$221.50 and left the invoice looking unpaid, with no Refunded status or refund record.

> Consolidates the duplicate report **#116** (same bug, filed twice via Mr. Wrangler) — superseding PR #118, which fixed it the same way but without a regression test.

## Root cause (proven against the canon)
- The **Refund** button shows for *any* paid invoice (`app.js:6447`).
- `refundInvoiceFlow` (`app.js:9659`) **always** called `backendCall('stripeRefundInvoice', …)`.
- But Cash/Check payments (#109, commit `18715ae`) are recorded purely client-side by `recordManualPayment` — **there is no Stripe charge to reverse**. The confirm dialog already prints "Refund \$221.50 to **Cash**?" (`app.js:6441`), proving the code knew it was cash, yet still routed to Stripe.
- That call reversed `amountPaid` but never set `inv.refunded`, so `invoiceTotals` (`app.js:910` — `if (inv.refunded) status = 'Refunded'`) fell through to **Unpaid**. Exactly the reported symptom.

## Fix (minimal)
`refundInvoiceFlow` now detects a manual method (`Cash` / `Check #…`) via a new `isManualMethod` helper and applies the full refund **locally through the same `applyPayment` path a card refund uses** — flipping the invoice to `Refunded`, recording `refundedAmount`, and releasing line allocations (SPEC §4 invariant #13). Card/ACH refunds are untouched — no money/card/auth logic weakened.

## Gates
- `node ci/smoke.mjs` ✓
- `node ci/logic-test.mjs` ✓ (two new checks lock the refund behavior)
- `node ci/gen-rule-usage.mjs --check` ✓ (no markup change)

Closes #117
Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
