### PR TITLE
Mobile: tool rail above logo/rings; remove Work Orders card toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -4980,7 +4980,7 @@ function currentMobileMember() {
 }
 // §M1 — the flat card list the phone toggle bar offers. On desktop, inspections + work
 // orders live INSIDE the Unit card (hidden tabs); on phone they get their own toggles too.
-const MOBILE_CARDS = ['units', 'categories', 'inspections', 'serviceOrders', 'workOrders', 'rentals', 'calendar', 'customers', 'invoices'];
+const MOBILE_CARDS = ['units', 'categories', 'inspections', 'serviceOrders', 'rentals', 'calendar', 'customers', 'invoices'];
 // §M1 — jump straight to a card (flattens the 3-column model on phones): set the column +
 // member, flip the visible column, and show that card's LIST.
 function goToCard(member) {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619i" />
+  <link rel="stylesheet" href="style.css?v=20260619j" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619i"></script>
-  <script type="module" src="app.js?v=20260619i"></script>
+  <script src="rule-usage.js?v=20260619j"></script>
+  <script type="module" src="app.js?v=20260619j"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -333,16 +333,16 @@ input { font-family: inherit; }
 /* ── §M4 — phone header: logo + ALL FIVE KPI rings share the TOP row (rings shrunk to
    fit), and the global search wraps to its own full-width row underneath. ── */
 .is-phone .header { flex-wrap: wrap; align-items: center; gap: 6px 8px; padding: 10px 10px 0; }
-.is-phone .logo { width: 58px; height: 58px; }
-.is-phone .kpis { order: 1; flex: 1 1 auto; min-width: 0; display: flex; justify-content: space-around; gap: 2px; }   /* logo + rings share row 1 */
+.is-phone .logo { width: 58px; height: 58px; order: 1; }
+.is-phone .kpis { order: 1; flex: 1 1 auto; min-width: 0; display: flex; justify-content: space-around; gap: 2px; }   /* logo + rings share a row, below the tool bar */
 .is-phone .kpi-ring { min-width: 0; flex: 0 1 auto; padding: 1px 0 0; }
 .is-phone .ring-wrap svg { width: 52px; height: 52px; }
 .is-phone .kpi-ring .ring-label { font-size: 8.5px; letter-spacing: .1px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.is-phone .header-right { order: 3; flex: 1 1 100%; min-width: 0; }   /* global search on its own full-width row */
-/* the tool bar opened up ACROSS THE TOP (phone only) — its own full-width row under the rings */
+.is-phone .header-right { order: 2; flex: 1 1 100%; min-width: 0; }   /* global search on its own full-width row */
+/* the tool bar ACROSS THE TOP, ABOVE the logo/rings (phone only) — its own full-width row */
 .top-toolbar { display: none; }
-.is-phone .top-toolbar { order: 2; display: flex; flex: 1 1 100%; align-items: center; justify-content: space-between;
-  gap: 2px; overflow-x: auto; scrollbar-width: none; padding: 4px 0 0; }
+.is-phone .top-toolbar { order: 0; display: flex; flex: 1 1 100%; align-items: center; justify-content: space-between;
+  gap: 2px; overflow-x: auto; scrollbar-width: none; padding: 0 0 2px; }
 .is-phone .top-toolbar::-webkit-scrollbar { display: none; }
 .is-phone .top-toolbar .iconbtn { flex: 0 0 auto; min-height: 42px; padding: 0 9px; position: relative; }   /* anchor the badge to its button (else it escapes to the screen corner) */
 .is-phone .top-toolbar .bb-sep { display: none; }


### PR DESCRIPTION
Phone-only (desktop unchanged):
- **Tool rail moved above** the logo/KPI rings — header order is now: tool bar (row 1) → logo + rings (row 2) → global search (row 3).
- **Removed the Work Orders** card-toggle (not a needed tab). Card bar is now 8: units, categories, inspections, service, rentals, calendar, customers, invoices.

Cache-bust → `20260619j` (synced past main #169).

Verified at 390px: toolbar sits above the logo/rings, 8 toggles (no Work Orders), no overflow. Gates: `smoke` ✅ · `logic-test` 60/60 ✅ · `gen-rule-usage --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uXwJpKXQnovj1n3TkN4ZK

---
_Generated by [Claude Code](https://claude.ai/code/session_017uXwJpKXQnovj1n3TkN4ZK)_