### PR TITLE
Wrangler fix: category click during a rental window jumps to Units filtered by availability

### DIFF
--- a/app.js
+++ b/app.js
@@ -1330,6 +1330,15 @@ function openStandard(card, recId, recType) {
   pushCardHistory(cs);       // Task 1 — record the prior (list) view so Back can return
   cs.mode = 'standard'; cs.recId = recId; cs.recType = recType || null; cs.graphView = false;   // opening a record exits the in-column graph view
   ackComments(recOf(entityCardOf(card, recType), recId));   // viewing = acknowledged (Phase 6)
+  // §10 + #54 — opening a Category while the rental-window picker is live (a window's
+  // picked, so availWin is set) pivots the left column to Units, pre-filled with the
+  // category name so Units narrows to that category's window-available units (the
+  // 'available' chip is already pinned by enterAvailabilitySearch). The category stays
+  // in standard mode, so it remains the calendar's availability subject (greyed days).
+  if (card === 'categories' && state.winpicker && availWin) {
+    const cat = IDX.category.get(recId), s = activeSession(), us = s.cards.units;
+    if (cat && us) { us.search = cat.name; us.listLimit = undefined; if (s.cols && s.cols.left) s.cols.left = 'units'; }
+  }
   render();
 }
 /** Universal pill rule (§0.2): clicking any pill forces its target card into
@@ -10017,6 +10026,9 @@ function exitAvailabilitySearch() {
     cs.filterTerms = (cs.filterTerms || []).filter((t) => !/^(?:un)?available$/i.test(t.t));
     if (/^available$/i.test((cs.search || '').trim())) cs.search = '';   // legacy plain-text form
   });
+  // #54 — drop the category-name seed the picker shortcut pushed onto Units
+  const us = s.cards.units, seed = (us && us.search || '').trim().toLowerCase();
+  if (seed && DATA.categories.some((c) => (c.name || '').toLowerCase() === seed)) us.search = '';
 }
 function winPickDay(iso) {
   const wp = state.winpicker; if (!wp) return;


### PR DESCRIPTION
## Report
[#54](https://github.com/operations-jacrentals/rental-wrangler/issues/54) (`wrangler-fix`): with a Rental Window open, clicking a category should send you to the **Units** card with the search pre-filled to that category and the list filtered to the units **available during the window's dates**.

## Verdict — built (greenlit `wrangler-fix`)
The pieces already existed; only the category→Units shortcut was missing:
- `enterAvailabilitySearch()` already pins an **`available`** chip on the Units card and sets `availWin` when a window is picked (app.js).
- A unit's search blob already contains its **category name** (app.js:406), and `blobMatches` is a whole-query substring match (app.js:1526) — so seeding the Units search with the category name precisely narrows to that category.
- `rowMatches` ANDs the `available` term (routed through `availWin`) with the text query → **available units of that category** (app.js:1541-1566).

## What changed (12 lines, app.js)
- **`openStandard`** — when a Category is opened while the picker is live (`state.winpicker && availWin`): set the Units card search to the category name, reset its list limit, and flip `cols.left` to **units**. The category stays in `standard` mode, so it remains the **§10 calendar availability subject** (greyed unbookable days) — purely additive, nothing existing is removed.
- **`exitAvailabilitySearch`** — clear the seeded category-name search so Units resets when the window closes.

Units and Categories share the left column (config.js:279), so "navigate to the Units card" = flipping `cols.left`. `winPickSubject()` reads card *state*, not the visible column, so the §10 subject survives the pivot.

## Verification (Playwright, `#local` demo)
Reserved rental, window 2026-06-17→06-22, click category **Light Tower** (2 units: Beacon, Lumen):
- left column → **units**; Units search input shows **"Light Tower"**; `available` chip pinned.
- rendered list shows **only Beacon** — Lumen is booked in that window, correctly filtered out.
- categories card stays `standard` (calendar subject preserved); seed clears on window close.

Gates: `ci/smoke.mjs`, `ci/logic-test.mjs`, `ci/gen-rule-usage.mjs --check` all green. No new UI markup → no rule-usage drift.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)