### PR TITLE
Wrangler fix: minimize option for the Mr. Wrangler dock

### DIFF
--- a/app.js
+++ b/app.js
@@ -1186,7 +1186,7 @@ const state = {
   filterTerms: [],            // §5.4 — AND-narrowing filter terms (type + Enter)
   unitPick: null,             // { ids, from } — Invoice +WO narrows the Units list to the invoice's linked units (Phase 4)
   chat: { open: false, activeId: null, draft: '', chats: [] },   // §17 internal team dock (Phase 7): PERSISTENT chats (never deleted). Each = { id, tags, participants, messages, seen{userKey:lastViewedAt} }. Empty participants = dormant; reopen via a tagged element.
-  wrangler: { open: false, messages: [], busy: false, error: '', draft: '', attach: [], card: null, recId: null, recType: null, reqNumber: null, reqTitle: null, reqUrl: null },   // §18 Mr. Wrangler dock — survives minimize, restores conversation on reopen
+  wrangler: { open: false, min: false, messages: [], busy: false, error: '', draft: '', attach: [], card: null, recId: null, recType: null, reqNumber: null, reqTitle: null, reqUrl: null },   // §18 Mr. Wrangler dock — min collapses it to the header bar; survives minimize, restores conversation on reopen
   mobileCol: 0,               // §M1 — which column the phone shows (0 Yard · 1 Rentals · 2 Customers); drives swipe position + the per-column bottom strip
   woPartForm: null,           // woId whose "+ Add Part/Labor" inline form is open
   invLineForm: null,          // invoiceId whose "+ Add Custom" inline form is open
@@ -4917,7 +4917,8 @@ function wranglerDockEl() {
       <span class="wr-dock-title">Mr. Wrangler</span>
       ${chip}
       <span class="spacer"></span>
-      <button class="iconbtn js-wr-close" aria-label="Minimize" data-tip="Minimize">×</button>
+      <button class="iconbtn js-wr-min" aria-label="${o.min ? 'Expand' : 'Minimize'}" data-tip="${o.min ? 'Expand' : 'Minimize'}">${I.chev}</button>
+      <button class="iconbtn js-wr-close" aria-label="Close" data-tip="Close">×</button>
     </div>
     ${reqBar}
     <div class="wr-feed">${turns}${o.busy ? '<div class="wr-msg assistant"><span class="wr-av">🤠</span><div class="wr-bub wr-think">…wrangling an answer</div></div>' : ''}</div>
@@ -4939,6 +4940,7 @@ function mountWranglerDock() {
 function openWranglerDock(opts) {
   const w = state.wrangler;
   w.open = true;
+  w.min = false;   // an explicit open always expands the dock
   if (opts.messages !== undefined) w.messages = opts.messages;
   if (opts.busy !== undefined) w.busy = opts.busy; else w.busy = false;
   if (opts.error !== undefined) w.error = opts.error; else w.error = '';
@@ -7341,7 +7343,7 @@ function render() {
   // §17 — the internal team dock floats bottom-right above the bar when open
   if (state.chat.open) { const d = el('div', 'chat-dock', ''); d.dataset.drop = 'chat'; d.innerHTML = chatDockEl(); $('#app').appendChild(d); }
   // §18 — Mr. Wrangler dock floats alongside the team chat (or alone at bottom-right)
-  if (state.wrangler.open) { const d = el('div', 'wrangler-dock' + (state.chat.open ? ' wr-beside-chat' : '')); d.innerHTML = wranglerDockEl(); $('#app').appendChild(d); }
+  if (state.wrangler.open) { const d = el('div', 'wrangler-dock' + (state.chat.open ? ' wr-beside-chat' : '') + (state.wrangler.min ? ' wr-min' : '')); d.innerHTML = wranglerDockEl(); $('#app').appendChild(d); }
   // §18e — floating bottom-right cluster: notification bell + the Requests inbox.
   // Hidden while a dock owns that corner.
   if (!state.chat.open && !state.wrangler.open) $('#app').appendChild(fabStackEl());
@@ -7986,7 +7988,8 @@ function onClick(e) {
   if (closest('.js-cmt-save')) { e.stopPropagation(); return saveCommentOverlay(); }
   if (closest('.js-fb-send')) { e.stopPropagation(); return sendFeedback(); }
   if (closest('.js-wr-send')) { e.stopPropagation(); return wranglerSend(); }   // §18 Mr. Wrangler
-  if (closest('.js-wr-close')) { e.stopPropagation(); state.wrangler.open = false; return render(); }   // §18 minimize the wrangler dock
+  if (closest('.js-wr-min')) { e.stopPropagation(); state.wrangler.min = !state.wrangler.min; return render(); }   // §18 collapse/expand the wrangler dock to its header bar, in place
+  if (closest('.js-wr-close')) { e.stopPropagation(); state.wrangler.open = false; return render(); }   // §18 close the wrangler dock back to the launcher (conversation is preserved)
   if (closest('.js-wr-act')) { e.stopPropagation(); return wranglerFileAction(Number(closest('.js-wr-act').dataset.mi)); }   // §18d file the fix/request Mr. Wrangler proposed inline
   if (closest('.js-wr-apply')) { e.stopPropagation(); const o = state.wrangler; if (!o.open) return; const m = o.messages[Number(closest('.js-wr-apply').dataset.mi)]; if (!m || !m.action || m.filed) return; const plan = m.action._plan || wrValidatePlan(m.action); if (!plan.ops.length) return; m.filed = true; applyWranglerData(plan); return; }   // Mr. Wrangler applies the previewed add/update/import
   if (closest('.js-wr-unattach')) { e.stopPropagation(); const o = state.wrangler; if (o.open && o.attach) { o.attach.splice(Number(closest('.js-wr-unattach').dataset.i), 1); render(); } return; }   // §18d drop a pending image attachment

--- a/style.css
+++ b/style.css
@@ -1082,6 +1082,13 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wrangler-dock .wr-feed { flex: 1 1 auto; overflow-y: auto; min-height: 80px; }
 .wrangler-dock .wr-compose { flex: 0 0 auto; }
 .wrangler-dock.wr-drag { outline: 2px dashed var(--accent); outline-offset: -4px; }
+/* Minimized → collapse to just the header bar so it stops blocking content; one click on the chevron restores it. */
+.wrangler-dock.wr-min { max-height: none; }
+.wrangler-dock.wr-min > :not(.wr-dock-head) { display: none; }
+.wrangler-dock.wr-min .wr-dock-head { border-bottom: 0; }
+.js-wr-min .chev { transition: transform .12s; }
+.wrangler-dock.wr-min .js-wr-min .chev { transform: rotate(180deg); }   /* chevron flips up = expand */
+@media (prefers-reduced-motion: reduce) { .js-wr-min .chev { transition: none; } }
 @media (max-width: 760px) { .wrangler-dock { right: 8px; left: 8px; width: auto; bottom: 56px; max-height: 76vh; } .wrangler-dock.wr-beside-chat { right: 8px; } }
 
 /* §6.2 #11 inline edit */


### PR DESCRIPTION
## What
Adds a real **minimize** to the Mr. Wrangler (cowboy) dock — the in-app reported request in #42 ("minimize or reposition the cowboy popup so it doesn't block content"), approved in-app by the Owner.

The user landed on *"or minimize it"* and Mr. Wrangler agreed a minimize would be cleaner than repositioning — so this implements **collapse-in-place**, not drag.

## Behavior
- A new header **chevron** collapses the dock down to just its stamped header bar (🤠 MR. WRANGLER), so it stops blocking content. The chevron flips **up** to restore. Conversation, record context chip, and position are all preserved.
- The `×` is now a plain **Close** (back to the launcher, conversation preserved). Previously the single `×` was labeled "Minimize" but actually closed — the two affordances were conflated.

## Root cause / gap
There was no way to tuck the panel aside without fully dismissing it; the only control was the `×` (close-to-launcher) mislabeled "Minimize".

## How
- `state.wrangler.min` toggles a `wr-min` class on `.wrangler-dock`; CSS hides every non-header child and drops the header's bottom border so it reads as a slim bar.
- Token-only CSS → themes (dark/light/ranch) for free; no new color literals.
- New button is a plain `iconbtn` matching the sibling close button — **not** in the R0 flash-lint family (`.pill/.add-field/.flag/...`), so no `data-r` stamp needed and `rule-usage.js` is unchanged.
- No money / card / auth / WO-completion logic touched.

## Verified
- Gates: `node ci/smoke.mjs` ✅ · `node ci/logic-test.mjs` (48/48) ✅ · `node ci/gen-rule-usage.mjs --check` ✅
- Real browser (#local): expanded 400×266 → minimized 400×56 (header only), same bottom-right anchor, feed hidden, aria + chevron toggle Minimize↔Expand, restore works.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)