### PR TITLE
Tier 2 work surfaces: board/boardview header rail

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260618c" />
+  <link rel="stylesheet" href="style.css?v=20260618d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260618c"></script>
-  <script type="module" src="app.js?v=20260618c"></script>
+  <script src="rule-usage.js?v=20260618d"></script>
+  <script type="module" src="app.js?v=20260618d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1313,6 +1313,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* back-office board popups (§0.4 / §7.9–7.12) — simple spreadsheet */
 .board-popup { width: 86vw; height: 80vh; }
 .board-popup .popup-head .c-count { font-size: 11px; font-weight: 700; color: var(--txt-3); background: var(--panel-2); padding: 1px 8px; border-radius: 999px; }
+/* ── Tier 2 WORK SURFACE (board / boardview) — riveted header rail + 2px orange baseline,
+   NO hazard cap: calmer than a dialog because you work IN these, not dismiss them ── */
+.board-popup { border-color: var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.45); }
+.board-popup .popup-head { position: relative; background: linear-gradient(180deg, var(--panel-2), var(--panel)); border-bottom: 2px solid var(--accent); }
+.board-popup .popup-head::before, .board-popup .popup-head::after { content: ''; position: absolute; top: 11px; width: 6px; height: 6px; border-radius: 50%; z-index: 1; pointer-events: none; background: radial-gradient(circle at 35% 30%, #434c58, #0f1318); box-shadow: inset 0 0 0 1px rgba(0,0,0,.55); }
+.board-popup .popup-head::before { left: 9px; } .board-popup .popup-head::after { right: 9px; }
 .board-body { padding: 0; overflow: auto; }
 
 /* §13.3 Card Graph view — data-plate analytics (Phase 4) */


### PR DESCRIPTION
Board + boardview get the Tier 2 work-surface treatment: lighter-steel riveted header rail + 2px orange baseline, orange halo dropped. No hazard cap (reserved for dialogs). Part of the popup-tiers series.