### PR TITLE
UI: unify sort chip, full-bleed search strip, rivets on top

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619k" />
+  <link rel="stylesheet" href="style.css?v=20260619l" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619k"></script>
-  <script type="module" src="app.js?v=20260619k"></script>
+  <script src="rule-usage.js?v=20260619l"></script>
+  <script type="module" src="app.js?v=20260619l"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@
   --accent: #ff7a1a; --accent-soft: rgba(255,122,26,.14); --accent-line: rgba(255,122,26,.5);
   --bg: #0b0c0f; --bg-2: #101216; --panel: #15171c; --panel-2: #1b1e24;
   --card: #14161b; --card-head: #191c22;
+  --sbw: 9px; --listbar-strip: var(--card);   /* scrollbar width (matches *::-webkit-scrollbar) + the search-bar strip fill that bleeds under the scroll gutter */
   --line: #262a31; --line-soft: #1f232a;
   --txt: #e9edf4; --txt-2: #a7afbc; --txt-3: #6b7480; --track: #22262e; --on-orange: #1a1205;
 
@@ -300,7 +301,7 @@ input { font-family: inherit; }
    grow the genuinely TAPPABLE controls on phones (single column = room to spare).
    Glyphs keep their size — only the hit box grows. ── */
 .is-phone .rbtn { width: 44px; height: 44px; }                                  /* row eye / open-tab (was 22) */
-.is-phone .sortbtn { height: 44px; }
+.is-phone .sort { height: 44px; }
 .is-phone .sort .dir { width: 40px; height: 44px; }                             /* was 26×32 */
 .is-phone .mini-search { min-height: 44px; }                                    /* was 24 */
 .is-phone .pill.gate { height: 40px; }                                          /* status gate = interactive (was 28); wide, so width clears the floor */
@@ -719,17 +720,23 @@ select.lf-in { appearance: none; cursor: pointer; }
 }
 
 /* list-view search/sort bar (§12 in-card Sort) — floating chips, no hard line */
-.listbar { position: sticky; top: 0; z-index: 3; display: flex; align-items: center; gap: 7px; padding: 6px 10px; background: linear-gradient(var(--card) 70%, transparent); }
+.listbar { position: sticky; top: 0; z-index: 3; display: flex; align-items: center; gap: 7px; padding: 6px 10px; background: linear-gradient(var(--card) 70%, transparent); box-shadow: var(--sbw) 0 0 0 var(--listbar-strip); }   /* the strip bleeds under the scroll gutter (full card width) so the scrollbar hovers above it instead of leaving a funny gap */
 .listbar .mini-search { flex: 1; min-width: 0; height: 32px; padding: 0 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 12px; box-shadow: var(--chip-shadow); }
 .listbar .mini-search:focus { outline: none; border-color: var(--accent-line); }
-.sort { display: flex; align-items: center; gap: 4px; }
-.sortbtn { display: inline-flex; align-items: center; gap: 5px; height: 32px; padding: 0 9px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); font-size: 11px; font-weight: 600; box-shadow: var(--chip-shadow); white-space: nowrap; }
-.sortbtn:hover { border-color: var(--accent-line); color: var(--txt); }
+/* §12 sort control — ONE unified chip: [field ⌄ │ ▲▼]. The two segments share a
+   single steel chip (no second box, no extra horizontal space) split by a
+   saddle-stitch seam, matching the .card-jog stepper (recognition over recall). */
+.sort { display: inline-flex; align-items: stretch; height: 32px; border-radius: var(--chip-radius); overflow: hidden; background: var(--panel); border: 1px solid var(--line); box-shadow: var(--chip-shadow); }
+.sort:hover, .sort:has(.sortbtn.viewing) { border-color: var(--accent-line); }
+.sortbtn { display: inline-flex; align-items: center; gap: 5px; height: 100%; padding: 0 9px; border: 0; background: transparent; color: var(--txt-2); font-size: 11px; font-weight: 600; white-space: nowrap; }
+.sortbtn:hover { color: var(--txt); }
+.sortbtn.viewing { color: var(--accent); }
 .sortbtn .chev { width: 12px; height: 12px; opacity: .6; }
