### PR TITLE
Cross-device Mr. Wrangler rail + lit-up team-chat sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -5320,6 +5320,7 @@ async function wranglerRailPersist(snap) {
   const online = typeof backendPassword !== 'undefined' && backendPassword;
   if (online && (snap.messages || []).some((m) => m.filed)) wrOffloadChatImages(snap);   // on-file: free the local copies (safe — they ride the issue)
   wrEnforceBudget();                                                                     // threshold: keep the store ≤ budget
+  pushWranglerRailSoon();                                                                // cross-device: sync the rail to the backend (debounced)
 }
 // ── The storage guarantee: offload to Drive + bounded eviction (never overflow) ──
 const WR_LOCAL_BUDGET = 25 * 1024 * 1024;   // hard ceiling for the Wrangler store
@@ -5406,6 +5407,7 @@ async function wranglerRailLoad() {
     state.wranglerRail = (all || []).sort((a, b) => (b.ts || 0) - (a.ts || 0));
     if (state.wranglerRail.length) render();
   } catch (e) { toast('⚠ Couldn’t load chat history — ' + ((e && e.message) || 'storage error')); }
+  loadWranglerRail();   // cross-device: union the local rail with the role's backend rail
 }
 // A short, human title for a conversation: its first thing-said, else the request title.
 function wranglerConvoTitle(o) {
@@ -11552,6 +11554,7 @@ async function refreshFromBackend() {
         if (m.changed) applied++;
       }
     } catch (e) { /* chat sync is best-effort */ }
+    loadWranglerRail();   // also pull this role's Mr. Wrangler rail (cross-device) — best-effort, self-renders
     if (applied && !state.overlay && !DRAG.active && !hoverNode) { state.cascade = createCascade(DATA); render(); }
   } catch (e) { /* offline / blip → retry next tick */ }
   finally { refreshing = false; }
@@ -11609,6 +11612,49 @@ async function loadChats() {
     const { changed, localAhead } = mergeChats(r.chats);
     if (localAhead) pushChats(); else lastChatsJson = JSON.stringify(state.chat.chats);   // mark synced (or send local-only threads up)
     if (changed) render();
+  } catch (e) { /* offline → the refresh poll retries */ }
+}
+// ── Cross-device Mr. Wrangler rail sync (per ROLE; mirrors team-chat sync) ──
+// The rail lives in IndexedDB per device (#181); this makes it follow the role
+// login across devices. PURE merge: union by id, newest ts wins, reports
+// localAhead. The caller applies it to state + the IndexedDB cache.
+let railPushTimer = null, lastRailJson = null;
+function mergeWranglerRails(local, remote) {
+  const byId = new Map((local || []).map((c) => [c.id, c]));
+  let changed = false, localAhead = false;
+  (remote || []).forEach((rc) => {
+    if (!rc || !rc.id) return;
+    const lc = byId.get(rc.id);
+    if (!lc) { byId.set(rc.id, rc); changed = true; }                       // a chat from another device
+    else if ((rc.ts || 0) > (lc.ts || 0)) { byId.set(rc.id, rc); changed = true; }   // remote is newer → wins
+    else if ((lc.ts || 0) > (rc.ts || 0)) { localAhead = true; }            // we're newer → push up
+  });
+  const remoteIds = new Set((remote || []).map((c) => c && c.id));
+  if ((local || []).some((c) => c && !remoteIds.has(c.id))) localAhead = true;   // a local-only chat → push up
+  const merged = [...byId.values()].sort((a, b) => (b.ts || 0) - (a.ts || 0));
+  return { merged, changed, localAhead };
+}
+function pushWranglerRailSoon() { if (booting || !backendPassword) return; clearTimeout(railPushTimer); railPushTimer = setTimeout(pushWranglerRail, 1200); }
+async function pushWranglerRail() {
+  if (!backendPassword) return;
+  for (const c of state.wranglerRail) { try { await wrOffloadChatImages(c); } catch (e) {} }   // full fidelity: images → Drive URLs before they ride the sync
+  const chats = state.wranglerRail, js = JSON.stringify(chats);
+  if (js === lastRailJson) return;                                          // nothing new since the last push
+  try { const r = await backendCall('setWranglerRail', { chats }); if (r && r.ok) lastRailJson = js; } catch (e) { /* offline → retries */ }
+}
+async function loadWranglerRail() {
+  if (!backendPassword) return;
+  try {
+    const r = await backendCall('getWranglerRail');
+    if (!r || !r.ok || !Array.isArray(r.chats)) return;
+    const localBefore = state.wranglerRail;
+    const { merged, changed, localAhead } = mergeWranglerRails(localBefore, r.chats);
+    if (changed) {
+      const beforeById = new Map(localBefore.map((c) => [c.id, c]));
+      for (const rc of r.chats) { const lc = beforeById.get(rc.id); if (rc && rc.id && (!lc || (rc.ts || 0) > (lc.ts || 0))) { try { await wrStore.putChat(rc); } catch (e) {} } }   // cache the remote winners
+      state.wranglerRail = merged; render();
+    }
+    if (localAhead) pushWranglerRailSoon(); else lastRailJson = JSON.stringify(state.wranglerRail);
   } catch (e) { /* offline → the refresh poll retries */ }
 }
 function saveSoon() { if (booting || !backendPassword) return; clearTimeout(saveTimer); saveTimer = setTimeout(flushSave, 1200); }
