### PR TITLE
Fix: gate-timeline dropdown stretched to full viewport width

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260618g" />
+  <link rel="stylesheet" href="style.css?v=20260618h" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260618g"></script>
-  <script type="module" src="app.js?v=20260618g"></script>
+  <script src="rule-usage.js?v=20260618h"></script>
+  <script type="module" src="app.js?v=20260618h"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -710,7 +710,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .dropdown-menu .dd-item .x:hover { opacity: 1; color: var(--red); }
 /* ── Gate TIMELINE dropdown (the four ordered status gates) — steel panel + vertical
    hazard rail, NO orange halo (that stays for dialogs); monochrome progress states ── */
-.dropdown-menu.gt { min-width: 234px; padding: 0; overflow: hidden; position: relative; border: 1px solid var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); }
+.dropdown-menu.gt { width: 244px; min-width: 234px; max-width: 92vw; padding: 0; overflow: hidden; position: relative; border: 1px solid var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); }   /* explicit width: the width:100% rows otherwise stretch this fixed box to the full viewport */
 .gt-haz { position: absolute; left: 0; top: 0; bottom: 0; width: 7px; background: repeating-linear-gradient(180deg, var(--yellow) 0 11px, #14181d 11px 22px); }
 .gt-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 10px; color: var(--txt-3); padding: 10px 12px 4px 20px; }
 .gt-body { padding: 2px 10px 9px 18px; }


### PR DESCRIPTION
The gate-timeline dropdown (.dropdown-menu.gt) had no explicit width, so its width:100% rows stretched the fixed element to the full viewport — status/funnel/WO-phase pills opened a screen-wide box with content at the far-left edge, reading as 'nothing opens'. Sets width:244px (max 92vw). Regression from #141.