### PR TITLE
test: /start flow smoke-test rider (comment-only)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260620h" />
+  <link rel="stylesheet" href="style.css?v=20260621a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260620h"></script>
-  <script type="module" src="app.js?v=20260620h"></script>
+  <script src="rule-usage.js?v=20260621a"></script>
+  <script type="module" src="app.js?v=20260621a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2509,6 +2509,7 @@ body { font-variant-numeric: tabular-nums; }
    same signature as the login data-plate, so the two reads as one yard system);
    HOT (chip over it, release = cancel) snaps to a red DANGER state with red
    chevrons + an armed inset glow. apex height = --arc-apex (≈20% of middle card). */
+/* (smoke-test rider: /start flow verification — comment-only, no rule/logic change) */
 .cancel-arc { position: fixed; left: -20vw; bottom: 48px; width: 140vw; height: var(--arc-apex); border-radius: 100% 100% 0 0; overflow: hidden; background: linear-gradient(180deg, #1b2129, #0c0e11 72%); display: flex; align-items: flex-start; justify-content: center; padding-top: calc(var(--arc-apex) * .22); transform: translateY(150%); transition: transform .22s cubic-bezier(.2, .7, .2, 1); box-shadow: 0 -22px 52px -28px #000; }
 .cancel-arc::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 8px; background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 13px, #14181d 13px 26px); }
 .cancel-arc.show { transform: translateY(0); }


### PR DESCRIPTION
## What

Comment-only rider in `style.css` to exercise the full `/start` promotion flow end-to-end: `design-system/start-flow-smoke-test` → `area/design-system` → `staging` → PR to `main`.

## Why

Testing the new `/start` skill + the post-PR wrap-up routine (`/tidy-sessions` + handoff note).

## Scope / safety

- One-line CSS comment near the `.cancel-arc` reference block. **No `data-r` rule change, no logic change.** `rule-usage.js` untouched.
- Required CI `smoke` check validates server-side (playwright isn't installed locally).

## Separate follow-up (not in this PR)

`node ci/gen-rule-usage.mjs --check` reports `rule-usage.js` STALE — verified **pre-existing on `main`** (generator reads only `app.js`; persists on a clean tree). Worth a standalone regen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)