### PR TITLE
Wrangler fix: two-entry name+phone quick-add in Customers search

### DIFF
--- a/app.js
+++ b/app.js
@@ -9145,7 +9145,12 @@ function startNewCustomer(prefill) { openCustomerForm(null, prefill); }
    invoice; "Full intake" hands the typed values to the complete form. (Jac 2026-06-13) */
 /* QUICK ADD lives in the Customers search bar (Jac 2026-06-16): a search that
    carries BOTH a name and a phone, on Enter, instantly creates the customer and
-   opens it in Standard View — NOT linked to anything (you drag it where it goes). */
+   opens it in Standard View — NOT linked to anything (you drag it where it goes).
+   Two-entry flow (Jac 2026-06-17, #62): type the name → Enter stages it as a pill
+   (no customer yet) → type the phone → Enter combines staged name + phone → create. */
+function titleCaseName(s) {
+  return (s || '').split(/\s+/).map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w)).join(' ');
+}
 function parseQuickCustomer(q) {
   q = (q || '').trim(); if (!q) return null;
   const pm = q.match(/(\+?\d[\d\s().+-]{6,}\d)/);   // a phone-like run (≥8 chars, ends in a digit)
@@ -10844,7 +10849,18 @@ function boot() {
     // §5.4 (per-card) — same Enter-to-pin / Backspace-to-pop on a card's list search.
     if (e.target.classList.contains('mini-search') && e.target.dataset.card && !e.target.classList.contains('js-history-search')) {
       const card = e.target.dataset.card; const cs = activeSession().cards[card];
-      if (e.key === 'Enter') { e.preventDefault(); if (card === 'customers' && quickAddCustomerFromSearch(e.target.value)) return; addFilterTerm(card, e.target.value); return; }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (card === 'customers') {
+          // #62 two-entry quick-add: fold any staged name pill(s) into this entry (the
+          // phone) so name+phone across two Enters creates the customer. Staged terms are
+          // lowercased by addFilterTerm, so title-case the name half before parsing.
+          const staged = (cs.filterTerms || []).map((ft) => ft.t).join(' ').trim();
+          const combined = staged ? `${titleCaseName(staged)} ${e.target.value}`.trim() : e.target.value;
+          if (quickAddCustomerFromSearch(combined)) return;
+        }
+        addFilterTerm(card, e.target.value); return;
+      }
       if (e.key === 'Backspace' && !e.target.value && (cs.filterTerms || []).length) { e.preventDefault(); removeFilterTerm(card, cs.filterTerms.length - 1); return; }
       return;
     }


### PR DESCRIPTION
## What & why

In-app report via Mr. Wrangler — **#62** (labeled `wrangler-fix`, approved in-app by the Owner).

**Root cause.** Quick Add already lives in the Customers search bar (SPEC §588; `parseQuickCustomer` / `quickAddCustomerFromSearch` in `app.js`), but it only created a customer when the name **and** phone were typed in a **single** entry. The reporter's flow is two entries: type the name → Enter (stages it as a filter pill, no customer yet) → type the phone → Enter → create. The second Enter just stacked another filter pill, so no customer was ever made.

**Fix.** In the customers search `Enter` handler, fold any staged filter pill(s) into the current entry before handing it to `quickAddCustomerFromSearch`, so a name + phone split across two Enters creates the customer (which then surfaces in Standard View, draggable onto the rental — no popup, exactly as requested). Staged filter terms are lowercased by `addFilterTerm`, so the name half is title-cased before parsing. The legacy single-entry `name+phone` path is byte-for-byte unchanged.

Minimal, keyboard-handler-only change — no new UI element, no `data-r` stamp, so `rule-usage.js` is unchanged.

## Gates
- ✅ `node ci/smoke.mjs`
- ✅ `node ci/logic-test.mjs` (48/48)
- ✅ `node ci/gen-rule-usage.mjs --check` (current)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)