### PR TITLE
Add Claude Code skill suite: /start, /role, /clasp, /audit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,37 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(node:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(clasp:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git branch:*)",
+      "Bash(git merge:*)",
+      "Bash(git diff:*)",
+      "Bash(git stash:*)",
+      "Bash(gh:*)",
+      "mcp__Claude_Preview__preview_start",
+      "mcp__Claude_Preview__preview_eval",
+      "mcp__Claude_Preview__preview_screenshot",
+      "mcp__Claude_Preview__preview_console_logs",
+      "mcp__Claude_Preview__preview_click",
+      "mcp__Claude_Preview__preview_resize",
+      "mcp__Claude_Preview__preview_list",
+      "mcp__Claude_Preview__preview_snapshot",
+      "mcp__Claude_Preview__preview_network",
+      "mcp__Claude_Preview__preview_logs",
+      "mcp__Claude_Preview__preview_fill",
+      "mcp__Claude_Preview__preview_inspect",
+      "mcp__Claude_Preview__preview_stop"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {
@@ -6,6 +39,16 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/skills/audit/scripts/token-watch.mjs"
           }
         ]
       }

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: audit
+description: Token-efficiency + model-appropriateness coaching report for the current Claude Code session. Run with /audit anytime; also fired automatically by a hook roughly every 100k tokens. Reports cache hit rate, redundant file reads, oversized tool outputs, whether the model tier fit the work (Haiku / Sonnet / Opus), and 2-4 concrete habit changes with estimated savings.
+---
+
+# /audit — Token + Model Efficiency Coach
+
+Analyzes THIS session and coaches Jac on saving tokens — including whether the wrong (or overkill) Claude model was used for the work.
+
+## Steps
+1. **Run the analyzer** (Node is installed):
+   ```bash
+   node ".claude/skills/audit/scripts/audit.mjs"
+   ```
+   It auto-detects the current session transcript and prints a JSON metrics blob. (A hook may pass `--transcript <path>`.)
+2. **Read the JSON.** Do NOT re-read the raw transcript — the script already crunched it.
+3. **Write a SHORT coaching report** (see format). Terse and specific to this session's actual numbers — a long report defeats its own purpose.
+
+## What to flag
+- **Cache hit rate** (`cacheHitRate`): healthy is ≥ 0.85. Below that → context is being invalidated (e.g. editing files high in context, long gaps, big mid-conversation inserts). Name the likely cause.
+- **Redundant reads** (`repeatedReads`): same file read 2+ times → read once, or `Grep` for the specific line instead of re-reading the whole file.
+- **Oversized outputs** (`bigOutputs`, `bigOutputApproxTokens`): large tool results → use narrower `Read` ranges, `Grep` with `head_limit`, or targeted queries instead of dumping whole files.
+- **Read-vs-search ratio** (`reads` vs `grepGlob`): many reads with few greps → suggest `Grep`/`Glob` first to locate before reading.
+- **Long assistant blocks** (`longAssistantBlocks`): verbose replies → default to terser answers.
+
+## Model-appropriateness (`models` breakdown)
+Compare the model(s) used against the work actually done this session:
+
+| If the session was mostly… | Ideal tier | Coaching |
+|---|---|---|
+| Read-only exploration, grep/list, format/convert, simple Q&A | **Haiku** | "This was mechanical — Haiku at ~1/5 the cost would've handled it." |
+| Normal coding, debugging, design decisions | **Sonnet** | "Sonnet was the right call." |
+| Hard architecture, multi-system reasoning, repeated wrong answers | **Opus** | "Worth Opus here." or, if used on simple work, "Opus was overkill — Sonnet/Haiku would do." |
+
+Note subagent/mechanical work specifically: if the session spawned agents for grep/read, those should run on Haiku. Frame model notes as **suggestions, not corrections** — a session can look simple from tool calls while involving nuanced reasoning in the text.
+
+## Output format
+```
+⚡ /audit — <approxContextTotal/1000>k ctx · cache <cacheHitRate*100>% · model: <models>
+
+<🔴 / 🟡 / ✅ one line per flagged item, with the number and the fix>
+
+Model fit: <one line>
+
+Try next:
+1. <concrete habit change>
+2. <concrete habit change>
+Est. savings: ~<rough number/percent> if applied.
+```
+
+## Rules
+- Keep it to a dozen lines or so. Bullets, not essays.
+- Cite this session's real numbers — never generic advice.
+- End with a single estimated-savings line so the coaching is actionable, not abstract.

