### PR TITLE
Make rentals searchable by natural date ("Jun 18"), not just ISO

### DIFF
--- a/app.js
+++ b/app.js
@@ -612,7 +612,9 @@ function searchBlob(card, rec) {
     case 'rentals': {
       const u = un(rec.unitId), c = ca(rec.categoryId), cust = cu(rec.customerId);
       p = [rec.rentalName, rec.legacyUnitName, rec.startTime, rec.deliveryAddress, rec.po, rec.notes,
-        rec.fieldCall ? 'field call fc' : '', rec.startDate, rec.endDate, rec.invoiceId,
+        rec.fieldCall ? 'field call fc' : '', rec.startDate, rec.endDate,
+        fmtShortDate(rec.startDate), fmtShortDate(rec.endDate),   // human date forms ("Jun 18") so a natural date search matches, not just ISO
+        rec.invoiceId,
         rec.status, L('rentalStatus', rec.status), L('rentalStatus', rentalDisplayStatus(rec)),
         rec.transportType, L('transportType', rec.transportType),
         u?.name, u?.make, u?.model, u?.serial, c?.name, cust?.name, cust?.company];

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260620f" />
+  <link rel="stylesheet" href="style.css?v=20260620g" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260620f"></script>
-  <script type="module" src="app.js?v=20260620f"></script>
+  <script src="rule-usage.js?v=20260620g"></script>
+  <script type="module" src="app.js?v=20260620g"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Problem
Searching a natural date like **"Jun 18"** in the global search returns **nothing** — even when rentals exist on that day. It looks like missing data, but it's a format mismatch.

The global search is a literal, lowercased **substring** match (`app.js` `blobMatches`: `blob.includes(query)`), and a rental's search blob carried only the **ISO** dates (`2026-06-18`). `"jun 18"` is never a substring of `"2026-06-18"`, so the query filters every column to empty.

## Fix
Add `fmtShortDate(startDate)` / `fmtShortDate(endDate)` (→ `"Jun 18"`) to the rentals search blob — the **same ISO-plus-human pattern already used** for expenses (`app.js:660`) and company files (`app.js:657`). Now both `Jun 18` and `06-18` find the rental. The blob is lowercased at build time (`app.js:669`), so matching stays case-insensitive.

## Scope
Two-line change to the rentals blob + cache-bust bump. No visual/UI change, no rule-usage change.

## Gates
- `node ci/smoke.mjs` ✓
- `node ci/logic-test.mjs` → **96/96** ✓
- `node ci/gen-rule-usage.mjs --check` ✓
- Cache-bust token bumped `…f → …g` (main was already on `f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw5PSqJP8ehggbQPmb9ZFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw5PSqJP8ehggbQPmb9ZFh)_