### PR TITLE
Wrangler fix: persist bulk imports immediately + warn on unsaved unload

### DIFF
--- a/app.js
+++ b/app.js
@@ -6940,6 +6940,10 @@ function applyWranglerData(plan) {
   if (first) { const s = activeSession(); if (s.cols) s.cols.right = 'customers'; const ccs = s.cards.customers; if (created === 1) { ccs.mode = 'standard'; ccs.recId = first; } else { ccs.mode = 'list'; ccs.recId = null; ccs.search = ''; } ccs.graphView = false; }
   render();
   toast(`Mr. Wrangler ${[created ? `added ${created}` : '', updated ? `updated ${updated}` : ''].filter(Boolean).join(' · ') || 'made no changes'}. 🤠`);
+  // A bulk import is a one-shot action the operator immediately closes/reloads after
+  // (to go see the new records) — the 1200ms saveSoon() debounce would never fire and
+  // the in-memory records would be lost. Kick the diff-sync NOW instead of waiting.
+  if (created || updated) flushSave();
 }
 
 // Build the GitHub repro packet from Mr. Wrangler's structured report + the live
@@ -11116,6 +11120,16 @@ async function flushSave() {
   saving = false;
   if (savePending) { savePending = false; saveSoon(); }
 }
+// Safety net: a debounced save that hasn't flushed yet — or a large bulk-import sync
+// still in flight — would be lost silently if the page closes/reloads first (#164).
+// If anything is still un-persisted, kick a final flush and let the browser show its
+// "unsaved changes" prompt so the operator can't drop records without noticing.
+window.addEventListener('beforeunload', (e) => {
+  if (booting || !backendPassword || !lastSaved) return;   // demo/offline: nothing to persist
+  if (!saving && !savePending && !computeChanges().n) return;   // everything's already saved → leave quietly
+  flushSave();
+  e.preventDefault(); e.returnValue = '';
+});
 function renderLogin(msg) {
   $('#app').innerHTML = `<div class="login-screen"><form class="login-box" id="login-form">
     <span class="rivet tl"></span><span class="rivet tr"></span><span class="rivet bl"></span><span class="rivet br"></span>

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -205,9 +205,15 @@ try {
     ok(wrUpd && wrUpd.fields.notes === 'WR test note' && !('currentHours' in wrUpd.fields), 'update keeps allowlisted notes, DROPS currentHours');
     ok(!wrPlan.ops.some((o) => o.entity === 'invoices'), 'invoices edit is REFUSED entirely (never touch money)');
     const custBefore = T.DATA.customers.length; const u3 = T.IDX.unit.get('U003'); const noteBefore = u3.notes, hoursBefore = u3.currentHours;
+    window.JT.snapshotSaved();   // #164 baseline the diff-sync against the CURRENT data
     T.applyWranglerData(wrPlan);
     ok(T.DATA.customers.length === custBefore + 2, 'applyWranglerData added exactly the 2 imported customers');
     ok(T.IDX.unit.get('U003').notes === 'WR test note' && T.IDX.unit.get('U003').currentHours === hoursBefore, 'applied the safe note, did NOT write the money/ops field');
+    // #164 — the bulk import must reach the diff-sync (it was being lost when the page
+    // closed before the 1200ms debounce fired). computeChanges sees the new + updated.
+    const wrDiff = window.JT.computeChanges();
+    ok(wrDiff.upserts.customers && wrDiff.upserts.customers.length >= 2, 'imported customers are QUEUED for the diff-sync (persist, not just in-memory)');
+    ok(wrDiff.upserts.units && wrDiff.upserts.units.some((u) => u.id === 'U003'), 'the applied unit note is queued for persistence too');
     T.DATA.customers.length = custBefore; u3.notes = noteBefore;   // restore
 
     // #152 a big import reply can be TRUNCATED by the model's output limit (no closing ```);

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619d" />
+  <link rel="stylesheet" href="style.css?v=20260619e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619d"></script>
-  <script type="module" src="app.js?v=20260619d"></script>
+  <script src="rule-usage.js?v=20260619e"></script>
+  <script type="module" src="app.js?v=20260619e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What broke (#164)
A 173-row bulk customer import "silently failed" — page closed, no confirmation, records gone.

## Root cause (proven)
`applyWranglerData()` creates the records in memory and relies **only** on the 1200ms-debounced `saveSoon()` (fired via `reindex`/`logAction`) to push them to the backend. There is **no flush on page unload** (verified: no `beforeunload`/`pagehide` handler existed). A bulk import is the one workflow where the operator immediately closes/reloads to "go see the new records" — within that 1200ms window the diff-sync never fired, so the records, which only ever lived in memory, vanished on reload.

`docs/wrangler-pipeline.md:10` promises *"the normal diff-sync persists it"* — that promise breaks for a one-shot bulk action followed by immediate navigation. The apply path itself is correct (the existing logic-test confirms the records are created), so this is purely a **persistence-timing** defect.

## Fix
- `applyWranglerData()` now calls `flushSave()` **immediately** after a bulk apply — the sync starts the instant the operator clicks Apply, not 1200ms later.
- New `beforeunload` safety net: if anything is still un-persisted (debounce pending, or a large sync still in flight), kick a final flush and show the browser's native "unsaved changes" prompt so records can't be dropped silently. Gated on `backendPassword`, so demo/offline (and CI) are unaffected.
- `ci/logic-test.mjs`: new assertions that an applied bulk import is **queued for the diff-sync** (`computeChanges` sees the new customers + the updated unit), not just held in memory.

No money / card / auth / WO-completion logic touched.

## Gates
- `node ci/smoke.mjs` ✅
- `node ci/logic-test.mjs` ✅ (60/60)
- `node ci/gen-rule-usage.mjs --check` ✅
- Cache-bust `?v=` bumped to `20260619e`.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)