--- a/.claude/skills/audit/scripts/audit.mjs
+++ b/.claude/skills/audit/scripts/audit.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// /audit analyzer — crunch the current Claude Code session transcript for
+// token efficiency + model-appropriateness. Prints a compact JSON metrics blob.
+// Usage: node audit.mjs [--transcript <path.jsonl>]
+// No deps; Node 18+. Reused by the ~100k auto-audit hook.
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function findNewestTranscript() {
+  const root = join(homedir(), '.claude', 'projects');
+  let best = null;
+  let projects;
+  try { projects = readdirSync(root, { withFileTypes: true }); } catch { return null; }
+  for (const proj of projects) {
+    if (!proj.isDirectory()) continue;
+    const projDir = join(root, proj.name);
+    let entries;
+    try { entries = readdirSync(projDir, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      // top-level session files only — skip subagents/ and workflows/ subdirs
+      if (!e.isFile() || !e.name.endsWith('.jsonl')) continue;
+      const p = join(projDir, e.name);
+      const m = statSync(p).mtimeMs;
+      if (!best || m > best.m) best = { p, m };
+    }
+  }
+  return best?.p ?? null;
+}
+
+const argIdx = process.argv.indexOf('--transcript');
+const transcript = argIdx >= 0 ? process.argv[argIdx + 1] : findNewestTranscript();
+if (!transcript) { console.log(JSON.stringify({ error: 'no transcript found' })); process.exit(0); }
+
+let lines;
+try { lines = readFileSync(transcript, 'utf8').split('\n').filter(Boolean); }
+catch (e) { console.log(JSON.stringify({ error: 'cannot read transcript', transcript })); process.exit(0); }
+
+let input = 0, output = 0, cacheRead = 0, cacheCreate = 0;
+const models = {};
+const tools = {};
+const readPaths = {};
+let bigOutputs = 0, bigOutputChars = 0, longAssistant = 0, reads = 0, grepGlob = 0;
+const BIG = 20000;    // chars (~5k tokens): a "big" tool result
+const LONGTXT = 6000; // chars: a "long" assistant text block
+
+for (const line of lines) {
+  let o; try { o = JSON.parse(line); } catch { continue; }
+  const msg = o.message || o;
+  const role = msg.role;
+  if (role === 'assistant') {
+    const u = msg.usage || o.usage || {};
+    input += u.input_tokens || 0;
+    output += u.output_tokens || 0;
+    cacheRead += u.cache_read_input_tokens || 0;
+    cacheCreate += u.cache_creation_input_tokens || 0;
+    const model = msg.model || o.model || 'unknown';
+    const mm = models[model] || (models[model] = { turns: 0, output: 0 });
+    mm.turns++; mm.output += u.output_tokens || 0;
+    for (const c of (msg.content || [])) {
+      if (c.type === 'tool_use') {
+        tools[c.name] = (tools[c.name] || 0) + 1;
+        if (c.name === 'Read') { reads++; const fp = c.input?.file_path; if (fp) readPaths[fp] = (readPaths[fp] || 0) + 1; }
+        else if (c.name === 'Grep' || c.name === 'Glob') grepGlob++;
+      } else if (c.type === 'text' && typeof c.text === 'string' && c.text.length > LONGTXT) {
+        longAssistant++;
+      }
+    }
+  } else if (role === 'user') {
+    const content = Array.isArray(msg.content) ? msg.content : [];
+    for (const c of content) {
+      if (c && c.type === 'tool_result') {
+        const t = typeof c.content === 'string' ? c.content : JSON.stringify(c.content || '');
+        if (t.length > BIG) { bigOutputs++; bigOutputChars += t.length; }
+      }
+    }
+  }
+}
+
+const totalInputish = input + cacheRead + cacheCreate;
+const cacheHitRate = totalInputish ? +(cacheRead / totalInputish).toFixed(3) : null;
+const repeatedReads = Object.entries(readPaths)
+  .filter(([, n]) => n > 1)
+  .map(([file, n]) => ({ file, reads: n }))
+  .sort((a, b) => b.reads - a.reads)
+  .slice(0, 10);
+
+console.log(JSON.stringify({
+  transcript,
+  turns: lines.length,
+  tokens: { input, output, cacheRead, cacheCreate, approxContextTotal: totalInputish + output },
+  cacheHitRate,
+  models,
+  tools,
+  reads, grepGlob,
+  repeatedReads,
+  bigOutputs, bigOutputApproxTokens: Math.round(bigOutputChars / 4),
+  longAssistantBlocks: longAssistant,
+}, null, 2));

--- a/.claude/skills/audit/scripts/token-watch.mjs
+++ b/.claude/skills/audit/scripts/token-watch.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// UserPromptSubmit hook — fires the /audit coaching report roughly every 100k
+// tokens used this session. Reads the hook JSON on stdin (transcript_path,
+// session_id), sums non-cache input+output across assistant turns, and when a
+// new 100k bucket is crossed, prints a reminder that becomes context so Claude
+// runs /audit after handling the current message. Silent otherwise. No deps.
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const THRESHOLD = 100000;
+
+let stdin = '';
+try { stdin = readFileSync(0, 'utf8'); } catch {}
+let info = {}; try { info = JSON.parse(stdin || '{}'); } catch {}
+const transcript = info.transcript_path || info.transcriptPath;
+const sessionId = info.session_id || info.sessionId || 'unknown';
+if (!transcript || !existsSync(transcript)) process.exit(0);
+
+let used = 0;
+try {
+  for (const line of readFileSync(transcript, 'utf8').split('\n')) {
+    if (!line) continue;
+    let o; try { o = JSON.parse(line); } catch { continue; }
+    const m = o.message || o;
+    if (m.role === 'assistant') {
+      const u = m.usage || o.usage || {};
+      used += (u.input_tokens || 0) + (u.output_tokens || 0); // non-cache work
+    }
+  }
+} catch { process.exit(0); }
+
+const bucket = Math.floor(used / THRESHOLD);
+const stateDir = join(tmpdir(), 'rw-audit-state');
+const stateFile = join(stateDir, String(sessionId).replace(/[^a-zA-Z0-9_-]/g, '_') + '.json');
+let last = 0;
+try { last = JSON.parse(readFileSync(stateFile, 'utf8')).bucket || 0; } catch {}
+
+if (bucket > last) {
+  try { mkdirSync(stateDir, { recursive: true }); writeFileSync(stateFile, JSON.stringify({ bucket })); } catch {}
+  const k = Math.round(used / 1000);
+  process.stdout.write(
+    `[token checkpoint] ~${k}k tokens used this session (crossed ${bucket}x100k). ` +
+    `After you finish the user's current request, run the /audit skill and give Jac a brief token + model-fit coaching report.`
+  );
+}
+process.exit(0);

--- a/.claude/skills/clasp/SKILL.md
+++ b/.claude/skills/clasp/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: clasp
+description: Deploy the Google Apps Script backend via clasp (the backend ships via clasp, NOT git — it is gitignored). Use when changing or deploying backend Code.js, wiring clasp auth from the env secret, or pushing a new GAS deployment. ADDITIVE changes only; ALWAYS stops for explicit confirmation before any production deploy. Invoke with /clasp.
+---
+
+# /clasp — Deploy the Apps Script backend (via clasp, NOT git)
+
+The Rental Wrangler backend is a Google Apps Script web app. It ships through **clasp**, never through git — `Code.gs`/`Code.js` are gitignored because the repo is **public** via GitHub Pages. This skill wires auth, pulls the live code, makes additive changes, tests on a throwaway deployment, then (only after your OK) promotes to the same prod URL.
+
+## ⛔ Safety rails — read every time
+1. **Additive changes only.** Never remove or rewrite existing actions/handlers. Add new ones alongside.
+2. **STOP before prod.** After the throwaway test passes, **halt and get explicit "OK" from Jac** before the production deploy. No exceptions.
+3. **Never commit `Code.gs` / `Code.js`.** They're gitignored; the repo is public. If you ever see them staged, unstage them.
+4. **Never print secrets or passwords** — not `~/.clasprc.json`, not `$CLASPRC_JSON_B64`, not `$RW_PW`, not any role password. Don't echo them, don't paste them into reports.
+5. **Throwaway-test before prod.** Always `clasp deploy -d "test"` → curl-test → `clasp undeploy <test-id>` before touching the live deployment.
+6. **`clasp push --force` updates HEAD only** — it does NOT change the live `/exec` URL. Only `clasp deploy -i <prod-id>` goes live.
+
+## Backend identifiers
+Read the `scriptId`, prod `deployment id`, and `exec URL` from `references/backend-ids.local.md` (gitignored — never published). If that file is absent (e.g. a fresh cloud container), take them from env vars `RW_SCRIPT_ID` / `RW_PROD_DEPLOYMENT_ID` / `EXEC_URL`, or ask Jac. **Never hardcode them in this committed file.**
+
+## Step 1 — Wire clasp auth from the env secret (self-contained)
+```bash
+[ -n "$CLASPRC_JSON_B64" ] && printf '%s' "$CLASPRC_JSON_B64" | base64 -d > ~/.clasprc.json && chmod 600 ~/.clasprc.json
+clasp --version                                   # expect 3.x
+test -f ~/.clasprc.json && echo AUTHED || echo "NO AUTH — stop and tell Jac"
+```
+If `CLASPRC_JSON_B64` is empty, this session started **before the secret existed** — stop and ask Jac to restart it. Don't guess.
+
+## Step 2 — Backend working copy
+```bash
+mkdir -p ~/rw-backend && cd ~/rw-backend && clasp pull \
+  || clasp clone "$RW_SCRIPT_ID"
+```
+
+## Step 3 — Deploy runbook
+```
+a. clasp pull            — start from the LIVE code
+b. edit Code.js          — ADDITIVE
+c. node --check Code.js  — syntax gate
+d. clasp push --force    — updates HEAD only; does NOT touch the live URL
+e. THROWAWAY TEST:  clasp deploy -d "test"  →  curl-test the new /exec  →  clasp undeploy <test-id>
+f. *** STOP — confirm with Jac before going to prod ***
+g. GO LIVE (same URL):  clasp deploy -i "$RW_PROD_DEPLOYMENT_ID" -d "what changed"
+h. VERIFY: call an existing action (e.g. auth) on the prod exec URL and confirm it still works.
+```
+
+## Curl test
+`text/plain` avoids a CORS preflight GAS can't answer; `-L` follows the redirect; password via `$RW_PW`.
+```bash
+curl -sS -L -H 'Content-Type: text/plain;charset=utf-8' \
+  --data '{"action":"auth","password":"'"$RW_PW"'"}' "$EXEC_URL"
+```
+No `RW_PW` set? You can only test the **auth-rejection** path — ask Jac for a role password if you need a money-action test.
+
+## Environment
+clasp (backend), GitHub, Google Drive, Gmail, Figma, HeyGen are available in the clasp-enabled session. This runbook is written for that (Linux/bash) environment; on the local Windows desktop, clasp auth comes from the desktop's own `~/.clasprc.json` instead of the env secret.
+
+## Note for /jac-start
+This skill is referenced by the startup skill: at session start, if clasp is available, jac-start should remind that **the backend is reachable via `/clasp` — do not ask how to access the backend, use clasp.**

--- a/.claude/skills/role/SKILL.md
+++ b/.claude/skills/role/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: role
+description: Audit a feature spec, design, or screen through all 15 Jac Rentals role lenses + a 12-step authority / data-sensitivity / gate checklist. Use right after generating or reviewing a SPEC, a new feature, a new screen, or a permissions change — to catch role gaps, margin/PII leaks, missing gates, and broken audit trails BEFORE building. Invoke with /role (optionally /role <path-to-spec>).
+---
+
+# /role — Role-Lens Spec Audit
+
+Reviews a spec/design against the real Jac Rentals org: 15 roles (Dispatcher → Customer/Contractor) and a cross-role authority + data-sensitivity framework grounded in the actual Rental Wrangler app. Catches the leaks and gaps that a single-perspective spec misses.
+
+## When to run
+- Right after a SPEC doc is generated, or before building a new feature/screen.
+- After any change to permissions, pricing visibility, customer-facing surfaces, or status/gate logic.
+- Anytime the user types `/role` (with no spec named, audit the most recently generated spec or the feature under discussion).
+
+## Inputs
+- **Target:** the spec/feature to audit. If the user passed a path (`/role docs/spec-x.md`), read it. Otherwise use the most recent spec doc generated this session, or the feature currently under discussion — if genuinely ambiguous, ask which.
+- **Reference (always load before auditing):**
+  - `references/framework.md` — authority hierarchy, the 9-tier data-sensitivity matrix, shared views, cross-role conflicts, design principles, and the 12-step checklist.
+  - `references/roles.md` — the 15 role cards with each role's `spec_audit_questions` (the crown jewel).
+  - `references/research-raw.local.json` — full source research (gitignored, local-only; not present in cloud sessions). Do NOT load by default (it's large); consult only when a card lacks the depth a specific question needs.
+
+## Steps
+1. **Read** `references/framework.md` and `references/roles.md`. (Token note: these two are enough — do not pull `research-raw.json` unless a specific gap requires it.)
+2. **Run the 12-step checklist** from `framework.md` against the target spec, in order. Steps 3 (data-sensitivity) and 4 (customer isolation) are HARD-FAIL gates — a violation there is a blocker, not a suggestion.
+3. **For every role flagged in step 1**, run that role's `spec_audit_questions` from `roles.md` and record pass / fail / gap for each.
+4. **Output the report** (below). Lead with blockers. Be specific and cite the role + the exact field/flow — never generic.
+
+## Output format
+```
+# /role audit — <spec name>
+
+## Roles touched
+<primary actor(s)> · <incidental readers> — one line each on their lens
+
+## 🔴 Blockers (HARD-FAIL)
+- <data-sensitivity / isolation / authority violation> — role, field, why, fix
+
+## 🟡 Gaps
+- <missing gate / audit trail / cascade / mobile / KPI issue> — role, why, fix
+
+## Per-role audit questions
+**<Role>** — ✅/❌/⚠️ per question, one line each
+
+## ✅ Clears
+- <what the spec already handles well>
+
+## Recommended fixes (ordered)
+1. <concrete change>
+```
+
+## Rules
+- **Silence = pass.** If a role has no issue, don't pad the report — list it under Clears in one line.
+- **Margin floors are radioactive** (Bottom Dollar, True Cost, ROI, part cost): any appearance on a Sales-shared or customer-facing surface is an automatic 🔴.
+- **Customer isolation and gates are server-side concerns** — "the UI hides it" is never an acceptable answer; flag it.
+- Keep it tight and actionable. This skill is a scalpel, not an essay — the user reads blockers first and wants the fix, not a lecture.
+- This audit does not write code or change the spec; it produces findings. Offer to apply fixes only after presenting them.

--- a/.claude/skills/role/references/framework.md
+++ b/.claude/skills/role/references/framework.md
@@ -1,0 +1,91 @@
+# Jac Rentals — Cross-Role Design Framework
+
+The backbone of the `/role` review. Source: role-research workflow `wf_93bd5fe5` (2026-06-20), grounded in the actual Rental Wrangler app/spec. Pair this with `roles.md` (per-role audit questions).
+
+---
+
+## Authority Hierarchy (who can do what)
+
+- **Tier 0 — Backend/System (no human role):** Stripe secret keys, full PAN, HMAC price-lock seal, Sheets pricing tables, Drive ACLs. No frontend role ever sees these. Row-level isolation and gate enforcement live here, **not in the UI**.
+- **Tier 1 — Owner/Admin (Jac):** the admin ceiling. Full view+edit on every entity. Sole authority to override any system block (no-card, blacklist, member-incomplete, invoice-required) via Admin-password gate; set/change pricing and the $150k goal; manage Stripe credentials; all back-office boards; blacklist/unblacklist. Every override is force-logged (actor+timestamp+reason).
+- **Tier 2 — Office Manager (money authority):** the only non-owner role that can move money. Charge/partial/refund via Stripe, lock/unlock invoices, manage card-on-file, gate money-sensitive transitions, enforce PO + agreement hard gates. Admin-override only through a separate logged Admin-password gate. View-only on shop internals, unit specs, fleet financials.
+- **Tier 3 — Operational editors (domain-scoped write, no money):** Dispatcher (status transitions, wash flags, driver tasks, Field Call), Fleet/Asset Manager (Fleet Status, current-hours, service logging, WO create/advance; Asset Mgr also purchase fields), Mechanic/M.Tech (Inspections, Work Orders, Service Orders, current-hours). Write only inside their board; view-only on invoices/pricing; cannot override blocks or process payments.
+- **Tier 4 — Sales/CRM editors (customer + funnel write, no money, no margin):** Outside Sales, Inside Sales, Equipment Sales, Marketing. Edit customer contact, funnel pills, Activity Log, Schedule, interested categories; create rentals up to Reserved (Equipment Sales also flips its own units For Sale/Sold). View-only on financial totals; **walled off from margin floors** (Bottom Dollar/Ask/ROI) and from payments/card-gate override.
+- **Tier 5 — View-only analysts:** Investment Manager (+ Marketing for fleet/utilization). Read all data for analysis; no edits, no pricing, no payments, no rental creation. Power = Board View formula engine, not write access.
+- **Tier 6 — Field operator (Driver):** write scoped to own dispatch tasks only — On Rent/Off Rent/Returned, attach delivery/return media, set Wash Requested, trigger Field Call. No pricing, invoice, account-type, or override. Mobile-first reality despite a desktop-only app.
+- **Tier 7 — Customer/Contractor (external, row-isolated):** view-only on their OWN account; edit limited to rental/extension requests, own card (selfie-gated), contact info, and paying own invoices. **Strict server-side row-level isolation** — never reaches another customer's data or any internal margin/maintenance/staff data.
+
+---
+
+## Data-Sensitivity Matrix (which roles may see each tier)
+
+| Tier | Data | Allowed | Key note |
+|---|---|---|---|
+| **T0** | Secrets & crypto: Stripe secret key, full PAN/CVV, HMAC seed, Admin passcode, Drive ACLs | Backend only | No human role, not even Owner, sees raw secrets. Card stored only as brand+last4+exp+PM-id. |
+| **T1** | **Margin & investment floors:** Bottom Dollar, Ask, MSRP markup, True Cost, ROI, Time/Dollar Util, Avg Rev/Expense, WO part cost & vendor markup | Owner, Asset Mgr, Investment Mgr, Fleet Mgr (asset layer), Marketing (aggregates only) | **The most over-shared-by-accident tier. RADIOACTIVE.** Forbidden to ALL customer-facing & shared-screen roles (Sales, Equipment Sales cost basis, Driver, Dispatcher, Mechanic/M.Tech, Customer). A rep's screen faces the contractor — exposing the floor destroys rate integrity. Must never render where a customer could see over a shoulder. |
+| **T2** | Money & payment state: invoice line items, totals, aging, payment ledger, charge/refund, lock/unlock, card validity, PO, deposits, membership fees | Owner, Office Manager | Edit/action is Office+Owner only. Card-on-file **validity** (yes/no) is broader-read (Dispatcher/Sales/Customer need it to gate booking) but the ledger/line-items/charges stay T2. Every money action → append-only, attributed History. |
+| **T3** | Customer PII & CRM: name, phone, address, selfie, signature, agreement text, funnel stage, interested categories, Activity Log, Active%, membership | Owner, Office, Outside/Inside/Equipment Sales, Marketing, Customer (own only) | Operational roles get only the **thin slice** for the job: Dispatcher/Driver need name/phone/address for delivery; Mechanic/M.Tech need name+account-type only (billability), NOT full contact. **Blacklist reasoning is Owner-only** (legal); others see only red styling. |
+| **T4** | Transport & dispatch ops: Dispatch Time Grid, rental status, transport type, delivery address, drive time, city-lookup flat fee, Field Call flag, wash-requested, Round-Trip legs | Owner, Office, Dispatcher, Driver (own), Outside/Inside Sales, Customer (own transport) | Shared operational spine. Transport **flat fee** is visible (customer-facing charge) but its derivation/margin is not. |
+| **T5** | Maintenance & asset condition: Inspection Status, Work Orders + journey/parts/labor, Service countdowns, current/purchase hours, GPS status, Total Repair Cost, FC WO type | Owner, Mechanic, M.Tech, Fleet Mgr, Asset Mgr, Investment Mgr (cost rollups, read) | Shop-owned. Office sees only the **billed WO total** (not shop margin/part/vendor). Dispatcher/Driver see only the Inspection **badge** (Ready/Not Ready/Failed) as a gate. Customer NEVER sees maintenance internals (only resulting availability), except an FC event on their live rental. |
+| **T6** | HR & compliance: CDL/medical card, MVR result, equipment-type certs, training logs, I-9, incident log, dispatch-eligibility flag | Owner, HR | Net-new board, HR-only edit. Only the **derived dispatch-eligibility pill** (green/red) surfaces outward to the Dispatch Grid. Raw MVR/medical/incident records are need-to-know — not visible to peers or other operational roles. |
+| **T7** | Owner-level aggregates: Revenue Goal ring, total AR exposure, fleet risk summary, override audit log, blended ROI, capital deployed | Owner (+ each role sees only ITS OWN KPI ring) | Each role sees its own ring (Sales→Revenue Goal/Pipeline; Mechanic→Renting/WO/Bill; Driver→On-Time/Wash) but NOT other rings' internals or the cross-role rollup. Override audit log is Owner-only. $150k goal is Owner-settable. |
+| **T8** | Public/availability-only: unit availability for a window, published rates, category names | All internal roles + Customer | Only tier safe to expose externally. Customer sees **availability** (yes/no) + the **rate** they'll be charged — never WHY a unit is unavailable (Failed/Not Ready hidden; only "unavailable" shows). |
+
+---
+
+## Shared Views (build once, project per role)
+
+1. **Office Dispatch Time Grid** — Dispatcher, Office, Driver, Outside/Inside Sales, HR (read), Owner. The most cross-consumed screen. Build one data layer with role-scoped overlays (Office $-overlay, Sales rate context, HR eligibility pill each appear only for the entitled role) — not five separate grids.
+2. **Rental detail + status bar / transport journey picker** — Dispatcher, Driver, Office, Outside/Inside Sales, Customer (own, read-mostly). Same record, sharply different write scopes; gate the action affordances on the same surface.
+3. **Units list + Board View** — Fleet/Asset/Investment Mgr, Owner, Mechanic/M.Tech (condition columns only). Shared analytical surface; gate write access and which columns render (margin columns hidden from shop).
+4. **Shop card (Inspections / WOs / Service Orders, urgency-sorted)** — Mechanic, M.Tech, Fleet Mgr (read), Owner (read). True single-cluster surface; no customer/sales role belongs here. Field-Call jobs need a filter.
+5. **Customer card (funnel + Activity Log + account snapshot)** — Outside/Inside/Equipment Sales, Marketing, Office (financial sections). Card SPLITS: Sales/Marketing own funnel top; Office owns ledger/agreement bottom. Margin floors + ledger internals gated even within the shared card.
+6. **KPI ring header strip** — every role, but each sees only its own ring(s). Treat as a per-role projection, never a shared dashboard.
+7. **Customer self-service portal** — Customer (own only). The ONE view that must NOT share a surface with internal roles: separate, mobile-responsive, row-isolated build. The one place the desktop-only 1180px rule has to break.
+8. **HR / People board** — HR (own), Owner. Net-new, HR-private. Only outward projection is the dispatch-eligibility pill.
+
+---
+
+## Cross-Role Conflicts (and their resolution patterns)
+
+1. **Speed vs. audit trail** — Dispatcher/Driver want one-tap transitions; Owner/Office require every transition logged. → One tap acts; the system *silently* writes the attributed History entry. Never make the actor fill a form; never let speed skip the log.
+2. **Margin concealment vs. quoting speed** — Sales needs an instant rate on a customer-visible screen that must never expose Bottom Dollar/True Cost/ROI. → Compute the customer-facing price from floor data the rep can't see; floor stays server-side.
+3. **Hard gate vs. deal momentum** — Office/Owner want card/agreement/PO as hard blocks; Sales loses the deal on a dead-end error mid-close. → Gate fires EARLY (quote/reservation, not delivery morning), gives an actionable next step, plus an Owner-only logged override.
+4. **One inspection badge, two truths** — Dispatcher/Driver want the badge as a hard gate; Mechanic/M.Tech own the WO internals and need the badge live. → Badge derives live from shop state, no manual refresh (kill the stale-read window).
+5. **Current-hours, cascading blast radius** — Mechanic/M.Tech edit hours; Asset/Investment/Fleet ROI, utilization, and countdowns all derive from it. → Show a last-updated/staleness indicator; cascade edits immediately to countdowns + availability.
+6. **Field Call: fast action vs. clean 5-place record** — one tap must atomically create a WO, set unit Failed, flag the rental, maybe trigger a swap. → One action fans out transactionally; never touch five cards; never leave a partial write.
+7. **Transport flat fee: authoritative lookup vs. silent failure** — unresolved city must ALERT the quoting role (not quote $0/dash); flat fee must never be hand-editable.
+8. **HR eligibility vs. dispatch assumption** — Round-Trip auto-assigns Driver tasks assuming anyone can take any task; HR needs cert enforcement. → The derived eligibility pill gates assignment; uncertified-operator assignment surfaces a hard warning sourced from HR data the Dispatcher can't otherwise see.
+9. **Equipment Sales close vs. fleet availability** — a For Sale flip must *atomically* block rental availability; closing to Sold must capture sale price (for realized gain/loss). Used-sale revenue currently excluded from the Sales ring.
+10. **Member Unlimited-Transport: $0 promise vs. invoice truth** — the $0-transport entitlement must flow automatically from a COMPLETE membership into both the quote AND the invoice line, and be refused to Incomplete accounts in both places consistently.
+
+---
+
+## Design Principles
+
+1. **Gate at the earliest possible moment, never the last.** Card/agreement/PO/cert/inspection blocks fire at quote/reservation/loading — not at the yard gate with a crew waiting.
+2. **Same data, role-scoped projection.** Build the surface once; project role-specific overlays/columns/affordances. Don't fork parallel screens that drift.
+3. **Margin floors are radioactive** on shared & customer-facing screens. Compute customer prices from floor data the requesting role can't see.
+4. **One action, full fan-out, full audit — automatically.** High-friction actions complete in one tap while transactionally writing every linked record + an attributed History entry. Speed and traceability are not a trade-off.
+5. **Derive the gate, surface only the verdict.** Expose a single derived pill/badge (eligibility, availability, member entitlement), never the underlying records.
+6. **Stale-read is a correctness bug, not a UX nit.** Any cascading field updates downstream live + shows staleness where the source is a manual edit.
+7. **Mobile reality for field roles**, even in a desktop-first app. Driver (gloves, dead zones), Outside Sales (jobsite), Customer (truck) need pan/large-tap, offline capture with queued retry, no hover-only affordances. The customer portal needs its own responsive, row-isolated build.
+8. **Enforce isolation and gates server-side.** UI hiding a field is not security. Row-isolation, price-lock HMAC, override gates, and the data-sensitivity tiers are an access-control spec, not styling.
+9. **Make business parameters Owner-settable, not hardcoded.** Rates, $150k goal, transport tiers, tax, service intervals route through the Sheets backend / Settings board, with KPI-ring impact documented.
+
+---
+
+## The 12-Step Role Checklist (the engine `/role` runs)
+
+1. **Identify roles touched** — which of the 15 roles create / read / edit / are gated by this feature? List primary actor(s) + every incidental reader. For a shared screen, name each role and its lens.
+2. **Authority check** — does each role's action stay within its tier? Flag any path where a role gains write/money/override/pricing power above its tier. Only Owner overrides blocks; only Office+Owner move money.
+3. **Data-sensitivity check** — map every rendered field to the matrix. **HARD-FAIL** if margin floors appear on a Sales-shared/customer surface, if full PAN/Stripe secret surfaces anywhere, if HR raw docs reach a peer/operational role, or if customer PII beyond the thin operational slice reaches Dispatcher/Driver/Mechanic/M.Tech.
+4. **Customer isolation check** — any customer-reachable surface: row-level isolation enforced SERVER-SIDE, no path to another customer's data, internal-only reasons (Failed/Not Ready, blacklist reasoning, staff notes) hidden — only availability/own-data shows.
+5. **Gate timing + override check** — every block fires at the EARLIEST point, gives an actionable next step (not a dead end), and exposes an Owner-only override that is force-logged.
+6. **Audit-trail check** — every money action, override, status transition, and gate bypass writes an append-only, timestamped, attributed History entry *automatically* (no form). Speed doesn't skip the log.
+7. **Atomicity + cascade check** — if it fans out to linked records (Field Call, For Sale→block, hours→countdowns/ROI/availability, WO phase→badge), ONE action completes all writes transactionally with no partial/stale state. Derived badges/pills are live, not manual-refresh.
+8. **Shared-surface projection check** — multiple consumers → ONE data layer with role-scoped overlays/columns/affordances (not a forked screen), each overlay gated to the entitled role only.
+9. **Field/mobile + offline check** — field role (Driver, Outside Sales) or Customer: works in pan/large-tap, tolerates offline capture with queued retry, no hover-only affordances, critical action in ~3–5 taps.
+10. **Rental-domain integrity check** — honors the invariants: transport flat-fee from the authoritative city lookup (no hand-edit, alert on unresolved city), 10.75% tax, member Unlimited-Transport=$0 only when complete, For-Sale/Inactive/Failed units blocked from availability, Round-Trip surfaces BOTH legs, price-lock HMAC respected on locked invoices.
+11. **KPI + parameter check** — does it move any KPI ring formula (each role limited to its own ring)? Are business parameters Owner-settable, with ring impact documented?
+12. **Run role-specific audit questions** — for each role flagged in step 1, run its `roles.md` audit questions against the spec; record pass/fail/gap. Output the consolidated failures, tier/isolation violations, and concrete fixes.

--- a/.claude/skills/role/references/roles.md
+++ b/.claude/skills/role/references/roles.md
@@ -1,0 +1,340 @@
+# Jac Rentals — Role Cards (audit lenses)
+
+The 15 role lenses for the `/role` skill. Each card's **audit questions** are the core of step 12 of the checklist in `framework.md`. Full detail (jobs, priorities, pain points, features) is in `research-raw.json` — not loaded by default. Source: workflow `wf_93bd5fe5` (2026-06-20).
+
+---
+
+## Dispatcher (Operations)
+> The Dispatcher is the air-traffic controller of the yard: they own the transport lifecycle from booking confirmation to wheels-rolling, hold real-time awareness of every unit's location and status, sequence driver routes to avoid conflicts, and serve as the first responder when a rental goes sideways mid-delivery.
+
+- **Authority:** Operational-edit over rental status transitions (Reserved → On Rent, On Rent → Returned, triggering Field Call), unit wash-request flags, and driver task assignment; view-only on invoices, pricing, and customer financial history; cannot approve Admin-override of no-card-on-file block or process payments
+- **Device:** Desktop — the Dispatch Time Grid requires horizontal screen real-estate; key status transitions must be reachable on a narrow viewport even if the full grid is desktop-only.
+- **Must NOT see:**
+  - Customer payment card details (brand/last4 is acceptable; full PAN never)
+  - Invoice pricing, margins, and balance — the Dispatcher needs to know a rental exists and where it goes, not what it costs
+  - Customer funnel stages (Used Sales / Membership) — sales pipeline data is irrelevant to logistics
+  - Category ROI, Dollar Utilization, and investment-level financials — those are owner/sales metrics
+  - Other drivers' personal performance metrics beyond what is needed to assign a run
+
+**Audit questions:**
+1. Does this feature update the Dispatch Time Grid in real time, or does the Dispatcher have to manually refresh to see a new delivery that was just booked?
+2. When a rental transitions to On Rent, does the app surface the unit's current inspection status and wash-requested flag as a hard gate or just an advisory — and is an Admin override logged?
+3. For Round-Trip rentals, does the feature expose BOTH the Delivery task and the Recovery task as separate actionable items, or does the Recovery leg only appear after the Delivery is marked complete?
+4. If the customer address does not match a city in the §10 transport lookup table, does the feature fail silently (showing a dash for drive time) or alert the Dispatcher so they can resolve it before the driver leaves?
+5. Does the feature allow the Dispatcher to trigger a Field Call, auto-create the linked Work Order, and log an Order Swap or Field Repair decision in three or fewer interactions — or does it require navigating to three separate cards?
+6. When a unit returns late and a wash is needed before the next morning's delivery, does this feature surface that conflict (wash-requested + tomorrow delivery on the same unit) proactively, or does the Dispatcher have to catch it manually by cross-referencing the unit and rental cards?
+
+---
+
+## Office Manager (Operations/Admin)
+> The Office Manager is the financial and contractual spine of Jac Rentals — she owns every invoice, payment, deposit, rental agreement, and customer account from first contact through collections, and is the only non-owner role with money-action authority in the system.
+
+- **Authority:** Operational-edit and financial over customer records, invoices, and payment actions (charge, partial payment, refund, invoice lock/unlock, card-on-file management); view-only over unit specs, WO journey internals, and shop operations; cannot access Owner/Admin Settings board or override rental blocks without a separate Admin-password gate that is logged
+- **Device:** Desktop — entirely office-based; she may occasionally hand a phone to a customer for selfie/signature capture during onboarding but she herself operates on a workstation.
+- **Must NOT see:**
+  - Mechanic-facing WO journey details (part costs, vendor contacts, repair labor hours) beyond what appears on a billed WO line item — she needs the billable total, not the shop margin
+  - GPS placement details and unit hardware configuration (GPS Type/Placement/Status)
+  - Driver performance scores and individual driving event logs
+  - M.Tech field-call operational notes beyond what feeds the billed Field Call WO
+  - Raw Stripe secret key or any backend credential (she operates through the frontend charge/refund flows only)
+  - Owner-level passcode or Admin password (she holds Office role, not Admin/Owner)
+
+**Audit questions:**
+1. Does this feature touch invoice line items, totals, or payment state after a charge has been recorded — and if so, does it respect the price-lock HMAC seal and prevent silent edits to locked invoices?
+2. When a customer's card-on-file is expired or missing, does this feature block or warn at the earliest possible moment (reservation creation, not delivery dispatch) — and is the Admin override logged with attribution?
+3. Does this feature correctly apply the 10.75% tax rate, the city-lookup transport flat fee (no manual override), and the WO tiered-markup pricing — or does it introduce any path where those amounts can be freehandedly changed?
+4. If this feature involves a membership customer, does it gate member-rate pricing and Unlimited-Transport on a completed agreement (signedAt + card on file) and refuse those entitlements to 'Member Incomplete' accounts?
+5. Does this feature surface PO-required status before the invoice is sent, not after — and is the send blocked (hard gate) rather than warned (soft prompt) when PO is absent on a flagged account?
+6. Is every money action (charge, refund, lock, unlock, override) written to an append-only, timestamped, attributed History entry that the Office Manager can produce verbatim if a customer disputes the transaction?
+
+---
+
+## Owner (Leadership)
+> Jac himself — the single decision-maker who owns the revenue goal, sets every price, absorbs every liability, and needs the whole operation visible at a glance so he can redirect people, approve exceptions, and know exactly whether the month is winning or losing.
+
+- **Authority:** Full admin over all entities and all scopes: can view and edit any record, approve any status transition, override any system block (no-card, blacklist, member-incomplete) via Admin-password gate, change pricing in the Sheets backend, manage Stripe credentials and payment settings, and access all back-office boards (Parts / Vendors / Expenses / Company Files). The only actions gated above 'Admin' do not exist in this app — Owner IS the admin ceiling.
+- **Device:** Desktop — the app is intentionally desktop-only (min-width 1180px, never reflows). Occasional phone pan is possible but not a success metric for this role.
+- **Must NOT see:**
+  - Individual employee performance details that are not already surfaced in role KPI rings (e.g., raw driver GPS logs)
+  - Customer credit card numbers, full PANs, or Stripe secret keys — the app correctly stores only brand+last4+exp+PM-id
+  - Other tenants' data (not applicable — single-store, but worth noting if multi-location is ever added)
+
+**Audit questions:**
+1. Does this feature expose margin (revenue minus parts cost, transport cost, or WO cost) per unit or category, or only gross rental revenue? An Owner cannot make pricing or disposal decisions from top-line numbers alone.
+2. Is every exception or override this feature enables logged with actor, timestamp, and reason to a permanent, append-only History entry? The Owner needs a full audit trail for liability and disputed-charge situations.
+3. Does this feature affect the Revenue Goal calculation or any KPI ring formula — and if so, is the impact documented so the Owner is not surprised by a ring moving unexpectedly?
+4. If this feature blocks or gates a rental transition (no card, blacklist, member-incomplete, invoice required), does the Admin-password override path exist, and is the override itself blocked from going unlogged?
+5. Can the Owner change the business parameter this feature depends on (rate, goal amount, transport price tier, service interval) without a code change — either via the Sheets backend or a future Settings board — or is it hardcoded?
+6. Does this feature surface fleet-risk information (Field Call history, uninspected returned units, expired card on file, lapsed agreements) in a way the Owner can act on during a daily 60-second scan, or is it buried three clicks deep in individual records?
+
+---
+
+## Asset Manager (Finance/Assets)
+> The financial conscience of the fleet — this person tracks every dollar spent acquiring, repairing, and maintaining each piece of iron, then decides whether a unit is earning its keep or should be sold before it becomes a liability.
+
+- **Authority:** View-only over all unit, category, work order, service order, and inspection data; operational-edit over Fleet Status (Active / For Sale / Sold / Inactive) and unit purchase fields (Purchase Price, True Cost, Purchase Date, Purchase Hours, Current Hours); no financial authority over invoice payments or Stripe actions; no authority to create or close rentals
+- **Device:** Desktop — asset analysis requires side-by-side comparison of multiple units and categories with dense financial data; occasional mobile pan when walking the yard to verify unit condition.
+- **Must NOT see:**
+  - Individual customer PII beyond what is needed to understand billing patterns (name, contact details not needed for fleet analysis)
+  - Customer payment ledger details, Stripe card data, and per-invoice payment method — asset analysis does not require payment instrument visibility
+  - Employee performance data at the individual level (Driver scores, individual Mechanic WO completion rates) beyond what impacts unit condition
+  - Sales funnel stages and membership negotiation details for individual customers
+
+**Audit questions:**
+1. Does this feature update or depend on Total Repair Cost, and if so, does it source that figure from all closed Work Order journey line items (including labor at the configured rate) or only from parts — because understated repair cost produces inflated ROI?
+2. If this feature touches Fleet Status (Active / For Sale / Sold / Inactive), does it enforce the block that prevents For-Sale and Inactive units from appearing as available in the rental availability window?
+3. Does this feature expose per-unit financial data (Purchase Price, True Cost, repair history) or only category-level aggregates — and if per-unit, is the data completeness visible so the user knows when a field is missing and the derived ROI number is unreliable?
+4. When this feature modifies unit hours (manually or via GPS sync), does it immediately cascade to all service order countdowns and the availability derivation, or is there a stale-read window where the old hours still drive decisions?
+5. Does this feature surface the distinction between a unit's annualized ROI (which requires Purchase Date and normalizes for age) and its raw revenue-minus-cost figure — and does it handle the missing-Purchase-Date fallback in a way that makes the assumption visible rather than silent?
+6. If this feature creates or closes a Work Order, does it update the unit's Total Repair Cost in real time, and does it correctly attribute Field Call WOs separately so the Asset Manager can distinguish damage-driven costs from normal maintenance when evaluating a unit's risk profile?
+
+---
+
+## Investment Manager (Finance)
+> The person who decides whether to buy the next excavator or walk away — tracking every dollar from purchase price through repair bills to rental revenue to determine whether the fleet is earning its keep or bleeding capital.
+
+- **Authority:** View-only over all fleet, category, unit, rental, invoice, and WO data for financial analysis; no authority to edit unit records, create rentals, approve invoices, or change pricing (category pricing is backend-only per spec). May need read access to Expenses board for cost basis verification. No Stripe or payment-processing authority.
+- **Device:** Desktop — works with multi-column comparative data that requires the full 1180px fixed layout; the Board View spreadsheet popup with formula columns is the primary analysis surface. No meaningful mobile use case.
+- **Must NOT see:**
+  - Individual customer payment details and card-on-file data (Stripe PM IDs, last4, agreement signatures) — those are finance-operational, not investment-analytical
+  - Driver-level operational data (wash completion logs, GPS driving events, route details)
+  - Internal staff KPI rings for Mechanic / M.Tech / Driver roles — workforce performance metrics are outside the investment mandate
+  - Customer funnel stages and sales pipeline data (Used Sales funnel, membership funnel activity log) — CRM data is outside investment scope unless aggregated into revenue projections
+
+**Audit questions:**
+1. Does this feature affect how Total Repair Cost is calculated per unit — and if so, does it capture ALL WO spend (billed and unbilled) or only customer-billed lines? Unbilled internal repair is still a real capital cost.
+2. Does this feature touch category pricing fields (Bottom Dollar, Ask, MSRP, daily rates)? If so, who can edit them and is the change auditable? Pricing changes directly affect ROI and payback models.
+3. Does this feature surface utilization data (time utilization % or dollar utilization %) — and if so, is the time window clearly labeled (30-day rolling per spec, or all-time)? Mixing windows invalidates cross-category comparison.
+4. If this feature adds or modifies unit records (purchase price, purchase date, true cost, purchase hours), does it update the annualized ROI formula — specifically the DaysOwned denominator — without requiring a manual refresh?
+5. Does this feature expose fleet-level aggregate figures (total capital deployed, blended fleet ROI), or only per-unit/per-category numbers? Portfolio-level views are what ownership actually needs for capital allocation decisions.
+6. If this feature involves disposing of or selling a unit (fleet status change to Sold), does it capture the final sale price so realized gain/loss against True Cost can be computed — or does the financial outcome of the sale disappear from the record?
+
+---
+
+## Fleet Manager (Operations/Assets)
+> The Fleet Manager is the asset P&L owner who treats every piece of iron as a revenue-generating investment — they obsess over what each unit earned vs. what it cost to own, which yard slots are cold, and whether the right mix of heavy vs. light equipment is available to take tomorrow's calls.
+
+- **Authority:** Operational-edit over fleet asset records (unit fleet status, inspection status escalation, service completion logging, WO creation and phase advancement); read-only over rental records and invoices; no financial authority to charge customers, issue refunds, or alter pricing
+- **Device:** Desktop — fleet management is a planning and analysis task done at a desk with multiple data points in view simultaneously; a tablet may be used when walking the yard for a physical inventory check.
+- **Must NOT see:**
+  - Customer payment card numbers, Stripe payment method IDs, or partial card details beyond last-4
+  - Customer PII beyond what is needed to identify who is currently using a specific unit (name, company, rental status)
+  - Invoice aging, collection status, or AR balances — that is the Office/Finance role's domain
+  - Employee wages, commission structures, or HR data
+  - Owner-level margin breakdowns or company P&L beyond the fleet asset layer
+
+**Audit questions:**
+1. Does this feature surface utilization rate (rented days ÷ available days) at both the unit and category level, or only raw rental counts? Raw counts hide the difference between a busy low-rate unit and a high-rate unit that books every time it is offered.
+2. If a unit is currently on rent when a new service interval comes due, does the feature give the Fleet Manager advance warning before the rental ends — not just a Past Due flag after the unit returns?
+3. Can the Fleet Manager see, in a single view, every unit that is Active in fleet status but currently earning nothing (Ready + not on any open rental) — i.e., provable idle iron — without manually cross-referencing the Rentals card?
+4. Does this feature account for repair expense accumulation when computing or displaying asset value? A unit at $86k purchase price with $24k in WO repairs has a very different ROI story than one with $1k in repairs.
+5. When a category shows '0 Available' for a requested window, does the feature tell the Fleet Manager WHY each unit is blocked (on rent, Failed inspection, Not Ready, Inactive/Sold) so they can decide if any blocker is recoverable before turning away the booking?
+6. Does this feature create or surface any data that helps capture lost-demand signals — i.e., when a customer asks for equipment we cannot provide, is there anywhere to record that miss so fleet purchasing decisions can be data-driven?
+
+---
+
+## HR (Support)
+> The keeper of who is legally cleared to operate what — HR owns operator certifications, CDL records, training logs, and OSHA compliance so that every Driver and M.Tech on the road or on a site is qualified, documented, and not a liability.
+
+- **Authority:** Operational-edit over the HR/People board only (employee records, certifications, training logs, incident log, dispatch-eligibility flag). View-only on Units (to read category type and determine required certs), View-only on the Office Dispatch Time Grid (to see who is scheduled and cross-check against eligibility). No access to financial records, customer payment data, or invoice/pricing boards. HR cannot change rental statuses, create work orders, or modify equipment records.
+- **Device:** Desktop — HR work is document-heavy (uploading CDL scans, reviewing expiry grids, completing onboarding checklists) and happens at a desk. Occasional mobile need: a field supervisor snapping a photo of a Driver's renewed CDL to upload.
+- **Must NOT see:**
+  - Customer payment card data (Stripe PM ids, last4, card-on-file status) — PCI scope, HR has no need
+  - Customer PII beyond what is incidentally visible in a rental record they happen to open (phone, address, company) — HR does not work customer accounts
+  - Invoice line items, rental pricing, category ROI, and revenue KPIs — financial performance data belongs to Owner and Sales
+  - Work Order part costs, markup tiers, and vendor pricing — margin data
+  - Sales funnel stages and membership pipeline for customers — Sales-owned data
+  - Other employees' compensation details — if payroll is ever integrated, compensation is strictly need-to-know
+
+**Audit questions:**
+1. Does this feature respect the equipment-authorization boundary — specifically, if a Driver is not certified on the unit type being rented (e.g., CDL-B holder dispatched on a CDL-A load, or uncertified operator on an aerial work platform), does the system surface a hard warning or block rather than just silently allowing the assignment?
+2. When a certification, CDL, or medical card expires, does this feature automatically flip the employee's dispatch-eligibility flag and propagate that block to the Office Dispatch Time Grid before the next booking can be created — or does HR have to manually catch it?
+3. Does this feature create or modify any employee-facing data that could be visible to the employee themselves or to other non-HR roles (e.g., a Mechanic seeing another Mechanic's MVR result or incident record)? If so, what is the access control?
+4. If a Driver is terminated mid-rental-window (i.e., they have an active delivery or recovery task on the Dispatch Grid today), what does this feature do — does it flag the open task as unassigned and alert Office, or does the task silently stay assigned to a terminated employee?
+5. Does this feature store or display the physical CDL document scan, medical card scan, or signed training record in Google Drive via the app's wrapped viewer (per §18), and is that file access gated so only HR-role sessions can open the link — or is the Drive link accessible to any authenticated session?
+6. When the spec references 'Round-Trip auto-creates two Driver tasks' or 'Wash flow: Driver logs washed', does this feature assume any Driver is eligible for any task, or does it check the operator-authorization matrix first — and if a qualified Driver is not available, how does that surface to the dispatcher?
+
+---
+
+## Marketing (Growth)
+> The person (likely doubling as or directing the Sales function at a single-yard independent rental) who turns fleet utilization data, customer history, and seasonal construction demand into bookings — running promotions on slow categories, driving membership enrollment, and making sure Jac Rentals wins the quote before United Rentals even gets the call.
+
+- **Authority:** View-only over all customer records, rental history, funnel stages, and category/unit utilization data. Operational-edit over customer funnel stage pills (Used-Sales and Membership), Activity Log recorded actions, and Schedule entries on customer records. No financial authority — cannot edit rates, apply discounts, create invoices, or trigger payments. Cannot edit category pricing (backend-only per spec). Cannot change rental status or approve card overrides.
+- **Device:** Desktop — the app is desktop-only (1180px fixed, §4.4), and Marketing's work (building campaign lists, reviewing pipeline, writing activity log notes) is desk-based. Phone panning tolerated per spec but not a success metric.
+- **Must NOT see:**
+  - Individual customer payment method details (card brand/last4 is fine; full Stripe payment method IDs are not needed)
+  - Invoice line-item pricing details beyond totals — Marketing needs aggregate revenue, not per-transaction margin forensics that belong to Owner/Office
+  - Work Order journey details, parts costs, labor hours — internal shop data irrelevant to demand generation
+  - Mechanic, Driver, and M.Tech role KPI details (WO completion rates, wash logs, field calls) — operational data outside Marketing's domain
+  - Unit GPS placement and GPS status — equipment tracking is a Shop/M.Tech function
+  - Admin override logs and card-on-file override history — financial compliance data, not marketing data
+
+**Audit questions:**
+1. Does this feature tell Marketing WHICH categories are underutilized right now — not just per-customer, but as a ranked fleet list — so we can decide what to promote before the month's idle days are sunk?
+2. Can Marketing pull a list of all customers interested in a specific equipment category (via the Used-Sales 'Interested Categories' pills) without clicking through individual records, and can that list be used to trigger outreach or export a contact list?
+3. Does this feature affect the Revenue Goal ring calculation, and if so, does it preserve the distinction between new-customer revenue and repeat-customer revenue so Marketing can measure acquisition impact separately from retention?
+4. If this feature involves a discount, rate change, or promotional pricing, does it flow correctly through the rental price formula and invoice line items without requiring Marketing to touch backend Category pricing (which is admin-only in Sheets)?
+5. Does this feature expose membership value quantitatively — specifically the dollar savings from Unlimited Transport — in a way Marketing can show a prospect during the 'Payment Discussed' funnel conversation?
+6. When a customer's Active% drops below a threshold or their funnel stage has been stale for N days, does this feature surface that as an actionable signal (an alert, a sorted list, a badge) rather than burying it in per-record detail views that Marketing must manually patrol?
+
+---
+
+## Sales (Outside) (Growth)
+> The field-facing revenue hunter who builds contractor relationships on job sites, converts quotes to signed agreements, and owns the customer from first call through active account health — measured every month against a $150k revenue goal.
+
+- **Authority:** Operational-edit over customer funnel fields (stage pills, Activity Log entries, Schedule, interested Categories, Account Notes), rental creation (Quote and Reserved status), and customer contact/profile fields. View-only on financial totals, invoice line items, and payment records. Cannot approve Admin overrides (card-on-file bypass), change invoice status, process payments, edit category pricing, or access the Expenses board.
+- **Device:** Mobile (phone pan) for on-site lookups — contractors expect instant answers in the field; desktop is the primary device for end-of-day funnel updates and pipeline review back at the yard.
+- **Must NOT see:**
+  - Stripe secret keys, payment processing credentials, and raw Stripe account details
+  - Admin-override logs showing which bookings were forced through despite no card on file (audit trail for Owner/Admin only)
+  - Unit Purchase Price, True Cost, Bottom Dollar, Ask price, and ROI — margin data the rep should not disclose to customers or use as negotiating floor without Owner authorization
+  - Other employees' personal data or compensation details
+  - Blacklist reasons beyond the visual red styling (legal sensitivity)
+  - Expense & Receipts board: vendor costs, part costs, and internal markup rates that inform WO billing are not for customer-facing conversations
+
+**Audit questions:**
+1. Can a Sales rep produce a credible quote — rate tier, total price, transport cost, and unit availability for a given window — in a single card view without navigating to three separate cards or making a phone call? If the answer requires anchoring a unit, opening a rental draft, and then reading three different sections, the flow is too slow for a job-site conversation.
+2. Does the feature expose unit cost, purchase price, true cost, bottom dollar, or markup rates anywhere a Sales rep (or a customer looking over their shoulder) could see them? Margin data must never surface on a customer-facing screen or in a role that regularly shares their screen.
+3. When the feature changes rental status to Reserved or On Rent, does it enforce the 'no valid card on file blocks booking' rule — and if so, does it give the Sales rep a clear, actionable next step (e.g., 'Ask customer to call Office to add a card') rather than a dead-end error that kills the deal?
+4. Does the feature keep the Used-Sales and Membership funnel stages and the Activity Log writable from a phone-panned view? Any funnel update that requires precise desktop interaction will be deferred until the rep is back at the yard, meaning the funnel data is always stale.
+5. If a customer's Active Status % has dropped to near zero, does the feature surface that signal on the customer list row or in a ring/dashboard view so the rep can prioritize re-engagement without running a manual report? Or does the rep have to open each record individually to discover churn risk?
+6. Does the feature correctly handle the Unlimited Transport flag on Member accounts — auto-pricing transport at $0 in the quote — so the rep never tells a Member they owe transport and then has Office correct it, which destroys the membership value proposition in that conversation?
+
+---
+
+## Inside Sales (Growth)
+> The phone-and-screen rep who converts inbound calls into rentals, moves leads through the funnel, owns quoting and availability, and enters the order before the yard ever touches equipment.
+
+- **Authority:** Operational-edit over Customers (create, edit contact/funnel fields), Rentals (create, enter window/transport/address, cycle status up to Reserved), and Invoices (create, add lines). View-only over Categories and Units (no price editing — that is backend/Owner only). Cannot approve card-override bookings (Admin gate). Cannot edit category rates or unit specs in-app.
+- **Device:** Desktop — this is a phone-at-ear, keyboard-at-hand workflow; the app's 1180px fixed desktop frame is the natural fit.
+- **Must NOT see:**
+  - Category pricing fields below Ask (Bottom Dollar is the negotiating floor — should not be visible to Sales without an explicit override, as it undermines rate integrity on calls)
+  - WO journey line-item cost details and vendor names (cost-of-repair data is Mechanic/Owner territory)
+  - Expense & Receipt board data (internal cost accounting)
+  - Other customers' full contact and payment details when not relevant to the current call
+  - Admin password or override logs (card-override audit trail is Owner/Admin territory)
+
+**Audit questions:**
+1. When the customer gives me a date window on the phone, how many taps does it take to see which categories have units available for that exact window — and does the UI show me the count, the conflicting rental status, and sort available units to the top without leaving the Rentals creation flow?
+2. Does the rental price and transport cost auto-compute the moment I set the window and address, or do I have to save and re-open the record to see the quote — because I need to read the number to the customer while they are still on the line?
+3. If a returning customer calls in and they are Late+60 or have no valid card on file, does the UI surface that warning before I confirm a reservation, or only at the On Rent gate when the Driver is already loading the unit?
+4. When I log a funnel touchpoint or advance a lead's stage, is the Activity Log entry automatic (zero extra steps) or does it require a separate save action — and does it timestamp who made the change?
+5. Does the Membership funnel enforce that 'Member Incomplete' blocks member-rate pricing on new rentals, and is that block visible to me as the rep taking the order (not just to an Admin after the fact)?
+6. If I quote a round-trip delivery to a city not in the transport lookup table, does the app tell me immediately that the city is unresolved (showing a dash or alert) rather than silently quoting $0 transport and letting the order go through at wrong margin?
+
+---
+
+## Equipment Sales (Growth)
+> The person who converts idle or retiring fleet assets into revenue by selling used/retired construction equipment outright — working a 7-stage prospect funnel, quoting against MSRP/Ask/Bottom-Dollar price anchors, and managing the unit disposition from For Sale through Sold.
+
+- **Authority:** Operational-edit over the Used Sales funnel (stage, action, interested categories, activity log) and unit Fleet Status transitions to For Sale / Sold on their own assigned units; view-only over Category pricing anchors (MSRP/Ask/Bottom Dollar are backend-only edits per spec §7.2); no financial authority over invoices, payments, or Stripe charges
+- **Device:** Desktop — the app is desktop-only (fixed 1180px, never reflows to mobile per spec §4.4); Equipment Sales is a desk/office role working the funnel and preparing quotes.
+- **Must NOT see:**
+  - Stripe secret keys and backend payment credentials
+  - Other customers' card-on-file details, payment methods, or Stripe IDs
+  - Admin override logs (card-block overrides, admin password usage) on other customers
+  - Mechanic-internal WO cost details on units not currently For Sale — exposing full repair-cost history on active fleet could create competitive intelligence leaks
+  - Employee-level operational data from other roles (Driver dispatch queue, Mechanic service schedules) beyond what is needed to confirm unit availability for a sale
+
+**Audit questions:**
+1. Does this feature capture a CLOSED SALE price per unit — or only funnel stage? A 'Paid' funnel stage tells us we won the deal but not what we sold for relative to Ask vs Bottom Dollar. Equipment sales margin is the whole point.
+2. When a unit flips to For Sale, does the feature immediately block new rental reservations on that unit AND surface it to the Sales role as an available listing — or are those two state changes manual and unconnected?
+3. Does this feature make used-sales revenue visible in the Sales KPI ring, or will it continue to be excluded from the Revenue Goal? Right now the role's biggest wins are invisible to the one ring they watch.
+4. If a prospect is interested in a specific unit (e.g. a 2019 12k Excavator with 1,800 hours), can the feature capture unit-level interest rather than only category-level — so when that exact unit becomes For Sale we can notify the right lead?
+5. Does this feature support scheduling a follow-up from the Activity Log in a single action that creates a visible reminder — or does the salesperson have to remember to come back manually after entering a Schedule date?
+6. When a deal closes and Fleet Status changes to Sold, does the feature atomically remove the unit from rental availability, close any open For-Sale inquiry, and record the sale price — or does closing a used-equipment deal require touching three separate cards with no guided workflow?
+
+---
+
+## Mechanic (Technical)
+> The Mechanic is the hands-on equipment fixer whose diagnostic decisions directly control what units the fleet can rent — every hour a Failed unit sits uninspected is revenue the company cannot book.
+
+- **Authority:** Operational-edit over Work Orders (create, phase-advance, add journey lines), Service Orders (complete and reset countdown), and Inspections (conduct the 3-step gate, record Pass/Fail, attach photo). View-only over Rentals, Categories, Invoices, and Customers. Cannot change unit pricing, cannot approve invoices, cannot override the 'On Rent requires invoice' gate, cannot perform Admin-password overrides for card-on-file blocks.
+- **Device:** Desktop (shop PC or a fixed workstation in the service bay). A tablet propped near the lift would be ideal in practice, but the app does not currently optimize for touch.
+- **Must NOT see:**
+  - Customer payment details, card numbers, Stripe payment method IDs, and invoice financial ledger data
+  - Customer PII beyond what is needed to decide billability on a WO (name and account type sufficient; full contact info, address, membership fees not needed)
+  - Sales funnel stage and membership payment data for any customer
+  - Invoice line-item pricing, transport costs, and rate calculations — the Mechanic's output is cost and hours, not the rental price structure
+  - Revenue Goal, Active Customer Rate, and Pipeline KPIs (Sales role metrics)
+  - Office collection-rate and reputation metrics
+
+**Audit questions:**
+1. When a WO phase changes to 'Part Ordered' and an ETA is picked, does that ETA date surface on the Unit card and the Shop list row so dispatch can tell at a glance when the unit is expected back — or is it buried inside the WO detail only?
+2. After a Failed inspection auto-creates a WO and the WO is marked Complete, the spec says the unit reverts to Not Ready. Does the app visibly prompt for a new inspection immediately (e.g. a pending-inspection entry in the Shop list), or does the Mechanic have to remember to go trigger one manually?
+3. The Service Order countdown is driven by Current Hours, which are a manual edit on the Unit. If a Mechanic forgets to update hours after a job, every countdown for that unit is silently wrong. Is there any staleness indicator or last-updated timestamp on the Current Hours field so the Mechanic can spot drift?
+4. On the Shop card's merged list, when a unit has both an open WO (stalled on Part Needed) AND an overdue Service Order, do both items appear as separate rows for that unit, or does only the most urgent surface? If both appear, can the Mechanic act on each independently without losing their place?
+5. The 'Bill To Customer' determination on a WO is required at creation time, but damage vs. normal wear is often unclear until mid-repair. Does the spec allow the Mechanic to change Bill To Customer (and the linked Customer pill) after the WO is in progress, or is it locked once an invoice line has been added?
+6. A Field Call WO is type 'Field Call' and looks identical in the list to a shop repair except for the badge. When the Mechanic opens the Shop queue first thing in the morning, is there a filter or segment that separates Field Call jobs (may need road deployment or a loaner unit) from in-shop repairs so they can be routed without reading every WO description?
+
+---
+
+## Maintenance Tech (M.Tech) (Technical)
+> The M.Tech is the unit's last line of defense before it goes back on rent — inspecting, servicing, and clearing equipment so it is provably rental-ready, not just assumed to be.
+
+- **Authority:** Operational-edit over Shop entities (Inspections, Work Orders, Service Orders) and Unit current-hours field. View-only over Rentals, Customers, Categories, and Invoices. Cannot change rental status, approve bookings, process payments, or access back-office financial boards (Expenses and Receipts).
+- **Device:** Desktop — the app is desktop-only at 1180px min-width. M.Tech typically accesses it from an office terminal or a laptop in the shop. In-field (Field Call) access is via phone panning the fixed-width layout, which is tolerated but not a success metric.
+- **Must NOT see:**
+  - Customer payment details, card-on-file data, Stripe payment method IDs, or invoice payment ledger entries
+  - Customer PII beyond what is needed to bill an inspection back to them (name + account type is sufficient; full address/phone/email are unnecessary)
+  - Invoice pricing internals, margin data, or the Bottom Dollar / Ask pricing thresholds on categories
+  - Sales funnel stages, membership status, or activity log entries for customers
+  - Admin password gate or override logs
+
+**Audit questions:**
+1. Does this feature require the M.Tech to update unit hours before it functions correctly — and if GPS is not yet live, what happens when hours are stale or zero?
+2. If this feature changes a unit's Inspection Status or Service Order completion, does it correctly trigger the downstream cascade: service-complete → Not Ready → new inspection required → Ready only after passing the 3-step gate?
+3. Can the M.Tech complete the critical action (log inspection result, mark service done with photo proof, advance WO phase) in under 5 taps on a shop floor, without needing to navigate away from the Shop card?
+4. Does this feature distinguish between 'inspection pass/fail' and 'service completion' — two separate flows with different outcomes — or does it blur them in a way that lets a unit skip back to Ready without a clean inspection?
+5. When a unit is currently On Rent, does the Service Order list or this feature make it unambiguous that service cannot be performed yet, and does it show the return date so the M.Tech can plan the maintenance window?
+6. Does this feature respect the 1-inspection-to-1-WO constraint on Fail (not allowing multiple open WOs from one failed inspection), and does the WO completion correctly feed back to the inspection record via the linked WO pill?
+
+---
+
+## Driver (Operations)
+> The Driver is the last physical touchpoint before and after a unit earns revenue — they move iron from the yard to the customer's site, verify condition at handoff, capture proof of delivery and damage documentation, and bring equipment back, all from a phone with gloves on and sometimes no signal.
+
+- **Authority:** Operational-edit scoped to their own dispatch tasks: can mark a rental On Rent / Off Rent / Returned, attach on-rent and returning videos, set Wash Requested, and trigger a Field Call. Cannot change rental pricing, customer account type, invoice status, or any financial record. Cannot approve an Admin override for a blocked booking.
+- **Device:** Mobile — the Driver is always in a truck or on a job site. In practice, any Driver-facing feature must work in the minimum-tap panning mode: large tap targets, no hover-only affordances, and offline-tolerant capture.
+- **Must NOT see:**
+  - Invoice dollar amounts, line-item pricing, or invoice balance — pricing is an Office/Sales function
+  - Customer payment method, Stripe card details, or payment status
+  - Category cost and investment data (MSRP, Ask, Bottom Dollar, ROI, Avg Revenue/Unit)
+  - Other employees' KPI ring details beyond their own Driver ring
+  - Admin-override logs or the admin password gate
+  - Funnel stage or membership sales data on customers
+
+**Audit questions:**
+1. Can the Driver see their full day's run — every Delivery, Recovery, and Round-Trip task in time order — in a single glance without opening individual rentals?
+2. Can a Driver capture a delivery photo and customer signature in under 3 taps while wearing gloves, and does the capture queue locally if LTE drops before the upload completes?
+3. Does the feature expose the unit's current Inspection Status before the Driver loads the truck, so a Failed unit is never dispatched without an explicit override?
+4. For a Round-Trip rental, does the app show BOTH the outbound Delivery task AND the future Recovery task on the same screen, so the Driver knows to come back without a separate reminder?
+5. When a Driver triggers a Field Call mid-rental, does the flow auto-create the Work Order and set the unit Failed in a single action, or does it require the Driver to navigate to two separate cards in the field?
+6. Does the Wash Requested tap happen at the same moment as the return photo capture — one workflow, not two — so it actually gets logged every time a unit comes back to the yard?
+
+---
+
+## Customer (Contractor) (External)
+> A contractor — running a jobsite in Sulphur or SE Texas — who rents excavators and heavy equipment from Jac, manages their own account digitally, and needs instant clarity on what they owe, what they have out, and how long they have it.
+
+- **Authority:** View-only over their own account data (rentals, invoices, card on file, agreement). Operational-edit limited to: submitting rental requests/extensions, updating their card on file (requires selfie per Section 13 of the agreement), updating contact info. No ability to change rental status, pricing, transport routing, or invoice line items. Financial scope limited to initiating payment on their own invoices only.
+- **Device:** Mobile (phone), secondary desktop. Contractors check status from job trucks and trailers; quick lookups (return dates, balances) happen on a phone; invoice review and agreement signing may happen on desktop.
+- **Must NOT see:**
+  - Other customers' rental records, invoices, contact info, or account details (strict row-level isolation)
+  - Internal pricing floors: Bottom Dollar, Ask price, MSRP markup, Category ROI, Dollar Utilization, Avg Revenue/Unit, Avg Expenses/Unit — these are internal margin data
+  - Unit inspection status internals: whether a unit is Not Ready or Failed for internal reasons should not be shown (only availability matters to them)
+  - Work order details on equipment they're currently renting (unless it's a field-call event that directly affects their rental)
+  - Service order countdowns and maintenance schedules
+  - Other staff roles' KPIs, Dispatch Time Grid, Sales funnel data
+  - Payment ledger entries from other customers
+  - Internal history log entries that contain staff notes about the customer (e.g., 'Blacklisted' reasoning, internal account flags)
+  - Stripe secret keys, backend configuration, any internal admin overrides logged to history
+  - Driver schedules beyond their own delivery/recovery
+
+**Audit questions:**
+1. Does this feature expose the return-date countdown in a way that makes the rental-period-ends-at-yard-return rule unambiguous — so a contractor knows their liability doesn't end when they stop using the unit, but when Jac physically has it back?
+2. If the contractor's card on file is expired or missing, does this feature surface a clear, actionable warning BEFORE they're blocked from a new booking, or does it only surface the block at reservation time?
+3. Can the contractor see the exact rate they'll be charged (member vs. retail, day/7-day/4-week tier) BEFORE they commit to a rental request — and does the rate shown match what will actually appear on the invoice?
+4. Does this feature reveal any internal pricing floor (Bottom Dollar, Ask, Category ROI, margin data) or inspection/maintenance status that Jac intends to keep internal?
+5. If a contractor needs to update their card on file from a phone in a truck, can they complete the selfie + card capture flow in under 2 minutes on a mobile browser without the 1180px desktop constraint breaking the UI?
+6. Does this feature create any path — direct or indirect — where one customer can see another customer's rental, invoice, or account data; and is row-level isolation enforced server-side, not just by the frontend hiding fields?

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: start
+description: Jac Rentals session startup routine — run at the top of a session with /start. Probes the toolchain (node/npm/clasp/gh/git), orients on the current git branch vs staging/main, recalls relevant memory, PROPOSES a feature branch + dated session-output folder and waits for your OK before creating them, and sets token-efficiency + role-aware working rules for the rest of the session.
+---
+
+# /start — Jac Rentals session startup
+
+Run this first thing in a session. It gets the session organized so parallel chats and branches stop colliding, and primes Claude with the right tools, conventions, and discipline. Built for both local (Windows/PowerShell) and cloud (Linux) sessions.
+
+## 1. Toolchain probe
+Run and report a short table — node, npm, clasp, gh, git:
+```
+node --version; npm --version; clasp --version; gh --version; git --version
+```
+- **clasp is installed → the GAS backend is reachable via the `/clasp` skill. NEVER ask how to access the backend; use `/clasp`** (additive-only; it STOPS before any prod deploy).
+- If a tool is missing, say so plainly — don't assume it's there.
+
+## 2. Branch + status orientation
+- Run: `git branch --show-current`, `git status -sb`, `git log --oneline -5`.
+- Show how the current branch differs from the integration branch when available: `git diff --stat origin/staging...HEAD` (or vs `origin/main`).
+- Recall memory: read `MEMORY.md` and surface anything relevant to this session's topic (e.g. `[[jactec-skill-build-plan]]`, `[[jactec-tooling]]`, `[[jactec-design-prefs]]`).
+
+## 3. Propose branch + session folder — DO NOT create without an OK
+Per the one-branch-per-chat convention:
+- **Feature branch:** `feature/<YYYY-MM-DD>-<short-topic>` off `staging`.
+- **Session-output folder:** `<YYYY-MM-DD> <Topic>/` in the project root (git-ignored; for OUTPUTS only — exports, reports, scratch — never source files).
+
+State the exact branch name and folder you intend to create, then **WAIT for Jac's confirmation** before creating either. If the session's topic isn't clear yet, defer this step until the first real task is defined. (Use today's date.)
+
+## 4. Working rules for this session (state briefly, then follow)
+- **Token discipline:** terse by default; `Grep`/`Glob` before `Read`; read only the range you need; spawn subagents for large isolated work to protect the main context.
+- **Clarifying questions:** use the `AskUserQuestion` popup — not inline prose — whenever a decision is genuinely Jac's to make.
+- **Specs:** after generating or changing a spec/feature/screen, offer to run `/role` to audit it through the 15 role lenses.
+- **Efficiency:** `/audit` is available anytime; the ~100k-token auto-audit hook will also prompt a coaching report.
+
+## 5. Ready summary
+End with 3–4 lines: tools OK/missing, current branch + what's in flight, the proposed branch/folder (awaiting OK), and "what are we working on?"
+
+## Conventions reference
+- **Branches:** `feature/<date>-<topic>` → merge to `staging` → `staging` → `main` (`main` = live at app.jacrentals.com). Prereq: the `staging` branch + deployed `staging.app.jacrentals.com` (Cloudflare/Netlify) must exist.
+- **Backend:** ships via `/clasp` (clasp), never git. `Code.gs`/`Code.js` are gitignored (public repo).
+- **Sibling skills:** `/clasp` (backend deploy), `/role` (spec audit), `/audit` (token + model-fit coaching).
+- **At session end:** write a short handoff note (what changed, what's pending, which branch) into the session folder so the next chat isn't lost.

--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,16 @@
 Thumbs.db
 *.log
 
-# Local tooling (not part of the app) — but COMMIT shared skills + the shared
-# SessionStart hook so they travel + work in Claude Code web sessions (local
-# settings like settings.local.json stay ignored).
+# Local tooling — commit shared skills + the shared SessionStart hook so they
+# travel + work in Claude Code web/cloud sessions; keep local settings
+# (settings.local.json) and any *.local.* secret/dump (backend IDs, research
+# dumps) private.
 .claude/*
 !.claude/skills/
 !.claude/settings.json
 !.claude/hooks/
+.claude/skills/**/*.local.md
+.claude/skills/**/*.local.json
 
 # Internal handoff: the spec + RAW customer/parts/work-order CSVs — NOT for the
 # public site (the served app uses the curated demo data in data.js instead).


### PR DESCRIPTION
Adds four shared Claude Code skills alongside the existing suite, plus dev-permission allowlists and a token/model auto-audit hook.

**What's added**
- `/start` — session startup: toolchain probe, branch orientation, proposes a feature branch + dated session folder, sets token/role working rules.
- `/role` — audits a spec through all 15 Jac Rentals role lenses + a 12-step authority / data-sensitivity / gate checklist.
- `/clasp` — additive-only Apps Script backend deploy runbook (stops before prod; complements the existing `session-start.sh` clasp bridge).
- `/audit` — token + model-fit coaching (zero-dep Node analyzer) + a `UserPromptSubmit` hook that auto-runs it ~every 100k tokens.
- `.claude/settings.json` — **merged**: preserves the existing `SessionStart` clasp bridge, adds dev allowlists (node/npm/clasp/git/gh/preview MCP) + the auto-audit hook.

**Safety**
- Touches **only** `.claude/` + `.gitignore` — zero app files, so the live Pages site is byte-identical.
- Secrets/dumps (`backend-ids.local.md`, `research-raw.local.json`) stay gitignored via new `*.local.*` rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)