### PR TITLE
Audit fixes: mask role passwords + Wrangler rail overhang

### DIFF
--- a/app.js
+++ b/app.js
@@ -2158,11 +2158,13 @@ function settingsBoardHtml(o) {
 }
 function settingsLoginsPane(o) {
   const cfg = o.config || { roles: {}, admin: '' };
-  const roleRows = Object.keys(cfg.roles || {}).map((role) => `<label class="set-row"><span class="set-role">${esc(role)}</span><input class="set-input" data-role="${esc(role)}" value="${esc(cfg.roles[role])}" autocomplete="off" /></label>`).join('');
+  const pwType = o.revealPw ? 'text' : 'password';   // masked by default so passwords don't shoulder-surf; toggle to reveal
+  const roleRows = Object.keys(cfg.roles || {}).map((role) => `<label class="set-row"><span class="set-role">${esc(role)}</span><input class="set-input" type="${pwType}" data-role="${esc(role)}" value="${esc(cfg.roles[role])}" autocomplete="off" /></label>`).join('');
   return `
     <div class="set-pane-head"><h4>Roles &amp; Logins</h4><p>Each role signs in with its password (plus their name). Changes apply at next sign-in.</p></div>
+    <div class="set-reveal-row"><button class="set-reveal js-set-reveal" type="button">${I.eye} ${o.revealPw ? 'Hide passwords' : 'Show passwords'}</button></div>
     ${roleRows}
-    <label class="set-row set-admin"><span class="set-role">Admin</span><input class="set-input" data-admin="1" value="${esc(cfg.admin || '')}" autocomplete="off" /></label>
+    <label class="set-row set-admin"><span class="set-role">Admin</span><input class="set-input" type="${pwType}" data-admin="1" value="${esc(cfg.admin || '')}" autocomplete="off" /></label>
     <div class="set-row" style="margin-top:14px;align-items:center"><span class="set-role" style="flex:0 0 auto" data-tip="ON: dropping a unit onto a conflicting rental links anyway — both sides get a pulsing red 'Overbooked' flag while the overlap exists. OFF: the drop is blocked, naming the conflict.">Allow overbooking</span>${segCtl([{ label: 'Off', js: 'js-overbook', data: { val: '0' }, on: state.overbookOn ? null : 'red' }, { label: 'On', js: 'js-overbook', data: { val: '1' }, on: state.overbookOn ? 'green' : null }])}</div>
     <p class="set-note">Drag &amp; drop policy — saved on this device.</p>
     <div class="set-row" style="margin-top:12px;align-items:center"><span class="set-role" style="flex:0 0 auto" data-tip="A light vibration confirms committed actions on phones (post a chat, drop a link, complete a WO, release-to-cancel). Android only — iOS has no vibration.">Haptic feedback</span>${segCtl([{ label: 'Off', js: 'js-haptics', data: { val: '0' }, on: state.hapticsOff ? 'red' : null }, { label: 'On', js: 'js-haptics', data: { val: '1' }, on: state.hapticsOff ? null : 'green' }])}</div>
@@ -9451,6 +9453,7 @@ function onClick(e) {
   if (closest('.js-logo')) return openLogoMenu(closest('.js-logo'));
   if (closest('.js-switch-user')) { e.stopPropagation(); return switchUser(); }
   if (closest('.js-open-settings')) { e.stopPropagation(); return openSettings(); }
+  if (closest('.js-set-reveal')) { e.stopPropagation(); const o = state.overlay; if (o) { captureLoginEdits(o); o.revealPw = !o.revealPw; renderOverlay(); } return; }   // toggle masked role passwords
   if (closest('.js-settings-save')) { e.stopPropagation(); return saveSettings(); }
   if (closest('.js-settings-resetpage')) { e.stopPropagation(); return resetPageSettings(); }   // gentle: default just this tab
   if (closest('.js-settings-reset')) { e.stopPropagation(); const o = state.overlay; if (!o) return; if (o.resetArm) return resetAllSettings(); o.resetArm = true; renderOverlay(); return; }   // armed two-click confirm

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260622b" />
+  <link rel="stylesheet" href="style.css?v=20260622c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260622b"></script>
-  <script type="module" src="app.js?v=20260622b"></script>
+  <script src="rule-usage.js?v=20260622c"></script>
+  <script type="module" src="app.js?v=20260622c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1179,6 +1179,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-rc-needs .wr-rc-dot { background: var(--red); }
 .wr-railchip.wr-flash { animation: attnGlow 1.6s ease-in-out infinite; border-color: var(--accent-line); }
 .is-phone .wr-rail { max-width: 62vw; }
+/* Recent-chat snap chips spilled over the rightmost card (Jac 2026-06-22). Collapse them
+   at rest so the corner stays clean; reveal on hover/focus of the cluster. Action-required
+   (wr-rc-needs) chips always show — they flash and need an answer. */
+.fab-stack .wr-railchip:not(.wr-rc-needs) { display: none; }
+.fab-stack:hover .wr-railchip:not(.wr-rc-needs),
+.fab-stack:focus-within .wr-railchip:not(.wr-rc-needs) { display: inline-flex; }
 @media (prefers-reduced-motion: reduce) { .wr-railchip:hover { transform: none; } .wr-railchip.wr-flash { animation: none; box-shadow: 0 0 0 2px var(--accent-soft), 0 6px 18px -6px rgba(0,0,0,.6); } }
 
 /* §17 INTERNAL TEAM DOCK (Jac, Phase 7) — headerless: tagged-element pill rail on top,
@@ -1436,6 +1442,12 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .set-pane-head em { font-style: normal; font-family: ui-monospace, monospace; color: var(--txt); }
 .set-note { font-size: 10.5px; color: var(--txt-3); margin: 4px 0 0; }
 .set-err { align-self: center; color: var(--red); font-size: 12px; font-weight: 600; margin-right: 4px; }
+/* Roles & Logins — passwords masked by default; this toggles reveal (stamped, not a native control). */
+.set-reveal-row { display: flex; justify-content: flex-end; margin: -2px 0 8px; }
+.set-reveal { display: inline-flex; align-items: center; gap: 5px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-size: 10px; font-weight: 700; color: var(--txt-3); background: none; border: 1px solid var(--line); border-radius: 8px; padding: 4px 9px; cursor: pointer; transition: color .12s, border-color .12s; }
+.set-reveal:hover { color: var(--txt); border-color: var(--accent-line); }
+.set-reveal:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.set-reveal svg { width: 13px; height: 13px; }
 .set-danger { color: var(--txt-3); }
 .set-danger:hover { color: var(--red); border-color: var(--red); }
 .set-danger.armed { color: var(--on-red, #fff); background: var(--red); border-color: var(--red); animation: flagPulse 1s ease-in-out infinite; }


### PR DESCRIPTION
From the live design audit: mask Settings role passwords (type=password + reveal toggle); collapse the Wrangler recent-chat rail chips at rest so they stop spilling over the rightmost card. Cache-bust 20260622c.