### PR TITLE
Raise audit threshold to 1M + area-branch routing

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: Token-efficiency + model-appropriateness coaching report for the current Claude Code session. Run with /audit anytime; also fired automatically by a hook roughly every 100k tokens. Reports cache hit rate, redundant file reads, oversized tool outputs, whether the model tier fit the work (Haiku / Sonnet / Opus), and 2-4 concrete habit changes with estimated savings.
+description: Token-efficiency + model-appropriateness coaching report for the current Claude Code session. Run with /audit anytime; also fired automatically by a hook roughly every 1M tokens. Reports cache hit rate, redundant file reads, oversized tool outputs, whether the model tier fit the work (Haiku / Sonnet / Opus), and 2-4 concrete habit changes with estimated savings.
 ---
 
 # /audit — Token + Model Efficiency Coach

--- a/.claude/skills/audit/scripts/token-watch.mjs
+++ b/.claude/skills/audit/scripts/token-watch.mjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
-// UserPromptSubmit hook — fires the /audit coaching report roughly every 100k
-// tokens used this session. Reads the hook JSON on stdin (transcript_path,
-// session_id), sums non-cache input+output across assistant turns, and when a
-// new 100k bucket is crossed, prints a reminder that becomes context so Claude
-// runs /audit after handling the current message. Silent otherwise. No deps.
+// UserPromptSubmit hook — fires the /audit coaching report roughly every
+// 1,000,000 tokens used this session. Reads the hook JSON on stdin
+// (transcript_path, session_id), sums non-cache input+output across assistant
+// turns, and when a new 1M bucket is crossed, prints a reminder that becomes
+// context so Claude runs /audit after handling the current message. Silent
+// otherwise. No deps.
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const THRESHOLD = 100000;
+const THRESHOLD = 1000000;
 
 let stdin = '';
 try { stdin = readFileSync(0, 'utf8'); } catch {}
@@ -39,8 +40,9 @@ try { last = JSON.parse(readFileSync(stateFile, 'utf8')).bucket || 0; } catch {}
 if (bucket > last) {
   try { mkdirSync(stateDir, { recursive: true }); writeFileSync(stateFile, JSON.stringify({ bucket })); } catch {}
   const k = Math.round(used / 1000);
+  const mark = +(THRESHOLD * bucket / 1000000).toFixed(2); // millions
   process.stdout.write(
-    `[token checkpoint] ~${k}k tokens used this session (crossed ${bucket}x100k). ` +
+    `[token checkpoint] ~${k}k tokens used this session (crossed the ${mark}M mark). ` +
     `After you finish the user's current request, run the /audit skill and give Jac a brief token + model-fit coaching report.`
   );
 }

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: Jac Rentals session startup routine — run at the top of a session with /start. Probes the toolchain (node/npm/clasp/gh/git), orients on the current git branch vs staging/main, recalls relevant memory, PROPOSES a feature branch + dated session-output folder and waits for your OK before creating them, and sets token-efficiency + role-aware working rules for the rest of the session.
+description: Jac Rentals session startup routine — run at the top of a session with /start. Probes the toolchain (node/npm/clasp/gh/git), orients on the current git branch vs staging/main, recalls relevant memory, ROUTES the session to the right long-lived area branch (using the branch map, based on what you want to work on) and proposes a dated session-output folder — waiting for your OK before switching — then sets token-efficiency + role-aware working rules for the rest of the session.
 ---
 
 # /start — Jac Rentals session startup
@@ -20,24 +20,25 @@ node --version; npm --version; clasp --version; gh --version; git --version
 - Show how the current branch differs from the integration branch when available: `git diff --stat origin/staging...HEAD` (or vs `origin/main`).
 - Recall memory: read `MEMORY.md` and surface anything relevant to this session's topic (e.g. `[[jactec-skill-build-plan]]`, `[[jactec-tooling]]`, `[[jactec-design-prefs]]`).
 
