### PR TITLE
Wrangler fix: activity-log date no longer orphans above the text

### DIFF
--- a/style.css
+++ b/style.css
@@ -1983,6 +1983,12 @@ body { font-variant-numeric: tabular-nums; }
 .act-col-lbl { font-size: 13px; font-weight: 700; line-height: 1; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); padding-bottom: 7px; white-space: nowrap; }
 .act-cols { display: flex; gap: 14px; align-items: flex-start; }
 .act-col { flex: 1; min-width: 0; }
+/* Mr. Wrangler #129: keep each activity row's date in its gutter and let ONLY the
+   text wrap. The shared .hitem flex-wrap orphaned a long entry's date onto its own
+   line above the text (the longest entry — often the first — broke first); pin the
+   row to one line and wrap the text within its own cell instead. */
+.act-col .hitem { flex-wrap: nowrap; align-items: baseline; }
+.act-col .hitem > span:not(.htime) { flex: 1 1 auto; min-width: 0; }
 /* Rented categories — R9 flags wrapping right (Jac 2026-06-12) */
 .rented-cats { display: flex; align-items: baseline; gap: 8px; width: 100%; justify-content: flex-end; margin-top: 2px; }
 .rented-cats .rc-flags { display: flex; flex-wrap: wrap; gap: 4px 10px; justify-content: flex-end; }


### PR DESCRIPTION
## The glitch (#129)
On a customer's activity log, the first entry's date label rendered on its own
line **above** the text, orphaned from the entry, while every other entry showed
date + text together. Reported on Justin Youngblood (customers:C0003), first entry
"Called about grapple", Admin / list view / 1536×776.

## Proof
`.act-col .hitem` inherited the shared `.hitem` rule `flex-wrap: wrap`
(style.css:1166) together with `.htime { min-width: 92px }` (style.css:1167).
When an entry's text is long relative to the anchored card's column width, the
flex line wraps and the text drops **below** the 92px date gutter — orphaning the
date on its own line. The **longest** entry breaks first; in the report that was
the first one. Shorter entries stayed on one row, so only the first looked broken.

Reproduced in a real browser (Playwright, `#local` seed): at column width ~205px
**only** "Called about grapple" wrapped while the shorter entries stayed put —
matching the report exactly. After the fix, no entry wraps the date at any width.

## The fix (minimal, scoped)
Scoped to the activity columns only so history / invoice-ledger / WO-line
`.hitem` rows keep their existing wrap behavior:

```css
.act-col .hitem { flex-wrap: nowrap; align-items: baseline; }
.act-col .hitem > span:not(.htime) { flex: 1 1 auto; min-width: 0; }
```

The date stays pinned in its gutter aligned to the first line; only the text
wraps, within its own cell.

## Gates
- `node ci/smoke.mjs` ✅
- `node ci/logic-test.mjs` ✅ (56/56)
- `node ci/gen-rule-usage.mjs --check` ✅ (no rule-usage change — CSS only)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)