-.sort .dir { display: flex; flex-direction: column; width: 26px; height: 32px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); align-items: center; justify-content: center; box-shadow: var(--chip-shadow); }
-.sort .dir:hover { border-color: var(--accent-line); }
+.sort .dir { display: flex; flex-direction: column; width: 22px; height: 100%; border: 0; border-left: 1px dashed rgba(194,146,90,.55); background: transparent; align-items: center; justify-content: center; }   /* saddle-stitch seam (same as .card-jog) */
+.sort .dir:hover { background: var(--accent-soft); }
 .sort .dir span { font-size: 9px; line-height: 1.05; color: var(--txt-3); }
 .sort .dir span.on { color: var(--accent); }
+.sort > button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
 /* reusable floating dropdown menu (sort fields, status options) — Tier 3 SELECTOR-LIST:
    steel panel + a left hazard rail (the signature), no orange halo (dialogs keep that). */
@@ -772,7 +779,6 @@ select.lf-in { appearance: none; cursor: pointer; }
 .gt-s .gt-lbl { color: var(--txt-3); font-style: italic; }
 .gt-a .gt-node { color: var(--on-orange); background: linear-gradient(180deg, #ff9038, var(--accent)); box-shadow: 0 0 0 3px var(--accent-soft); }
 .gt-a .gt-lbl { color: var(--accent); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 800; font-size: 13.5px; }
-.sortbtn.viewing { color: var(--accent); border-color: var(--accent-line); }
 
 /* ── Shop card (merged Work Orders + Service Orders + Inspections) ───────── */
 .shopbar { display: flex; align-items: center; gap: 6px; padding: 6px 10px 4px; flex-wrap: wrap; }
@@ -1335,7 +1341,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .pl-cap { height: 8px; width: 100%; flex: 0 0 auto; border-bottom: 1px solid #000;   /* THE signature — hi-vis caution band, matches the card cap + login band */
   background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 13px, #14181d 13px 26px); }
 .pl-cap.danger { background: repeating-linear-gradient(135deg, var(--red, #ff4242) 0 13px, #1a0808 13px 26px); }   /* abort/destroy popups */
-.pl-rivet { position: absolute; width: 6px; height: 6px; border-radius: 50%; z-index: 2; pointer-events: none;
+.pl-rivet { position: absolute; width: 6px; height: 6px; border-radius: 50%; z-index: 12; pointer-events: none;   /* top layer of the popup plate — above head/body/foot content */
   background: radial-gradient(circle at 35% 30%, #434c58, #0f1318); box-shadow: inset 0 0 0 1px rgba(0,0,0,.55); }
 .pl-rivet.tl { top: 18px; left: 12px; } .pl-rivet.tr { top: 18px; right: 12px; }
 .pl-rivet.bl { bottom: 12px; left: 12px; } .pl-rivet.br { bottom: 12px; right: 12px; }
@@ -1807,7 +1813,7 @@ select.nc-in { cursor: pointer; }
   background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 13px, #14181d 13px 26px);
   border-bottom: 1px solid #000;
 }
-.login-box .rivet { position: absolute; width: 6px; height: 6px; border-radius: 50%;
+.login-box .rivet { position: absolute; width: 6px; height: 6px; border-radius: 50%; z-index: 12;   /* top layer of the login plate */
   background: radial-gradient(circle at 35% 30%, #434c58, #0f1318); box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .55); }
 .login-box .rivet.tl { top: 20px; left: 14px; } .login-box .rivet.tr { top: 20px; right: 14px; }
 .login-box .rivet.bl { bottom: 13px; left: 14px; } .login-box .rivet.br { bottom: 13px; right: 14px; }
@@ -2422,7 +2428,7 @@ body.dragging .row.drop-ok { opacity: 1; }
   border-bottom:1px solid rgba(0,0,0,.6); pointer-events:none;
 }
 [data-theme="yard"] .col > .card::after {        /* four corner rivets bolting the plate down */
-  content:''; position:absolute; inset:0; z-index:5; pointer-events:none; border-radius:inherit;
+  content:''; position:absolute; inset:0; z-index:12; pointer-events:none; border-radius:inherit;   /* rivets are the TOP layer of the plate */
   background:
     radial-gradient(circle at 12px 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
     radial-gradient(circle at calc(100% - 12px) 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
@@ -2518,7 +2524,7 @@ body.dragging .row.drop-ok { opacity: 1; }
   border-bottom:1px solid rgba(0,0,0,.6); pointer-events:none;
 }
 [data-theme="bluedsteel"] .col > .card::after {   /* four corner rivets — same as Yard, blued */
-  content:''; position:absolute; inset:0; z-index:5; pointer-events:none; border-radius:inherit;
+  content:''; position:absolute; inset:0; z-index:12; pointer-events:none; border-radius:inherit;   /* rivets are the TOP layer of the plate — never under a badge/text/icon */
   background:
     radial-gradient(circle at 12px 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
     radial-gradient(circle at calc(100% - 12px) 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
@@ -2556,7 +2562,7 @@ body.dragging .row.drop-ok { opacity: 1; }
 }
 /* search/sort sub-header (.listbar) — a clean solid dark strip so the floor/card
    texture never bleeds through the controls (Jac) */
-[data-theme="bluedsteel"] .listbar { background: linear-gradient(180deg, #0c1320 80%, transparent); }
+[data-theme="bluedsteel"] .listbar { background: linear-gradient(180deg, #0c1320 80%, transparent); --listbar-strip: #0c1320; }
 
 /* global search bar (.searchwrap, the top "Search everything…") — was a flat panel;
    now a blued-steel plate: the same plate material + a machined top lip as the cards,


### PR DESCRIPTION
Three small yard-plate fixes from Jac. **CSS / tokens only** — no new builders, markup, or `data-r` stamps.

## 1. Sort control → one chip
The View/Sort button and the asc/desc (▲▼) arrows were two separate chips with a gap. They now share **one steel chip** — `[field ⌄ │ ▲▼]` — split by a saddle-stitch seam (the same seam as the `.card-jog` stepper, so it reads as part of the system). Stops the control eating extra horizontal space. Both segments keep their own click targets (open menu / toggle direction) and `:focus-visible`.

## 2. Search strip spans the full card width
The in-card search bar (`.listbar`) dark strip stopped short of the scrollbar gutter, leaving a "funny" lighter gap beside the scrollbar. It now **bleeds its fill under the gutter** via a right `box-shadow` sized to a new `--sbw` token, so the strip is full-width and the scrollbar **hovers above** it. Theme-aware through a new `--listbar-strip` token (bluedsteel keeps `#0c1320`; other themes fall back to `var(--card)`). No layout shift, no added overflow.

> Note: the project forces a 9px WebKit scrollbar, so the gap only appears on classic-scrollbar desktops (Jac's screenshot). Headless test browsers use overlay scrollbars (0 gutter), where this is a verified no-op; the fill is reasoned for the classic case.

## 3. Rivets are the top layer
Corner rivets could sit under badges/labels/icons. They're now the **top layer** of every plate — card `::after`, popup `.pl-rivet`, login `.rivet` → `z-index: 12` (still `pointer-events: none`, still below the portal/overlay floor at z≥50, so dialogs/toasts/tooltips correctly cover them).

## Verification
- Playwright: unified chip renders compact, asc/desc toggle works, no console errors, all 3 columns render.
- Gates green: `smoke` ✅ · `logic` 60/60 ✅ · `gen-rule-usage --check` ✅.
- Cache-bust token → `20260619l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169qu6Md4oKjLVAAZUhKPHv)_