### PR TITLE
Mr. Wrangler chat-rail storage — IndexedDB + Drive offload

### DIFF
--- a/app.js
+++ b/app.js
@@ -5309,12 +5309,82 @@ async function wrIngestImages(chatId, images) {
   return out;
 }
 /* Persist a rail snapshot to IndexedDB (ingesting its image blobs). Async +
-   LOUD on failure — the old silent localStorage catch is gone for good. */
+   LOUD on failure — the old silent localStorage catch is gone for good. Then run
+   the two offload triggers: a FILED chat's images go to Drive (they're in the
+   issue now), and the budget check keeps the store bounded. */
 async function wranglerRailPersist(snap) {
   try {
     for (const m of (snap.messages || [])) { if (m.images) m.images = await wrIngestImages(snap.id, m.images); }
     await wrStore.putChat(snap);
-  } catch (e) { toast('⚠ Couldn’t save this chat locally — ' + ((e && e.message) || 'storage error')); }
+  } catch (e) { toast('⚠ Couldn’t save this chat locally — ' + ((e && e.message) || 'storage error')); return; }
+  const online = typeof backendPassword !== 'undefined' && backendPassword;
+  if (online && (snap.messages || []).some((m) => m.filed)) wrOffloadChatImages(snap);   // on-file: free the local copies (safe — they ride the issue)
+  wrEnforceBudget();                                                                     // threshold: keep the store ≤ budget
+}
+// ── The storage guarantee: offload to Drive + bounded eviction (never overflow) ──
+const WR_LOCAL_BUDGET = 25 * 1024 * 1024;   // hard ceiling for the Wrangler store
+function wrRevoke(blobKey) { if (wrBlobUrls[blobKey]) { try { URL.revokeObjectURL(wrBlobUrls[blobKey]); } catch (e) {} delete wrBlobUrls[blobKey]; } }
+function wrBlobToDataUrl(blob) { return new Promise((res, rej) => { const r = new FileReader(); r.onload = () => res(r.result); r.onerror = () => rej(r.error); r.readAsDataURL(blob); }); }
+/* Offload a chat's un-synced image blobs to Drive (online only): set driveUrl,
+   drop the local blob (it re-fetches from the URL). _upload is a test seam. */
+async function wrOffloadChatImages(chat, _upload) {
+  const upload = _upload || ((typeof backendPassword !== 'undefined' && backendPassword) ? ((p) => backendCall('uploadCapture', p)) : null);
+  if (!upload || !chat) return false;
+  let changed = false;
+  for (const m of (chat.messages || [])) for (const img of (m.images || [])) {
+    if (!img || typeof img !== 'object' || !img.blobKey || img.driveUrl) continue;
+    try {
+      const blob = await wrStore.getBlob(img.blobKey); if (!blob) continue;
+      const res = await upload({ dataUrl: await wrBlobToDataUrl(blob), name: 'wrchat_' + chat.id + '_' + img.blobKey });
+      if (res && res.ok && res.url) { await wrStore.delBlob(img.blobKey); wrRevoke(img.blobKey); img.driveUrl = res.url; delete img.blobKey; changed = true; }   // blob now lives on Drive
+    } catch (e) { /* leave the blob — never lose it */ }
+  }
+  if (changed) { try { await wrStore.putChat(chat); } catch (e) {} }
+  return changed;
+}
+/* Drop a chat's LOCAL image blobs to free space. Synced blobs (have a driveUrl)
+   are a SAFE cache drop — re-fetchable; un-synced is a lossy last resort. */
+async function wrEvictChatBlobs(chat, unsyncedOk) {
+  let n = 0;
+  for (const m of (chat.messages || [])) for (const img of (m.images || [])) {
+    if (!img || typeof img !== 'object' || !img.blobKey) continue;   // no local blob to drop
+    if (img.driveUrl || unsyncedOk) {
+      try { await wrStore.delBlob(img.blobKey); } catch (e) {}
+      wrRevoke(img.blobKey);
+      if (!img.driveUrl) img.gone = true;   // un-synced + dropped → image lost (render shows nothing); text/ref kept
+      delete img.blobKey;                   // local blob gone → not re-counted on a later pass
+      n++;
+    }
+  }
+  if (n) { try { await wrStore.putChat(chat); } catch (e) {} }   // persist the ref changes
+  return n;
+}
+/* Keep the Wrangler store ≤ WR_LOCAL_BUDGET so localStorage's silent overflow can
+   never recur — layered, loss-averse, loud: (1) images → Drive when online,
+   (2) synced-first blob eviction, (3) un-synced eviction + (4) oldest-text trim as
+   the unreachable backstop. Text is never dropped before every image is gone. */
+let _wrEnforcing = false;
+async function wrEnforceBudget() {
+  if (_wrEnforcing) return;
+  let usage; try { usage = (await wrStore.estimate()).usage || 0; } catch (e) { return; }
+  if (usage < WR_LOCAL_BUDGET * 0.6) return;                                    // comfortably under → nothing to do
+  _wrEnforcing = true;
+  const under = async () => { try { return ((await wrStore.estimate()).usage || 0) < WR_LOCAL_BUDGET * 0.6; } catch (e) { return true; } };
+  const over = async () => { try { return ((await wrStore.estimate()).usage || 0) >= WR_LOCAL_BUDGET; } catch (e) { return false; } };
+  try {
+    const oldest = [...state.wranglerRail].sort((a, b) => (a.ts || 0) - (b.ts || 0));
+    const online = typeof backendPassword !== 'undefined' && backendPassword;
+    if (online) { for (const c of oldest) { await wrOffloadChatImages(c); if (await under()) return; } }   // Layer 1
+    for (const c of oldest) { await wrEvictChatBlobs(c, false); if (await under()) return; }               // Layer 2 (synced-first, safe)
+    if (await over()) {                                                                                     // Layer 3 (lossy, LOUD)
+      let dropped = 0; for (const c of oldest) { dropped += await wrEvictChatBlobs(c, true); if (await under()) break; }
+      if (dropped) toast('⚠ Freed local space — ' + dropped + ' un-synced chat image' + (dropped === 1 ? '' : 's') + ' dropped. Reconnect to save them to Drive.');
+      if (await over()) {                                                                                   // Layer 4 (text backstop)
+        for (const c of oldest) { try { await wrStore.delChat(c.id); } catch (e) {} state.wranglerRail = state.wranglerRail.filter((x) => x.id !== c.id); if (await under()) break; }
+        toast('⚠ Trimmed the oldest chats to stay under the storage limit.'); render();
+      }
+    }
+  } finally { _wrEnforcing = false; }
 }
 /* Boot: migrate the legacy localStorage rail into IndexedDB (one-time), then load
    ALL stored chats into the in-memory rail (newest first). Keep-all retention —
@@ -11953,7 +12023,7 @@ function exposeTestApi() {
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
       wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction,
-      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad };
+      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs };
   } catch (e) { /* no window (non-browser) */ }
 }
 

