### PR TITLE
fix(clasp bridge): SessionStart hook honors CLASPRC_JSON_B64

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,18 +1,37 @@
 #!/bin/bash
 # Rental Wrangler — Claude Code on the web: clasp DEPLOY BRIDGE bootstrap.
 # Wires up clasp so the agent can deploy the Apps Script backend (gitignored
-# Code.gs) without manual pasting. It is a safe no-op unless CLASPRC_JSON is set
-# (a Google clasp credential held ONLY as an environment variable in the env
-# settings — never in this repo). See docs/handoffs/backend-deploy-via-clasp.md.
+# Code.gs) without manual pasting. It is a safe no-op unless CLASPRC_JSON_B64
+# (or raw CLASPRC_JSON) is set — a Google clasp credential held ONLY as an
+# environment secret in the env settings, never in this repo or chat.
+# See docs/handoffs/backend-deploy-via-clasp.md.
 set -euo pipefail
 
 # Only meaningful in the remote (Claude Code on the web) environment.
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then exit 0; fi
-# No credential configured → nothing to wire (silent, safe default).
-if [ -z "${CLASPRC_JSON:-}" ]; then exit 0; fi
+
+# Resolve the clasp credential from either CLASPRC_JSON_B64 (preferred — base64
+# survives env-var newline/quoting cleanly) or raw CLASPRC_JSON. Held ONLY as an
+# environment secret in the env settings, never in this repo or chat.
+cred=""
+if [ -n "${CLASPRC_JSON_B64:-}" ]; then
+  cred="$(printf '%s' "$CLASPRC_JSON_B64" | base64 -d 2>/dev/null || true)"
+elif [ -n "${CLASPRC_JSON:-}" ]; then
+  cred="${CLASPRC_JSON}"
+fi
+
+# Sanity-check it decoded to a JSON object before writing — guards against a
+# placeholder/garbage secret silently clobbering ~/.clasprc.json with junk.
+case "$cred" in
+  *'{'*'}'*) : ;;
+  *)
+    echo "clasp deploy bridge: no valid clasp credential configured (set CLASPRC_JSON_B64 to the base64 of a clasp-login ~/.clasprc.json); skipping — clasp will be unauthenticated."
+    exit 0
+    ;;
+esac
 
 # 1) Write the clasp credential so clasp is authenticated for this session.
-printf '%s' "$CLASPRC_JSON" > "$HOME/.clasprc.json"
+printf '%s' "$cred" > "$HOME/.clasprc.json"
 chmod 600 "$HOME/.clasprc.json"
 
 # 2) Bind a working dir to the Apps Script project (Script ID from env).

--- a/docs/handoffs/backend-deploy-via-clasp.md
+++ b/docs/handoffs/backend-deploy-via-clasp.md
@@ -8,19 +8,27 @@ This runbook lets the agent deploy it directly with [clasp](https://github.com/g
 
 | Variable | Value | Secret? |
 |---|---|---|
-| `CLASPRC_JSON` | full contents of a `~/.clasprc.json` from `clasp login` (a Google OAuth credential for the account that owns the script) | **Yes** — env var only, never in the repo/chat |
+| `CLASPRC_JSON_B64` | **base64** of a `~/.clasprc.json` from `clasp login` (a Google OAuth credential for the account that owns the script). Generate with `base64 -w0 ~/.clasprc.json`. Base64 is preferred — it survives env-var newline/quoting cleanly. | **Yes** — env secret only, never in the repo/chat |
 | `APPS_SCRIPT_ID` | the backend project's Script ID (Apps Script → ⚙ Project Settings → Script ID) | No (not a credential) |
 
 The **SessionStart hook** (`.claude/hooks/session-start.sh`) wires these at session
-boot: it writes `~/.clasprc.json` and `~/rw-backend/.clasp.json`. It's a safe no-op
-when `CLASPRC_JSON` isn't set. The credential is revocable anytime at
-`myaccount.google.com/permissions` → "clasp".
+boot: it base64-decodes `CLASPRC_JSON_B64` (or accepts raw `CLASPRC_JSON`) into
+`~/.clasprc.json` and writes `~/rw-backend/.clasp.json`. It's a safe no-op when no
+valid credential is set (a non-JSON/garbage value is rejected rather than written).
+The credential is revocable anytime at `myaccount.google.com/permissions` → "clasp".
 
-> Note: `CLASPRC_JSON` can't be minted by `clasp login` on every network (some
-> firewalls/AV kill the token-exchange to `oauth2.googleapis.com` — "Premature
-> close"). If so, run the OAuth code-exchange from the container instead (clasp's
-> public client id/secret live in `@google/clasp/.../auth/oauth_client.js`), then
-> save the resulting tokens as the `CLASPRC_JSON` env var.
+> **Why clasp isn't working in a fresh session:** the most common cause is the
+> `CLASPRC_JSON_B64` secret being unset or a placeholder. Decode-and-check it:
+> `printf '%s' "$CLASPRC_JSON_B64" | base64 -d | head -c1` should print `{`. If it
+> doesn't, re-mint the secret (below). The network is *not* the blocker — clasp
+> reaches Google's API fine once `~/.clasprc.json` exists.
+
+> Note: the credential can't always be minted by `clasp login` on every network
+> (some firewalls/AV kill the token-exchange to `oauth2.googleapis.com` —
+> "Premature close"). If so, run `clasp login` on a machine that can, then
+> `base64 -w0 ~/.clasprc.json` and save the result as the `CLASPRC_JSON_B64`
+> secret. To keep the live token out of chat/logs, generate the base64 yourself
+> and paste it straight into the env settings — don't have the agent print it.
 
 ## Deploy flow
 


### PR DESCRIPTION
## Why clasp never "just works" in a fresh web session

The SessionStart hook (`.claude/hooks/session-start.sh`) is supposed to materialize `~/.clasprc.json` from an environment secret so every session boots authenticated. But it read **`$CLASPRC_JSON`** (raw JSON), while the provisioned environment secret is named **`CLASPRC_JSON_B64`** (base64). A name **and** format mismatch — so the hook silently no-op'd on every fresh session and clasp was left unauthenticated. (Sessions that *did* have auth got it hand-dropped, which doesn't carry over.)

## Fix

- Decode `CLASPRC_JSON_B64` (base64) into `~/.clasprc.json`, still accepting raw `CLASPRC_JSON` as a fallback.
- **Sanity-check** the decoded value looks like a JSON object before writing, so a placeholder/garbage secret (e.g. the current 42-char value) is rejected rather than clobbering the auth file with junk.
- Sync `docs/handoffs/backend-deploy-via-clasp.md` to document `CLASPRC_JSON_B64`, how to generate it (`base64 -w0 ~/.clasprc.json`), and a quick "why is clasp unauthenticated" decode-check.

## One manual step still required (only you can do it)

This is a repo fix — it makes the existing secret *slot* work. The secret **value** is still a 42-char placeholder. To finish: set the `CLASPRC_JSON_B64` environment secret to the base64 of a real `clasp login` credential. Generate it yourself and paste it straight into the env settings so the live OAuth token never lands in chat/logs.

## Test

Verified locally: a valid base64 value writes a correct `~/.clasprc.json` + `~/rw-backend/.clasp.json`; the current 42-char garbage value cleanly no-ops (exit 0, no file written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw5PSqJP8ehggbQPmb9ZFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw5PSqJP8ehggbQPmb9ZFh)_