@@ -12030,7 +12076,7 @@ function exposeTestApi() {
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
       wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction,
-      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs, driveViewUrl };
+      latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs, driveViewUrl, mergeWranglerRails };
   } catch (e) { /* no window (non-browser) */ }
 }
 

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -330,6 +330,19 @@ try {
     await T.offloadPhotoNow(recE, 'photo', 'ne', null, null, fidUp);
     ok(recE.photo === 'https://drive.google.com/uc?export=view&id=Z9', 'offloadPhotoNow: stores the embeddable Drive URL when the backend returns a fileId');
 
+    // 18) cross-device Wrangler rail merge — union by id, newest ts wins, localAhead
+    const A = { id: 'a', ts: 10 }, A2 = { id: 'a', ts: 20 }, B = { id: 'b', ts: 5 }, C = { id: 'c', ts: 7 };
+    let m = T.mergeWranglerRails([A], [B]);
+    ok(m.merged.length === 2 && m.changed === true && m.localAhead === true, 'mergeWranglerRails: remote-only chat added (changed), local-only chat flags localAhead');
+    m = T.mergeWranglerRails([A], [A2]);
+    ok(m.merged.find((c) => c.id === 'a').ts === 20 && m.changed === true && m.localAhead === false, 'mergeWranglerRails: remote newer ts wins');
+    m = T.mergeWranglerRails([A2], [A]);
+    ok(m.merged.find((c) => c.id === 'a').ts === 20 && m.changed === false && m.localAhead === true, 'mergeWranglerRails: local newer ts kept + flags localAhead');
+    m = T.mergeWranglerRails([A2, C], [A2, C]);
+    ok(m.changed === false && m.localAhead === false, 'mergeWranglerRails: identical rails → no change, not ahead');
+    m = T.mergeWranglerRails([], [C, B]);
+    ok(m.merged.map((c) => c.id).join(',') === 'c,b' && m.changed === true, 'mergeWranglerRails: empty local → adopts remote, sorted newest-first');
+
     return out;
   });
 