--- a/app.js
+++ b/app.js
@@ -1440,7 +1440,7 @@ const state = {
   previewsOn: (() => { try { return localStorage.getItem('jactec.previewsOff') !== '1'; } catch (e) { return true; } })(),   // hover previews (per device)
   overbookOn: (() => { try { return localStorage.getItem('jactec.overbook') === '1'; } catch (e) { return false; } })(),   // §10 allow-overbooking policy (per device, default OFF — drag build)
   hapticsOff: (() => { try { return localStorage.getItem('jactec.hapticsOff') === '1'; } catch (e) { return false; } })(),   // §M-touch Vibration-API feedback (per device, default ON; Android-only, no-op on iOS)
-  wranglerRail: (() => { try { return JSON.parse(localStorage.getItem('jactec.wranglerRail') || '[]'); } catch (e) { return []; } })(),   // §18g the bottom-right rail of past Mr. Wrangler conversations (per device); each = a snapshot { id, title, ts, card, recId, recType, reqNumber, reqTitle, reqUrl, messages }
+  wranglerRail: [],   // §18g the bottom-right rail of past Mr. Wrangler conversations (per device), each a snapshot { id, title, ts, card, recId, recType, reqNumber, reqTitle, reqUrl, messages }. Loaded async from IndexedDB (wranglerRailLoad) — IndexedDB replaced the localStorage rail that silently overflowed.
 };
 const activeSession = () => (state.activeTabId ? state.tabs.find((t) => t.id === state.activeTabId)?.session : state.defaultSession) || state.defaultSession;
 /** Next unique invoice id — a monotonic counter so deleting a Quote-stage invoice can't reuse a number. */
@@ -5175,7 +5175,7 @@ function wranglerDockEl() {
               ? `<span class="wr-actdone" style="color:var(--txt-3)">…filing</span>`
               : `<button class="wr-actbtn${ak === 'plan' ? ' wr-actbtn-build' : ''} js-wr-act" data-mi="${i}">${btnLbl}</button>`;
         }
-        const imgs = (m.images && m.images.length) ? `<div class="wr-bub-imgs">${m.images.map((s) => `<img src="${esc(s)}" alt="attached image">`).join('')}</div>` : '';
+        const imgs = (m.images && m.images.length) ? `<div class="wr-bub-imgs">${m.images.map((img) => { const s = wrImgSrc(img); return s ? `<img src="${esc(s)}" alt="attached image">` : ''; }).join('')}</div>` : '';
         const files = (m.files && m.files.length) ? `<div class="wr-bub-files">${m.files.map((f) => `<span class="wr-file-chip" data-tip="${esc(f.name)}">${I.paperclip || '📎'}<span class="wr-file-n">${esc(f.name)}</span></span>`).join('')}</div>` : '';
         const txt = m.content ? `${esc(m.content).replace(/\n/g, '<br>')}` : '';
         return `<div class="wr-msg ${m.role}">${m.role === 'assistant' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub">${imgs}${files}${txt}${act}</div></div>`;