-## 3. Propose branch + session folder — DO NOT create without an OK
-Per the one-branch-per-chat convention:
-- **Feature branch:** `feature/<YYYY-MM-DD>-<short-topic>` off `staging`.
-- **Session-output folder:** `<YYYY-MM-DD> <Topic>/` in the project root (git-ignored; for OUTPUTS only — exports, reports, scratch — never source files).
-
-State the exact branch name and folder you intend to create, then **WAIT for Jac's confirmation** before creating either. If the session's topic isn't clear yet, defer this step until the first real task is defined. (Use today's date.)
+## 3. Route to an area branch — DO NOT switch without an OK
+The app is organized into long-lived **area branches** (`area/*`) off `staging`, each owning a domain (rentals/dispatch, invoicing, units/fleet, design system, etc.). Many sessions share one area branch; the flow is **`area/<domain>` → `staging` (preview/debug) → `main` (live)**.
+- Read **`references/branch-map.md`**, match what Jac described to the best-fitting area, and **PROPOSE** it in one line (e.g. *"This is invoicing work → switch to `area/invoicing-payments`?"*). **WAIT for his OK** before switching.
+- On OK: `git fetch origin && git checkout <area-branch> && git pull --ff-only` so you start from the latest. Commit and push to that same area branch.
+- If two areas overlap, name both and let Jac pick (use `AskUserQuestion`). If **nothing** fits, propose a NEW `area/<slug>` branched off `staging`.
+- Also offer a session-output folder `<YYYY-MM-DD> <Topic>/` (git-ignored; OUTPUTS only — exports, scratch — never source). Use today's date.
+- If the topic isn't clear yet, defer routing until the first real task is defined — don't switch branches blind.
 
 ## 4. Working rules for this session (state briefly, then follow)
 - **Token discipline:** terse by default; `Grep`/`Glob` before `Read`; read only the range you need; spawn subagents for large isolated work to protect the main context.
 - **Clarifying questions:** use the `AskUserQuestion` popup — not inline prose — whenever a decision is genuinely Jac's to make.
 - **Specs:** after generating or changing a spec/feature/screen, offer to run `/role` to audit it through the 15 role lenses.
-- **Efficiency:** `/audit` is available anytime; the ~100k-token auto-audit hook will also prompt a coaching report.
+- **Efficiency:** `/audit` is available anytime; the ~1M-token auto-audit hook will also prompt a coaching report.
 
 ## 5. Ready summary
 End with 3–4 lines: tools OK/missing, current branch + what's in flight, the proposed branch/folder (awaiting OK), and "what are we working on?"
 
 ## Conventions reference