--- a/docs/handoffs/wrangler-rail-sync-backend.gs
+++ b/docs/handoffs/wrangler-rail-sync-backend.gs
@@ -1,0 +1,116 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * Backend additions — cross-device chat sync (team chat + Mr. Wrangler rail)
+ * Secret-free; spliced into the gitignored backend/Code.gs and clasp-deployed.
+ * See docs/superpowers/specs/2026-06-20-wrangler-rail-cross-device-sync-design.md
+ *
+ * Two Sheet tabs, one row per chat (each cell well under the 50k-char cap):
+ *   teamChats     [id, json]          — SHARED across the team (never deleted)
+ *   wranglerRails [role, id, json]    — per-ROLE (role from roleForPassword; a
+ *                                       client reads/writes only its own rows)
+ *
+ * NOTE: team-chat sync's frontend (pushChats/loadChats/mergeChats) was already
+ * built; only this backend handler was missing, so it was dormant. This lights
+ * it up. Reuses ss()/rowIndexById()/LockService from Code.gs.
+ *
+ * Wire into doPost's action switch, next to saveSession/getSession:
+ *   if (action === 'getChats')        return json(getChats_(body, role));
+ *   if (action === 'setChats')        return json(setChats_(body, role));
+ *   if (action === 'getWranglerRail') return json(getWranglerRail_(body, role));
+ *   if (action === 'setWranglerRail') return json(setWranglerRail_(body, role));
+ * (Any signed-in role. role is already resolved server-side from the password.)
+ * ───────────────────────────────────────────────────────────────────────── */
+
+var TEAMCHATS_TAB = 'teamChats';
+var WRANGLERRAIL_TAB = 'wranglerRails';
+
+/* ── Team chat (SHARED, persistent — upsert-only, never delete) ───────────── */
+function getChats_(body, role) {
+  var s = ss().getSheetByName(TEAMCHATS_TAB), out = [];
+  if (s) {
+    var last = s.getLastRow();
+    if (last >= 2) {
+      var vals = s.getRange(2, 2, last - 1, 1).getValues();   // the json column
+      for (var i = 0; i < vals.length; i++) {
+        try { var c = JSON.parse(vals[i][0]); if (c && c.id) out.push(c); } catch (e) {}
+      }
+    }
+  }
+  return { ok: true, chats: out };
+}
+function setChats_(body, role) {
+  var chats = (body && body.chats) || [];
+  var n = 0;
+  if (!chats.length) return { ok: true, saved: 0 };
+  var lock = LockService.getScriptLock(); lock.waitLock(30000);
+  try {
+    var s = ss().getSheetByName(TEAMCHATS_TAB);
+    if (!s) { s = ss().insertSheet(TEAMCHATS_TAB); s.getRange(1, 1, 1, 2).setValues([['id', 'json']]); }
+    var idMap = rowIndexById(s), appends = [];
+    chats.forEach(function (c) {
+      if (!c || !c.id) return;
+      var id = String(c.id), js = JSON.stringify(c), row = idMap[id];
+      if (row) s.getRange(row, 1, 1, 2).setValues([[id, js]]);
+      else appends.push([id, js]);
+      n++;
+    });
+    if (appends.length) s.getRange(s.getLastRow() + 1, 1, appends.length, 2).setValues(appends);
+  } finally { lock.releaseLock(); }
+  return { ok: true, saved: n };
+}
+
+/* ── Mr. Wrangler rail (per-ROLE; client only ever touches its own rows) ──── */
+function wranglerRailSheet_() {
+  var s = ss().getSheetByName(WRANGLERRAIL_TAB);
+  if (!s) { s = ss().insertSheet(WRANGLERRAIL_TAB); s.getRange(1, 1, 1, 3).setValues([['role', 'id', 'json']]); }
+  return s;
+}
+function getWranglerRail_(body, role) {
+  var s = ss().getSheetByName(WRANGLERRAIL_TAB), out = [];
+  if (s) {
+    var last = s.getLastRow();
+    if (last >= 2) {
+      var vals = s.getRange(2, 1, last - 1, 3).getValues();   // role, id, json
+      for (var i = 0; i < vals.length; i++) {
+        if (String(vals[i][0]) !== String(role)) continue;     // ISOLATION: only this role's rows
+        try { var c = JSON.parse(vals[i][2]); if (c && c.id) out.push(c); } catch (e) {}
+      }
+    }
+  }
+  return { ok: true, chats: out };
+}
+// Reconcile THIS role's rail to exactly body.chats (upsert present, delete absent).
+// The client always sends its full in-memory rail (like setChats), so deletes
+// propagate. Other roles' rows are never read or touched.
+function setWranglerRail_(body, role) {
+  var chats = (body && body.chats) || [];
+  var n = 0;
+  var lock = LockService.getScriptLock(); lock.waitLock(30000);
+  try {
+    var s = wranglerRailSheet_();
+    var last = s.getLastRow();
+    var rowOf = {}, existing = {};
+    if (last >= 2) {
+      var meta = s.getRange(2, 1, last - 1, 2).getValues();    // role, id
+      for (var i = 0; i < meta.length; i++) {
+        if (String(meta[i][0]) !== String(role)) continue;
+        var eid = String(meta[i][1]); rowOf[eid] = i + 2; existing[eid] = true;
+      }
+    }
+    var keep = {}, appends = [];
+    // 1) upsert existing rows in place (no index shift)
+    chats.forEach(function (c) {
+      if (!c || !c.id) return;
+      var id = String(c.id), js = JSON.stringify(c); keep[id] = true;
+      if (rowOf[id]) s.getRange(rowOf[id], 1, 1, 3).setValues([[String(role), id, js]]);
+      else appends.push([String(role), id, js]);
+      n++;
+    });
+    // 2) delete this role's rows absent from the payload (high→low, before appends)
+    var del = [];
+    Object.keys(existing).forEach(function (id) { if (!keep[id]) del.push(rowOf[id]); });
+    del.sort(function (a, b) { return b - a; }).forEach(function (r) { s.deleteRow(r); });
+    // 3) append the new rows
+    if (appends.length) s.getRange(s.getLastRow() + 1, 1, appends.length, 3).setValues(appends);
+  } finally { lock.releaseLock(); }
+  return { ok: true, saved: n };
+}

