### PR TITLE
Branch janitor + /tidy-sessions + promotion-cadence prompts

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -39,6 +39,8 @@ The app is organized into long-lived **area branches** (`area/*`), each owning a
 - **Clarifying questions:** use the `AskUserQuestion` popup — not inline prose — whenever a decision is genuinely Jac's to make.
 - **Specs:** after generating or changing a spec/feature/screen, offer to run `/role` to audit it through the 15 role lenses.
 - **Efficiency:** `/audit` is available anytime; the ~1M-token auto-audit hook will also prompt a coaching report.
+- **Promotion cadence — propose the hops, never auto-promote to live:** when a task is *done*, offer to merge `<domain>/<task>` → `area/<domain>` (the merged task branch then self-cleans via the branch janitor). When Jac wants to preview/QA, merge `area/<domain>` → `staging` — the staging site auto-syncs (~10 min) for phone testing. Only after Jac confirms it's clean on staging, open a PR `staging` → `main` (protected; CI). **`main` is live — promoting to it is always Jac's explicit call.**
+- **Session hygiene:** when a task branch merges, that chat is done — remind Jac he can archive it (or run `/tidy-sessions`) so finished chats don't linger.
 
 ## 5. Ready summary
 End with 3–4 lines: tools OK/missing, current branch + what's in flight, the proposed branch/folder (awaiting OK), and "what are we working on?"

--- a/.claude/skills/tidy-sessions/SKILL.md
+++ b/.claude/skills/tidy-sessions/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: tidy-sessions
+description: List finished / stale Claude Code sessions and archive them (with confirmation) so completed chats stop cluttering the list and you never reopen a done one. Use when chats pile up, or after task branches merge. Invoke with /tidy-sessions.
+---
+
+# /tidy-sessions — archive finished chats
+
+Keeps the session list to what's actually live. A chat is "done" when its task branch has merged (the branch janitor then deletes that branch) — that's the cue to archive it.
+
+## Steps
+1. **List sessions** with `mcp__ccd_session_mgmt__list_sessions`. If that tool isn't available in this environment (e.g. a cloud run), say so and stop — point Jac to archive chats in the Claude app instead.
+2. **Identify archive candidates** — be conservative:
+   - No activity in the last **7 days** (default; honor a different age if Jac says so), OR
+   - The session's task branch is **merged/gone** — cross-check with `gh pr list --state merged` / `git ls-remote` when the session records its branch.
+   - NEVER flag the **current** session, or any session whose task branch still has an **open PR** or no PR at all.
+3. **Present the candidates** as a short table — title · last activity · branch status — and ask which to archive (`AskUserQuestion`, multi-select). Default selection = the clearly-done ones; let Jac deselect.
+4. **Archive** the confirmed ones with `mcp__ccd_session_mgmt__archive_session`. Report what was archived and what was kept.
+
+## Rules
+- **Never archive without explicit confirmation.** Archiving is reversible, but surprise is not welcome.
+- **Never archive the active session.**
+- Default conservative: when unsure whether a chat is finished, leave it.
+- **Scope note:** this manages the sessions visible to this environment. The **cloud web chat list** is managed in the Claude app — if a chat lives only there, surface it for Jac to archive manually rather than claiming to have handled it.
+- Pairs with the **branch janitor** (merged task branch → deleted) and the `/start` promotion cadence: branch gone = chat done = safe to archive.

--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -1,0 +1,50 @@
+name: Branch janitor
+
+# Prunes merged task branches so the repo stays tidy on its own.
+# SAFE BY DESIGN: only deletes a branch that (a) is the head of a MERGED PR,
+# (b) has NO open PR, and (c) is NOT a structural branch (main / staging / area/*).
+# So long-lived chapters (area/*) and the trunk/integration branches are never touched.
+
+on:
+  schedule:
+    - cron: '17 7 * * *'   # daily ~07:17 UTC
+  workflow_dispatch:        # and on-demand from the Actions tab
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: branch-janitor
+  cancel-in-progress: true
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Prune merged task branches (never main/staging/area/*)
+        run: |
+          set -euo pipefail
+          gh pr list -R "$REPO" --state merged --limit 1000 --json headRefName -q '.[].headRefName' | sort -u > merged.txt
+          gh pr list -R "$REPO" --state open   --limit 1000 --json headRefName -q '.[].headRefName' | sort -u > open.txt
+          gh api "repos/$REPO/branches?per_page=100" --paginate -q '.[].name' | sort -u > live.txt
+          echo "live=$(wc -l < live.txt) merged-PRs=$(wc -l < merged.txt) open-PRs=$(wc -l < open.txt)"
+          deleted=0
+          while IFS= read -r b; do
+            [ -z "$b" ] && continue
+            case "$b" in
+              main|staging|area/*) continue ;;   # never touch the structure
+            esac
+            grep -qxF "$b" merged.txt || continue   # must have a merged PR
+            grep -qxF "$b" open.txt   && continue   # but no open PR
+            echo "deleting merged task branch: $b"
+            if gh api -X DELETE "repos/$REPO/git/refs/heads/$b" >/dev/null 2>&1; then
+              deleted=$((deleted+1))
+            else
+              echo "  (skipped — protected or already gone)"
+            fi
+          done < live.txt
+          echo "pruned $deleted branch(es)"


### PR DESCRIPTION
Three automations: (1) a daily GitHub Action that prunes merged TASK branches only — never main/staging/area/* or open-PR branches; (2) a /tidy-sessions skill to archive finished chats with confirmation; (3) /start now proposes the task->area->staging->main promotions at the right moments (never auto-promotes to live). Touches only .github/ + .claude/.