### PR TITLE
Re-ship gate timelines, fixed: .dropdown-menu.gt position:fixed (not relative)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7325,10 +7325,11 @@ function openDropdown(anchorEl, html, { align = 'left', cls = '' } = {}) {
   return dd;
 }
 function openStatusDropdown(rentalId, anchorEl) {
-  // Plain list (gate timeline reverted 2026-06-18 — it mispositioned on Jac's live layout; gateTimeline() kept dormant for a future re-ship). Tomorrow/Today are DERIVED display states — excluded.
-  const html = Object.keys(STATUS.rentalStatus).filter((v) => v !== 'Tomorrow' && v !== 'Today').map((v) =>
-    `<button class="dd-item js-setstatus" data-rec="${esc(rentalId)}" data-val="${esc(v)}">${statusPill('rentalStatus', v)}</button>`).join('');
-  openDropdown(anchorEl, html);
+  // progressing timeline; Tomorrow/Today are DERIVED display states excluded by GATE_TL.order
+  const cur = IDX.rental.get(rentalId)?.status || '';
+  const html = gateTimeline('rentalStatus', cur, 'Rental status', (v, inner, sc) =>
+    `<button class="gt-row ${sc} js-setstatus" data-rec="${esc(rentalId)}" data-val="${esc(v)}">${inner}</button>`);
+  openDropdown(anchorEl, html, { cls: 'gt' });
 }
 function openFleetDropdown(unitId, anchorEl) {
   const html = Object.keys(STATUS.unitFleetStatus).map((v) =>
@@ -7358,9 +7359,10 @@ function setExpenseReconcile(expenseId, val) {
 function openFunnelDropdown(custId, which, anchorEl) {
   const cust = IDX.customer.get(custId);
   const cur = which === 'membership' ? cust?.membershipStage : cust?.usedSalesStage;
-  const html = Object.keys(STATUS.funnelStage).map((v) =>
-    `<button class="dd-item js-setfunnel ${v === cur ? 'on' : ''}" data-rec="${esc(custId)}" data-which="${which}" data-val="${esc(v)}">${badge(getStatus('funnelStage', v).label, getStatus('funnelStage', v).color)}</button>`).join('');
-  openDropdown(anchorEl, html);
+  const title = which === 'membership' ? 'Membership funnel' : 'Used sales funnel';
+  const html = gateTimeline('funnelStage', cur || 'N/A', title, (v, inner, sc) =>
+    `<button class="gt-row ${sc} js-setfunnel" data-rec="${esc(custId)}" data-which="${which}" data-val="${esc(v)}">${inner}</button>`);
+  openDropdown(anchorEl, html, { cls: 'gt' });
 }
 function setFunnelStage(custId, which, val) {
   const c = IDX.customer.get(custId);
@@ -8771,9 +8773,11 @@ function removeUnitInvoiceLine(r, unitId) {
   logAction(inv, `${IDX.unit.get(unitId)?.name || unitId} line(s) removed — No Show / Cancel (not billed)`);
 }
 function openUnitStatusDropdown(rentalId, unitId, anchorEl) {
-  const html = Object.keys(STATUS.rentalStatus).filter((v) => v !== 'Tomorrow' && v !== 'Today').map((v) =>
-    `<button class="dd-item js-setunitstatus" data-rec="${esc(rentalId)}" data-unit="${esc(unitId)}" data-val="${esc(v)}">${statusPill('rentalStatus', v)}</button>`).join('');
-  openDropdown(anchorEl, html);
+  const r = IDX.rental.get(rentalId); const eu = r && unitEntry(r, unitId);
+  const cur = eu ? unitStatus(r, eu) : '';
+  const html = gateTimeline('rentalStatus', cur, 'Unit status', (v, inner, sc) =>
+    `<button class="gt-row ${sc} js-setunitstatus" data-rec="${esc(rentalId)}" data-unit="${esc(unitId)}" data-val="${esc(v)}">${inner}</button>`);
+  openDropdown(anchorEl, html, { cls: 'gt' });
 }
 /* §9 Field Call — a unit breaks mid-rental: flag the rental (red FC), fail the unit,
    and auto-open a Field-Call work order so the M.Tech can dispatch parts/swap. */
@@ -10161,9 +10165,11 @@ function setWoLinePhase(woId, idx, val) {
   reanchorRender();
 }
 function openWoPhaseDropdown(woId, anchorEl, lineIdx) {
-  const html = Object.keys(STATUS.woPhase).map((v) =>
-    `<button class="dd-item ${lineIdx == null ? 'js-setwophase' : 'js-setwolinephase'}" data-rec="${esc(woId)}"${lineIdx == null ? '' : ` data-idx="${lineIdx}"`} data-val="${esc(v)}">${statusPill('woPhase', v)}</button>`).join('');
-  openDropdown(anchorEl, html);
+  const w = IDX.wo.get(woId);
+  const cur = lineIdx == null ? (w?.phase || '') : (w?.lineItems?.[lineIdx]?.phase || '');
+  const html = gateTimeline('woPhase', cur, lineIdx == null ? 'Work order phase' : 'Line phase', (v, inner, sc) =>
+    `<button class="gt-row ${sc} ${lineIdx == null ? 'js-setwophase' : 'js-setwolinephase'}" data-rec="${esc(woId)}"${lineIdx == null ? '' : ` data-idx="${lineIdx}"`} data-val="${esc(v)}">${inner}</button>`);
+  openDropdown(anchorEl, html, { cls: 'gt' });
 }
 
 /* ── §12.2 rental-window range picker — a single popup: a time selector above a

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260618j" />
+  <link rel="stylesheet" href="style.css?v=20260618i" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260618j"></script>
-  <script type="module" src="app.js?v=20260618j"></script>
+  <script src="rule-usage.js?v=20260618i"></script>
+  <script type="module" src="app.js?v=20260618i"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260618i" />
+  <link rel="stylesheet" href="style.css?v=20260618k" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260618i"></script>
-  <script type="module" src="app.js?v=20260618i"></script>
+  <script src="rule-usage.js?v=20260618k"></script>
+  <script type="module" src="app.js?v=20260618k"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -710,7 +710,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .dropdown-menu .dd-item .x:hover { opacity: 1; color: var(--red); }
 /* ── Gate TIMELINE dropdown (the four ordered status gates) — steel panel + vertical
    hazard rail, NO orange halo (that stays for dialogs); monochrome progress states ── */
-.dropdown-menu.gt { width: 244px; min-width: 234px; max-width: 92vw; padding: 0; overflow: hidden; position: relative; border: 1px solid var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); }   /* explicit width: the width:100% rows otherwise stretch this fixed box to the full viewport */
+.dropdown-menu.gt { width: 244px; min-width: 234px; max-width: 92vw; padding: 0; overflow: hidden; position: fixed; border: 1px solid var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); }   /* MUST be position:fixed (a fixed box still anchors the absolute rail/connectors). `relative` here overrode the base .dropdown-menu's fixed → openDropdown's top/left measured from page flow, dumping the menu ~1 viewport below the fold (the "opens far below screen" bug). Width is explicit so the width:100% rows don't stretch it to the viewport. */
 .gt-haz { position: absolute; left: 0; top: 0; bottom: 0; width: 7px; background: repeating-linear-gradient(180deg, var(--yellow) 0 11px, #14181d 11px 22px); }
 .gt-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 10px; color: var(--txt-3); padding: 10px 12px 4px 20px; }
 .gt-body { padding: 2px 10px 9px 18px; }


### PR DESCRIPTION
Root cause of the whole 'dropdowns won't open / open far below screen' saga: `.dropdown-menu.gt` was `position: relative`, overriding the base menu's `position: fixed`. openDropdown's top/left then offset from the in-flow position at the bottom of <body>, not the viewport, so the menu rendered ~1 viewport below the fold (off-screen). Only .gt was affected; plain dropdowns (:not(.gt)) stayed fixed and worked (hence Fleet worked, gates didn't). Fix = position:relative→fixed (a fixed box still anchors the absolute rail/connectors). Re-adds the timeline openers (un-reverts #148). Verified rendering at the pill, fully on-screen, at narrow (scroll-snap) AND desktop widths.