--- a/docs/superpowers/specs/2026-06-20-wrangler-rail-cross-device-sync-design.md
+++ b/docs/superpowers/specs/2026-06-20-wrangler-rail-cross-device-sync-design.md
@@ -1,0 +1,129 @@
+# Cross-device Mr. Wrangler rail — server sync
+
+**Date:** 2026-06-20
+**Status:** Approved (design) — ready for implementation plan
+**Surfaces:** the Wrangler rail (`state.wranglerRail`, `wranglerRailLoad`/
+`wranglerRailPersist`, `wrOffloadChatImages`) — frontend; new
+`getWranglerRail`/`setWranglerRail` actions — backend `Code.gs` (deployed via
+clasp, same deployment id).
+
+## Summary
+
+The Mr. Wrangler AI rail is **device-local** (IndexedDB, #181). This makes a
+user's chats **follow their login across devices**, mirroring the proven
+team-chat sync. Local IndexedDB stays the device cache + offline buffer; the
+backend becomes the cross-device source of truth. Images ride **Drive URLs**
+(#181/#182), so they appear on every device.
+
+## Decisions (locked 2026-06-20)
+
+| Question | Decision |
+|---|---|
+| Identity key | **By role login** (server-derived from the password; a client reads/writes only its own rail). Roles map ~1:1 to people in the JacRentals roster. |
+| Images on sync | **Full fidelity** — offload a chat's blobs to Drive *before* it pushes, so images appear on every device |
+| Merge grain | **Whole-chat last-writer-wins**, union by `chatId` (Wrangler messages have no stable ids → per-message merge isn't possible) |
+| Local store | IndexedDB (#181) stays the **device cache / offline buffer**; backend is the **cross-device source of truth** |
+| Backend storage | A `wranglerRails` Sheet tab, **one row per chat**: `[roleKey, chatId, json]` (each row well under the 50k-char cell cap) |
+| Deploy | Claude builds **and** clasp-deploys `Code.gs` to the **same deployment id** (frontend URL unchanged), throwaway-row tested first |
+
+## Scope / non-goals
+
+- **Per-role**, not per-typed-name. Shared-role privacy is acceptable (roster is
+  1:1). Not building per-user-within-a-role separation.
+- Not changing team chat, the live-chat request shape, or the wrangler-issue flow.
+- Not real-time push (no websockets) — sync rides the existing boot + refresh
+  poll + debounced push, exactly like team chat.
+- No per-message conflict resolution (whole-chat grain, by design).
+
+## Architecture
+
+### A · Backend — `Code.gs` (built + clasp-deployed)
+
+Mirror the team-chat (`getChats`/`setChats`) + entity-sheet conventions.
+
+- **Storage:** a `wranglerRails` tab, rows `[roleKey, chatId, json]`. One row per
+  chat keeps every cell well under the 50k cap; a heavy rail is many rows.
+- **`getWranglerRail_(body, role)`** → `{ ok, chats: [...] }` — every row whose
+  `roleKey === role`, `json`-parsed. The role is resolved **server-side** from
+  the password (`roleForPassword`); the client never names a role, so it can
+  only read its own rail.
+- **`setWranglerRail_(body, role)`** → upsert the caller's chats by
+  `(role, chatId)`; delete the role's rows absent from the payload (so a deleted
+  chat propagates). `{ ok, saved: n }`.
+- **Dispatch:** `if (action === 'getWranglerRail') …` / `setWranglerRail` next to
+  the team-chat cases (any valid role; role-scoped).
+- **Isolation invariant:** role A can never read or overwrite role B's rows
+  (enforced by the server-derived role on every read/write).
+
+### B · Frontend — mirror `pushChats`/`loadChats`
+
+- **`pushWranglerRail()`** (debounced via `pushWranglerRailSoon`, ~1.2 s): for
+  each chat queued to sync, first `await wrOffloadChatImages(chat)` (Drive URLs,
+  full fidelity), then `backendCall('setWranglerRail', { chats })`. Skip when
+  unchanged (a `lastRailJson` guard, like `lastChatsJson`).
+- **`loadWranglerRail()`** on boot (after `wranglerRailLoad`) and in
+  `refreshFromBackend`: `getWranglerRail` → `mergeWranglerRail(remoteChats)`.
+- **`mergeWranglerRail(remote)`** (pure, testable): union by `chatId`; for a chat
+  in both, the **newer `ts`** wins; a remote-only chat is added; a local chat
+  newer-or-absent-remotely flags `localAhead` → `pushWranglerRail()`. Writes the
+  merged result to IndexedDB (`wrStore.putChat`) so the local cache stays current.
+
+### Data flow
+
+```
+chat snapshot → IndexedDB (wrStore) ──┐  (local durability, #181)
+                                      ├─ pushWranglerRailSoon → offload images → setWranglerRail → Sheet row
+boot / refresh → getWranglerRail → mergeWranglerRail (union by id, newest ts)
+                                      └─ writes merged chats to IndexedDB + renders
+result → your Wrangler rail is identical on every device you log into as that role
+```
+
+### Hook into the existing flow
+
+- `wranglerRailPersist` (the IndexedDB writer, #181) also kicks
+  `pushWranglerRailSoon()` after a successful `putChat`.
+- `wranglerRailLoad` (boot, #181) calls `loadWranglerRail()` once the local rail
+  is in memory, so boot = union(local, backend).
+- `refreshFromBackend` calls `loadWranglerRail()` alongside `loadChats()`.
+
+## Error handling & edges
+
+- Offline / no backend → push and pull are silent no-ops (guarded by
+  `backendPassword`); local IndexedDB keeps working; syncs on reconnect.
+- A chat whose images failed to offload (offline) → it still syncs its **text**;
+  images offload + re-push on the next online pass (never blocks the text).
+- Role change mid-session (re-login) → the rail reloads for the new role (a
+  login already re-boots; `loadWranglerRail` runs for the new role).
+- Whole-chat last-writer-wins: a rare concurrent edit to the *same* chatId on two
+  devices keeps only the newer. Pull-before-edit makes this uncommon; acceptable
+  for v1.
+- Deleted chat: absent from the push payload → the backend deletes the role's
+  row → it disappears on other devices on their next pull.
+
+## Testing
+
+- **Frontend logic-seam** (`mergeWranglerRail` is pure):
+  - union adds a remote-only chat; newer-`ts` wins both directions; a
+    local-newer chat sets `localAhead`; identical input is a no-op.
+  - merged chats are written to `wrStore` (cache stays current).
+- **Backend** (throwaway row via the live exec URL, per the runbook):
+  - `setWranglerRail` then `getWranglerRail` round-trips a chat for a role;
+  - **isolation:** a different role's `getWranglerRail` does NOT return it;
+  - a delete (omit from payload) removes the row;
+  - clean up the throwaway rows.
+- `smoke` + `logic-test` + `gen-rule-usage --check`; cache-bust bump.
+
+## Gates / deploy (per CLAUDE.md + the clasp runbook)
+
+- Backend: `clasp pull` → add the functions + dispatch → `clasp push --force` →
+  `clasp deploy -i <prod deployment id> -d "wrangler rail sync"` (**same id** so
+  the exec URL is unchanged). Verify on a throwaway role row, then delete it.
+- Keep a secret-free copy of the additions in
+  `docs/handoffs/wrangler-rail-sync-backend.gs`.
+- Frontend three gates (port-swap 8000→9147, restore `ci/`); `?v=` bump; ship
+  via feature branch → PR → squash-merge (main is branch-protected).
+
+## Open items
+
+- None blocking. (`uploadCapture` reuse for image offload is already confirmed
+  generic and live-verified.)

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260620d" />
+  <link rel="stylesheet" href="style.css?v=20260620e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260620d"></script>
-  <script type="module" src="app.js?v=20260620d"></script>
+  <script src="rule-usage.js?v=20260620e"></script>
+  <script type="module" src="app.js?v=20260620e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Makes the Mr. Wrangler AI rail follow a user's **role login across devices**, and — discovered mid-build — **lights up team-chat sync**, which was dormant (frontend ready, backend handler missing).

## Backend — built + clasp-deployed to the live exec URL ✅

Pulled the live `Code.gs`, added four role-aware actions, **tested on a throwaway deployment** (round-trip + delete-propagation + isolation), then deployed to the **same prod deployment id** (exec URL unchanged) and verified live (`auth` still healthy — nothing broken). Secret-free copy: `docs/handoffs/wrangler-rail-sync-backend.gs`.

- `getChats`/`setChats` — team chat (shared, `teamChats` tab). **This handler was missing**, so team-chat cross-device sync never actually worked; it does now.
- `getWranglerRail`/`setWranglerRail` — per-role (`wranglerRails` tab, one row per chat). Role resolved server-side from the password → a client only ever reads/writes its own rows (isolation).

## Frontend (this PR)

- `pushWranglerRail`/`loadWranglerRail` mirror the team-chat sync; hooked into `wranglerRailPersist` (push), `wranglerRailLoad` (boot pull), `refreshFromBackend` (poll).
- **Pure `mergeWranglerRails`** (union by id, newest-`ts` wins, `localAhead`) — unit-tested.
- Images offload to Drive **before** a chat syncs (full fidelity, reuses #181/#182).
- IndexedDB stays the device cache; backend is the cross-device source of truth.

## Live status note
The **backend is already live**, so **team-chat sync works in production right now** (its frontend shipped earlier). The **Wrangler-rail** sync activates when this PR's frontend merges.

## Verified
Backend throwaway round-trip + isolation + delete (live); `mergeWranglerRails` 96/96 logic; smoke green; cache-bust bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)