-- **Branches:** `feature/<date>-<topic>` → merge to `staging` → `staging` → `main` (`main` = live at app.jacrentals.com). Prereq: the `staging` branch + deployed `staging.app.jacrentals.com` (Cloudflare/Netlify) must exist.
-- **Backend:** ships via `/clasp` (clasp), never git. `Code.gs`/`Code.js` are gitignored (public repo).
-- **Sibling skills:** `/clasp` (backend deploy), `/role` (spec audit), `/audit` (token + model-fit coaching).
-- **At session end:** write a short handoff note (what changed, what's pending, which branch) into the session folder so the next chat isn't lost.
+- **Branches:** work on an **`area/*`** branch (see `references/branch-map.md`) → merge to `staging` (preview/debug) → `staging` → `main` (`main` = live at app.jacrentals.com via GitHub Pages). `main` is protected: changes land via PR + CI.
+- **Backend:** ships via `/clasp` (clasp), never git. `Code.gs`/`Code.js` are gitignored (public repo). In cloud sessions a `SessionStart` hook auto-wires clasp auth from the `CLASPRC_JSON_B64` env secret.
+- **Sibling skills:** `/clasp` (backend deploy), `/role` (spec audit), `/audit` (token + model-fit coaching). Plus the existing suite: `jactec-ui`, `frontend`, `mobile-*`, `webapp-testing`, `wrangler-fix`.
+- **At session end:** write a short handoff note (what changed, what's pending, which area branch) into the session folder so the next chat — local or cloud — picks up cleanly.

--- a/.claude/skills/start/references/branch-map.md
+++ b/.claude/skills/start/references/branch-map.md
@@ -1,0 +1,32 @@
+# Branch map — area branches off `staging`
+
+**How branching works here**
+- The app is divided into long-lived **area branches** (`area/*`), each owning one domain. Many sessions — local or cloud — share the same area branch.
+- Flow: **`area/<domain>` → merge to `staging`** (integration + preview/debug) → after debugging, **`staging` → `main`** (live at app.jacrentals.com).
+- `/start` reads this map, matches what you describe to an area, and (with your OK) checks out that branch so every session starts from the latest shared state. This is the antidote to scattered one-off `claude/*` chats.
+- `main` is protected (PR + CI required); never commit straight to it. `staging` is where areas converge and get debugged together before promotion.
+
+**Routing table** — match the user's described work to an area:
+
+| Area branch | Covers | Route here when they say… |
+|---|---|---|
+| `area/rentals-dispatch` | Rental lifecycle, dispatch time grid, transport journeys (Yard→Truck→Site), driver tasks, round-trip delivery/recovery, field calls, no-show + per-unit status engine, multi-unit rentals | "dispatch", "rental status", "delivery", "pickup", "field call", "transport", "round trip", "multi-unit" |
+| `area/invoicing-payments` | Invoices, line items, Stripe charge/refund, card-on-file picker, payment ledger, aging/collections ladder, PO gate, price-lock HMAC, partial-payment allocation, cash refunds, tax (10.75%) | "invoice", "payment", "refund", "billing", "collections", "PO", "price lock", "cash" |
+| `area/customers-crm` | Customer accounts, onboarding (selfie/signature/agreement packet), card-on-file consent, funnel stages, activity log, blacklist, quick-add | "customer", "onboarding", "agreement", "card on file", "funnel", "activity log", "blacklist" |
+| `area/memberships` | Membership state machine (Incomplete→Paid), unlimited-transport entitlement, renewals/Paid-Until, member pricing gating | "membership", "member rate", "renewal", "unlimited transport" |
+| `area/units-fleet` | Units, categories, fleet status (Active/For Sale/Sold/Inactive), inspections (Ready/Not Ready/Failed), GPS status, purchase/cost data, availability window/calendar | "unit", "category", "fleet", "inspection", "availability", "GPS", "purchase cost" |
+| `area/maintenance-shop` | Work orders (journey/phases/parts), service orders + countdowns, mechanic/M.Tech queues, the merged Shop card, parts inventory, vendors | "work order", "WO", "maintenance", "service", "mechanic", "M.Tech", "parts", "vendor", "shop" |
+| `area/financials-kpi` | KPI rings, ROI/annualization, time + dollar utilization, $150k revenue goal, owner dashboard, Board View formula engine, gamification score pops, expenses/receipts | "KPI", "ROI", "revenue goal", "dashboard", "board view", "utilization", "expenses", "gamification" |
+| `area/backend-data` | clasp/GAS backend, Google Sheets sync + persistence, saved Views/searches store, data import/migration, real-data vs demo seed | "backend", "clasp", "sheets", "persistence", "sync", "import", "migration", "views", "saved search" |
+| `area/design-system` | The R-rulebook (R-rules), `jactec-ui` tokens/recipes, cards/pills/flags, popups & dialogs (tiers/shell), anti-slop, Design Inspector/Lint | "design", "rulebook", "R-rule", "pill", "flag", "card style", "popup", "dialog", "tokens", "theme" |
+| `area/mobile-remote` | Mobile navigation/touch/viewport, responsive reflow, the customer self-service portal (row-isolated), phone/remote ergonomics | "mobile", "phone", "responsive", "touch", "viewport", "customer portal", "self-service" |
+| `area/hr-compliance` | Employee records, CDL/medical-card/MVR tracking, equipment-type certifications, dispatch-eligibility pill, training logs (net-new domain) | "HR", "certification", "CDL", "MVR", "eligibility", "license", "training", "compliance" |
+| `area/sales-growth` | Quotes, outside/inside sales, equipment/used-equipment sales, marketing, pipeline depth, lead handling | "quote", "sales", "equipment sale", "used sale", "marketing", "pipeline", "lead" |
+| `area/maps-location` | Maps integration, the dispatch map/cockpit, address capture/geocoding, drive-time + city-lookup transport pricing (§10) | "map", "address", "drive time", "route", "geocode", "location", "cockpit" |
+| `area/search-views` | Global search (incl. phone-number + natural-date tokens), filters/pinned chips, saved Views menu, anchored-card navigation, list/dispatcher rows, toolbar | "search", "filter", "find", "navigation", "list view", "saved view", "chip", "toolbar" |
+
+**Rules for routing**
+- Pick the single best area. If two genuinely overlap (e.g. a dispatch feature that's mostly a map), name both and let Jac choose via `AskUserQuestion`.
+- Cross-cutting design tweaks (pills, R-rules) → `area/design-system` even if they touch another area's screen.
+- If nothing fits, propose a NEW `area/<slug>` off `staging` (don't force a bad match).
+- Never route onto `main` directly — it's protected and live.


### PR DESCRIPTION
Per Jac: token logger 100k -> 1M. Adds long-lived `area/*` branch routing to `/start` via a new branch map (describe work -> the skill picks the branch). Touches only .claude/ — no app files.