### PR TITLE
Fix: lift card search bar out of the scroll so the strip is full-width (desktop)

### DIFF
--- a/app.js
+++ b/app.js
@@ -4351,6 +4351,14 @@ function columnEl(col, session) {
   // §M1 — phones invert the desktop layout: the card "footer" (totals) sits at the TOP,
   // while the toggles + search live in the bottom dock. Desktop keeps it as a footer.
   if (tot) { if (document.body.classList.contains('is-phone')) card.insertBefore(tot, card.firstChild); else card.appendChild(tot); }
+  // Desktop: freeze the search/sort bar out of the scroll too — a full-width card
+  // header so the card-body scrollbar runs ONLY through the list below it, never in
+  // a gutter alongside the bar (the "funny" gap). Mirrors the .list-totals footer
+  // freeze; on phones render() relocates the bar to the bottom dock instead.
+  if (!document.body.classList.contains('is-phone')) {
+    const lb = card.querySelector('.card-body .listbar'), body = card.querySelector('.card-body');
+    if (lb && body) card.insertBefore(lb, body);
+  }
   wrap.appendChild(card);
   return wrap;
 }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619l" />
+  <link rel="stylesheet" href="style.css?v=20260619m" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619l"></script>
-  <script type="module" src="app.js?v=20260619l"></script>
+  <script src="rule-usage.js?v=20260619m"></script>
+  <script type="module" src="app.js?v=20260619m"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -10,7 +10,6 @@
   --accent: #ff7a1a; --accent-soft: rgba(255,122,26,.14); --accent-line: rgba(255,122,26,.5);
   --bg: #0b0c0f; --bg-2: #101216; --panel: #15171c; --panel-2: #1b1e24;
   --card: #14161b; --card-head: #191c22;
-  --sbw: 9px; --listbar-strip: var(--card);   /* scrollbar width (matches *::-webkit-scrollbar) + the search-bar strip fill that bleeds under the scroll gutter */
   --line: #262a31; --line-soft: #1f232a;
   --txt: #e9edf4; --txt-2: #a7afbc; --txt-3: #6b7480; --track: #22262e; --on-orange: #1a1205;
 
@@ -720,7 +719,11 @@ select.lf-in { appearance: none; cursor: pointer; }
 }
 
 /* list-view search/sort bar (§12 in-card Sort) — floating chips, no hard line */
-.listbar { position: sticky; top: 0; z-index: 3; display: flex; align-items: center; gap: 7px; padding: 6px 10px; background: linear-gradient(var(--card) 70%, transparent); box-shadow: var(--sbw) 0 0 0 var(--listbar-strip); }   /* the strip bleeds under the scroll gutter (full card width) so the scrollbar hovers above it instead of leaving a funny gap */
+.listbar { position: sticky; top: 0; z-index: 3; display: flex; align-items: center; gap: 7px; padding: 6px 10px; background: linear-gradient(var(--card) 70%, transparent); }
+/* Desktop lifts the bar OUT of the scroll into a full-width card header (see
+   columnEl) so the card-body scrollbar runs only through the list below it — no
+   gutter gap beside the search strip. */
+.card > .listbar { flex: 0 0 auto; position: static; background: var(--card); }
 .listbar .mini-search { flex: 1; min-width: 0; height: 32px; padding: 0 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 12px; box-shadow: var(--chip-shadow); }
 .listbar .mini-search:focus { outline: none; border-color: var(--accent-line); }
 /* §12 sort control — ONE unified chip: [field ⌄ │ ▲▼]. The two segments share a
@@ -2562,7 +2565,8 @@ body.dragging .row.drop-ok { opacity: 1; }
 }
 /* search/sort sub-header (.listbar) — a clean solid dark strip so the floor/card
    texture never bleeds through the controls (Jac) */
-[data-theme="bluedsteel"] .listbar { background: linear-gradient(180deg, #0c1320 80%, transparent); --listbar-strip: #0c1320; }
+[data-theme="bluedsteel"] .listbar { background: linear-gradient(180deg, #0c1320 80%, transparent); }
+[data-theme="bluedsteel"] .card > .listbar { background: #0c1320; }
 
 /* global search bar (.searchwrap, the top "Search everything…") — was a flat panel;
    now a blued-steel plate: the same plate material + a machined top lip as the cards,


### PR DESCRIPTION
## The real scrollbar fix

PR #175's box-shadow gutter-fill **didn't actually work on desktop** — it's clipped by the card's `overflow:hidden` and it assumed a fixed 9px scrollbar, so the "funny" gap beside the search bar stayed (as Jac confirmed).

**Real fix:** on desktop, lift the search/sort bar (`.listbar`) **out of the scrolling `.card-body` into a full-width card header** — exactly how the `.list-totals` footer is already frozen out of the scroll. Now the card-body scrollbar runs **only through the list below the bar**, never in a gutter alongside it. The dark search strip spans the full card width on every browser, regardless of scrollbar width/type.

- Phones unchanged — `render()` still relocates the bar to the bottom dock (my move is desktop-only, mirroring the totals freeze).
- Reverts the box-shadow hack and the `--sbw`/`--listbar-strip` tokens.

### Trade-off to flag
The scrollbar no longer runs *alongside* the search bar (so it doesn't literally "hover above" the strip) — instead the bar is a clean full-width header and the scrollbar lives in the list beneath it. This removes the gap definitively. If you'd rather the scrollbar overlay the strip, that needs OS-level overlay scrollbars (not controllable cross-browser via CSS), so this header approach is the robust choice.

## Verification
Playwright with a simulated classic scrollbar (`scrollbar-gutter: stable`, since headless uses overlay): the bar spans the full card width (`482 == 482`) while the 9px gutter is reserved only inside the list below it. Gates green: `smoke` ✅ · `logic` 60/60 ✅ · `gen-rule-usage --check` ✅. Token → `20260619m`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169qu6Md4oKjLVAAZUhKPHv)_