### PR TITLE
Wrangler fix: mark Cash/Check invoices Refunded instead of replenishing balance

### DIFF
--- a/app.js
+++ b/app.js
@@ -9658,6 +9658,19 @@ async function chargeInvoiceFlow(invoiceId) {
 // refund flips the invoice to Refunded. The server is authoritative.
 async function refundInvoiceFlow(invoiceId) {
   const o = state.overlay; if (!o || o.kind !== 'payment') return;
+  const inv = IDX.invoice.get(invoiceId); if (!inv) return;
+  // Cash/Check payments (#109) never touched Stripe, so there's no charge to reverse —
+  // refund them BY HAND, client-side, exactly as they were recorded (#117). Flip the
+  // invoice to Refunded (status derives from inv.refunded) and keep amountPaid so the
+  // balance reads $0; release line assignments per the full-refund invariant (§4).
+  if (/^cash$/i.test(inv.paymentMethod || '') || /^check/i.test(inv.paymentMethod || '')) {
+    const t = invoiceTotals(inv); const before = t.status;
+    inv.refunded = true; inv.refundedAmount = t.paid; inv.allocations = {};
+    o.confirmRefund = false; o.busy = false; o.error = '';
+    reindex('invoices', inv);
+    logAction(inv, `Refunded ${money(t.paid)} (${inv.paymentMethod}) — ${before} → Refunded`);
+    toast('Refunded ✓'); render(); renderOverlay(); return;
+  }
   const live = () => state.overlay === o;
   o.busy = true; o.error = ''; o.confirmRefund = false; renderOverlay();
   try {


### PR DESCRIPTION
## Report
#117 — Refunding a fully-paid **Cash** invoice (05I17JU26, $221.50) replenished the balance to $221.50 and left it looking unpaid, with no "Refunded" status and no refund record.

## Root cause (proven)
Cash/Check payments (#109, `recordManualPayment` app.js:9689) are recorded **purely client-side with no Stripe** — see the comment at app.js:6411-6415. But `refundInvoiceFlow` (app.js:9659) **unconditionally** called `backendCall('stripeRefundInvoice')`, a Stripe-only operation. A cash invoice has no Stripe charge to reverse, so the server can't return a proper refund result: `inv.refunded` never gets set, and the invoice never reaches **Refunded** (status is derived solely from `inv.refunded` at app.js:910).

## Fix (minimal)
When `inv.paymentMethod` is Cash or Check, refund **by hand, client-side** — mirroring how it was recorded:
- set `inv.refunded = true`, record `inv.refundedAmount`
- release line assignments (`inv.allocations = {}`) per the §4 full-refund invariant
- log the refund transaction line

Card/ACH refunds still go through the authoritative Stripe path, **untouched** — money/card logic is not weakened.

## Verification
- All 3 gates green: `node ci/smoke.mjs`, `node ci/logic-test.mjs`, `node ci/gen-rule-usage.mjs --check` (no rule-usage drift — no `data-r` stamps changed).
- Drove the real UI in a headless browser: cash payment → Refund → Confirm refund → status **Refunded**, balance **$0**, `refundedAmount` set, allocations cleared, history line `"Refunded $X (Cash) — Paid → Refunded"`. Confirmed a non-cash (card) invoice still takes the Stripe branch.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)