### PR TITLE
Cache-busting: version-stamp app.js / style.css / rule-usage.js per deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,12 @@ Reference implementations: `.login-*` and `.cancel-arc` blocks in `style.css`.
   Also develop on the session's feature branch and open a **draft PR**.
 - **Gates (must pass before push):** `node ci/smoke.mjs`,
   `node ci/logic-test.mjs`, `node ci/gen-rule-usage.mjs --check`.
+- **Cache-bust on every deploy:** bump the `?v=` token on `style.css`, `rule-usage.js`,
+  and `app.js` in `index.html` (one shared token) so a release loads immediately —
+  Pages serves `max-age=600` with no per-file hashing, so without this a phone/desktop
+  keeps the stale cached files. Don't add `?v=` to the ES-module imports inside `app.js`
+  (relative imports drop the query → a sub-module loaded both versioned and unversioned
+  would instantiate twice); the module graph revalidates within the 10-min window.
 - **R-rulebook:** UI is stamped with `data-r="Rxx"`; `rule-usage.js` is generated
   by `ci/gen-rule-usage.mjs` (has a `--check` drift guard + duplicate-rule guard).
   Regenerate (drop `--check`) when rule usage changes.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
   <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%23ff7a18'/%3E%3Ctext%20x='16'%20y='23'%20font-size='19'%20font-family='sans-serif'%20font-weight='700'%20text-anchor='middle'%20fill='%231a1205'%3EJ%3C/text%3E%3C/svg%3E" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Saira+Condensed:wght@600;700;800&family=Zilla+Slab:wght@500;600;700&family=Rye&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="style.css" />
+  <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
+       desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
+       sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
+  <link rel="stylesheet" href="style.css?v=20260618b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -19,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js"></script>
-  <script type="module" src="app.js"></script>
+  <script src="rule-usage.js?v=20260618b"></script>
+  <script type="module" src="app.js?v=20260618b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Why
After merging the mobile pass, the live site kept showing the **old** UI on a phone even after closing/reopening the app. The live server was confirmed serving the new code — the browser was holding a **cached** `app.js`/`style.css`. GitHub Pages serves every file with `cache-control: max-age=600` and no per-file content hashing, so there's nothing in the URL to tell the browser the file changed.

## Fix
Add a shared `?v=` token to the three top-level entry points in `index.html` (`style.css`, `rule-usage.js`, `app.js`), bumped on **every deploy**. A new release then loads immediately on desktop **and** mobile instead of serving stale cached assets. `CLAUDE.md` → Deploy & gates now requires the bump.

## Deliberately NOT versioning the module imports
`app.js`'s ES-module imports (`data.js`, `config.js`, `cascade.js`, `service-countdown.js`, `agreements.js`) are left unversioned **on purpose**: relative imports don't inherit the query string, so a sub-module imported both as `?v=X` (from `app.js`) and unversioned (transitively from another module) would resolve to two different URLs and **instantiate twice** as two separate module instances — a real bug. Leaving the graph unversioned keeps it consistent; it revalidates within the 10-min window. All UI changes live in `app.js`/`style.css`, which now bust immediately.

## Note
GitHub Pages also caches `index.html` itself at `max-age=600`, so the *new* `index.html` (carrying the bumped token) is picked up within ~10 min of a deploy; after that, assets are guaranteed fresh and matched. A one-time cache clear / private-tab load is still needed to get past the **currently** cached `index.html` from before this change.

## Gates
- `node ci/smoke.mjs` ✅ · `node ci/logic-test.mjs` 56/56 ✅ · `node ci/gen-rule-usage.mjs --check` ✅
- Verified locally: all three versioned assets return `200` and the app boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uXwJpKXQnovj1n3TkN4ZK

---
_Generated by [Claude Code](https://claude.ai/code/session_017uXwJpKXQnovj1n3TkN4ZK)_