### PR TITLE
Card save: surface failures loudly + always land on the signing tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -9936,6 +9936,9 @@ async function saveCardFlow(btn) {
   const errBox = document.getElementById('sl-card-error');
   const setErr = (m) => { if (errBox) errBox.textContent = m || ''; };
   const reset = () => { btn.disabled = false; btn.textContent = 'Save card'; };
+  // Surface failures LOUDLY (a toast), not just in the small card-field box, so a
+  // backend/Stripe error can't silently look like "nothing happened".
+  const fail = (m) => { setErr(m); toast('Card not saved — ' + (m || 'try again.')); reset(); };
   // §7.1b a card saves UNSIGNED — the signature/selfie are captured per-card AFTER
   // saving (the signing tab), so DON'T gate the save on a customer-level signature.
   const live = () => state.overlay === o;   // bail if the overlay changed/closed mid-await
@@ -9943,14 +9946,14 @@ async function saveCardFlow(btn) {
   try {
     const r = await backendCall('stripeSetupIntent', { customerId: c.customerId });
     if (!live()) return;
-    if (!r || !r.ok) { setErr(friendlyPayErr(r)); reset(); return; }
+    if (!r || !r.ok) return fail(friendlyPayErr(r));
     const { setupIntent, error } = await stripe.confirmCardSetup(r.clientSecret, { payment_method: { card: _cardElement, billing_details: { name: c.name || undefined, email: c.email || undefined, phone: c.phone || undefined } } });
     if (!live()) return;
-    if (error) { setErr(error.message); reset(); return; }
-    if (!setupIntent || setupIntent.status !== 'succeeded') { setErr('Card could not be saved — try again.'); reset(); return; }
+    if (error) return fail(error.message);
+    if (!setupIntent || setupIntent.status !== 'succeeded') return fail('Card could not be saved — try again.');
     const s = await backendCall('stripeSaveCard', { customerId: c.customerId, paymentMethodId: setupIntent.payment_method, setupIntentId: setupIntent.id });
     if (!live()) return;
-    if (!s || !s.ok) { setErr(friendlyPayErr(s)); reset(); return; }
+    if (!s || !s.ok) return fail(friendlyPayErr(s));
     c.stripeId = r.stripeId || c.stripeId;
     if (!Array.isArray(c.cards)) c.cards = [];
     const firstCard = customerCards(c).length === 0;
@@ -9964,11 +9967,12 @@ async function saveCardFlow(btn) {
     reindex('customers', c); logAction(c, `Card added — ${brandName(s.card.brand)} ••••${s.card.last4} (unsigned)`);
     destroyCardElement();
     toast('Card saved — sign to authorize ✓');
-    if (sub) { o.cardSub = false; o.tab = newCardId; renderOverlay(); }   // §14 close the card panel, jump to the new card's tab to sign
+    // Land on the new card's SIGNING tab no matter how Add-card was opened.
+    if (sub) { o.cardSub = false; o.tab = newCardId; renderOverlay(); }   // §14 panel beside the form → switch its tab
     else if (o.returnTo === 'payment' && o.invoiceId) openPayInvoice(o.invoiceId);
-    else closeOverlay();
+    else { closeOverlay(); openCustomerForm(c.customerId); if (state.overlay) { state.overlay.tab = newCardId; renderOverlay(); } }   // standalone → open the account form on the signing tab
     render();
-  } catch (e) { setErr('Network error — try again.'); reset(); }
+  } catch (e) { fail('Network error — try again.'); }
 }
 
 // Save ACH: bank SetupIntent (server) → confirmUsBankAccountSetup (browser; raw

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619d" />
+  <link rel="stylesheet" href="style.css?v=20260619e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619d"></script>
-  <script type="module" src="app.js?v=20260619d"></script>
+  <script src="rule-usage.js?v=20260619e"></script>
+  <script type="module" src="app.js?v=20260619e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Follow-up to #162 for the "still not seeing the signing window" report.

The consent-gate removal (#162) is live (confirmed: the new card-panel copy shows), so the save is no longer blocked client-side. But two things could still make it *look* like nothing happens:

1. **Silent failures.** If `stripeSetupIntent` / `confirmCardSetup` / `stripeSaveCard` fails, the only signal was the tiny `#sl-card-error` box — easy to miss, reads as "no signing window appeared." Now every failure **also raises a toast** (`Card not saved — <reason>`), so the real cause (incomplete card entry, backend/Stripe error, network) is visible.
2. **Entry-point routing.** A card added via the **standalone** Add-card overlay closed on success instead of prompting the signature. Now, on success, the flow lands on the new card's **per-card signing tab regardless of entry point** — the side-panel switches its tab (as before), and the standalone overlay opens the account form on that card's signing tab.

This is partly diagnostic: if the underlying issue is a backend/Stripe save failure (not a UI routing bug), the new toast will name it precisely so we can fix that next.

## Verification
`smoke` ✓ · `logic-test` 58/58 ✓ · `gen-rule-usage --check` ✓. (The live Stripe Card Element can't be exercised headlessly, so this couldn't be reproduced end-to-end here — hence the loud-error diagnostic.) Cache-bust → `20260619e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtQi8X8evFiiwkhC9WnL3r)_