@@ -5204,6 +5204,7 @@ function wranglerDockEl() {
 }
 function mountWranglerDock() {
   const d = document.querySelector('.wrangler-dock'); if (!d) return;
+  wrHydrateBlobs(state.wrangler.messages);   // resolve any image blob refs → object URLs, then repaint
   const inp = d.querySelector('.js-wr-in');
   if (inp) inp.addEventListener('paste', (ev) => {
     const items = (ev.clipboardData && ev.clipboardData.items) || [];
@@ -5216,8 +5217,9 @@ function mountWranglerDock() {
 // §18g Conversation rail — the bottom-right strip of past Mr. Wrangler chats.
 // Opening Mr. Wrangler always starts a NEW chat; the one you leave is snapshotted
 // here so you can hop back in. A `needs-jac` chat (Mr. Wrangler is waiting on you)
-// rides the rail flashing until you answer it.
-const WR_RAIL_MAX = 8;   // how many stored chats the rail keeps (newest win)
+// rides the rail flashing until you answer it. Retention: KEEP ALL chats (the old
+// 8-chat localStorage cap is retired); the rail UI shows the recent few, the store
+// keeps everything, bounded by the size budget/offload layer.
 /* ── wrStore — IndexedDB for the Mr. Wrangler rail ────────────────────────────
    The rail used to live in localStorage with inline-base64 images; image-heavy
    chats blew the ~5MB cap and a silent try/catch swallowed the QuotaExceeded, so
@@ -5266,7 +5268,75 @@ const wrStore = {
     ? navigator.storage.estimate() : Promise.resolve({ usage: 0, quota: 0 }),
 };
 function wranglerNewId() { return 'wc' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6); }
-function wranglerRailSave() { try { localStorage.setItem('jactec.wranglerRail', JSON.stringify(state.wranglerRail.slice(0, WR_RAIL_MAX))); } catch (e) {} }
+/* A stored message's image is a ref { blobKey, driveUrl?, mime? } — or, for an
+   un-migrated LIVE message, a legacy base64 string. wrImgSrc → a renderable src:
+   the Drive URL if offloaded, else a session object URL for the local blob
+   (hydrated async, then a re-render paints it), else '' until ready. */
+const wrBlobUrls = Object.create(null);   // blobKey → object URL (per-session cache)
+function wrImgSrc(img) {
+  if (!img) return '';
+  if (typeof img === 'string') return img;              // legacy inline base64
+  if (img.driveUrl) return img.driveUrl;
+  return wrBlobUrls[img.blobKey] || '';                 // '' until hydrated, then re-render
+}
+let _wrHydrating = false;
+async function wrHydrateBlobs(messages) {
+  const need = new Set();
+  (messages || []).forEach((m) => (m.images || []).forEach((img) => {
+    if (img && typeof img === 'object' && img.blobKey && !img.driveUrl && !wrBlobUrls[img.blobKey]) need.add(img.blobKey);
+  }));
+  if (!need.size || _wrHydrating) return;
+  _wrHydrating = true; let any = false;
+  for (const key of need) { try { const b = await wrStore.getBlob(key); if (b) { wrBlobUrls[key] = URL.createObjectURL(b); any = true; } } catch (e) {} }
+  _wrHydrating = false;
+  if (any && state.wrangler.open) render();              // paint the now-resolved images (guard prevents a loop)
+}
+/* Convert a message's images into refs, storing any base64 as a blob. Idempotent:
+   an existing ref passes through. Never loses an image — keeps the base64 inline
+   if the blob store fails. */
+async function wrIngestImages(chatId, images) {
+  if (!images || !images.length) return images || null;
+  const out = [];
+  for (let i = 0; i < images.length; i++) {
+    const img = images[i];
+    if (img && typeof img === 'object') { out.push(img); continue; }                 // already a ref
+    if (typeof img === 'string' && img.startsWith('data:')) {
+      const key = 'b_' + chatId + '_' + i + '_' + Math.random().toString(36).slice(2, 6);
+      try { const blob = await (await fetch(img)).blob(); await wrStore.putBlob(key, blob); out.push({ blobKey: key, mime: blob.type }); }
+      catch (e) { out.push(img); }                                                    // keep base64 — never lose the image
+    } else if (img) out.push(img);
+  }
+  return out;
+}
+/* Persist a rail snapshot to IndexedDB (ingesting its image blobs). Async +
+   LOUD on failure — the old silent localStorage catch is gone for good. */
+async function wranglerRailPersist(snap) {
+  try {
+    for (const m of (snap.messages || [])) { if (m.images) m.images = await wrIngestImages(snap.id, m.images); }
+    await wrStore.putChat(snap);
+  } catch (e) { toast('⚠ Couldn’t save this chat locally — ' + ((e && e.message) || 'storage error')); }
+}
+/* Boot: migrate the legacy localStorage rail into IndexedDB (one-time), then load
+   ALL stored chats into the in-memory rail (newest first). Keep-all retention —
+   the size guarantee is enforced by the budget/offload layer, not by dropping. */
+async function wranglerRailLoad() {
+  let legacy = null; try { legacy = localStorage.getItem('jactec.wranglerRail'); } catch (e) {}
+  if (legacy) {
+    try {
+      for (const c of (JSON.parse(legacy) || [])) {
+        if (!c || !c.id) continue;
+        for (const m of (c.messages || [])) { if (m.images) m.images = await wrIngestImages(c.id, m.images); }
+        await wrStore.putChat(c);
+      }
+      try { localStorage.removeItem('jactec.wranglerRail'); } catch (e) {}            // migrated — drop the legacy key
+    } catch (e) { /* leave the legacy key in place if migration fails — don't lose it */ }
+  }
+  try {
+    const all = await wrStore.listChats();
+    state.wranglerRail = (all || []).sort((a, b) => (b.ts || 0) - (a.ts || 0));
+    if (state.wranglerRail.length) render();
+  } catch (e) { toast('⚠ Couldn’t load chat history — ' + ((e && e.message) || 'storage error')); }
+}
 // A short, human title for a conversation: its first thing-said, else the request title.
 function wranglerConvoTitle(o) {
   const fu = (o.messages || []).find((m) => m.role === 'user' && m.content && m.content.trim());
@@ -5282,8 +5352,7 @@ function wranglerRailSnapshot() {
     messages: o.messages.map((m) => ({ role: m.role, content: m.content, images: m.images || null, files: m.files || null, action: m.action || null, filed: m.filed || false, issue: m.issue || null })) };
   const i = state.wranglerRail.findIndex((c) => c.id === snap.id);
   if (i >= 0) state.wranglerRail[i] = snap; else state.wranglerRail.unshift(snap);
-  state.wranglerRail = state.wranglerRail.slice(0, WR_RAIL_MAX);
-  wranglerRailSave();
+  wranglerRailPersist(snap);   // → IndexedDB (keep all; ingest image blobs; loud on failure)
 }
 // Start a fresh conversation (snapshotting whatever was open first).
 function wranglerNewChat(seed) {
@@ -7175,7 +7244,7 @@ async function wranglerFileAction(mi) {
   const m = o.messages[mi]; if (!m || !m.action || m.filed) return;
   const isPlan = m.action.action === 'plan';
   const { title, body, label } = wranglerActionPacket(o, m.action);
-  const images = []; (o.messages || []).forEach((mm) => (mm.images || []).forEach((s) => { if (images.length < 8) images.push(s); }));   // §18e carry the chat’s photos onto the issue
+  const images = []; (o.messages || []).forEach((mm) => (mm.images || []).forEach((img) => { const s = wrImgSrc(img); if (images.length < 8 && (s.startsWith('data:') || s.startsWith('http'))) images.push(s); }));   // §18e carry the chat’s photos onto the issue (base64 or an offloaded Drive URL — never a local object URL)
   const okToast = (n) => isPlan ? `Building to your plan — #${n}. 🤠` : label === 'wrangler-request' ? `Sent #${n} to the developer for the OK. 🤠` : `Filed #${n} — Mr. Wrangler’s on it. 🤠`;
   if (typeof backendPassword !== 'undefined' && backendPassword) {
     m.filing = true; render();
@@ -11521,6 +11590,7 @@ function finishLoad() {
   buildIndexes(); state.cascade = createCascade(DATA); booting = false; render();
   loadGlobalViews();                                            // pull the shared, company-wide view set
   loadChats();                                                  // pull the shared team-chat threads (§ team-chat sync)
+  wranglerRailLoad();                                           // load the Mr. Wrangler rail from IndexedDB (+ one-time localStorage migration)
   refreshWranglerRequests();                                    // §18e populate the approval-inbox badge
   refreshWranglerNotifications();                               // §18f populate the notification-bell badge
   startRefreshPoll();                                           // live multi-user: poll for others' changes (§ refreshFromBackend)
@@ -11831,7 +11901,7 @@ function boot() {
 
 // #local — render straight from data.js with NO backend (offline/demo + dev smoke test).
 // saveSoon() already no-ops without a password, so edits stay in-memory only.
-function offlineBoot() { buildIndexes(); state.cascade = createCascade(DATA); seedDemoRequests(); booting = false; render(); exposeTestApi(); }
+function offlineBoot() { buildIndexes(); state.cascade = createCascade(DATA); seedDemoRequests(); booting = false; render(); exposeTestApi(); wranglerRailLoad(); }
 /* #local demo only: a sample Requests-inbox entry so the review/continue flow is
    visible without a backend. Real installs fetch live requests via the backend. */
 function seedDemoRequests() {
@@ -11883,7 +11953,7 @@ function exposeTestApi() {
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
       wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction,
-      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore };
+      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad };
   } catch (e) { /* no window (non-browser) */ }
 }
 

--- a/app.js
+++ b/app.js
@@ -5218,6 +5218,53 @@ function mountWranglerDock() {
 // here so you can hop back in. A `needs-jac` chat (Mr. Wrangler is waiting on you)
 // rides the rail flashing until you answer it.
 const WR_RAIL_MAX = 8;   // how many stored chats the rail keeps (newest win)
+/* ── wrStore — IndexedDB for the Mr. Wrangler rail ────────────────────────────
+   The rail used to live in localStorage with inline-base64 images; image-heavy
+   chats blew the ~5MB cap and a silent try/catch swallowed the QuotaExceeded, so
+   history vanished. IndexedDB (gigabytes, native Blobs) replaces it. Two stores:
+   `chats` keyed by chat id (snapshot text + message refs), `blobs` keyed by a
+   blob key (the image Blob itself). A thin promise wrapper — no deps. Every call
+   REJECTS loudly on failure; callers surface it (never a silent drop again).
+   See docs/superpowers/specs/2026-06-20-wrangler-chat-storage-design.md. */
+const WR_DB = 'jactec.wrangler', WR_DB_VER = 1;
+let _wrDbPromise = null;
+function wrDbOpen() {
+  if (_wrDbPromise) return _wrDbPromise;
+  _wrDbPromise = new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') { reject(new Error('no-indexeddb')); return; }
+    let req; try { req = indexedDB.open(WR_DB, WR_DB_VER); } catch (e) { reject(e); return; }
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains('chats')) db.createObjectStore('chats', { keyPath: 'id' });
+      if (!db.objectStoreNames.contains('blobs')) db.createObjectStore('blobs');   // out-of-line keys (blobKey)
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error || new Error('idb-open-failed'));
+  });
+  return _wrDbPromise;
+}
+/* Run one store op in its own transaction; resolve with the request's result once
+   the tx COMMITS (so a write is durable before we move on). fn returns an IDBRequest. */
+function wrTx(store, mode, fn) {
+  return wrDbOpen().then((db) => new Promise((resolve, reject) => {
+    let tx, req;
+    try { tx = db.transaction(store, mode); req = fn(tx.objectStore(store)); } catch (e) { reject(e); return; }
+    tx.oncomplete = () => resolve(req ? req.result : undefined);
+    tx.onerror = () => reject(tx.error || new Error('idb-tx-error'));
+    tx.onabort = () => reject(tx.error || new Error('idb-abort'));
+  }));
+}
+const wrStore = {
+  putChat: (c) => wrTx('chats', 'readwrite', (os) => os.put(c)),
+  getChat: (id) => wrTx('chats', 'readonly', (os) => os.get(id)),
+  delChat: (id) => wrTx('chats', 'readwrite', (os) => os.delete(id)),
+  listChats: () => wrTx('chats', 'readonly', (os) => os.getAll()),
+  putBlob: (key, blob) => wrTx('blobs', 'readwrite', (os) => os.put(blob, key)),
+  getBlob: (key) => wrTx('blobs', 'readonly', (os) => os.get(key)),
+  delBlob: (key) => wrTx('blobs', 'readwrite', (os) => os.delete(key)),
+  estimate: () => (typeof navigator !== 'undefined' && navigator.storage && navigator.storage.estimate)
+    ? navigator.storage.estimate() : Promise.resolve({ usage: 0, quota: 0 }),
+};
 function wranglerNewId() { return 'wc' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6); }
 function wranglerRailSave() { try { localStorage.setItem('jactec.wranglerRail', JSON.stringify(state.wranglerRail.slice(0, WR_RAIL_MAX))); } catch (e) {} }
 // A short, human title for a conversation: its first thing-said, else the request title.
@@ -11836,7 +11883,7 @@ function exposeTestApi() {
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
       wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction,
-      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets };
+      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore };
   } catch (e) { /* no window (non-browser) */ }
 }
 

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -302,6 +302,24 @@ try {
     const est = await S.estimate();
     ok(est && typeof est.usage === 'number' && typeof est.quota === 'number', 'wrStore: estimate() returns usage/quota numbers');
 
+    // 16) Drive offload + eviction for the Wrangler store (the size guarantee)
+    const wrUp = async (p) => ({ ok: true, url: 'https://drive/' + encodeURIComponent(p.name) });
+    const ob = new Blob([new Uint8Array([9, 9, 9, 9, 9])], { type: 'image/png' });
+    await S.putBlob('b_wc-off_0', ob);
+    const offChat = { id: 'wc-off', ts: 2, messages: [{ role: 'user', content: 'x', images: [{ blobKey: 'b_wc-off_0' }] }] };
+    await S.putChat(offChat);
+    const did = await T.wrOffloadChatImages(offChat, wrUp);
+    ok(did === true && offChat.messages[0].images[0].driveUrl && !offChat.messages[0].images[0].blobKey, 'wrOffloadChatImages: un-synced blob → Drive URL set, local blobKey cleared');
+    ok((await S.getBlob('b_wc-off_0')) === undefined, 'wrOffloadChatImages: local blob dropped after offload (re-fetchable from driveUrl)');
+    ok((await T.wrOffloadChatImages(offChat, wrUp)) === false, 'wrOffloadChatImages: idempotent — a synced chat is a no-op');
+    // eviction: a synced blob is a safe cache drop; an un-synced one needs unsyncedOk
+    await S.putBlob('b_wc-ev_0', ob); await S.putBlob('b_wc-ev_1', ob);
+    const evChat = { id: 'wc-ev', ts: 3, messages: [{ role: 'user', content: 'y', images: [{ blobKey: 'b_wc-ev_0', driveUrl: 'https://drive/x' }, { blobKey: 'b_wc-ev_1' }] }] };
+    ok((await T.wrEvictChatBlobs(evChat, false)) === 1, 'wrEvictChatBlobs: drops only the synced blob when unsyncedOk=false (text untouched)');
+    ok(evChat.messages[0].content === 'y' && evChat.messages[0].images.length === 2, 'wrEvictChatBlobs: message text + refs preserved — only the local blob is freed');
+    ok((await T.wrEvictChatBlobs(evChat, true)) === 1, 'wrEvictChatBlobs: drops the un-synced blob only as a last resort (unsyncedOk=true)');
+    await S.delChat('wc-off'); await S.delChat('wc-ev');
+
     return out;
   });
 

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -283,6 +283,25 @@ try {
     ok(T.base64PhotoTargets().length === 0, 'base64PhotoTargets: empty after a full offload pass (idempotent)');
     T.DATA.inspections.pop(); T.IDX.insp.delete('INS-OFFLOAD'); T.DATA.workOrders.pop(); T.IDX.wo.delete('WO-OFFLOAD');   // restore
 
+    // 15) wrStore — the IndexedDB layer for the Wrangler rail (real round-trips)
+    const S = T.wrStore;
+    const chat = { id: 'wc-test-1', title: 'hi', ts: 1, messages: [{ role: 'user', content: 'yo', images: [{ blobKey: 'b_wc-test-1_0' }] }] };
+    await S.putChat(chat);
+    const got = await S.getChat('wc-test-1');
+    ok(got && got.id === 'wc-test-1' && got.messages[0].images[0].blobKey === 'b_wc-test-1_0', 'wrStore: putChat/getChat round-trip keeps the message ref');
+    const listed = await S.listChats();
+    ok(Array.isArray(listed) && listed.some((c) => c.id === 'wc-test-1'), 'wrStore: listChats returns the stored chat');
+    const blob = new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'image/jpeg' });
+    await S.putBlob('b_wc-test-1_0', blob);
+    const gotBlob = await S.getBlob('b_wc-test-1_0');
+    ok(gotBlob instanceof Blob && gotBlob.size === 4, 'wrStore: putBlob/getBlob round-trip returns the Blob (binary, not base64)');
+    await S.delBlob('b_wc-test-1_0');
+    ok((await S.getBlob('b_wc-test-1_0')) === undefined, 'wrStore: delBlob removes the blob');
+    await S.delChat('wc-test-1');
+    ok((await S.getChat('wc-test-1')) === undefined, 'wrStore: delChat removes the chat');
+    const est = await S.estimate();
+    ok(est && typeof est.usage === 'number' && typeof est.quota === 'number', 'wrStore: estimate() returns usage/quota numbers');
+
     return out;
   });
 

