### PR TITLE
Wrangler fix: stop card save hanging on 'Saving…' forever

### DIFF
--- a/app.js
+++ b/app.js
@@ -10106,6 +10106,15 @@ function mountCardElement() {
 }
 function destroyCardElement() { if (_cardElement) { try { _cardElement.destroy(); } catch (e) {} } _cardElement = null; _cardElements = null; }
 
+// Reject if a promise hasn't settled in `ms` so a STALLED (never-resolving) backend
+// round-trip can't leave the save button spinning "Saving…" forever with no error.
+// fetch() has no built-in timeout; a hung Apps Script call otherwise never rejects.
+// Only wraps human-free server round-trips — never the interactive 3DS confirm step.
+function withTimeout(promise, ms, label) {
+  let t; const timeout = new Promise((_, rej) => { t = setTimeout(() => { const e = new Error((label || 'Request') + ' timed out'); e.rwTimeout = true; rej(e); }, ms); });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(t));
+}
+
 // Save card: SetupIntent (server) → confirmCardSetup (browser) → persist (server).
 // DOM-driven (no renderOverlay) so the Card Element isn't wiped mid-entry.
 async function saveCardFlow(btn) {
@@ -10124,14 +10133,14 @@ async function saveCardFlow(btn) {
   const live = () => state.overlay === o;   // bail if the overlay changed/closed mid-await
   btn.disabled = true; btn.textContent = 'Saving…'; setErr('');
   try {
-    const r = await backendCall('stripeSetupIntent', { customerId: c.customerId });
+    const r = await withTimeout(backendCall('stripeSetupIntent', { customerId: c.customerId }), 30000, 'Setting up the card');
     if (!live()) return;
     if (!r || !r.ok) return fail(friendlyPayErr(r));
     const { setupIntent, error } = await stripe.confirmCardSetup(r.clientSecret, { payment_method: { card: _cardElement, billing_details: { name: c.name || undefined, email: c.email || undefined, phone: c.phone || undefined } } });
     if (!live()) return;
     if (error) return fail(error.message);
     if (!setupIntent || setupIntent.status !== 'succeeded') return fail('Card could not be saved — try again.');
-    const s = await backendCall('stripeSaveCard', { customerId: c.customerId, paymentMethodId: setupIntent.payment_method, setupIntentId: setupIntent.id });
+    const s = await withTimeout(backendCall('stripeSaveCard', { customerId: c.customerId, paymentMethodId: setupIntent.payment_method, setupIntentId: setupIntent.id }), 30000, 'Saving the card');
     if (!live()) return;
     if (!s || !s.ok) return fail(friendlyPayErr(s));
     c.stripeId = r.stripeId || c.stripeId;
@@ -10158,7 +10167,7 @@ async function saveCardFlow(btn) {
     else if (o.returnTo === 'payment' && o.invoiceId) openPayInvoice(o.invoiceId);
     else { closeOverlay(); openCustomerForm(c.customerId); if (state.overlay) { state.overlay.tab = newCardId; renderOverlay(); } }   // standalone → open the account form on the signing tab
     render();
-  } catch (e) { fail('Network error — try again.'); }
+  } catch (e) { fail(e && e.rwTimeout ? 'Saving timed out — check your connection and try again.' : 'Network error — try again.'); }
 }
 
 // Save ACH: bank SetupIntent (server) → confirmUsBankAccountSetup (browser; raw

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619j" />
+  <link rel="stylesheet" href="style.css?v=20260619k" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619j"></script>
-  <script type="module" src="app.js?v=20260619j"></script>
+  <script src="rule-usage.js?v=20260619k"></script>
+  <script type="module" src="app.js?v=20260619k"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Report
#172 — Card save hangs on 'Saving…' and never completes (label: `wrangler-fix`).

## Verdict — confirmed
The symptom (infinite "Saving…", **no error shown**, **no console error**) can only happen if an awaited promise in `saveCardFlow` never *resolves* — a stall, not a throw. A throw or `{ok:false}` already routes through `fail()` (toast + reset).

**Root cause:** `backendCall()` (`app.js:11148`) uses `fetch()` with **no timeout/abort**, so a hung Google Apps Script round-trip for `stripeSetupIntent` / `stripeSaveCard` leaves the button spinning forever. The `fail()` path fires only on rejection or `{ok:false}`, never on a stall — directly contradicting the flow's own stated intent (`app.js:10119-10120`, commit f4d3763): surface failures *loudly* so "nothing happened" can't be silent.

## Fix (minimal, non-weakening)
- Add a scoped `withTimeout()` helper and wrap the two **human-free backend round-trips** (`stripeSetupIntent`, `stripeSaveCard`) at 30s. On stall it rejects → the existing `catch` → `fail()` → toast + button reset → retry.
- `catch` now distinguishes a timeout ("Saving timed out — check your connection and try again.") from a network error.
- The interactive `stripe.confirmCardSetup` (3DS) step is **left untimed** — it can legitimately wait on a human.

⚠️ Touches the card-on-file flow but **weakens nothing**: no money/card validation or math changed. It only converts a silent infinite spinner into a recoverable, visible error.

## Gates
- `node ci/smoke.mjs` ✅
- `node ci/logic-test.mjs` ✅ (60/60)
- `node ci/gen-rule-usage.mjs --check` ✅ (no markup change)
- Cache-bust token bumped `?v=20260619j` → `k`.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)