### PR TITLE
Mobile polish: full-width search band, uniform control sizes, Tools to top-right, inspections toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -4851,16 +4851,16 @@ function headerEl() {
       <span class="ring-label">${esc(label)}</span>
     </button>`;
   const rings = ROLES.map((role) => roleRing(role.id, role.label, kpiFor(role.id), role.color)).join('');
-  // §M1 — phone-only Tools menu, parked top-right in the header (uses the empty top space;
-  // holds Notifications + Requests + the rest). Hidden on desktop via CSS.
-  const pend = unseenNotifs() + wranglerRequests.length;
-  const toolsTop = `<button class="iconbtn tools-top js-mtools" data-tip="Tools, notifications &amp; requests">${I.sliders || I.menu || '☰'}${pend ? `<span class="bb-badge">${pend > 9 ? '9+' : pend}</span>` : ''}</button>`;
-  // Decluttered top: logo + rings, then the GLOBAL item tabs above the global search.
-  // The action toolbar (New / Dashboard / tools) lives in a bottom bar (bottomBarEl).
+  // §M1 — phone-only TOP TOOLBAR: the full tool set opened up across the top of the screen
+  // (logo + rings stay on their own row above it). Notifications + Requests live here too.
+  const nu = unseenNotifs();
+  const notifBtn = `<button class="iconbtn js-notifications" data-tip="Notifications">${I.bell}${nu ? `<span class="bb-badge">${nu > 9 ? '9+' : nu}</span>` : ''}</button>`;
+  const topBar = `<div class="top-toolbar">${notifBtn}${bottomBarInner()}</div>`;
+  // Decluttered top: logo + rings on one row, the tool bar across the next.
   h.innerHTML = `
     <button class="logo js-logo" aria-label="Jac Rentals"></button>
     <div class="kpis">${rings}</div>
-    ${toolsTop}
+    ${topBar}
     <div class="header-right">
       <div class="hr-top">
         <div class="header-tabs tabstrip">${tabStrip(state.tabs)}</div>
@@ -7672,8 +7672,9 @@ function render() {
   const grid = el('div', 'grid');
   const shown = phone ? [COLUMNS[Math.max(0, Math.min(2, state.mobileCol))]] : COLUMNS;
   for (const col of shown) grid.appendChild(columnEl(col, session));
-  const bottomBar = bottomBarEl();
-  $('#app').replaceChildren(header, grid, bottomBar);
+  // §M1 — desktop keeps the bottom toolbar; on phone the tools open up across the top header instead.
+  if (phone) $('#app').replaceChildren(header, grid);
+  else $('#app').replaceChildren(header, grid, bottomBarEl());
   if (phone) {
     const dock = mobileDockEl();
     $('#app').appendChild(dock);

--- a/app.js
+++ b/app.js
@@ -4851,11 +4851,16 @@ function headerEl() {
       <span class="ring-label">${esc(label)}</span>
     </button>`;
   const rings = ROLES.map((role) => roleRing(role.id, role.label, kpiFor(role.id), role.color)).join('');
+  // §M1 — phone-only Tools menu, parked top-right in the header (uses the empty top space;
+  // holds Notifications + Requests + the rest). Hidden on desktop via CSS.
+  const pend = unseenNotifs() + wranglerRequests.length;
+  const toolsTop = `<button class="iconbtn tools-top js-mtools" data-tip="Tools, notifications &amp; requests">${I.sliders || I.menu || '☰'}${pend ? `<span class="bb-badge">${pend > 9 ? '9+' : pend}</span>` : ''}</button>`;
   // Decluttered top: logo + rings, then the GLOBAL item tabs above the global search.
   // The action toolbar (New / Dashboard / tools) lives in a bottom bar (bottomBarEl).
   h.innerHTML = `
     <button class="logo js-logo" aria-label="Jac Rentals"></button>
     <div class="kpis">${rings}</div>
+    ${toolsTop}
     <div class="header-right">
       <div class="hr-top">
         <div class="header-tabs tabstrip">${tabStrip(state.tabs)}</div>
@@ -4917,9 +4922,9 @@ function currentMobileMember() {
   const s = activeSession();
   return (s.cols && s.cols[colObj.id]) || colObj.default;
 }
-// §M1 — the flat card list the phone switcher offers (the hidden inspections/work-orders
-// live inside the Unit card, so they're not in the switcher). Order = a natural workflow.
-const MOBILE_CARDS = ['units', 'categories', 'serviceOrders', 'rentals', 'calendar', 'customers', 'invoices'];
+// §M1 — the flat card list the phone toggle bar offers. On desktop, inspections + work
+// orders live INSIDE the Unit card (hidden tabs); on phone they get their own toggles too.
+const MOBILE_CARDS = ['units', 'categories', 'inspections', 'serviceOrders', 'workOrders', 'rentals', 'calendar', 'customers', 'invoices'];
 // §M1 — jump straight to a card (flattens the 3-column model on phones): set the column +
 // member, flip the visible column, and show that card's LIST.
 function goToCard(member) {
@@ -4939,10 +4944,8 @@ function mobileDockEl() {
     const on = m === cur;
     return `<button class="mcard-tog${on ? ' on' : ''}" data-gocard="${m}" data-tip="${esc(MEMBER_TITLE[m] || m)}"><span class="mct-ico">${memberIcon(m)}</span>${on ? `<span class="mct-lbl">${esc(MEMBER_TITLE[m] || m)}</span>` : ''}</button>`;
   }).join('');
-  const pend = unseenNotifs() + wranglerRequests.length;   // surface hidden notifications/requests as a badge on the menu
-  const tools = `<button class="iconbtn mdock-act js-mtools" data-tip="Tools, notifications &amp; requests">${I.sliders || I.menu || '☰'}${pend ? `<span class="bb-badge">${pend > 9 ? '9+' : pend}</span>` : ''}</button>`;
   const d = el('div', 'mobile-dock');
-  d.innerHTML = `<div class="mdock-searchslot"></div><div class="mdock-row"><div class="mcard-bar">${togs}</div>${tools}</div>`;
+  d.innerHTML = `<div class="mdock-searchslot"></div><div class="mdock-row"><div class="mcard-bar">${togs}</div></div>`;
   return d;
 }
 /* ════════════════════════════════════════════════════════════════════════

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619e" />
+  <link rel="stylesheet" href="style.css?v=20260619f" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619e"></script>
-  <script type="module" src="app.js?v=20260619e"></script>
+  <script src="rule-usage.js?v=20260619f"></script>
+  <script type="module" src="app.js?v=20260619f"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619d" />
+  <link rel="stylesheet" href="style.css?v=20260619e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619d"></script>
-  <script type="module" src="app.js?v=20260619d"></script>
+  <script src="rule-usage.js?v=20260619e"></script>
+  <script type="module" src="app.js?v=20260619e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -334,15 +334,18 @@ input { font-family: inherit; }
    fit), and the global search wraps to its own full-width row underneath. ── */
 .is-phone .header { flex-wrap: wrap; align-items: center; gap: 6px 8px; padding: 10px 10px 0; }
 .is-phone .logo { width: 58px; height: 58px; }
-.is-phone .kpis { order: 1; flex: 1 1 auto; min-width: 0; display: flex; justify-content: space-around; gap: 2px; }
+.is-phone .kpis { order: 1; flex: 1 1 auto; min-width: 0; display: flex; justify-content: space-around; gap: 2px; }   /* logo + rings share row 1 */
 .is-phone .kpi-ring { min-width: 0; flex: 0 1 auto; padding: 1px 0 0; }
 .is-phone .ring-wrap svg { width: 52px; height: 52px; }
 .is-phone .kpi-ring .ring-label { font-size: 8.5px; letter-spacing: .1px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.is-phone .header { position: relative; }
-.is-phone .header-right { order: 2; flex: 1 1 100%; min-width: 0; }   /* global search on its own full-width row, underneath the rings */
-.is-phone .kpis { padding-right: 48px; }   /* reserve the top-right corner for the Tools button */
-.tools-top { display: none; }   /* the header Tools menu is phone-only */
-.is-phone .tools-top { display: inline-flex; position: absolute; top: 10px; right: 10px; }
+.is-phone .header-right { order: 3; flex: 1 1 100%; min-width: 0; }   /* global search on its own full-width row */
+/* the tool bar opened up ACROSS THE TOP (phone only) — its own full-width row under the rings */
+.top-toolbar { display: none; }
+.is-phone .top-toolbar { order: 2; display: flex; flex: 1 1 100%; align-items: center; justify-content: space-between;
+  gap: 2px; overflow-x: auto; scrollbar-width: none; padding: 4px 0 0; }
+.is-phone .top-toolbar::-webkit-scrollbar { display: none; }
+.is-phone .top-toolbar .iconbtn { flex: 0 0 auto; min-height: 42px; padding: 0 9px; position: relative; }   /* anchor the badge to its button (else it escapes to the screen corner) */
+.is-phone .top-toolbar .bb-sep { display: none; }
 /* bigger Back/Forward jog on phones (the ‹ › card-history control) */
 .is-phone .card-jog { height: 44px; }                                           /* un-clip the 26px container so the bigger jog buttons actually show */
 .is-phone .card-jog .jog-btn { min-width: 46px; min-height: 44px; }

--- a/style.css
+++ b/style.css
@@ -267,13 +267,16 @@ input { font-family: inherit; }
    bar is hidden; each column docks its own strip (Yard→chat · Rentals→tools ·
    Customers→external chats). Swipe (native scroll-snap) moves between columns. */
 .is-phone .bottombar { display: none; }
-.mobile-dock { flex: 0 0 auto; display: flex; flex-direction: column; gap: 6px; border-top: 1px solid var(--line);
-  background: var(--panel); padding: 6px 8px max(6px, env(safe-area-inset-bottom)); touch-action: pan-y; }   /* pan-y lets our pointer swipe own the horizontal */
-/* the card's search/sort row, relocated here from the top of the list (empty in record view) */
+.mobile-dock { flex: 0 0 auto; display: flex; flex-direction: column; gap: 0; border-top: 1px solid var(--line);
+  background: var(--panel); padding: 0 0 max(6px, env(safe-area-inset-bottom)); touch-action: pan-y; }   /* pan-y lets our pointer swipe own the horizontal */
+/* the card's search/sort row, relocated here — a FULL-WIDTH band (edge to edge) */
 .mdock-searchslot:empty { display: none; }
-.mdock-searchslot .listbar { margin: 0; }
+.is-phone .mdock-searchslot .listbar { position: static; margin: 0; padding: 8px; gap: 8px;
+  background: var(--bg-2); border-bottom: 1px solid var(--line); box-shadow: 0 5px 11px -7px rgba(0,0,0,.45); }
+.is-phone .mdock-searchslot .mini-searchwrap { min-height: 44px; }   /* match the graph/sort buttons so the row is one height */
+.is-phone .mdock-searchslot .mini-search { height: 44px; }
 /* the card-toggle BAR: every card as an icon; the selected one expands to icon + label */
-.mdock-row { display: flex; align-items: center; gap: 8px; }
+.mdock-row { display: flex; align-items: center; gap: 8px; padding: 6px 8px; }
 .mcard-bar { display: flex; align-items: center; gap: 3px; flex: 1 1 auto; min-width: 0; overflow-x: auto; scrollbar-width: none;
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; padding: 3px; box-shadow: var(--chip-shadow); }
 .mcard-bar::-webkit-scrollbar { display: none; }
@@ -335,7 +338,11 @@ input { font-family: inherit; }
 .is-phone .kpi-ring { min-width: 0; flex: 0 1 auto; padding: 1px 0 0; }
 .is-phone .ring-wrap svg { width: 52px; height: 52px; }
 .is-phone .kpi-ring .ring-label { font-size: 8.5px; letter-spacing: .1px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.is-phone .header { position: relative; }
 .is-phone .header-right { order: 2; flex: 1 1 100%; min-width: 0; }   /* global search on its own full-width row, underneath the rings */
+.is-phone .kpis { padding-right: 48px; }   /* reserve the top-right corner for the Tools button */
+.tools-top { display: none; }   /* the header Tools menu is phone-only */
+.is-phone .tools-top { display: inline-flex; position: absolute; top: 10px; right: 10px; }
 /* bigger Back/Forward jog on phones (the ‹ › card-history control) */
 .is-phone .card-jog { height: 44px; }                                           /* un-clip the 26px container so the bigger jog buttons actually show */
 .is-phone .card-jog .jog-btn { min-width: 46px; min-height: 44px; }


### PR DESCRIPTION
## Mobile footer/header polish (from Jac's screenshot)
Phone-only follow-ups on the inverted layout; desktop untouched.

| Issue | Fix |
|---|---|
| "Not everything is the same size" | The footer search row's input was 32px next to 44px graph/sort buttons — bumped to **44px** so the row is one uniform height |
| "Shadow behind card search doesn't stretch to width" | The relocated search row is now a **full-width band** (edge to edge, 0..390) — dropped the dock side-padding for it and gave it a solid band + divider |
| "Empty black space at the top… maybe the tools can go up there" | Moved the **Tools menu** (Notifications + Requests + tools) out of the footer to the **top-right of the header**, filling the empty top space; its pending badge rides along. Footer is now just the full-width card-toggle bar |
| "The inspections card toggle is missing" | Added **inspections + work orders** toggles (they were excluded as desktop "hidden tabs") — 9 cards now |

Cache-bust → `20260619e` (main already shipped `d`).

## Verified (390px)
- Search band spans 0..390; input + graph + sort all 44px.
- Tools button top-right, same row as the logo; badge present.
- 9 toggles incl. inspections; tapping inspections navigates.
- No horizontal overflow.

## Gates
`smoke` ✅ · `logic-test` 58/58 ✅ · `gen-rule-usage --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uXwJpKXQnovj1n3TkN4ZK

---
_Generated by [Claude Code](https://claude.ai/code/session_017uXwJpKXQnovj1n3TkN4ZK)_