--- a/docs/superpowers/specs/2026-06-20-wrangler-chat-storage-design.md
+++ b/docs/superpowers/specs/2026-06-20-wrangler-chat-storage-design.md
@@ -1,0 +1,187 @@
+# Mr. Wrangler chat-rail storage — IndexedDB + Drive offload
+
+**Date:** 2026-06-20
+**Status:** Approved (design) — ready for implementation plan
+**Surface:** the Mr. Wrangler dock + its bottom-right rail of past chats
+(`state.wranglerRail`, `wranglerRailSave` at `app.js:5190`; attachments at
+`app.js:6833`–`6839`).
+
+## Summary
+
+The Mr. Wrangler AI rail keeps up to 8 past conversations in **localStorage**,
+with image attachments stored as **inline base64**. Several image-heavy chats
+blow the ~5 MB localStorage cap, and the save is a silent `try/catch` — so
+history **vanishes without warning**. This moves the rail to **IndexedDB**
+(gigabytes of headroom, native Blobs), offloads images to **Drive**, and makes
+every failure **loud**. The mandate (Jac): *this silent loss can never happen
+again.*
+
+## Scope — what this is and isn't
+
+| Surface | Storage today | This spec |
+|---|---|---|
+| **Mr. Wrangler AI rail** (`state.wranglerRail`) | localStorage, base64 images, **per-device** | ✅ the subject |
+| **Team chat** (§17 dock, `state.chat.chats`) | backend-synced, text-only, **already cross-device** | ❌ untouched |
+
+- **Device-local only** (decided). Team chats already sync across devices via
+  `pushChats`/`loadChats`; the Wrangler rail stays per-device. Making the rail
+  *cross-device* (server-synced like team chat) is a **possible later
+  follow-up**, explicitly out of scope here.
+- Not the DATA/Sheet photo-offload (separate, shipped: inspection/part photos).
+
+## The problem (confirmed)
+
+- The rail loads from `localStorage['jactec.wranglerRail']` (`app.js:1424`) and
+  saves via `wranglerRailSave` (`app.js:5190`) — `localStorage.setItem(...,
+  JSON.stringify(rail.slice(0, 8)))`, wrapped in `try {} catch (e) {}`.
+- Attachments downscale to **1200 px / 0.7 JPEG base64** (~60–120 KB each, up to
+  4 per message; `app.js:6836`) and ride **inline** in each message's `images`
+  (snapshot at `app.js:5203`).
+- 8 chats × several image messages easily exceeds the ~5 MB cap → `setItem`
+  throws `QuotaExceededError` → the silent catch swallows it → **the rail isn't
+  saved and history is lost on reload.**
+
+## Decisions (locked 2026-06-20)
+
+| Question | Decision |
+|---|---|
+| Local store | **IndexedDB**, two object stores (`chats` + `blobs`) |
+| Image representation | **Blobs** in IndexedDB; messages carry a **ref** `{blobKey, driveUrl?}`, never inline base64 |
+| Drive offload trigger | **Both** — on filing a wrangler issue AND on a size threshold (`estimate()` budget) |
+| Retention | **Keep all chat text** (no count cap); bound the store by a **size budget** (`WR_LOCAL_BUDGET` ≈ 25 MB), defended in layers |
+| Offline over-budget | **Evict oldest local image blobs**, preferring ones already on Drive; text/messages **never** deleted in normal use; a **visible** notice names what was freed |
+| Failure handling | **No silent catch** — every persist failure surfaces; IndexedDB-unavailable → in-memory + a loud one-time notice |
+| Cross-device | Out of scope (device-local); team chat already covers the cross-device need |
+
+## Non-goals
+
+- No cross-device sync of the Wrangler rail (future follow-up).
+- No change to team chat, the live-chat send path's request shape, or the
+  wrangler-issue *content*.
+- No new dependency — a hand-rolled IndexedDB wrapper (vanilla single-file app).
+- No re-encoding; attachments already downscale at capture.
+
+## Architecture
+
+### A · `wrStore` — vanilla IndexedDB module (no deps)
+
+DB `jactec.wrangler`, version 1, two object stores:
+
+- **`chats`** (keyed by chat `id`): the snapshot
+  `{ id, title, ts, card, recId, recType, reqNumber, reqTitle, reqUrl, messages }`
+  — identical to today **except** each message's `images`/`files` hold
+  **refs** `{ blobKey, driveUrl, name, mime }`, not base64 strings.
+- **`blobs`** (keyed by `blobKey` = `b_<chatId>_<seq>`): the image **Blob**.
+
+A ~80-line promise wrapper exposing: `open()`, `putChat(c)`, `getChat(id)`,
+`listChats()` (metadata + message refs, cheap — no blob reads), `delChat(id)`,
+`putBlob(key, blob)`, `getBlob(key)`, `delBlob(key)`, `estimate()` (wraps
+`navigator.storage.estimate()`). One file, focused, independently testable.
+
+### B · Write path (replaces `wranglerRailSave`)
+
+- On chat update → `await wrStore.putChat(snapshot)`. Each new attachment Blob →
+  `wrStore.putBlob(key, blob)`; the message stores `{ blobKey: key }`.
+- **Render:** an image uses `driveUrl` when present, else
+  `URL.createObjectURL(await wrStore.getBlob(blobKey))` (object URLs revoked on
+  re-render to avoid leaks).
+- **Loud on failure:** a `putChat`/`putBlob` rejection raises an `attnFlash`/
+  toast naming the problem — never swallowed.
+
+### C · Drive offload (dual trigger)
+
+- **On file** — when a chat is filed as a wrangler-fix issue, upload its blobs to
+  Drive (reuse `uploadCapture`), set `driveUrl` on each message image, and the
+  issue carries the URLs (extends the existing gather at `app.js:7099`). The
+  local Blob becomes a droppable cache (`driveUrl` is now the source of truth).
+- **Threshold** — after a write, if the tracked store size passes a soft mark
+  (≈ 60 % of `WR_LOCAL_BUDGET`, the single budget constant defined in §D) **and**
+  online, offload the oldest chats' un-synced blobs to Drive, swap each to
+  `driveUrl`, and `delBlob` the local copy. Drains proactively so the store never
+  approaches the hard `WR_LOCAL_BUDGET` ceiling.
+
+### D · Retention & the storage guarantee (the "cap it somehow")
+
+**Keep all chat text** — no count cap (the old `WR_RAIL_MAX` hard-drop of the
+9th-oldest chat is retired; text is tiny and IndexedDB has room). The hard bound
+is a **size budget** `WR_LOCAL_BUDGET` (≈ 25 MB, a named constant — well under any
+IndexedDB quota), enforced via `estimate()` + the store's tracked size, defended
+in layers so the budget is a real guarantee that's effectively never felt:
+
+1. **Layer 1 — images → Drive.** On the size trigger (and online), offload the
+   oldest un-synced image blobs to Drive and `delBlob` the local copies. Images
+   are ~99 % of the weight, so this alone keeps text history growing for years.
+2. **Layer 2 — image eviction (offline over-budget).** Can't reach Drive: drop
+   oldest local blobs that **already have a `driveUrl`** first (safe cache drop,
+   re-fetchable); only then drop oldest **un-synced** blobs (lossy last resort) —
+   with a **visible notice** naming what was freed.
+3. **Layer 3 — text trim (the absolute backstop).** Only if text *alone* ever
+   approaches `WR_LOCAL_BUDGET` (pathological — tens of thousands of messages),
+   trim the oldest chats' text with a **visible notice**. Size-based, loud, and
+   effectively unreachable — but it makes the bound a hard guarantee.
+
+In every realistic scenario nothing is lost: text is kept, images live on Drive.
+The store is **always ≤ `WR_LOCAL_BUDGET`**, so localStorage's silent-overflow
+failure can never recur.
+
+The visible rail UI lists recent chats (scrollable); storage retaining all chats
+is decoupled from how many the rail shows at once.
+
+### E · Migration (one-time)
+
+On first load with the new code: if `localStorage['jactec.wranglerRail']` exists,
+import each chat into `chats`; each inline base64 image becomes a `blobs` entry
+with the message rewritten to a `{ blobKey }` ref; then `removeItem` the
+localStorage key. Guarded + idempotent (absent key → skip).
+
+### Data flow
+
+```
+attach image → Blob → wrStore.putBlob(key) ; message = { blobKey }
+chat update  → wrStore.putChat(snapshot)         (text + refs only — tiny)
+render       → driveUrl ?? objectURL(getBlob(blobKey))
+file issue   → upload blobs → driveUrl on messages → issue carries URLs → drop local Blob
+over budget  → online: offload oldest un-synced → Drive ; offline: evict (synced-first) + notice
+```
+
+## Error handling & the "never again" guarantee
+
+- Every persist path is `await`ed and its failure **surfaced** (no silent
+  `try/catch` that drops history). The old localStorage silent-catch is removed.
+- IndexedDB unavailable (private mode / disabled) → operate **in-memory** for the
+  session and show a **loud one-time notice** that history won't persist on this
+  device — strictly better than silent loss.
+- Threshold offload keeps the store well under any quota, so
+  `QuotaExceededError` is avoided in the normal (online) path entirely.
+
+## Testing
+
+- **Logic-seam tests** (expose `wrStore` + the policy helpers on `window.__rw`;
+  use a fresh test DB):
+  - `putChat`/`getChat` round-trip; `listChats` returns refs without reading
+    blobs; an image persists as a `{ blobKey }` ref, **not** base64.
+  - offload swaps `blobKey → driveUrl` (stubbed uploader) and `delBlob`s the
+    local copy.
+  - eviction drops synced blobs before un-synced and **never** removes message
+    text in normal use; over-budget offline path emits the notice; the Layer-3
+    text-trim backstop fires only past `WR_LOCAL_BUDGET` and emits its notice.
+  - migration imports a seeded `localStorage` rail into IndexedDB then clears the
+    key; a second run is a no-op.
+- **smoke:** app boots; opening the dock + rail renders from IndexedDB without
+  throwing (empty store → empty rail, no error).
+
+## Gates (per CLAUDE.md)
+
+- Any new/changed dock control runs through `jactec-ui` (the offline/quota notice
+  is new UI — emit via the established pattern; an `attnFlash`/toast needs no
+  `data-r`). Regenerate `rule-usage.js` only if a `data-r` element changes.
+- Three gates: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
+  `node ci/gen-rule-usage.mjs --check` (port-swap 8000→9147 first, restore `ci/`).
+- Bump the shared `?v=` token in `index.html`.
+- Ship via feature branch → PR → squash-merge (main is branch-protected).
+
+## Open item for Jac
+
+Same `uploadCapture` backend reuse as the photo-offload spec — confirm it accepts
+a generic `{dataUrl, name}` → `{ok, url}`. If yes, **no backend change**; the
+photo-offload spec's appendix already carries a paste-in handler if not.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260620b"></script>
-  <script type="module" src="app.js?v=20260620b"></script>
+  <script src="rule-usage.js?v=20260620c"></script>
+  <script type="module" src="app.js?v=20260620c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
The Mr. Wrangler AI rail kept up to 8 chats in **localStorage** with **base64** images; image-heavy chats blew the ~5 MB cap and a silent `try/catch` swallowed it, so **history vanished without warning**. This moves it to **IndexedDB** + **Drive** and makes every failure loud. Spec: `docs/superpowers/specs/2026-06-20-wrangler-chat-storage-design.md`.

