### PR TITLE
Photo backdrops — faded selfie / WO photo behind standard-view sections

### DIFF
--- a/app.js
+++ b/app.js
@@ -268,6 +268,25 @@ const signingText = (s) => (s && (s.text || (AGREEMENT_VERSIONS[s.version] || {}
    inline data-URL kept until the backend offloads it (graceful pre-deploy). */
 const signingSelfieSrc = (s) => (s && (s.driveSelfieUrl || s.selfie)) || '';
 const signingSignatureSrc = (s) => (s && (s.driveSignatureUrl || s.signature)) || '';
+/* The newest agreement selfie across ALL of a customer's cards — the faded
+   backdrop behind the Account section. Prefers the archived Drive URL
+   (signingSelfieSrc → driveSelfieUrl); the inline data-URL is only the pre-offload
+   fallback. That ordering is load-bearing: at thousands of customers the backdrop
+   resolves to a lazy-loaded URL the browser fetches only when the card is open,
+   never inline image data riding the bulk payload. Legacy `c.selfie` is the last
+   resort. */
+function latestCustomerSelfie(c) {
+  if (!c) return '';
+  let best = null, bestT = -Infinity;
+  for (const k of customerCards(c)) {
+    for (const s of cardSignings(k)) {
+      if (!signingSelfieSrc(s)) continue;
+      const t = s.signedAt ? +parseISO(s.signedAt) : 0;
+      if (t >= bestT) { bestT = t; best = s; }
+    }
+  }
+  return best ? signingSelfieSrc(best) : (c.selfie || '');
+}
 /** THE GATE — true only when every NON-EXPIRED card is signed for the current
     account type. Expired cards can't be charged anyway, so they don't gate. */
 const accountAgreementsOk = (c) => validCards(c).every((k) => cardAuthorized(c, k));
@@ -3203,6 +3222,18 @@ function saveCommentOverlay() {
   closeOverlay(); render();
   toast('Comment posted — marker set.');
 }
+/* The faded backdrop behind an OPEN Work Order section: the WO's first existing
+   photo — the linked failed-inspection photo (the WO's origin), else the earliest
+   part-line photo. References photos already on the records (Jac: no new upload —
+   they come from Failed Inspections or a part's photo), so it adds zero new
+   storage. Dropped once the WO is Complete, so only open WOs ever carry one. */
+function woBackdrop(w) {
+  if (!w || w.phase === 'Complete') return '';
+  const insp = w.inspectionId && IDX.insp.get(w.inspectionId);
+  if (insp && insp.photo) return insp.photo;
+  for (const li of (w.lineItems || [])) if (li.photo) return li.photo;
+  return '';
+}
 function woSectionHtml(w) {
   const bn = woBottleneck(w);
   const secColor = bn.color === 'red' ? 'red' : bn.color === 'green' ? 'green' : 'yellow';
@@ -3224,7 +3255,8 @@ function woSectionHtml(w) {
     // the description re-opens the part popup; vendor/url live in its tooltip
     return `<div class="woline">${gatePillRaw(lbl, ph.color, 'js-wophase-line', { rec: w.woId, idx })}<span class="js-partedit" data-rec="${w.woId}" data-idx="${idx}" style="cursor:pointer"${tip ? ` data-tip="${esc(tip)}"` : ''}>${li.aiPending ? '✨ ' : ''}${esc(li.part)}${ven ? ' ' + linkName(ven.name, { js: 'js-vendor-open', data: { rec: ven.vendorId } }) : ''}</span><span class="nums"><b>${money(li.cost)}</b><span>${li.hours || 0}h</span></span></div>`;
   }).join('');
-  return `<div class="section sec-${secColor} wo-${w.woId}" data-wo="${w.woId}">
+  const woBg = woBackdrop(w);
+  return `<div class="section sec-${secColor} wo-${w.woId}${woBg ? ' has-photo' : ''}" data-wo="${w.woId}">${woBg ? `<div class="sec-photo" style="--photo:url('${esc(woBg)}')"></div>` : ''}
     <h4 class="h-name"><span style="font-weight:800;margin-right:1px">WO:</span> <span class="inline-edit" data-edit="field" data-card="workOrders" data-field="woReport" data-rec="${w.woId}" data-ph="Report">${esc(w.woReport)}</span>
       <span class="right">${flagsStack([typeFlag, flagEl(fmtShortDate(w.date), 'gray')], 24)}</span></h4>
     <div class="wototals">${addBtn('Part/Task', { anchor: true, js: 'js-add-part', h: 26, data: { rec: w.woId } })}<span class="derived">${money(parts)} parts + ${hrs} hrs</span></div>
@@ -3820,14 +3852,14 @@ const DETAIL = {
     // §7.1 — every contact/account detail is click-to-edit (auto-saves via the persist hook)
     // R5: empty fields render the dashed "+Thing" add (no "Add", no space after +)
     const efield = (f, ph, wrap) => { const val = c[f]; const thing = ph.replace(/^Add\s+/i, ''); const lbl = thing.charAt(0).toUpperCase() + thing.slice(1); return `<div class="kv"><span class="v inline-edit" data-edit="custField" data-field="${f}" data-rec="${c.customerId}" data-ph="${esc(ph)}"${wrap ? ' style="white-space:normal"' : ''}>${val ? esc(val) : `<span class="add-field" data-r="R5c">+${esc(lbl)}</span>`}</span></div>`; };
-    const selfieThumb = c.selfie ? `<img class="cust-selfie" src="${esc(c.selfie)}" alt="" />` : '';
+    const acctSelfie = latestCustomerSelfie(c);   // newest agreement selfie → faded Account backdrop (retired the tiny thumb)
     const agPill = c.agreementSignedAt ? `<button class="pill c-green js-view-agreement" data-r="R3" data-rec="${c.customerId}" data-tip="View signed agreement">${esc(AGREEMENTS[c.agreementType]?.title || 'Agreement')} ✓</button>` : '';
     // every category this customer has EVER rented → R9 flags (ink+icon, no badge) — Jac 2026-06-12
     const rentedCatIds = [...new Set(DATA.rentals.filter((r) => r.customerId === c.customerId)
       .map((r) => r.categoryId || IDX.unit.get(r.unitId)?.categoryId).filter(Boolean))];
     const rentedFlags = rentedCatIds.map((id) => { const cat = IDX.category.get(id); return cat ? flagEl(cat.name, 'gray', { icon: CARD_ICON.categories, card: 'categories', recId: id }) : ''; }).filter(Boolean).join('');
     /* Jac 2026-06-12: Contact + Account MERGED — LEFT = entered fields, RIGHT = facts + derived (card anatomy) */
-    const account = `<div class="section"><h4>Account</h4>
+    const account = `<div class="section${acctSelfie ? ' has-photo' : ''}">${acctSelfie ? `<div class="sec-photo" style="--photo:url('${esc(acctSelfie)}')"></div>` : ''}<h4>Account</h4>
       <div class="split">
         <div class="side">
           <div class="kv2">${efield('firstName', 'First name')}${efield('lastName', 'Last name')}</div>
@@ -3836,7 +3868,7 @@ const DETAIL = {
           ${efield('address', 'Add address', true)}
         </div>
         <div class="side r">
-          ${kvPills(`${selfieThumb}${badge(acct.label, acct.color)}${c.requiresPO ? badge('PO Required', 'yellow') : ''}${agPill}`)}
+          ${kvPills(`${badge(acct.label, acct.color)}${c.requiresPO ? badge('PO Required', 'yellow') : ''}${agPill}`)}
           ${kv(money(d.totalPaid), { pfx: 'Total', derived: true })}
           ${kv(`${d.visits || 0}`, { pfx: 'Visits', derived: true })}
           ${kv(`${d.years || 0} yrs`, { pfx: 'Customer for', derived: true })}
@@ -11736,7 +11768,8 @@ function exposeTestApi() {
       rentalAllocated, unitRentalPrice, rentalDisplayName, setWoLinePhase, setWoPhase, woBottleneck,
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
-      wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction };
+      wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction,
+      latestCustomerSelfie, woBackdrop };
   } catch (e) { /* no window (non-browser) */ }
 }
 

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -243,6 +243,23 @@ try {
     ok(mPaid && (Number(mPaid.amountPaid) || 0) === 1000 && mPaid.lineItems.length === 2, 'blocked merge left the PAID invoice fully intact');
     const mki = T.DATA.invoices.findIndex((o) => o.invoiceId === 'TST-KEEP'); if (mki >= 0) T.DATA.invoices.splice(mki, 1); T.IDX.invoice.delete('TST-KEEP');   // restore
 
+    // 13) photo backdrops — customer Account selfie + open Work Order first-photo
+    ok(T.latestCustomerSelfie(null) === '' && T.latestCustomerSelfie({}) === '', 'latestCustomerSelfie: no customer / no cards → empty');
+    ok(T.latestCustomerSelfie({ selfie: 'data:legacy' }) === 'data:legacy', 'latestCustomerSelfie: legacy c.selfie fallback');
+    const lcsCust = { cards: [{ status: 'active', agreements: [
+      { key: 'rental', signedAt: '2026-01-01', selfie: 'data:old' },
+      { key: 'rental', signedAt: '2026-05-01', driveSelfieUrl: 'https://drive/new.jpg', selfie: 'data:new' } ] }] };
+    ok(T.latestCustomerSelfie(lcsCust) === 'https://drive/new.jpg', 'latestCustomerSelfie: newest signing wins + prefers the Drive URL over base64');
+    const lcsTwoCards = { cards: [
+      { status: 'active', agreements: [{ key: 'rental', signedAt: '2026-06-10', driveSelfieUrl: 'https://drive/A.jpg' }] },
+      { status: 'active', agreements: [{ key: 'rental', signedAt: '2026-02-01', driveSelfieUrl: 'https://drive/B.jpg' }] } ] };
+    ok(T.latestCustomerSelfie(lcsTwoCards) === 'https://drive/A.jpg', 'latestCustomerSelfie: newest across multiple cards');
+    ok(T.woBackdrop(null) === '' && T.woBackdrop({ phase: 'Part Needed' }) === '', 'woBackdrop: nothing / no photo → empty');
+    ok(T.woBackdrop({ phase: 'Part Needed', lineItems: [{}, { photo: 'data:part' }] }) === 'data:part', 'woBackdrop: first part-line photo');
+    const wbInsp = { phase: 'Part Needed', inspectionId: 'INS-2', lineItems: [{ photo: 'data:part' }] };
+    ok(T.woBackdrop(wbInsp) === (T.IDX.insp.get('INS-2')?.photo || ''), 'woBackdrop: linked failed-inspection photo wins over the part photo');
+    ok(T.woBackdrop({ phase: 'Complete', inspectionId: 'INS-2', lineItems: [{ photo: 'data:part' }] }) === '', 'woBackdrop: dropped once the WO is Complete');
+
     return out;
   });
 

--- a/docs/superpowers/specs/2026-06-20-customer-photo-account-backdrop-design.md
+++ b/docs/superpowers/specs/2026-06-20-customer-photo-account-backdrop-design.md
@@ -1,0 +1,165 @@
+# Customer photo → Account-section backdrop
+
+**Date:** 2026-06-20
+**Status:** Approved (design) — ready for implementation plan
+**Surface:** Customers card, standard view, Account section (`app.js:3830`)
+
+## Summary
+
+The most recent customer photo automatically becomes the **faded backdrop of
+the Account section** in a customer's standard view. The photo is the selfie
+captured during agreement signing — already stored on the customer's card-bound
+agreements — so nothing new is captured. As newer agreements get signed, the
+newest selfie wins automatically.
+
+This replaces the tiny `cust-selfie` thumbnail that lives in the Account
+section's right column today: the section *becomes* the photo instead of
+carrying a small chip of it.
+
+## Goals
+
+- A customer's face gives their record an at-a-glance identity, in the
+  "yard data-plate" language (the photo reads as a ghost behind the steel
+  panel, never a glamour shot).
+- Zero new capture, zero backend/schema change — read what's already on the
+  record.
+- Self-updating: the newest signing's selfie is always the one shown.
+
+## Non-goals
+
+- No new photo capture or upload flow.
+- No toggle / hide control — the newest selfie always shows (decided 2026-06-20).
+- No change to any card other than Customers, or any section other than
+  Account.
+- **Not** related to the IndexedDB chat-rail storage work (parked separately,
+  see `## Relationship to the storage spec`). This feature reads record fields,
+  not localStorage.
+
+## Decisions (locked 2026-06-20)
+
+| Question | Decision |
+|---|---|
+| Photo source | Newest agreement signing's selfie across all the customer's cards |
+| Treatment | Full-bleed faded backdrop behind the Account section, steel scrim |
+| Privacy / control | Always auto-show, no toggle |
+| Existing thumb pill | Retired — the section is the photo now |
+
+## Architecture
+
+### 1 · Photo source — `latestCustomerSelfie(c)`
+
+A new pure resolver (sits near the existing `signingSelfieSrc` /
+`cardSignings` helpers, ~`app.js:258`–`289`):
+
+```
+latestCustomerSelfie(c) →
+  1. collect every signing across the customer's cards:
+       customerCards(c).flatMap(cardSignings)
+  2. keep those with a selfie source (driveSelfieUrl || selfie)
+  3. pick the one with the newest signedAt
+  4. return signingSelfieSrc(newest)        // driveSelfieUrl || selfie
+  5. fallback: legacy customer-level c.selfie
+  6. else '' (no backdrop)
+```
+
+- **Prefer the Drive URL.** `signingSelfieSrc` already returns
+  `driveSelfieUrl || selfie`, so a signed-and-uploaded agreement yields a light
+  URL; only un-uploaded captures fall back to the base64 blob. This keeps the
+  DOM light — a base64 image in a CSS background is re-parsed on every render.
+- Pure function of the record; no I/O, independently testable. Add a case to
+  `ci/logic-test.mjs` (newest-wins, drive-over-base64, legacy fallback, empty).
+
+### 2 · Surface & DOM
+
+In the customers standard view (`app.js:3830`), the `account` template gains a
+backdrop layer and a marker class **only when a selfie exists**:
+
+```
+const selfie = latestCustomerSelfie(c);
+const account = `<div class="section sec-account${selfie ? ' has-photo' : ''}">
+  ${selfie ? `<div class="acct-photo" style="--acct-photo:url('${esc(selfie)}')"></div>` : ''}
+  <h4>Account</h4>
+  <div class="split"> … existing two columns, unchanged … </div>
+</div>`;
+```
+
+- The `.acct-photo` layer is absolutely positioned and fills the section,
+  sitting **behind** the content (the steel scrim + content render above it via
+  stacking context). `.section` gets `position:relative` / `overflow:hidden` on
+  the `.sec-account` variant only.
+- `esc()` the URL inside the `url('…')` to neutralize quote/paren breakouts
+  (selfie src is a data URL or a Drive URL; treat as untrusted).
+- Empty source → no `has-photo`, no `.acct-photo` node → today's exact plain
+  steel panel. Pure additive; nothing else moves.
+- Retire the `selfieThumb` chip from the right column's `kvPills(...)` at
+  `app.js:3839` (it becomes redundant). The `selfieThumb` const and its
+  `.cust-selfie` rule are removed.
+
+### 3 · Treatment — runs through `jactec-ui`
+
+The visual is built and screenshot-reviewed through the `jactec-ui` skill before
+showing Jac. Direction (not final CSS):
+
+- The face sits **faded and desaturated** under a steel scrim
+  (`linear-gradient(180deg, rgba(27,33,41,.86), rgba(12,14,17,.92))` over the
+  image) so it reads as a ghost behind the data-plate — industrial first,
+  never a portrait.
+- Text contrast preserved (stamped `Account` label, fields, derived rows all
+  stay legible against the scrim — quality-floor contrast check).
+- Static — no parallax/animation; reduced-motion is a non-issue but respected.
+- Rivets / stamped label / existing layout unchanged. The photo is a
+  background, not a new component.
+
+### 4 · Data flow
+
+```
+customer record (DATA)
+  └─ cards[].agreements[]  ──cardSignings──▶ newest signing by signedAt
+                                              └─ signingSelfieSrc → URL/blob
+                                                  └─ inline --acct-photo var
+                                                      └─ .acct-photo backdrop
+```
+
+No async, no fetch, no storage write. Render-time read only.
+
+### 5 · Error / edge handling
+
+- No agreements / no selfie → no backdrop (plain panel). Most-common new-customer
+  state; must look intentional, not broken.
+- Drive URL present but image 404s (deleted in Drive) → CSS background simply
+  doesn't paint; the scrim + steel panel still render fine. No JS error path.
+- Multiple cards, multiple signings → newest `signedAt` wins deterministically;
+  ties broken by array order (last signed).
+- Legacy customers with only `c.selfie` and no card agreements → fallback path
+  shows the legacy selfie.
+
+## Relationship to the storage spec
+
+Separate feature. The earlier discussion (robust IndexedDB storage for the
+Mr. Wrangler chat rail + feedback queue, hybrid Blob-now/Drive-on-file) is
+**parked** as its own spec. This backdrop feature reads selfies straight off
+the customer record and touches neither localStorage nor IndexedDB. They share
+only a philosophy: prefer a Drive URL over an inline base64 blob.
+
+## Testing
+
+- `ci/logic-test.mjs`: `latestCustomerSelfie` — newest-wins across cards,
+  drive-over-base64 preference, legacy `c.selfie` fallback, empty → ''.
+- `ci/smoke.mjs`: customers standard view renders with and without a selfie
+  (no thrown error, `has-photo` present only when a selfie exists).
+- Manual: a customer with a signed agreement shows the faded face; a brand-new
+  customer shows the plain panel; signing a newer agreement swaps the face.
+
+## Gates (per CLAUDE.md)
+
+- Build/review the visual through the `jactec-ui` skill; screenshot +
+  self-critique before showing Jac.
+- If any new affordance carries a `data-r` stamp, regenerate
+  `rule-usage.js` (`node ci/gen-rule-usage.mjs`) — a pure backdrop likely adds
+  none.
+- Pass the three gates: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
+  `node ci/gen-rule-usage.mjs --check` (port-swap 8000→9147 first, restore
+  `ci/` after).
+- Bump the shared `?v=` token on `style.css` / `app.js` / `rule-usage.js` in
+  `index.html`.
+- Ship via feature branch → PR → squash-merge (main is branch-protected).

--- a/docs/superpowers/specs/2026-06-20-customer-photo-account-backdrop-design.md
+++ b/docs/superpowers/specs/2026-06-20-customer-photo-account-backdrop-design.md
@@ -51,8 +51,8 @@ brief pre-upload window; the steady state is a URL.
 | Question | Decision |
 |---|---|
 | Customer photo source | Newest agreement signing's selfie across the customer's cards |
-| WO photo source | First photo uploaded to the WO; else the linked inspection's photo |
-| WO lifecycle | Frozen on first set; backdrop dropped when the WO is Complete |
+| WO photo source | The WO's first EXISTING photo — the linked failed-inspection photo, else the earliest part-line photo. **No new upload UI or stored field** (Jac, 2026-06-20): photos already arrive via Failed Inspections or a part's photo upload, so the resolver only references them. |
+| WO lifecycle | Deterministic first-photo (inspection origin wins); backdrop dropped when the WO is Complete |
 | Treatment (both) | Full-bleed faded backdrop behind the section, steel scrim |
 | Privacy / control | Always auto-show, no toggle |
 | Source representation | Drive URL preferred (lazy-loaded); base64 only as transient fallback |
@@ -84,113 +84,106 @@ brief pre-upload window; the steady state is a URL.
 6. else '' → no backdrop
 ```
 
-**Surface** — in the `account` template (`app.js:3830`), add a backdrop layer
-and marker class only when a source exists:
+**Surface** — in the `account` template, add the backdrop layer + marker class
+only when a source exists:
 
 ```
-const selfie = latestCustomerSelfie(c);
-const account = `<div class="section sec-account${selfie ? ' has-photo' : ''}">
-  ${selfie ? `<div class="acct-photo" style="--photo:url('${esc(selfie)}')"></div>` : ''}
-  <h4>Account</h4>
+const acctSelfie = latestCustomerSelfie(c);
+const account = `<div class="section${acctSelfie ? ' has-photo' : ''}">${
+  acctSelfie ? `<div class="sec-photo" style="--photo:url('${esc(acctSelfie)}')"></div>` : ''
+}<h4>Account</h4>
   <div class="split"> … existing columns, unchanged … </div>
 </div>`;
 ```
 
-Retire the `selfieThumb` chip + `.cust-selfie` rule (`app.js:3823`, `:3839`) —
-the section is the photo now.
+Retired the `selfieThumb` chip + `.cust-selfie` rule — the section is the photo
+now.
 
 ### B · Work Order backdrop
 
-**New persisted field:** `w.bgPhotoUrl` — a Drive URL, **written once** when the
-WO's first photo is attached, then immutable.
-
-**New capability:** attach a photo to a WO. Reuse the existing Drive upload
-infra (`uploadCapture` backend action / `uploadCaptureMedia`, `app.js:9272`):
-the file uploads to Drive, the returned URL is stored in `w.bgPhotoUrl` (and may
-also feed an attachments list later — out of scope here). The upload affordance
-lives in the WO section header (an `addBtn`/icon, `data-r` stamped).
+**No new field, no new UI** (Jac, 2026-06-20). WO photos already exist on the
+records — the linked failed-inspection's `photo`, or a part line's `li.photo`
+(captured for Mr. Wrangler's photo-autofill). The backdrop only *references* the
+first such photo, so it adds **zero new storage** and honors the "no new base64
+path" rule by construction.
 
 **Source resolver — `woBackdrop(w)`:**
 
 ```
-if (w.phase === 'Complete') return '';          // dropped on completion
-if (w.bgPhotoUrl) return w.bgPhotoUrl;          // frozen first upload
+if (!w || w.phase === 'Complete') return '';          // dropped on completion
 const insp = w.inspectionId && IDX.insp.get(w.inspectionId);
-if (insp && insp.photo) return insp.photo;      // fallback: spawning inspection
+if (insp && insp.photo) return insp.photo;            // origin: the failed inspection
+for (const li of (w.lineItems || [])) if (li.photo) return li.photo;  // else first part photo
 return '';
 ```
 
-- **Frozen:** once `w.bgPhotoUrl` is set it never changes (the first photo wins;
-  later uploads don't replace the backdrop).
+- **Deterministic "first photo":** for a Failed WO the inspection photo predates
+  any part work, so it wins (the genuine first photo); a Manual WO falls to its
+  earliest part-line photo. Both are stable, so the backdrop is effectively
+  frozen without a stored field.
 - **Dropped on Complete:** the resolver returns `''` for a completed WO → the
-  section reverts to plain steel. The stored `w.bgPhotoUrl` is *kept* (cheap, a
-  URL) so the field is stable, but it's simply not rendered. Only **open** WOs
-  carry a live backdrop — the working set stays small by design.
+  section reverts to plain steel. Only **open** WOs carry a live backdrop — the
+  working set stays small by design.
 
 **Surface** — the WO section template (`app.js:3227`) gets the same
-`has-photo` + `.acct-photo`/`.wo-photo` backdrop-layer pattern, driven by
-`woBackdrop(w)`.
+`has-photo` + `.sec-photo` backdrop-layer pattern, driven by `woBackdrop(w)`.
 
-### Shared treatment — runs through `jactec-ui`
+### Shared treatment — `.sec-photo` (built + screenshot-reviewed via `jactec-ui`)
 
-Built and screenshot-reviewed through the `jactec-ui` skill before showing Jac.
-Direction (not final CSS):
+One shared backdrop layer for both surfaces (`style.css`, by the `.section` rule):
 
-- The image sits **faded and desaturated** under a steel scrim
-  (`linear-gradient(180deg, rgba(27,33,41,.86), rgba(12,14,17,.92))`) so it
-  reads as a ghost behind the data-plate — industrial first.
-- Text contrast preserved (stamped label, fields, derived rows stay legible —
-  quality-floor contrast check).
-- Static; reduced-motion respected. Rivets / layout unchanged. The backdrop is
-  a background, not a new component.
-- Backdrop layer is absolutely positioned, `inset:0`, behind content; the
-  `.section` variant gets `position:relative; overflow:hidden`.
-- `esc()` the URL inside `url('…')` — treat the src as untrusted.
+- The image sits **faded and desaturated** (`filter: grayscale(.5) contrast(.96)`)
+  under a **fully tokenized** steel scrim —
+  `linear-gradient(180deg, color-mix(in srgb, var(--panel) 82%, transparent),
+  color-mix(in srgb, var(--bg) 91%, transparent))` — so it reads as a ghost
+  behind the data-plate (industrial first) **and themes itself** for dark /
+  light / yard / ranch with no per-theme CSS. Verified: dark = light text on a
+  dark scrim, light = dark text on a light scrim, both AA-legible.
+- Static; nothing for `prefers-reduced-motion` to disable. Rivets / layout
+  unchanged. The backdrop is a background, **not** a lint-family element, so it
+  carries **no `data-r`** and adds nothing to `rule-usage.js`.
+- Layer is `position:absolute; inset:0; z-index:0; pointer-events:none`; the
+  `.section.has-photo` gets `position:relative; overflow:hidden` and its content
+  children ride `z-index:1`. Tooltips/menus are `position:fixed` at body level,
+  so `overflow:hidden` clips nothing real.
+- `esc()` the URL inside `url('…')` — treat the src as untrusted (data-URLs and
+  Drive URLs carry no single-quote, so quoting holds).
 
 ### Data flow
 
 ```
 record (DATA)
   ├─ customer: cards[].agreements[] → newest signedAt → signingSelfieSrc → URL
-  └─ work order: w.bgPhotoUrl (frozen) ?? inspection.photo, gated by phase
-        └─ inline --photo var → .section.has-photo backdrop (lazy CSS bg)
+  └─ work order: inspection.photo ?? first lineItems[].photo, gated by phase
+        └─ inline --photo var → .section.has-photo .sec-photo backdrop (lazy CSS bg)
 ```
 
 No async at render; the browser lazy-fetches the referenced URL on view.
 
 ### Error / edge handling
 
-- No source → no `has-photo` → today's plain panel (must look intentional).
-- Drive URL 404 (deleted) → CSS bg simply doesn't paint; scrim + panel still
-  render; no JS error path.
+- No source → no `has-photo` → today's plain panel (looks intentional).
+- URL 404 (deleted) → CSS bg simply doesn't paint; scrim + panel still render;
+  no JS error path.
 - Customer: multiple signings → newest `signedAt` wins deterministically.
-- WO: first upload frozen; completion hides (not deletes) the backdrop.
-- Legacy customer with only `c.selfie` → fallback path renders it (transient
-  base64 until/unless migrated to a Drive URL).
+- WO: inspection photo wins over a part photo; completion hides the backdrop.
+- Legacy customer with only `c.selfie` → fallback path renders it.
 
-## Testing
+## Testing — DONE
 
-- `ci/logic-test.mjs`:
-  - `latestCustomerSelfie` — newest-wins, drive-over-base64, legacy fallback,
-    empty → ''.
-  - `woBackdrop` — frozen `bgPhotoUrl` wins; inspection-photo fallback; Complete
-    → ''; no source → ''.
-- `ci/smoke.mjs`: customer + WO standard views render with and without a source
-  (no throw; `has-photo` present only when a source exists; completed WO shows
-  no backdrop).
-- Manual: signed customer shows faded face; new customer shows plain panel;
-  signing a newer agreement swaps the face. Open WO with a photo shows the
-  backdrop; completing it reverts to steel; a second upload does not change it.
+- `ci/logic-test.mjs` (now 68/68): `latestCustomerSelfie` — newest-wins,
+  drive-over-base64, multi-card newest, legacy fallback, empty → '';
+  `woBackdrop` — first part photo, inspection-photo precedence, Complete → '',
+  no source → ''.
+- `ci/smoke.mjs`: app boots clean (both templates render without throw).
+- Visual self-critique: dark + light Account-backdrop screenshots reviewed
+  against `jactec-ui` (ghost-behind-plate, AA contrast, tokenized scrim). The WO
+  section reuses the identical `.sec-photo` layer.
 
-## Gates (per CLAUDE.md)
+## Gates (per CLAUDE.md) — PASSED
 
-- Build/review the visual through the `jactec-ui` skill; screenshot +
-  self-critique before showing Jac.
-- The WO upload affordance carries a `data-r` stamp → regenerate `rule-usage.js`
-  (`node ci/gen-rule-usage.mjs`). A pure backdrop adds none.
-- Pass the three gates: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
-  `node ci/gen-rule-usage.mjs --check` (port-swap 8000→9147 first, restore
-  `ci/` after).
-- Bump the shared `?v=` token on `style.css` / `app.js` / `rule-usage.js` in
-  `index.html`.
+- Three gates green: `node ci/smoke.mjs`, `node ci/logic-test.mjs` (68/68),
+  `node ci/gen-rule-usage.mjs --check` (current — no `data-r` change).
+- Shared `?v=` token bumped `20260619n → 20260620a` on `style.css` /
+  `rule-usage.js` / `app.js` in `index.html`.
 - Ship via feature branch → PR → squash-merge (main is branch-protected).

--- a/docs/superpowers/specs/2026-06-20-customer-photo-account-backdrop-design.md
+++ b/docs/superpowers/specs/2026-06-20-customer-photo-account-backdrop-design.md
@@ -1,162 +1,193 @@
-# Customer photo → Account-section backdrop
+# Photo backdrops — Account + Work Order (scale-safe)
 
 **Date:** 2026-06-20
-**Status:** Approved (design) — ready for implementation plan
-**Surface:** Customers card, standard view, Account section (`app.js:3830`)
+**Status:** Approved (design, v2) — ready for implementation plan
+**Surfaces:** Customers standard view → Account section (`app.js:3830`);
+Work Orders standard view → WO section (`app.js:3227`)
 
 ## Summary
 
-The most recent customer photo automatically becomes the **faded backdrop of
-the Account section** in a customer's standard view. The photo is the selfie
-captured during agreement signing — already stored on the customer's card-bound
-agreements — so nothing new is captured. As newer agreements get signed, the
-newest selfie wins automatically.
+A record's most relevant photo becomes the **faded backdrop of its section**,
+in the "yard data-plate" language (a ghost behind the steel panel, never a
+glamour shot):
 
-This replaces the tiny `cust-selfie` thumbnail that lives in the Account
-section's right column today: the section *becomes* the photo instead of
-carrying a small chip of it.
+- **Customer Account section** — the newest agreement selfie. Self-updating:
+  a newer signing's selfie wins automatically.
+- **Work Order section** — the WO's **first** photo, **frozen** (never changes).
+  The backdrop is **dropped once the WO is Complete**, so only open WOs ever
+  carry one.
 
-## Goals
+The unifying constraint — and the reason this is a single spec — is **scale
+safety**: at thousands of customers and a long tail of work orders, a backdrop
+must cost a lazy-loaded Drive URL per *viewed* card, never inline image data in
+the bulk payload.
 
-- A customer's face gives their record an at-a-glance identity, in the
-  "yard data-plate" language (the photo reads as a ghost behind the steel
-  panel, never a glamour shot).
-- Zero new capture, zero backend/schema change — read what's already on the
-  record.
-- Self-updating: the newest signing's selfie is always the one shown.
+## The scaling problem (why this is one spec, not cosmetics)
 
-## Non-goals
+The danger is **not** localStorage — these photos aren't stored there. They ride
+on records in `DATA`, which the app pulls **in bulk on every cold load**. So the
+real failure mode at thousands of customers is an **inline base64 selfie**
+(~30–80 KB) on every record: opening the app would download every face every
+load — tens to hundreds of MB of payload, fat Sheet cells, slow boot, memory
+pressure. A background viewed one-at-a-time must never cost shipping all of them
+to every device at startup.
 
-- No new photo capture or upload flow.
-- No toggle / hide control — the newest selfie always shows (decided 2026-06-20).
-- No change to any card other than Customers, or any section other than
-  Account.
-- **Not** related to the IndexedDB chat-rail storage work (parked separately,
-  see `## Relationship to the storage spec`). This feature reads record fields,
-  not localStorage.
+**The discipline (load-bearing, not optional):**
+
+1. **Reference, don't embed.** The backdrop source must be a **Drive URL**
+   (~60 bytes on the record), never inline base64 in the bulk payload.
+2. **Lazy-load per view.** The browser fetches the one image only when that
+   card is actually rendered (CSS background on a `.section` that exists only
+   for the open record). One face on demand, not thousands at boot.
+3. **No new path may re-embed base64** into a record that loads in bulk.
+
+The selfie path already enforces this: `app.js:394` —
+`if (r.selfieUrl) { sig.driveSelfieUrl = r.selfieUrl; sig.selfie = ''; }` swaps
+the Drive URL in and **clears** the base64 on sync. base64 exists only in the
+brief pre-upload window; the steady state is a URL.
 
 ## Decisions (locked 2026-06-20)
 
 | Question | Decision |
 |---|---|
-| Photo source | Newest agreement signing's selfie across all the customer's cards |
-| Treatment | Full-bleed faded backdrop behind the Account section, steel scrim |
+| Customer photo source | Newest agreement signing's selfie across the customer's cards |
+| WO photo source | First photo uploaded to the WO; else the linked inspection's photo |
+| WO lifecycle | Frozen on first set; backdrop dropped when the WO is Complete |
+| Treatment (both) | Full-bleed faded backdrop behind the section, steel scrim |
 | Privacy / control | Always auto-show, no toggle |
-| Existing thumb pill | Retired — the section is the photo now |
+| Source representation | Drive URL preferred (lazy-loaded); base64 only as transient fallback |
+| Existing selfie thumb | Retired — the section is the photo now |
+
+## Non-goals
+
+- No change to localStorage / IndexedDB. The Mr. Wrangler **chat-rail** storage
+  refactor (hybrid Blob-now / Drive-on-file in IndexedDB) is a **separate,
+  parked spec** — different problem (local device history), not this.
+- No backdrop on the compact/grid card face — standard view sections only.
+- No toggle / hide control (decided).
+- No re-encoding or thumbnail-derivative pipeline; the existing downscaled
+  capture (selfie ≈ 1200px / 0.6 JPEG) is enough for a faded background.
 
 ## Architecture
 
-### 1 · Photo source — `latestCustomerSelfie(c)`
+### A · Customer Account backdrop
 
-A new pure resolver (sits near the existing `signingSelfieSrc` /
-`cardSignings` helpers, ~`app.js:258`–`289`):
+**Source — `latestCustomerSelfie(c)`** (pure resolver near `signingSelfieSrc` /
+`cardSignings`, ~`app.js:258`–`289`):
 
 ```
-latestCustomerSelfie(c) →
-  1. collect every signing across the customer's cards:
-       customerCards(c).flatMap(cardSignings)
-  2. keep those with a selfie source (driveSelfieUrl || selfie)
-  3. pick the one with the newest signedAt
-  4. return signingSelfieSrc(newest)        // driveSelfieUrl || selfie
-  5. fallback: legacy customer-level c.selfie
-  6. else '' (no backdrop)
+1. customerCards(c).flatMap(cardSignings)          // every signing
+2. keep those with a selfie source                  // driveSelfieUrl || selfie
+3. pick newest by signedAt                           // ties → last in order
+4. return signingSelfieSrc(newest)                   // PREFERS driveSelfieUrl
+5. fallback: legacy customer-level c.selfie
+6. else '' → no backdrop
 ```
 
-- **Prefer the Drive URL.** `signingSelfieSrc` already returns
-  `driveSelfieUrl || selfie`, so a signed-and-uploaded agreement yields a light
-  URL; only un-uploaded captures fall back to the base64 blob. This keeps the
-  DOM light — a base64 image in a CSS background is re-parsed on every render.
-- Pure function of the record; no I/O, independently testable. Add a case to
-  `ci/logic-test.mjs` (newest-wins, drive-over-base64, legacy fallback, empty).
-
-### 2 · Surface & DOM
-
-In the customers standard view (`app.js:3830`), the `account` template gains a
-backdrop layer and a marker class **only when a selfie exists**:
+**Surface** — in the `account` template (`app.js:3830`), add a backdrop layer
+and marker class only when a source exists:
 
 ```
 const selfie = latestCustomerSelfie(c);
 const account = `<div class="section sec-account${selfie ? ' has-photo' : ''}">
-  ${selfie ? `<div class="acct-photo" style="--acct-photo:url('${esc(selfie)}')"></div>` : ''}
+  ${selfie ? `<div class="acct-photo" style="--photo:url('${esc(selfie)}')"></div>` : ''}
   <h4>Account</h4>
-  <div class="split"> … existing two columns, unchanged … </div>
+  <div class="split"> … existing columns, unchanged … </div>
 </div>`;
 ```
 
-- The `.acct-photo` layer is absolutely positioned and fills the section,
-  sitting **behind** the content (the steel scrim + content render above it via
-  stacking context). `.section` gets `position:relative` / `overflow:hidden` on
-  the `.sec-account` variant only.
-- `esc()` the URL inside the `url('…')` to neutralize quote/paren breakouts
-  (selfie src is a data URL or a Drive URL; treat as untrusted).
-- Empty source → no `has-photo`, no `.acct-photo` node → today's exact plain
-  steel panel. Pure additive; nothing else moves.
-- Retire the `selfieThumb` chip from the right column's `kvPills(...)` at
-  `app.js:3839` (it becomes redundant). The `selfieThumb` const and its
-  `.cust-selfie` rule are removed.
+Retire the `selfieThumb` chip + `.cust-selfie` rule (`app.js:3823`, `:3839`) —
+the section is the photo now.
 
-### 3 · Treatment — runs through `jactec-ui`
+### B · Work Order backdrop
 
-The visual is built and screenshot-reviewed through the `jactec-ui` skill before
-showing Jac. Direction (not final CSS):
+**New persisted field:** `w.bgPhotoUrl` — a Drive URL, **written once** when the
+WO's first photo is attached, then immutable.
 
-- The face sits **faded and desaturated** under a steel scrim
-  (`linear-gradient(180deg, rgba(27,33,41,.86), rgba(12,14,17,.92))` over the
-  image) so it reads as a ghost behind the data-plate — industrial first,
-  never a portrait.
-- Text contrast preserved (stamped `Account` label, fields, derived rows all
-  stay legible against the scrim — quality-floor contrast check).
-- Static — no parallax/animation; reduced-motion is a non-issue but respected.
-- Rivets / stamped label / existing layout unchanged. The photo is a
-  background, not a new component.
+**New capability:** attach a photo to a WO. Reuse the existing Drive upload
+infra (`uploadCapture` backend action / `uploadCaptureMedia`, `app.js:9272`):
+the file uploads to Drive, the returned URL is stored in `w.bgPhotoUrl` (and may
+also feed an attachments list later — out of scope here). The upload affordance
+lives in the WO section header (an `addBtn`/icon, `data-r` stamped).
 
-### 4 · Data flow
+**Source resolver — `woBackdrop(w)`:**
 
 ```
-customer record (DATA)
-  └─ cards[].agreements[]  ──cardSignings──▶ newest signing by signedAt
-                                              └─ signingSelfieSrc → URL/blob
-                                                  └─ inline --acct-photo var
-                                                      └─ .acct-photo backdrop
+if (w.phase === 'Complete') return '';          // dropped on completion
+if (w.bgPhotoUrl) return w.bgPhotoUrl;          // frozen first upload
+const insp = w.inspectionId && IDX.insp.get(w.inspectionId);
+if (insp && insp.photo) return insp.photo;      // fallback: spawning inspection
+return '';
 ```
 
-No async, no fetch, no storage write. Render-time read only.
+- **Frozen:** once `w.bgPhotoUrl` is set it never changes (the first photo wins;
+  later uploads don't replace the backdrop).
+- **Dropped on Complete:** the resolver returns `''` for a completed WO → the
+  section reverts to plain steel. The stored `w.bgPhotoUrl` is *kept* (cheap, a
+  URL) so the field is stable, but it's simply not rendered. Only **open** WOs
+  carry a live backdrop — the working set stays small by design.
 
-### 5 · Error / edge handling
+**Surface** — the WO section template (`app.js:3227`) gets the same
+`has-photo` + `.acct-photo`/`.wo-photo` backdrop-layer pattern, driven by
+`woBackdrop(w)`.
 
-- No agreements / no selfie → no backdrop (plain panel). Most-common new-customer
-  state; must look intentional, not broken.
-- Drive URL present but image 404s (deleted in Drive) → CSS background simply
-  doesn't paint; the scrim + steel panel still render fine. No JS error path.
-- Multiple cards, multiple signings → newest `signedAt` wins deterministically;
-  ties broken by array order (last signed).
-- Legacy customers with only `c.selfie` and no card agreements → fallback path
-  shows the legacy selfie.
+### Shared treatment — runs through `jactec-ui`
 
-## Relationship to the storage spec
+Built and screenshot-reviewed through the `jactec-ui` skill before showing Jac.
+Direction (not final CSS):
 
-Separate feature. The earlier discussion (robust IndexedDB storage for the
-Mr. Wrangler chat rail + feedback queue, hybrid Blob-now/Drive-on-file) is
-**parked** as its own spec. This backdrop feature reads selfies straight off
-the customer record and touches neither localStorage nor IndexedDB. They share
-only a philosophy: prefer a Drive URL over an inline base64 blob.
+- The image sits **faded and desaturated** under a steel scrim
+  (`linear-gradient(180deg, rgba(27,33,41,.86), rgba(12,14,17,.92))`) so it
+  reads as a ghost behind the data-plate — industrial first.
+- Text contrast preserved (stamped label, fields, derived rows stay legible —
+  quality-floor contrast check).
+- Static; reduced-motion respected. Rivets / layout unchanged. The backdrop is
+  a background, not a new component.
+- Backdrop layer is absolutely positioned, `inset:0`, behind content; the
+  `.section` variant gets `position:relative; overflow:hidden`.
+- `esc()` the URL inside `url('…')` — treat the src as untrusted.
+
+### Data flow
+
+```
+record (DATA)
+  ├─ customer: cards[].agreements[] → newest signedAt → signingSelfieSrc → URL
+  └─ work order: w.bgPhotoUrl (frozen) ?? inspection.photo, gated by phase
+        └─ inline --photo var → .section.has-photo backdrop (lazy CSS bg)
+```
+
+No async at render; the browser lazy-fetches the referenced URL on view.
+
+### Error / edge handling
+
+- No source → no `has-photo` → today's plain panel (must look intentional).
+- Drive URL 404 (deleted) → CSS bg simply doesn't paint; scrim + panel still
+  render; no JS error path.
+- Customer: multiple signings → newest `signedAt` wins deterministically.
+- WO: first upload frozen; completion hides (not deletes) the backdrop.
+- Legacy customer with only `c.selfie` → fallback path renders it (transient
+  base64 until/unless migrated to a Drive URL).
 
 ## Testing
 
-- `ci/logic-test.mjs`: `latestCustomerSelfie` — newest-wins across cards,
-  drive-over-base64 preference, legacy `c.selfie` fallback, empty → ''.
-- `ci/smoke.mjs`: customers standard view renders with and without a selfie
-  (no thrown error, `has-photo` present only when a selfie exists).
-- Manual: a customer with a signed agreement shows the faded face; a brand-new
-  customer shows the plain panel; signing a newer agreement swaps the face.
+- `ci/logic-test.mjs`:
+  - `latestCustomerSelfie` — newest-wins, drive-over-base64, legacy fallback,
+    empty → ''.
+  - `woBackdrop` — frozen `bgPhotoUrl` wins; inspection-photo fallback; Complete
+    → ''; no source → ''.
+- `ci/smoke.mjs`: customer + WO standard views render with and without a source
+  (no throw; `has-photo` present only when a source exists; completed WO shows
+  no backdrop).
+- Manual: signed customer shows faded face; new customer shows plain panel;
+  signing a newer agreement swaps the face. Open WO with a photo shows the
+  backdrop; completing it reverts to steel; a second upload does not change it.
 
 ## Gates (per CLAUDE.md)
 
 - Build/review the visual through the `jactec-ui` skill; screenshot +
   self-critique before showing Jac.
-- If any new affordance carries a `data-r` stamp, regenerate
-  `rule-usage.js` (`node ci/gen-rule-usage.mjs`) — a pure backdrop likely adds
-  none.
+- The WO upload affordance carries a `data-r` stamp → regenerate `rule-usage.js`
+  (`node ci/gen-rule-usage.mjs`). A pure backdrop adds none.
 - Pass the three gates: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
   `node ci/gen-rule-usage.mjs --check` (port-swap 8000→9147 first, restore
   `ci/` after).

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260619n" />
+  <link rel="stylesheet" href="style.css?v=20260620a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260619n"></script>
-  <script type="module" src="app.js?v=20260619n"></script>
+  <script src="rule-usage.js?v=20260620a"></script>
+  <script type="module" src="app.js?v=20260620a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -898,6 +898,23 @@ select.lf-in { appearance: none; cursor: pointer; }
 
 /* sections sit on their own sub-cards (§6.2 #5) — standard dark panel surface */
 .section { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 12px; }
+/* Faded photo backdrop behind a standard-view section — the Account selfie, or an
+   OPEN work order's first photo. The image rides --photo (a Drive URL or an
+   existing record photo, fetched lazily only when this card renders) under a fully
+   TOKENIZED steel scrim, so it reads as a ghost behind the data-plate and themes
+   itself (dark / light / yard / ranch) for free. Static → nothing for
+   prefers-reduced-motion to disable. Tooltips/menus are position:fixed at body
+   level, so overflow:hidden here clips nothing real. */
+.section.has-photo { position: relative; overflow: hidden; }
+.section.has-photo > :not(.sec-photo) { position: relative; z-index: 1; }
+.sec-photo {
+  position: absolute; inset: 0; z-index: 0; pointer-events: none;
+  background-image:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel) 82%, transparent), color-mix(in srgb, var(--bg) 91%, transparent)),
+    var(--photo);
+  background-size: cover; background-position: center;
+  filter: grayscale(.5) contrast(.96);
+}
 /* section headers CENTERED (v2 build); right-side flags pin absolutely so the
    title stays true-center */
 .section > h4 { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 8px; display: flex; align-items: center; justify-content: center; gap: 7px; position: relative; }
@@ -1605,7 +1622,6 @@ select.nc-in { cursor: pointer; }
 .nc-sigpad { width: 100%; height: 96px; border-radius: 9px; border: 1px solid var(--accent-line); background: #fff; touch-action: none; cursor: crosshair; }
 .nc-tile-act { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
 .nc-tile-act .pill, .nc-tile-act label.pill { font-size: 11px; padding: 6px 11px; cursor: pointer; }
-.cust-selfie { width: 30px; height: 30px; border-radius: 8px; object-fit: cover; border: 1px solid var(--line); flex: 0 0 auto; }
 .nc-ag-note { font-weight: 600; text-transform: none; letter-spacing: 0; color: var(--txt-3); }
 .nc-ag-ok { font-weight: 700; text-transform: none; letter-spacing: 0; color: var(--good, #1a9f57); }
 .nc-agreement { max-height: 168px; overflow-y: auto; white-space: pre-wrap; font-size: 11.5px; line-height: 1.5; color: var(--txt-2); background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 12px 13px; -webkit-overflow-scrolling: touch; }

--- a/style.css
+++ b/style.css
@@ -910,7 +910,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .sec-photo {
   position: absolute; inset: 0; z-index: 0; pointer-events: none;
   background-image:
-    linear-gradient(180deg, color-mix(in srgb, var(--panel) 82%, transparent), color-mix(in srgb, var(--bg) 91%, transparent)),
+    linear-gradient(180deg, color-mix(in srgb, var(--panel) 76%, transparent), color-mix(in srgb, var(--panel) 83%, transparent)),
     var(--photo);
   background-size: cover; background-position: center;
   filter: grayscale(.5) contrast(.96);


### PR DESCRIPTION
Faded, desaturated photo as the backdrop of a record's section, in the yard data-plate language — a ghost behind the steel plate, industrial first. Spec is in `docs/superpowers/specs/2026-06-20-...md` (kept in sync with the build).

## What landed

**Customer Account section** — newest agreement selfie via `latestCustomerSelfie(c)`. Prefers the **Drive URL** (`driveSelfieUrl`), base64 only as the pre-offload fallback. Retired the tiny `.cust-selfie` thumb — the section *is* the photo now.

**Open Work Order section** — its first **existing** photo via `woBackdrop(w)`: the linked failed-inspection photo (the WO's origin), else the earliest part-line photo. **No new upload UI, no new stored field** — it only references photos that already arrive from Failed Inspections or a part's photo upload, so it adds zero new storage. **Dropped once the WO is Complete**, so only open WOs ever carry a backdrop — the working set stays small by design.

## Scale safety (the load-bearing bit)

The risk at thousands of customers is the **bulk DATA/Sheet payload**, not localStorage. So the backdrop resolves to a **lazy-loaded URL** the browser fetches only when a card is open — never inline base64 in the bootstrap. The customer side leans on the existing `app.js:394` Drive-URL swap; the WO side references photos already on the records and introduces **no new base64 path**.

## Treatment

One shared `.sec-photo` layer: image under a **fully tokenized** steel scrim (`color-mix` on `--panel`/`--bg`) + `grayscale(.5)`, so it themes itself across dark / light / yard / ranch with no per-theme CSS. Static (nothing for reduced-motion to disable). It's a background, not a lint-family element → **no `data-r`**, no `rule-usage.js` change.

## Verification

- Self-critiqued dark + light Account-backdrop screenshots through the `jactec-ui` skill (ghost-behind-plate, AA contrast, tokenized scrim verified).
- Gates green: `smoke` ✅, `logic-test` **68/68** (+8 new checks for both resolvers), `gen-rule-usage --check` current.
- Cache-bust bumped `20260619n → 20260620a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)