### PR TITLE
Fix cash/check payments reverting on refresh

### DIFF
--- a/app.js
+++ b/app.js
@@ -10316,12 +10316,18 @@ async function refundInvoiceFlow(invoiceId) {
   // invoice to Refunded (status derives from inv.refunded) and keep amountPaid so the
   // balance reads $0; release line assignments per the full-refund invariant (§4).
   if (/^cash$/i.test(inv.paymentMethod || '') || /^check/i.test(inv.paymentMethod || '')) {
-    const t = invoiceTotals(inv); const before = t.status;
-    inv.refunded = true; inv.refundedAmount = t.paid; inv.allocations = {};
-    o.confirmRefund = false; o.busy = false; o.error = '';
-    reindex('invoices', inv);
-    logAction(inv, `Refunded ${money(t.paid)} (${inv.paymentMethod}) — ${before} → Refunded`);
-    toast('Refunded ✓'); render(); renderOverlay(); return;
+    // Cash/Check refunds never touched Stripe, but inv.refunded / refundedAmount are
+    // server-owned (sync-PROTECTED) — so the SERVER records the manual refund too, else
+    // it'd revert on refresh. applyPayment keeps amountPaid (balance reads $0) and flips
+    // the status to Refunded. (#109/#117)
+    const live = () => state.overlay === o;
+    o.busy = true; o.error = ''; o.confirmRefund = false; renderOverlay();
+    try {
+      const r = await backendCall('recordManualRefund', { invoiceId });
+      if (!live()) return;
+      if (r && r.ok) { applyPayment(invoiceId, r); o.busy = false; toast('Refunded ✓'); renderOverlay(); return; }
+      o.busy = false; o.error = friendlyPayErr(r); renderOverlay(); return;
+    } catch (e) { if (live()) { o.busy = false; o.error = 'Network error — try again.'; renderOverlay(); } return; }
   }
   const live = () => state.overlay === o;
   o.busy = true; o.error = ''; o.confirmRefund = false; renderOverlay();
@@ -10355,7 +10361,14 @@ function applyPayment(invoiceId, r, alloc) {
 // the exact cent (no ceiling/rounding) and clamped at the outstanding balance so a
 // payment can never overpay; partials just dial the amount down. amountPaid persists
 // through the normal record sync, exactly like every other invoice field.
-function recordManualPayment(invoiceId) {
+// Record a manual CASH / CHECK payment (#109) — no Stripe. The figure is captured to
+// the exact cent and clamped at the outstanding balance so a payment can never overpay.
+// The SERVER records it (recordManualPayment): invoice money fields (amountPaid,
+// paymentMethod, paidAt, payments) are server-owned / sync-PROTECTED, so a client-side
+// write gets stripped on sync and "reverts" on refresh (#bug). The backend is
+// authoritative — it caps at the live balance, appends to payments[] and audits the
+// ledger — exactly like a card charge; we apply its result via applyPayment.
+async function recordManualPayment(invoiceId) {
   const o = state.overlay; if (!o || o.kind !== 'payment') return;
   const inv = IDX.invoice.get(invoiceId); if (!inv) return;
   const numEl = document.querySelector('.overlay .js-check-num'); if (numEl) o.checkNum = numEl.value.trim();   // survive the error re-render
@@ -10367,18 +10380,20 @@ function recordManualPayment(invoiceId) {
   if (balCents <= 0) { o.error = 'Nothing left to pay on this invoice.'; return renderOverlay(); }
   const payCents = Math.min(Math.round(entered * 100), balCents);   // exact cents, never over the balance
   const isCheck = o.method === 'check';
-  let label = 'Cash';
-  if (isCheck) { const num = (o.checkNum || '').trim(); if (!num) { o.error = 'Enter the check number.'; return renderOverlay(); } label = 'Check #' + num; }
-  const before = t.status;
-  inv.amountPaid = (Math.round((Number(inv.amountPaid) || 0) * 100) + payCents) / 100;
-  inv.paymentMethod = label;
-  inv.paidAt = TODAY_ISO;
-  reindex('invoices', inv);
-  const after = invoiceTotals(inv).status;
-  logAction(inv, `${label} payment ${money2(payCents / 100)} — ${before} → ${after}`);
-  closeOverlay();
-  render();
-  toast(invoiceTotals(inv).balance <= 0.005 ? 'Paid in full ✓' : `${label} payment recorded ✓`);
+  const checkNum = (o.checkNum || '').trim();
+  if (isCheck && !checkNum) { o.error = 'Enter the check number.'; return renderOverlay(); }
+  const live = () => state.overlay === o;
+  o.busy = true; o.error = ''; renderOverlay();
+  try {
+    const r = await withTimeout(backendCall('recordManualPayment', { invoiceId, amountCents: payCents, method: isCheck ? 'check' : 'cash', checkNum: isCheck ? checkNum : '' }), 30000, 'Recording the payment');
+    if (!live()) return;
+    if (!r || !r.ok) { o.busy = false; o.error = friendlyPayErr(r); return renderOverlay(); }
+    applyPayment(invoiceId, r);   // server is authoritative (amountPaid / paymentMethod / paidAt)
+    o.busy = false; closeOverlay();
+    toast(invoiceTotals(inv).balance <= 0.005 ? 'Paid in full ✓' : `${r.paymentMethod || 'Cash'} payment recorded ✓`);
+  } catch (e) {
+    if (live()) { o.busy = false; o.error = (e && e.rwTimeout) ? 'Timed out — try again.' : 'Network error — try again.'; renderOverlay(); }
+  }
 }
 // Print / PDF a customer-facing invoice (#109) — a clean white document (not the dark
 // yard UI) rendered into #print-root; the @media print rules hide everything else and

--- a/docs/handoffs/cash-payment-backend.gs
+++ b/docs/handoffs/cash-payment-backend.gs
@@ -1,0 +1,72 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * MANUAL CASH / CHECK payments + refunds — backend fix (2026-06-19)
+ * -------------------------------------------------------------------------
+ * BUG: invoice money fields (amountPaid, payments, paymentMethod, paidAt,
+ * refunded, refundedAmount) are server-owned / sync-PROTECTED (PROTECTED.invoices)
+ * so a client can't fake a Stripe outcome. That ALSO silently stripped legitimate
+ * manual cash/check payments + refunds on sync, so they "reverted" on refresh.
+ *
+ * FIX: record them SERVER-SIDE via two money-role actions (mirrors the Stripe
+ * charge's server-authority). The frontend (recordManualPayment / refundInvoiceFlow
+ * cash branch) now calls these and applies the result via applyPayment(), instead
+ * of writing the protected fields locally and relying on the (stripping) sync.
+ *
+ * This file is the tracked source of truth — NO secrets. Two edits to Code.gs:
+ *
+ * EDIT 1 — dispatch (in handle(), right after the membershipActivate line):
+ *   if (action === 'recordManualPayment') return json(MONEY_ROLES[role] ? recordManualPayment_(body, role) : { ok: false, error: 'forbidden' });
+ *   if (action === 'recordManualRefund')  return json(MONEY_ROLES[role] ? recordManualRefund_(body, role) : { ok: false, error: 'forbidden' });
+ *
+ * EDIT 2 — paste the two functions below (anywhere top-level; e.g. after the
+ * Stripe section). They reuse existing helpers: readRecord_, writeRecord_,
+ * computeInvoiceCents_, appendLedger_, MAX_CHARGE_CENTS.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+// Record a manual CASH / CHECK payment. Money role only. Caps at the live balance,
+// derives amountPaid + paid, appends to payments[], audits to the ledger.
+function recordManualPayment_(body, role) {
+  var invoiceId = String(body.invoiceId || '');
+  var method = /check/i.test(String(body.method || '')) ? 'check' : 'cash';
+  var reqCents = Math.round(Number(body.amountCents) || 0);
+  var checkNum = String(body.checkNum || '').replace(/[^\w \-#]/g, '').slice(0, 40);
+  var lock = LockService.getScriptLock(); lock.waitLock(20000);
+  try {
+    var inv = readRecord_('invoices', invoiceId);
+    if (!inv) return { ok: false, error: 'invoice-not-found' };
+    var amt = computeInvoiceCents_(inv), balance = amt.balanceCents;
+    if (balance <= 0) return { ok: true, status: 'succeeded', alreadyPaid: true, amountPaid: Number(inv.amountPaid) || 0, paymentMethod: inv.paymentMethod || '' };
+    if (!(reqCents > 0)) return { ok: false, error: 'bad-amount' };
+    if (reqCents > MAX_CHARGE_CENTS) return { ok: false, error: 'over-ceiling' };
+    var cents = Math.min(reqCents, balance);                          // never overpay
+    var label = method === 'check' ? ('Check' + (checkNum ? ' #' + checkNum : '')) : 'Cash';
+    inv.amountPaid = (Math.round((Number(inv.amountPaid) || 0) * 100) + cents) / 100;
+    inv.payments = inv.payments || [];
+    inv.payments.push({ type: method, amountCents: cents, at: new Date().toISOString(), role: role, checkNum: checkNum || '' });
+    inv.paymentMethod = label;
+    inv.paidAt = new Date().toISOString();
+    inv.paid = (amt.totalCents > 0 && Math.round(inv.amountPaid * 100) >= amt.totalCents);
+    if (inv.refunded) delete inv.refunded;                            // a fresh payment un-refunds
+    writeRecord_('invoices', inv);
+    try { appendLedger_([new Date().toISOString(), invoiceId, inv.customerId || '', cents, '', role, method]); } catch (e) {}
+    return { ok: true, status: 'succeeded', amountPaid: inv.amountPaid, paid: inv.paid, paidAt: inv.paidAt, paymentMethod: label, chargedCents: cents };
+  } finally { lock.releaseLock(); }
+}
+
+// Manual CASH / CHECK refund (no Stripe to reverse). Money role only. Keeps amountPaid
+// (so the balance still reads $0) and flips inv.refunded → status Refunded.
+function recordManualRefund_(body, role) {
+  var invoiceId = String(body.invoiceId || '');
+  var lock = LockService.getScriptLock(); lock.waitLock(20000);
+  try {
+    var inv = readRecord_('invoices', invoiceId);
+    if (!inv) return { ok: false, error: 'invoice-not-found' };
+    var paidCents = Math.round((Number(inv.amountPaid) || 0) * 100);
+    if (paidCents <= 0) return { ok: false, error: 'nothing-to-refund' };
+    inv.refunded = true; inv.refundedAmount = paidCents / 100;
+    inv.payments = inv.payments || [];
+    inv.payments.push({ type: 'manual-refund', amountCents: paidCents, at: new Date().toISOString(), role: role });
+    writeRecord_('invoices', inv);
+    try { appendLedger_([new Date().toISOString(), invoiceId, inv.customerId || '', -paidCents, '', role, 'manual-refund']); } catch (e) {}
+    return { ok: true, status: 'refunded', refunded: true, refundedAmount: inv.refundedAmount, refundedCents: paidCents, amountPaid: Number(inv.amountPaid) || 0 };
+  } finally { lock.releaseLock(); }
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619m" />
+  <link rel="stylesheet" href="style.css?v=20260619n" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619m"></script>
-  <script type="module" src="app.js?v=20260619m"></script>
+  <script src="rule-usage.js?v=20260619n"></script>
+  <script type="module" src="app.js?v=20260619n"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## The bug
Marking an invoice **paid by cash/check** (or refunding one) appeared to work, but **reverted on the next refresh**. Root cause: invoice money fields (`amountPaid`, `payments`, `paymentMethod`, `paidAt`, `refunded`, `refundedAmount`) are server-owned / sync-`PROTECTED` so a client can't *fake* a Stripe outcome — but that same guard silently **stripped legitimate manual cash/check payments** on the way to the backend. So they never persisted. (Pre-existing; not introduced by the membership work.)

## The fix
Record manual payments/refunds **server-side**, exactly like card charges already are:
- **Frontend** (`app.js`): `recordManualPayment` and the cash branch of `refundInvoiceFlow` now call money-role backend actions (`recordManualPayment` / `recordManualRefund`) and apply the authoritative result via the existing `applyPayment()`, instead of writing protected fields locally and relying on the (stripping) sync.
- **Backend** (`Code.gs`, hand-paste/gitignored — tracked source in `docs/handoffs/cash-payment-backend.gs`): two money-role actions record the payment server-side — **capped at the live balance**, appended to `payments[]`, audited to the ledger.

## Status
- **Backend half: already deployed and verified live** (`AKfycbz…@26`, same URL). A throwaway-invoice test confirmed a $50 cash payment persists (`amountPaid: 50`, `paymentMethod: Cash`) where it previously came back blank.
- This PR is the **frontend half** — split out on its own (membership work stays parked in #174 so no membership UI ships).

## Gates
`node ci/smoke.mjs` ✓ · `node ci/logic-test.mjs` 60/60 ✓ · `node ci/gen-rule-usage.mjs --check` ✓ · cache-bust `?v=20260619n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw5PSqJP8ehggbQPmb9ZFh)_