### PR TITLE
Photo/chat offload: store the embeddable Drive URL (not the file-view page)

### DIFF
--- a/app.js
+++ b/app.js
@@ -5336,7 +5336,7 @@ async function wrOffloadChatImages(chat, _upload) {
     try {
       const blob = await wrStore.getBlob(img.blobKey); if (!blob) continue;
       const res = await upload({ dataUrl: await wrBlobToDataUrl(blob), name: 'wrchat_' + chat.id + '_' + img.blobKey });
-      if (res && res.ok && res.url) { await wrStore.delBlob(img.blobKey); wrRevoke(img.blobKey); img.driveUrl = res.url; delete img.blobKey; changed = true; }   // blob now lives on Drive
+      if (res && res.ok && res.url) { await wrStore.delBlob(img.blobKey); wrRevoke(img.blobKey); img.driveUrl = driveViewUrl(res); delete img.blobKey; changed = true; }   // blob now lives on Drive (embeddable URL)
     } catch (e) { /* leave the blob — never lose it */ }
   }
   if (changed) { try { await wrStore.putChat(chat); } catch (e) {} }
@@ -9521,7 +9521,7 @@ async function offloadPhotoNow(target, field, name, owner, coll, _upload) {
   try {
     const res = await upload({ dataUrl: v, name });
     if (res && res.ok && res.url && target[field] === v) {                          // unchanged since upload → safe to swap
-      target[field] = res.url;
+      target[field] = driveViewUrl(res);                                            // embeddable Drive URL (built from fileId), not the file-view page
       if (owner && coll) reindex(coll, owner);
       saveSoon();
       return true;
@@ -11462,6 +11462,13 @@ let backendPassword = sessionStorage.getItem('jactec.pw') || '';
 let booting = true;                       // suppresses saves during initial load
 let saveTimer = null, saving = false, savePending = false;
 
+/* uploadCapture returns url:f.getUrl() — a Drive file-VIEW page, which does NOT
+   render in an <img src> or CSS url(). For IMAGES we build the embeddable form
+   from the returned fileId (uc?export=view&id=…), matching the selfie/agreement
+   archive convention. Videos keep f.getUrl() (the nicer Drive-player page). */
+function driveViewUrl(res) {
+  return (res && res.fileId) ? ('https://drive.google.com/uc?export=view&id=' + res.fileId) : ((res && res.url) || '');
+}
 async function backendCall(action, extra) {
   // text/plain avoids a CORS preflight that GAS web apps can't answer
   const payload = Object.assign({ action, password: backendPassword }, extra || {});
@@ -12023,7 +12030,7 @@ function exposeTestApi() {
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
       wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction,
-      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs };
+      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs, driveViewUrl };
   } catch (e) { /* no window (non-browser) */ }
 }
 

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -320,6 +320,16 @@ try {
     ok((await T.wrEvictChatBlobs(evChat, true)) === 1, 'wrEvictChatBlobs: drops the un-synced blob only as a last resort (unsyncedOk=true)');
     await S.delChat('wc-off'); await S.delChat('wc-ev');
 
+    // 17) driveViewUrl — uploadCapture's file-view page → an embeddable <img> URL via fileId
+    ok(T.driveViewUrl({ ok: true, url: 'https://drive.google.com/file/d/FID/view', fileId: 'FID' }) === 'https://drive.google.com/uc?export=view&id=FID', 'driveViewUrl: builds the embeddable uc?export=view form from fileId');
+    ok(T.driveViewUrl({ ok: true, url: 'https://x/y' }) === 'https://x/y', 'driveViewUrl: falls back to res.url when no fileId');
+    ok(T.driveViewUrl(null) === '' && T.driveViewUrl({}) === '', 'driveViewUrl: empty when nothing usable');
+    // integration: an offload that returns a fileId stores the EMBEDDABLE url (not the file-view page)
+    const fidUp = async (p) => ({ ok: true, url: 'https://drive.google.com/file/d/Z9/view', fileId: 'Z9' });
+    const recE = { photo: 'data:image/jpeg;base64,EEE' };
+    await T.offloadPhotoNow(recE, 'photo', 'ne', null, null, fidUp);
+    ok(recE.photo === 'https://drive.google.com/uc?export=view&id=Z9', 'offloadPhotoNow: stores the embeddable Drive URL when the backend returns a fileId');
+
     return out;
   });
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260620c" />
+  <link rel="stylesheet" href="style.css?v=20260620d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260620c"></script>
-  <script type="module" src="app.js?v=20260620c"></script>
+  <script src="rule-usage.js?v=20260620d"></script>
+  <script type="module" src="app.js?v=20260620d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Why

Pulled the live `Code.gs` via clasp and reconciled: `uploadCapture_` is already generic (`{dataUrl, name}` → `{ok, url, fileId}`, any mime, ~10 MB cap), so the offloads in #180/#181 **call** it fine with **zero backend changes**.

**But** it returns `url: f.getUrl()` — the Drive **file-view page** (`drive.google.com/file/d/…/view`), which does **not** render in an `<img src>` or CSS `url()`. The selfie path already solves this (live `Code.js` returns the embeddable `uc?export=view&id=…` form). As-is, running the photo sweep / capturing with a live backend would clear the base64 and store a **non-rendering** link → broken backdrop / thumb / chat images.

## Fix (frontend only — no backend redeploy)

`uploadCapture` already returns `fileId`, so a small `driveViewUrl(res)` helper builds the embeddable `uc?export=view&id=<fileId>` form (matching the selfie/agreement-archive convention). Wired into:
- the **photo** offload (`offloadPhotoNow`, #180)
- the **chat** offload (`wrOffloadChatImages`, #181)

**Videos keep `f.getUrl()`** (the nicer Drive-player page) — only the two *image* paths change.

## Verification

- `logic-test` **91/91** (+4: `driveViewUrl` fileId→embeddable, url fallback, empty, and an `offloadPhotoNow` integration check that it stores the embeddable URL).
- `smoke` ✅, rule-usage current, cache-bust bumped `…c → …d`.

This should land **before** the photo sweep is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw5PSqJP8ehggbQPmb9ZFh)_