### PR TITLE
Dispatch rail: keep it open while dragging + keep the moved stop trackable

### DIFF
--- a/app.js
+++ b/app.js
@@ -5119,6 +5119,7 @@ function fmtClock(t) { const mn = timeToMin(t); if (mn == null) return '—:—'
 function dispatchFocusStop(stopId) {
   const day = state.dispatchDay || TODAY_ISO;
   const s = dispatchDayStops(day).find((x) => x.id === stopId); if (!s) return;
+  state.dispFocusId = stopId;   // remember the focused stop so the highlight survives a re-render
   const pos = (s.pin && Number.isFinite(s.pin.lat)) ? s.pin : _dispGeo[s.addr];
   if (_dispMap && pos) { _dispMap.panTo(pos); if (_dispMap.getZoom() < 14) _dispMap.setZoom(14); }
   document.querySelectorAll('.disp-tok.focus').forEach((n) => n.classList.remove('focus'));
@@ -5152,7 +5153,7 @@ function dispatchGridBody() {
     const kind = dispatchKind(s);
     const done = stopDone(s), isNext = s.id === nextId;
     const flag = done ? badge('Done', 'green') : (isNext ? `<span class="dt-next">${I.truck} Next</span>` : '');
-    return `<div class="disp-tok js-disp-tok kind-${kind}${done ? ' done' : ''}${isNext ? ' next' : ''}${s.pin ? '' : ' nopin'}" draggable="true" data-id="${esc(s.id)}" data-rec="${esc(s.rentalId)}" data-unit="${esc(s.unitId || '')}">
+    return `<div class="disp-tok js-disp-tok kind-${kind}${done ? ' done' : ''}${isNext ? ' next' : ''}${s.id === state.dispFocusId ? ' focus' : ''}${s.pin ? '' : ' nopin'}" draggable="true" data-id="${esc(s.id)}" data-rec="${esc(s.rentalId)}" data-unit="${esc(s.unitId || '')}">
       <div class="dt-rail"><span class="dt-dot"></span><b class="dt-mini">${timeToMin(s.time) != null ? esc(fmtClock(s.time)) : '—'}</b></div>
       <div class="dt-full">
         <div class="dt-r1"><span class="dt-grip" data-tip="Drag to reorder · or type a time">⠿</span><input class="dt-time js-disp-time" data-id="${esc(s.id)}" value="${esc(s.time || '')}" placeholder="—:—" maxlength="8" aria-label="Stop time" data-tip="Set the stop time — reorders the run" /><span class="spacer"></span>${flag}</div>
@@ -10664,7 +10665,7 @@ function boot() {
   // §2.3 dispatch route reorder — native drag, self-contained (re-render only on drop,
   // so the grid's custom pointer engine isn't involved). Reorders the day's run.
   let dispDragId = null;   // §2.3 cockpit rail: drag a stop token up/down to set the run order (overrides time-sort)
-  document.addEventListener('dragstart', (e) => { const s = e.target.closest && e.target.closest('.js-disp-tok'); if (s) { dispDragId = s.dataset.id; if (e.dataTransfer) { e.dataTransfer.effectAllowed = 'move'; try { e.dataTransfer.setData('text/plain', s.dataset.id); } catch (x) {} } s.classList.add('disp-dragging'); } });
+  document.addEventListener('dragstart', (e) => { const s = e.target.closest && e.target.closest('.js-disp-tok'); if (s) { dispDragId = s.dataset.id; if (e.dataTransfer) { e.dataTransfer.effectAllowed = 'move'; try { e.dataTransfer.setData('text/plain', s.dataset.id); } catch (x) {} } s.classList.add('disp-dragging'); const rail = s.closest('.disprail'); if (rail) rail.classList.add('dragging'); } });   // pin the rail OPEN for the whole drag (hover is lost mid-drag)
   document.addEventListener('dragover', (e) => { if (dispDragId && e.target.closest && e.target.closest('.disprail')) e.preventDefault(); });
   document.addEventListener('drop', (e) => {
     const rail = e.target.closest && e.target.closest('.disprail'); if (!dispDragId || !rail) return; e.preventDefault();
@@ -10674,9 +10675,9 @@ function boot() {
     const to = over && over.dataset.id !== dispDragId ? ids.indexOf(over.dataset.id) : ids.length;
     ids.splice(to < 0 ? ids.length : to, 0, dispDragId);
     const ord = dispatchOrderLS(); ord[rail.dataset.day] = ids; _lsSave('jactec.dispatchOrder', ord);
-    dispDragId = null; render();
+    state.dispFocusId = dispDragId; dispDragId = null; render();   // keep the moved stop highlighted so it stays trackable after the reorder
   });
-  document.addEventListener('dragend', () => { dispDragId = null; document.querySelectorAll('.disp-dragging').forEach((n) => n.classList.remove('disp-dragging')); });
+  document.addEventListener('dragend', () => { dispDragId = null; document.querySelectorAll('.disp-dragging').forEach((n) => n.classList.remove('disp-dragging')); document.querySelectorAll('.disprail.dragging').forEach((n) => n.classList.remove('dragging')); });
   // §2.3 route arrows — keyboard parity: Enter/Space arms or lands a leg; Escape cancels the draw.
   document.addEventListener('keydown', (e) => {
     const pt = e.target.closest && e.target.closest('.js-disp-arrowpt');

--- a/style.css
+++ b/style.css
@@ -488,7 +488,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* the rail floats over the map's right edge: a minimal time strip that widens on hover/focus */
 .disprail { position: absolute; top: 8px; right: 8px; bottom: 8px; width: 90px; z-index: 3; display: flex; flex-direction: column;
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; overflow: hidden; box-shadow: var(--chip-shadow); transition: width .16s ease, box-shadow .16s ease; }
-.disprail:hover, .disprail:focus-within { width: 256px; box-shadow: var(--shadow); }
+.disprail:hover, .disprail:focus-within, .disprail.dragging { width: 256px; box-shadow: var(--shadow); }   /* .dragging pins it open while reordering (hover drops mid-drag) */
+.disprail.dragging .dr-chev { transform: rotate(180deg); }
+.disprail.dragging .dr-title { opacity: 1; }
+.disprail.dragging .dr-sec { display: block; }
+.disprail.dragging .dt-rail { display: none; }
+.disprail.dragging .dt-full { display: block; }
 .dr-head { display: flex; align-items: center; gap: 6px; padding: 7px 9px; border-bottom: 1px solid var(--line); flex: 0 0 auto; }
 .dr-chev { color: var(--txt-3); font-size: 13px; flex: 0 0 auto; transition: transform .16s ease; }
 .disprail:hover .dr-chev, .disprail:focus-within .dr-chev { transform: rotate(180deg); }


### PR DESCRIPTION
Two issues from reordering:
1. The rail collapsed mid-drag (expand is hover/focus-based, and hover drops during a native drag). dragstart now pins .disprail.dragging (drives the same expanded state as :hover), removed on dragend. No render fires mid-drag, so it stays open.
2. After a reorder the row colors shifted (the next/orange marker recomputes) and the moved stop was hard to follow. The drop sets dispFocusId to the moved stop and it renders with the .focus ring (the #18b6ff you-are-here blue), so it stays marked. A tap focuses it too.

Gates green: smoke, logic 48/48, rule-usage.