### PR TITLE
Wrangler fix: compact the invoice ledger — anchor labels next to their figures

### DIFF
--- a/style.css
+++ b/style.css
@@ -1996,7 +1996,12 @@ body { font-variant-numeric: tabular-nums; }
 .inv-split { display: flex; gap: 16px; align-items: flex-start; }
 .inv-actions { flex: 0 0 auto; display: flex; flex-direction: column; gap: 7px; align-items: flex-start; min-width: 0; }
 .inv-data { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
-.inv-data .hitem { gap: 8px; }
+/* Compact ledger (Mr. Wrangler #39): label sits just left of its right-aligned
+   figure instead of spanning the full width — kill the spacer's push, anchor the
+   label+value pair to the right, and column-align the figures. */
+.inv-data .hitem { gap: 8px; justify-content: flex-end; }
+.inv-data .hitem .spacer { display: none; }
+.inv-data .inv-tot > b, .inv-data .inv-line > b { min-width: 84px; text-align: right; flex: 0 0 auto; }
 .inv-div { height: 1px; background: var(--line-soft); margin: 5px 0; }
 .inv-tot.big b { font-size: 14px; }
 .inv-tot.due b { color: var(--accent); }


### PR DESCRIPTION
## What & why
Reported via Mr. Wrangler (#39): the Invoice view's summary rows (Rental/Transport subtotal, Subtotal, Tax, Total, Paid, Due) and line items had a **full-width gap** between the left label and the right-aligned figure — hard to scan horizontally.

**Root cause:** each row is a `.hitem` flex row containing a global `.spacer { flex:1 }` (`style.css:1516`) that pushes the label hard-left and the figure hard-right.

**Fix (CSS-only, `style.css`):** scope the spacer off for `.inv-data` rows, anchor the label+value pair to the right (`justify-content:flex-end`), and column-align the figures (`min-width:84px; text-align:right`). Now reads like a compact receipt/ledger.

## Proof / verification
- All 3 gates green: `node ci/smoke.mjs`, `node ci/logic-test.mjs`, `node ci/gen-rule-usage.mjs --check`.
- No markup, §5 builders, or `data-r` stamps changed → no `rule-usage.js` regeneration needed.
- Does **not** touch money / card / auth / WO-completion logic.
- Verified in a real browser (Playwright) against `style.css` with the exact invoices-renderer markup (`app.js:3777-3814`).

**Before** — wide gap:

label ⟶ (full width) ⟶ figure

**After** — compact ledger: `Subtotal  $1,805`, label sits just left of its right-aligned, column-aligned amount.

Design language: reuses existing tokens + the 8px spacing step; no new colors/components (jactec-ui clean).

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)