### PR TITLE
clasp deploy bridge: SessionStart hook + runbook (hands-off backend deploys)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Rental Wrangler — Claude Code on the web: clasp DEPLOY BRIDGE bootstrap.
+# Wires up clasp so the agent can deploy the Apps Script backend (gitignored
+# Code.gs) without manual pasting. It is a safe no-op unless CLASPRC_JSON is set
+# (a Google clasp credential held ONLY as an environment variable in the env
+# settings — never in this repo). See docs/handoffs/backend-deploy-via-clasp.md.
+set -euo pipefail
+
+# Only meaningful in the remote (Claude Code on the web) environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then exit 0; fi
+# No credential configured → nothing to wire (silent, safe default).
+if [ -z "${CLASPRC_JSON:-}" ]; then exit 0; fi
+
+# 1) Write the clasp credential so clasp is authenticated for this session.
+printf '%s' "$CLASPRC_JSON" > "$HOME/.clasprc.json"
+chmod 600 "$HOME/.clasprc.json"
+
+# 2) Bind a working dir to the Apps Script project (Script ID from env).
+if [ -n "${APPS_SCRIPT_ID:-}" ]; then
+  mkdir -p "$HOME/rw-backend"
+  printf '{"scriptId":"%s","rootDir":"%s"}\n' "$APPS_SCRIPT_ID" "$HOME/rw-backend" > "$HOME/rw-backend/.clasp.json"
+fi
+
+# clasp itself is installed lazily at deploy time (keeps session start instant).
+echo "clasp deploy bridge: credential wired (~/.clasprc.json), project at ~/rw-backend. To deploy the backend, see docs/handoffs/backend-deploy-via-clasp.md."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,13 @@
 Thumbs.db
 *.log
 
-# Local tooling (not part of the app) — but COMMIT shared skills so they travel + work
-# in Claude Code web sessions (local settings like settings.local.json stay ignored).
+# Local tooling (not part of the app) — but COMMIT shared skills + the shared
+# SessionStart hook so they travel + work in Claude Code web sessions (local
+# settings like settings.local.json stay ignored).
 .claude/*
 !.claude/skills/
+!.claude/settings.json
+!.claude/hooks/
 
 # Internal handoff: the spec + RAW customer/parts/work-order CSVs — NOT for the
 # public site (the served app uses the curated demo data in data.js instead).

--- a/docs/handoffs/backend-deploy-via-clasp.md
+++ b/docs/handoffs/backend-deploy-via-clasp.md
@@ -1,0 +1,59 @@
+# Backend deploy via clasp (agent-driven, no manual paste)
+
+The Apps Script backend (`Code.gs`) is **gitignored** (it holds passwords + Stripe
+keys) and was historically deployed by hand-pasting into the Apps Script editor.
+This runbook lets the agent deploy it directly with [clasp](https://github.com/google/clasp).
+
+## Prerequisites (set ONCE, in the Claude Code web **environment variables**)
+
+| Variable | Value | Secret? |
+|---|---|---|
+| `CLASPRC_JSON` | full contents of a `~/.clasprc.json` from `clasp login` (a Google OAuth credential for the account that owns the script) | **Yes** — env var only, never in the repo/chat |
+| `APPS_SCRIPT_ID` | the backend project's Script ID (Apps Script → ⚙ Project Settings → Script ID) | No (not a credential) |
+
+The **SessionStart hook** (`.claude/hooks/session-start.sh`) wires these at session
+boot: it writes `~/.clasprc.json` and `~/rw-backend/.clasp.json`. It's a safe no-op
+when `CLASPRC_JSON` isn't set. The credential is revocable anytime at
+`myaccount.google.com/permissions` → "clasp".
+
+> Note: `CLASPRC_JSON` can't be minted by `clasp login` on every network (some
+> firewalls/AV kill the token-exchange to `oauth2.googleapis.com` — "Premature
+> close"). If so, run the OAuth code-exchange from the container instead (clasp's
+> public client id/secret live in `@google/clasp/.../auth/oauth_client.js`), then
+> save the resulting tokens as the `CLASPRC_JSON` env var.
+
+## Deploy flow
+
+```bash
+command -v clasp >/dev/null || npm install -g @google/clasp   # lazy install
+cd ~/rw-backend
+clasp pull                                                     # authoritative live Code.js + appsscript.json
+#  …apply the change to Code.js.  The backend's modular, secret-free additions are
+#  tracked in docs/handoffs/*.gs (e.g. cash-payment-backend.gs,
+#  membership-billing-additions.gs) — splice those in, or edit Code.js directly.
+clasp push --force                                             # upload to HEAD
+clasp deploy -i AKfycbzHahzgJqOYe9o4GKlRVGh-A7USRn1k4Dvyy4ajLh8EYCqVxofouM28qs8trNlObZw -d "what changed"
+```
+
+The `-i …` is the **production deployment id** (it's the `…/macros/s/<id>/exec`
+segment already public in `app.js`). Redeploying it keeps the **same exec URL** the
+app calls — never run a bare `clasp deploy` (that mints a new URL).
+
+## Verify after deploy
+
+The exec URL is reachable read-only with a valid role password (GET):
+
+```bash
+URL="https://script.google.com/macros/s/AKfycbzHahzg…/exec"
+curl -s -L -G --data-urlencode "action=load" --data-urlencode "password=<role-pw>" "$URL" | head -c 200
+```
+
+For money-path changes, prove it on a **throwaway** record (create → exercise the new
+action → read back → delete), e.g. a `DIAG-INV-*` invoice. Never test on real data.
+
+## Rules
+
+- **Never commit `Code.gs`** (gitignored; secrets). Keep tracked, secret-free
+  copies of *additions* in `docs/handoffs/*.gs`.
+- Always `clasp pull` first and diff, so you build on what's actually live.
+- Keep the **same deployment id** so the frontend's backend URL never changes.


### PR DESCRIPTION
## Why
The Apps Script backend (`Code.gs`) is gitignored and was deployed by **hand-pasting** into the editor. This wires up a **clasp bridge** so a Claude Code web session can deploy the backend directly — no pasting, ever — once two environment variables are set.

## What's in it
- **`.claude/hooks/session-start.sh`** — SessionStart hook (remote sessions only). Writes `~/.clasprc.json` from `CLASPRC_JSON` and binds `~/rw-backend` to `APPS_SCRIPT_ID`. **Safe no-op** when `CLASPRC_JSON` isn't set; clasp install is deferred to deploy time so session start stays instant.
- **`.claude/settings.json`** — registers the hook.
- **`.gitignore`** — whitelists the *shared* hook + `settings.json` (local `settings.local.json` stays ignored).
- **`docs/handoffs/backend-deploy-via-clasp.md`** — the deploy runbook: `clasp pull` → splice the secret-free additions from `docs/handoffs/*.gs` → `clasp push` → **redeploy to the same production deployment id** (keeps the exec URL the app calls).

## Setup (one-time, by the owner — not in this PR)
Two environment variables in the Claude Code web env settings:
- `CLASPRC_JSON` — a Google `clasp` credential (**secret**, env var only — never the repo/chat). Revocable at `myaccount.google.com/permissions`.
- `APPS_SCRIPT_ID` — the backend's Script ID (not a credential).

## Safety
- **No secrets in the repo** — verified the staged diff carries no tokens/keys/passwords.
- Hook is idempotent and a no-op without the credential, so merging this changes nothing until the env vars are set.
- Validated: hook wires the credential and `clasp show-authorized-user` confirms auth; with no credential it cleanly no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw5PSqJP8ehggbQPmb9ZFh)_