### PR TITLE
Fix: gate dropdowns opened far below the viewport (hard-clamp on-screen)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7302,12 +7302,23 @@ function openDropdown(anchorEl, html, { align = 'left', cls = '' } = {}) {
   dd._anchor = anchorEl;
   document.body.appendChild(dd);
   const rect = anchorEl.getBoundingClientRect();
-  const w = dd.offsetWidth || 180, h = dd.offsetHeight || 100;
-  let left = align === 'right' ? rect.right - w : rect.left;
-  left = Math.max(8, Math.min(left, window.innerWidth - w - 8));
-  let top = rect.bottom + 5;
-  if (top + h > window.innerHeight - 8) top = Math.max(8, rect.top - h - 5);
-  dd.style.left = left + 'px'; dd.style.top = top + 'px';
+  // Keep the menu fully on-screen. A tall menu (the 8-stage gate timeline) anchored
+  // low could otherwise spill far below the fold — flipping ALONE isn't enough, so we
+  // cap the height to the viewport and HARD-CLAMP top/left to both edges. Re-placed on
+  // the next frame because offsetHeight can grow after the first paint (fonts/icons).
+  dd.style.maxHeight = (window.innerHeight - 16) + 'px';
+  dd.style.overflowY = 'auto';
+  const place = () => {
+    const w = dd.offsetWidth || 180, h = dd.offsetHeight || 100;
+    let left = align === 'right' ? rect.right - w : rect.left;
+    left = Math.max(8, Math.min(left, window.innerWidth - w - 8));
+    let top = rect.bottom + 5;
+    if (top + h > window.innerHeight - 8) top = rect.top - h - 5;           // prefer flipping above the anchor
+    top = Math.max(8, Math.min(top, window.innerHeight - h - 8));           // …but never spill off either edge
+    dd.style.left = left + 'px'; dd.style.top = top + 'px';
+  };
+  place();
+  requestAnimationFrame(place);
   const off = (e) => { if (!dd.contains(e.target) && !anchorEl.contains(e.target)) { dd.remove(); document.removeEventListener('mousedown', off); } };
   dd._off = off;
   setTimeout(() => document.addEventListener('mousedown', off), 0);

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260618h" />
+  <link rel="stylesheet" href="style.css?v=20260618i" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260618h"></script>
-  <script type="module" src="app.js?v=20260618h"></script>
+  <script src="rule-usage.js?v=20260618i"></script>
+  <script type="module" src="app.js?v=20260618i"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
openDropdown only flipped above the anchor on bottom-overflow; it never hard-clamped, so a tall gate timeline (8 stages) anchored low could land far below the fold — opening off-screen, reading as 'clicking does nothing.' Now caps menu height to the viewport (maxHeight + overflow-y:auto) and hard-clamps top/left to both edges, re-placing on the next frame. Guarantees fully on-screen. Verified worst-case (pill at viewport bottom) now lands on-screen.