## Built in 4 verified increments

1. **`wrStore`** — vanilla IndexedDB module (no deps): `chats` + `blobs` stores; rejects loudly on failure.
2. **Migration + boot load** — one-time import of the localStorage rail into IndexedDB (then clears the key); boot loads all chats (keep-all).
3. **Write/read surgery** — snapshots persist with image **Blobs** + `{blobKey, driveUrl?}` refs (never inline base64); the render path hydrates refs → object URLs (legacy base64 still renders during transition). **Verified live**: a stored chat reopens from the rail and its image hydrates from the blob.
4. **Drive offload + budget guarantee** — `WR_LOCAL_BUDGET` ceiling enforced in layers: images→Drive (on filing + size threshold), synced-first blob eviction, then loud un-synced eviction + an oldest-text-trim backstop. The store stays ≤ budget, so the silent-overflow can't recur.

## Guarantees

- **No silent loss** — the localStorage silent-catch is gone; every persist failure surfaces; IndexedDB-unavailable → in-memory + a loud notice.
- **Never lose a photo** — base64 kept if a blob write fails; eviction drops synced (re-fetchable) blobs before un-synced; **text is never dropped before every image is gone**.
- **Keep all chat text** (the old 8-chat cap is retired).

## Scope

Device-local (team chats already sync cross-device — out of scope). 80/80 logic checks (+20: wrStore round-trips, offload, eviction), smoke green, cache-bust bumped.

## Open item

Reuses `uploadCapture` for the Drive offload — same backend confirmation as #180 (the appendix there has a paste-in if it's not already generic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)