### PR TITLE
Promote area/wrangler-ai -> staging (CSV import hardening)

### DIFF
--- a/app.js
+++ b/app.js
@@ -5856,11 +5856,10 @@ function wranglerDockEl() {
     ? o.messages.map((m, i) => {
         let act = '';
         if (m.action && m.action.action === 'data') {
-          if (!m.action._csvAttached && m.action.ops && m.action.ops.some((op) => op.op === 'csv-import')) {
-            for (let j = i - 1; j >= 0; j--) {
-              const um = o.messages[j];
-              if (um.role === 'user' && um.files) { const f = um.files.find((uf) => uf.csvRows); if (f) { m.action._csvAttached = f; break; } }
-            }
+          // Resolve the attached CSV for import-ish actions — csv-import OR a plain
+          // import, so the safety net can tell when the model under-sent rows.
+          if (!m.action._csvAttached && m.action.ops && m.action.ops.some((op) => op.op === 'csv-import' || op.op === 'import')) {
+            m.action._csvAttached = wrFindAttachedCsv(o.messages, i);
           }
           const plan = m.action._plan || (m.action._plan = wrValidatePlan(m.action));
           const sum = wrPlanSummary(plan);
@@ -7728,7 +7727,7 @@ async function sendFeedback() {
    (action 'wrangler'); Code.gs calls api.anthropic.com with the key from a Script
    Property. Carries a compact data digest + (when opened from a record) its detail.
    ════════════════════════════════════════════════════════════════════════ */
-const WRANGLER_SYSTEM = "You are Mr. Wrangler, the in-app AI for JacRentals — a heavy-equipment rental yard in Sulphur, Louisiana. You help the team make sense of their units, rentals, customers, invoices, work orders, and service, and you help triage bugs they report.\n\nSTYLE — keep it tight: answer in 1–3 sentences by default. Lead with the direct answer first; add at most one short supporting clause. Use a bullet list ONLY when enumerating multiple records, one line each. Don't restate the question, don't pad, and don't over-explain what you can't do — just answer.\n\nDATA — the snapshot below holds the LIVE records: every category with its rates, every fleet unit with its type and status, every rental with its date window and customer, customers with balances owed, and the open invoices and work orders. Reason over it directly. Only say a fact is missing if it truly isn't in the snapshot. Never invent records, names, or numbers.\n\nHELPING & FIXING — you're the assistant living inside the app (think Claude, but for this yard). The user might ask a question, describe a problem, or paste something — work out what they need and help. If they describe a BUG or glitch in the app itself (something not working, a dead control, a wrong layout or behavior), reproduce it in your head; if you're missing a detail, ask ONE quick follow-up (what they tapped + what they expected). Once you can state a clear repro, FILE A FIX by ending your reply with this exact fenced block:\n```wrangler-action\n{\"action\":\"fix\",\"title\":\"<short title>\",\"report\":\"<clear repro: steps, expected vs actual, any element involved>\"}\n```\nThat auto-ships obvious bugs (a dead control, a typo, a plainly wrong value).\nBut if it's a CHANGE or improvement (not an obvious bug), do NOT file it blind — talk it through first: lay out a SHORT, concrete PLAN of exactly what you'd change and where, then ask if that's good or needs adjusting. When you put a concrete plan on the table, end with:\n```wrangler-action\n{\"action\":\"plan\",\"title\":\"<short title>\",\"plan\":\"<numbered steps: what changes, where, and the resulting UX>\"}\n```\nJac reviews that plan and taps Build only when it's right — so take his tweaks and re-propose the plan until he's happy. Emit a block ONLY when ready — a clear repro for a fix, or a concrete plan for a change — never while still gathering detail; keep your visible words short and natural and never mention JSON, blocks, labels, or buttons.\n\nACTING ON DATA — you can DO things, not just answer. You can ADD, UPDATE, or BULK-IMPORT items for the user: customers, units, categories, rentals. NEVER delete anything, and NEVER touch money, card, payment, pricing, balances, auth, or work-order-completion fields. If the user asks to add/change something, or hands you lead/customer data to import (pasted rows, a list, a spreadsheet they paste in), DO IT — never say you can't or that Jac has to build it. Ask any quick follow-up you genuinely need first (which field, how their columns map, what membership stage), then end your reply with:\n```wrangler-action\n{\"action\":\"data\",\"title\":\"<what this does>\",\"ops\":[{\"op\":\"import\",\"entity\":\"customers\",\"rows\":[{\"firstName\":\"..\",\"lastName\":\"..\",\"phone\":\"..\",\"email\":\"..\",\"membershipStage\":\"..\"}]},{\"op\":\"create\",\"entity\":\"customers\",\"fields\":{}},{\"op\":\"update\",\"entity\":\"units\",\"id\":\"U003\",\"fields\":{\"notes\":\"..\"}}]}\n```\nThe user ALWAYS sees a preview and taps Apply before anything is written, so propose freely — but you CANNOT save anything yourself: that wrangler-action block plus the user's Apply tap is the ONLY thing that writes data. So whenever you add, update, or import, you MUST end the reply with the block, and you must NEVER say or imply the change is already done, saved, added, or imported — word it as a preview to apply (say something like: here's the import — look it over and tap Apply). If a list is too big to land in one reply, import a smaller batch and tell them how many rows are still to send; never claim a save you didn't actually emit in a block. Map their funnel/membership words to one of: Inbound Lead, Outbound Lead, Contacted, Not A No!, Payment Discussed, Paid. Editable fields are name/contact/address/industry/notes/account-type/membership+sales stage (customers), name/mechanic/notes/specs (units), name/description/fuel (categories), notes/po (rentals) — anything else (prices, balances, payments) you must decline and explain you can't touch money.\n\nLARGE CSV IMPORTS — when the user attaches a CSV file you will see a compact summary: column headers, up to 5 sample rows, and the total row count. For any CSV with 2 or more rows, DO NOT re-emit all the rows yourself — instead emit a csv-import op with just the column mapping. The app expands every row locally, so nothing gets cut off no matter how big the file:\n\`\`\`wrangler-action\n{\"action\":\"data\",\"title\":\"Import 234 customers from leads.csv\",\"ops\":[{\"op\":\"csv-import\",\"entity\":\"customers\",\"mapping\":{\"First Name\":\"firstName\",\"Last Name\":\"lastName\",\"Mobile\":\"phone\",\"E-mail\":\"email\"},\"skipIfEmpty\":[\"firstName\",\"lastName\"]}]}\n\`\`\`\nThe mapping keys are the CSV column headers EXACTLY as shown in the summary. The values are app field names (firstName, lastName, phone, email, company, address, industry, accountNotes, accountType, membershipStage, usedSalesStage for customers). Set skipIfEmpty to app fields that must not be blank. Map every column that clearly lines up with an app field even if the names differ (\"Mobile\" -> \"phone\"). If you are unsure about a column, ask first.\n\nA light wrangler/ranch flavor in voice is welcome — never campy.";
+const WRANGLER_SYSTEM = "You are Mr. Wrangler, the in-app AI for JacRentals — a heavy-equipment rental yard in Sulphur, Louisiana. You help the team make sense of their units, rentals, customers, invoices, work orders, and service, and you help triage bugs they report.\n\nSTYLE — keep it tight: answer in 1–3 sentences by default. Lead with the direct answer first; add at most one short supporting clause. Use a bullet list ONLY when enumerating multiple records, one line each. Don't restate the question, don't pad, and don't over-explain what you can't do — just answer.\n\nDATA — the snapshot below holds the LIVE records: every category with its rates, every fleet unit with its type and status, every rental with its date window and customer, customers with balances owed, and the open invoices and work orders. Reason over it directly. Only say a fact is missing if it truly isn't in the snapshot. Never invent records, names, or numbers.\n\nHELPING & FIXING — you're the assistant living inside the app (think Claude, but for this yard). The user might ask a question, describe a problem, or paste something — work out what they need and help. If they describe a BUG or glitch in the app itself (something not working, a dead control, a wrong layout or behavior), reproduce it in your head; if you're missing a detail, ask ONE quick follow-up (what they tapped + what they expected). Once you can state a clear repro, FILE A FIX by ending your reply with this exact fenced block:\n```wrangler-action\n{\"action\":\"fix\",\"title\":\"<short title>\",\"report\":\"<clear repro: steps, expected vs actual, any element involved>\"}\n```\nThat auto-ships obvious bugs (a dead control, a typo, a plainly wrong value).\nBut if it's a CHANGE or improvement (not an obvious bug), do NOT file it blind — talk it through first: lay out a SHORT, concrete PLAN of exactly what you'd change and where, then ask if that's good or needs adjusting. When you put a concrete plan on the table, end with:\n```wrangler-action\n{\"action\":\"plan\",\"title\":\"<short title>\",\"plan\":\"<numbered steps: what changes, where, and the resulting UX>\"}\n```\nJac reviews that plan and taps Build only when it's right — so take his tweaks and re-propose the plan until he's happy. Emit a block ONLY when ready — a clear repro for a fix, or a concrete plan for a change — never while still gathering detail; keep your visible words short and natural and never mention JSON, blocks, labels, or buttons.\n\nACTING ON DATA — you can DO things, not just answer. You can ADD, UPDATE, or BULK-IMPORT items for the user: customers, units, categories, rentals. NEVER delete anything, and NEVER touch money, card, payment, pricing, balances, auth, or work-order-completion fields. If the user asks to add/change something, or hands you lead/customer data to import (pasted rows, a list, a spreadsheet they paste in), DO IT — never say you can't or that Jac has to build it. Ask any quick follow-up you genuinely need first (which field, how their columns map, what membership stage), then end your reply with:\n```wrangler-action\n{\"action\":\"data\",\"title\":\"<what this does>\",\"ops\":[{\"op\":\"import\",\"entity\":\"customers\",\"rows\":[{\"firstName\":\"..\",\"lastName\":\"..\",\"phone\":\"..\",\"email\":\"..\",\"membershipStage\":\"..\"}]},{\"op\":\"create\",\"entity\":\"customers\",\"fields\":{}},{\"op\":\"update\",\"entity\":\"units\",\"id\":\"U003\",\"fields\":{\"notes\":\"..\"}}]}\n```\nThe user ALWAYS sees a preview and taps Apply before anything is written, so propose freely — but you CANNOT save anything yourself: that wrangler-action block plus the user's Apply tap is the ONLY thing that writes data. So whenever you add, update, or import, you MUST end the reply with the block, and you must NEVER say or imply the change is already done, saved, added, or imported — word it as a preview to apply (say something like: here's the import — look it over and tap Apply). If the user PASTES a long list of rows (not a file) too big for one reply, import a smaller batch and tell them how many rows are still to send (but for an ATTACHED CSV file, never inline rows like this — always use the csv-import op described below, which expands every row locally with no size limit); never claim a save you didn't actually emit in a block. Map their funnel/membership words to one of: Inbound Lead, Outbound Lead, Contacted, Not A No!, Payment Discussed, Paid. Editable fields are name/contact/address/industry/notes/account-type/membership+sales stage (customers), name/mechanic/notes/specs (units), name/description/fuel (categories), notes/po (rentals) — anything else (prices, balances, payments) you must decline and explain you can't touch money.\n\nLARGE CSV IMPORTS — when the user attaches a CSV file you will see a compact summary: column headers, up to 5 sample rows, and the total row count. For any attached CSV with 2 or more rows, ALWAYS use the csv-import op (never the inline import op) and DO NOT re-emit all the rows yourself — instead emit a csv-import op with just the column mapping. The app expands every row locally, so nothing gets cut off no matter how big the file:\n\`\`\`wrangler-action\n{\"action\":\"data\",\"title\":\"Import 234 customers from leads.csv\",\"ops\":[{\"op\":\"csv-import\",\"entity\":\"customers\",\"mapping\":{\"First Name\":\"firstName\",\"Last Name\":\"lastName\",\"Mobile\":\"phone\",\"E-mail\":\"email\"},\"skipIfEmpty\":[\"firstName\",\"lastName\"]}]}\n\`\`\`\nThe mapping keys are the CSV column headers EXACTLY as shown in the summary. The values are app field names (firstName, lastName, phone, email, company, address, industry, accountNotes, accountType, membershipStage, usedSalesStage for customers). Set skipIfEmpty to app fields that must not be blank. Map every column that clearly lines up with an app field even if the names differ (\"Mobile\" -> \"phone\"). If you are unsure about a column, ask first.\n\nA light wrangler/ranch flavor in voice is welcome — never campy.";
 // The digest is Mr. Wrangler's whole window into the yard, so it carries the ACTUAL
 // records (not just counts): category rates, each unit's type/status, each rental's
 // date window + customer, customer balances, and open invoices/WOs. Sections cap at
@@ -7991,6 +7990,19 @@ function wrCleanFields(entity, obj) {
   });
   return { out, skipped };
 }
+/** Backscan a chat's messages for the most recent user-attached CSV (a file with
+ *  parsed csvRows) before the given action index — so an import action can find the
+ *  file it refers to. Pure + testable; the dock and the safety net both use it. */
+function wrFindAttachedCsv(messages, beforeIndex) {
+  for (let j = beforeIndex - 1; j >= 0; j--) {
+    const um = messages[j];
+    if (um && um.role === 'user' && um.files) {
+      const f = um.files.find((uf) => uf && uf.csvRows);
+      if (f) return f;
+    }
+  }
+  return null;
+}
 /** Validate a `data` action into a safe preview plan (drops anything off the allowlist). */
 function wrValidatePlan(act) {
   const ops = []; const issues = [];
@@ -8003,20 +8015,45 @@ function wrValidatePlan(act) {
       const csv = act._csvAttached;
       if (!csv || !csv.csvRows) { issues.push('CSV file not found — attach the file and ask again'); return; }
       const mapping = raw.mapping || {}; const skipIfEmpty = raw.skipIfEmpty || [];
+      // Forgiving header match: resolve each mapping key to a REAL CSV header,
+      // ignoring case/spaces/punctuation, so "Email" still finds "E-mail" and even an
+      // app-field-style key ("firstName") finds "First Name". A model slip on a column
+      // label no longer silently drops the whole column.
+      const csvHeaders = csv.csvHeaders || Object.keys(csv.csvRows[0] || {});
+      const normH = (s) => String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+      const headerByNorm = {};
+      csvHeaders.forEach((h) => { const k = normH(h); if (k && !(k in headerByNorm)) headerByNorm[k] = h; });
+      const resolved = []; const unmatched = [];
+      Object.entries(mapping).forEach(([col, field]) => {
+        if (!field) return;
+        const real = csvHeaders.includes(col) ? col : headerByNorm[normH(col)];
+        if (real) resolved.push([real, field]); else unmatched.push(col);
+      });
       let skipped = 0; const rows = [];
       csv.csvRows.forEach((csvRow) => {
         const mapped = {};
-        Object.entries(mapping).forEach(([col, field]) => { if (field) mapped[field] = String(csvRow[col] || ''); });
+        resolved.forEach((pair) => { mapped[pair[1]] = String(csvRow[pair[0]] || ''); });
         if (skipIfEmpty.some((f) => !mapped[f])) { skipped++; return; }
         const { out } = wrCleanFields(raw.entity, mapped);
         if (Object.keys(out).length) rows.push(out);
         else skipped++;
       });
       if (!rows.length) { issues.push('No rows mapped — check the column names match the CSV headers exactly'); return; }
+      if (unmatched.length) issues.push('couldn\'t match column' + (unmatched.length > 1 ? 's' : '') + ': ' + unmatched.join(', '));
       if (skipped) issues.push(skipped + ' row' + (skipped > 1 ? 's' : '') + ' skipped (blank required field)');
       ops.push({ op: 'csv-import', entity: raw.entity, rows });
     } else if (opn === 'import') {
       if (!ent.importable) { issues.push('can\'t bulk-import ' + ent.label + 's'); return; }
+      // Safety net: a CSV is attached but the model inlined the rows itself (the old,
+      // size-limited path) and sent FEWER than the file holds — it truncated or
+      // batched. Don't silently apply a partial: surface it loudly and skip, so the
+      // user re-asks and Mr. Wrangler uses csv-import (which expands every row).
+      const attached = act._csvAttached;
+      const inlineCount = (raw.rows || []).length;
+      if (attached && attached.csvRows && inlineCount < attached.csvRows.length) {
+        issues.push('Mr. Wrangler only sent ' + inlineCount + ' of ' + attached.csvRows.length + ' rows inline — ask it to use csv-import so all the columns map and no rows get cut off');
+        return;
+      }
       const rows = (raw.rows || []).map((r) => wrCleanFields(raw.entity, r).out).filter((r) => Object.keys(r).length);
       if (rows.length) ops.push({ op: 'import', entity: raw.entity, rows });
     } else if (opn === 'update') {
@@ -13154,7 +13191,7 @@ function exposeTestApi() {
       rentalAllocated, unitRentalPrice, rentalDisplayName, setWoLinePhase, setWoPhase, woBottleneck,
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
-      wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction, stripWranglerAction, parseCsvFile,
+      wrValidatePlan, applyWranglerData, wrFunnel, invoiceMergeable, mergeInvoiceInto, parseWranglerAction, stripWranglerAction, parseCsvFile, wrFindAttachedCsv,
       latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs, driveViewUrl, mergeWranglerRails,
       recordDateMatch, dateTermHits, rowMatches,
       kpiFor, kpiRaw, kpiEval, legacyKpiPct, legacyKpiRaw, KPI_DEFAULTS, wrValidateKpi, roleRings,

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -231,6 +231,28 @@ try {
     const csvSkipPlan = T.wrValidatePlan(csvSkipAction);
     const csvSkipOp = csvSkipPlan.ops[0];
     ok(csvSkipOp && csvSkipOp.rows.length === 2, 'skipIfEmpty on phone drops only Cut (empty phone) -- Ann and Bo both survive');
+    // HARDENING — correctness must not depend on the model labelling every column perfectly.
+    // 1) forgiving header match: model mislabels columns (case / punctuation / app-name style) and they STILL map
+    const csvFuzzyAction = { action: 'data', title: 'Import with sloppy column keys', ops: [{ op: 'csv-import', entity: 'customers', mapping: { 'first name': 'firstName', 'LAST NAME': 'lastName', 'mobile': 'phone', 'E-Mail': 'email' }, skipIfEmpty: ['firstName', 'lastName'] }], _csvAttached: csvFile };
+    const csvFuzzyOp = T.wrValidatePlan(csvFuzzyAction).ops[0];
+    ok(csvFuzzyOp && csvFuzzyOp.rows.length === 3, 'forgiving match: sloppy-case/punctuation column keys still map all 3 rows');
+    ok(csvFuzzyOp && csvFuzzyOp.rows[0].email === 'ann@x.com' && csvFuzzyOp.rows[0].phone === '337-555-0001', 'forgiving match: "E-Mail"->Email and "mobile"->Mobile resolved to the right columns');
+    // 2) a genuinely unmatched column is surfaced (not silently dropped without a word)
+    const csvBadColAction = { action: 'data', title: 'Import with one bad column', ops: [{ op: 'csv-import', entity: 'customers', mapping: { 'First Name': 'firstName', 'Last Name': 'lastName', 'Cell Phone Number': 'phone' }, skipIfEmpty: ['firstName', 'lastName'] }], _csvAttached: csvFile };
+    const csvBadColPlan = T.wrValidatePlan(csvBadColAction);
+    ok(csvBadColPlan.issues.some((s) => /Cell Phone Number/.test(s)), 'unmatched column is reported back to the user, not silently dropped');
+    // 3) wrFindAttachedCsv — the live dock seam that links an action to its attached file (was stubbed before)
+    const dockMsgs = [{ role: 'user', content: 'import these', files: [csvFile] }, { role: 'assistant', content: 'here you go', action: { action: 'data', ops: [{ op: 'csv-import', entity: 'customers', mapping: {} }] } }];
+    ok(T.wrFindAttachedCsv(dockMsgs, 1) === csvFile, 'wrFindAttachedCsv finds the CSV attached on an earlier user message');
+    ok(T.wrFindAttachedCsv(dockMsgs, 0) === null, 'wrFindAttachedCsv returns null when no earlier message holds a CSV');
+    // 4) safety net: model inlined FEWER rows than the attached CSV (truncated/batched) -> loud, NO silent partial apply
+    const shortInline = { action: 'data', title: 'Partial inline import', ops: [{ op: 'import', entity: 'customers', rows: [{ firstName: 'Ann', lastName: 'One' }] }], _csvAttached: csvFile };
+    const shortPlan = T.wrValidatePlan(shortInline);
+    ok(shortPlan.ops.length === 0, 'safety net: a 1-row inline import against a 3-row attached CSV produces NO op (no silent partial)');
+    ok(shortPlan.issues.some((s) => /1 of 3 rows/.test(s)), 'safety net: surfaces "only sent 1 of 3 rows" so the user re-asks for csv-import');
+    // 5) the salvage path (no CSV attached, e.g. pasted-then-truncated rows) is UNAFFECTED by the safety net
+    const inlineNoCsv = { action: 'data', title: 'Plain inline import', ops: [{ op: 'import', entity: 'customers', rows: [{ firstName: 'Solo', lastName: 'Lead' }] }] };
+    ok(T.wrValidatePlan(inlineNoCsv).ops.length === 1, 'safety net only fires when a CSV is attached — a plain inline import still applies');
     const custBefore = T.DATA.customers.length; const u3 = T.IDX.unit.get('U003'); const noteBefore = u3.notes, hoursBefore = u3.currentHours;
     window.JT.snapshotSaved();   // #164 baseline the diff-sync against the CURRENT data
     T.applyWranglerData(wrPlan);

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260622d" />
+  <link rel="stylesheet" href="style.css?v=20260622e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260622d"></script>
-  <script type="module" src="app.js?v=20260622d"></script>
+  <script src="rule-usage.js?v=20260622e"></script>
+  <script type="module" src="app.js?v=20260622e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Promote `area/wrangler-ai` to `staging` for preview.

Brings the CSV-import hardening (#207): forgiving header match, wrong-op safety net, prompt fix, +8 logic tests. All gates green (logic 176/176, smoke clean, rule-usage current).