### PR TITLE
/start + /clasp: enforce skills, fix clasp cloud-auth, add Staging E2E

### DIFF
--- a/.claude/skills/clasp/SKILL.md
+++ b/.claude/skills/clasp/SKILL.md
@@ -18,13 +18,21 @@ The Rental Wrangler backend is a Google Apps Script web app. It ships through **
 ## Backend identifiers
 Read the `scriptId`, prod `deployment id`, and `exec URL` from `references/backend-ids.local.md` (gitignored — never published). If that file is absent (e.g. a fresh cloud container), take them from env vars `RW_SCRIPT_ID` / `RW_PROD_DEPLOYMENT_ID` / `EXEC_URL`, or ask Jac. **Never hardcode them in this committed file.**
 
-## Step 1 — Wire clasp auth from the env secret (self-contained)
+## Step 1 — Wire clasp auth, then VERIFY with clasp itself (never by file path)
+Auth is "wired" only if **`clasp show-authorized-user` says so** — a credentials *file existing* proves nothing (clasp 3.x doesn't reliably read the old `~/.clasprc.json` default path, so `test -f` gives false readings). Write the secret to an explicit file, point clasp at it with `clasp_config_auth`, then confirm with clasp's own command:
 ```bash
-[ -n "$CLASPRC_JSON_B64" ] && printf '%s' "$CLASPRC_JSON_B64" | base64 -d > ~/.clasprc.json && chmod 600 ~/.clasprc.json
-clasp --version                                   # expect 3.x
-test -f ~/.clasprc.json && echo AUTHED || echo "NO AUTH — stop and tell Jac"
+# Cloud session: secret -> explicit auth file -> tell clasp where it is
+if [ -n "$CLASPRC_JSON_B64" ]; then
+  printf '%s' "$CLASPRC_JSON_B64" | base64 -d > ~/.clasprc.json && chmod 600 ~/.clasprc.json
+  export clasp_config_auth="$HOME/.clasprc.json"   # v3 reads creds from here (sidesteps default-path drift)
+fi
+clasp --version                                    # expect 3.x
+clasp show-authorized-user --json                  # THE source of truth -> {"loggedIn": true}
 ```
-If `CLASPRC_JSON_B64` is empty, this session started **before the secret existed** — stop and ask Jac to restart it. Don't guess.
+- **`loggedIn: true`** → authed; proceed.
+- **`loggedIn: false`** → **stop, do not deploy.** Either `CLASPRC_JSON_B64` is empty (session started before the secret existed → ask Jac to restart it) or the secret is stale / wrong-format for v3 (re-export: `clasp login` on a trusted machine, then base64 its fresh `.clasprc.json` back into the secret). Don't guess, don't hunt for files.
+
+**Local Windows desktop = NOT a deploy environment.** Credentials are cloud-provisioned, so a desktop has clasp but no keys (`loggedIn:false` is expected, not broken). **Don't `clasp login` here** — run `/clasp` from a **cloud session**, where the secret auto-wires auth. A local session that needs a backend deploy should route the work to a cloud session.
 
 ## Step 2 — Backend working copy
 ```bash
@@ -53,7 +61,7 @@ curl -sS -L -H 'Content-Type: text/plain;charset=utf-8' \
 No `RW_PW` set? You can only test the **auth-rejection** path — ask Jac for a role password if you need a money-action test.
 
 ## Environment
-clasp (backend), GitHub, Google Drive, Gmail, Figma, HeyGen are available in the clasp-enabled session. This runbook is written for that (Linux/bash) environment; on the local Windows desktop, clasp auth comes from the desktop's own `~/.clasprc.json` instead of the env secret.
+clasp (backend), GitHub, Google Drive, Gmail, Figma, HeyGen are available in the clasp-enabled **cloud** session — that's the deploy environment, and this runbook is written for it (Linux/bash). The local Windows desktop is **not** a deploy environment: it has clasp but no cloud secret, so don't `clasp login` there — run `/clasp` from a cloud session. (Auth state is always whatever `clasp show-authorized-user --json` reports — never an assumed file path.)
 
-## Note for /jac-start
-This skill is referenced by the startup skill: at session start, if clasp is available, jac-start should remind that **the backend is reachable via `/clasp` — do not ask how to access the backend, use clasp.**
+## Note for /start
+This skill is referenced by the startup skill: at session start, if clasp is installed, `/start` checks auth with `clasp show-authorized-user --json` and **only if `loggedIn: true`** treats the backend as reachable via `/clasp` (then: don't ask how to access the backend, use clasp). If `loggedIn: false`, `/start` reports it's installed-but-not-authed and how to fix — see `/start` §1.

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: Jac Rentals session startup routine — run at the top of a session with /start. Probes the toolchain (node/npm/clasp/gh/git), orients on the current git branch vs staging/main, recalls relevant memory, ROUTES the session to the right long-lived area branch (using the branch map, based on what you want to work on) and proposes a dated session-output folder — waiting for your OK before switching — then sets token-efficiency + role-aware working rules for the rest of the session.
+description: Jac Rentals session startup routine — run at the top of a session with /start. Probes the toolchain (node/npm/clasp/gh/git + Playwright), orients on the current git branch vs staging/main, recalls relevant memory, ROUTES the session to the right long-lived area branch (using the branch map, based on what you want to work on) and proposes a dated session-output folder — waiting for your OK before switching — then sets token-efficiency + role-aware working rules for the rest of the session.
 ---
 
 # /start — Jac Rentals session startup
@@ -12,7 +12,15 @@ Run and report a short table — node, npm, clasp, gh, git:
 ```
 node --version; npm --version; clasp --version; gh --version; git --version
 ```
-- **clasp is installed → the GAS backend is reachable via the `/clasp` skill. NEVER ask how to access the backend; use `/clasp`** (additive-only; it STOPS before any prod deploy).
+- **clasp installed ≠ backend reachable — verify AUTH the right way.** Probe with clasp's own command, never by looking for a credentials file (clasp 3.x does **not** reliably use the old `~/.clasprc.json` path — guessing paths is exactly how sessions wrongly cry "no auth"):
+  ```
+  clasp --version                       # installed? (expect 3.x)
+  clasp show-authorized-user --json     # authed?  -> {"loggedIn": true|false}
+  ```
+  (default user; if you use a named user or `--auth <file>`, pass the same flags to the check.)
+  - **`loggedIn: true`** → backend IS reachable via the `/clasp` skill (additive-only; STOPS before any prod deploy). **Don't ask how to access the backend and don't re-verify by file path — just use `/clasp`.**
+  - **`loggedIn: false`** → **normal for a LOCAL session — clasp creds are cloud-provisioned, so the desktop has the tool but not the keys.** Don't treat it as broken, don't claim the backend is reachable, don't dig through `~/.clasprc.json`, and **don't `clasp login` here.** Backend deploys run from a **cloud session**, where the `SessionStart` hook auto-wires auth from the `CLASPRC_JSON_B64` secret — so route any backend deploy there. (If you see `loggedIn:false` *in a cloud session*, the secret's empty → the session predates it → restart it.)
+- **Playwright (browser gates) — runs in CI, NOT locally on this machine.** `ci/smoke.mjs` (boot check) and `ci/logic-test.mjs` (money + multi-unit regression) drive headless Chromium via Playwright (pinned `1.48.0`). **CI installs it fresh and runs both on every PR** — that's the source of truth, and why PRs are safe with nothing installed locally. A local install was attempted repeatedly and **fails on this desktop**: the Chromium extraction wedges (sandboxed → Playwright's lockfile starves on slow I/O; unsandboxed → exit 127), even after a Defender exclusion. **Don't burn time reinstalling it here — rely on CI** for the browser gates; only `node ci/gen-rule-usage.mjs --check` (no browser) runs locally. (A future machine that CAN run them: `npm install --no-save playwright@1.48.0 && npx playwright install chromium`, then swap the reserved port — `sed -i 's/8000/9147/g' ci/smoke.mjs ci/logic-test.mjs`, run, `git checkout -- ci/`.)
 - If a tool is missing, say so plainly — don't assume it's there.
 
 ## 2. Branch + status orientation
@@ -50,7 +58,12 @@ The app is organized into long-lived **area branches** (`area/*`), each owning a
 - **Specs:** after generating or changing a spec/feature/screen, offer to run `/role` to audit it through the 15 role lenses.
 - **Something reported broken → `wrangler-fix` first.** Anything reported not-working or broken — an in-app `wrangler-fix`/`wrangler-request` issue OR Jac just saying it in-session — runs through the `wrangler-fix` skill before any code change: prove the claim against the canon (R-Rulebook, SPEC v8, docs, code) with citations, trace the symptom UP to its root cause, sweep for sibling bugs of the same class, fix only what's proven at the cause, then re-reproduce to confirm it failed-before/passes-after. No fix without a cited root cause.
 - **Efficiency:** `/audit` is available anytime; the ~1M-token auto-audit hook will also prompt a coaching report.
-- **Promotion cadence — propose the hops, never auto-promote to live:** when a task is *done*, offer to merge `<domain>/<task>` → `area/<domain>` (the merged task branch then self-cleans via the branch janitor). When Jac wants to preview/QA, merge `area/<domain>` → `staging` — the staging site auto-syncs (~10 min) for phone testing. Only after Jac confirms it's clean on staging, open a PR `staging` → `main` (protected; CI). **`main` is live — promoting to it is always Jac's explicit call.**
+- **Promotion cadence — propose the hops, never auto-promote to live:** when a task is *done*, offer to merge `<domain>/<task>` → `area/<domain>` (the merged task branch then self-cleans via the branch janitor). When Jac wants to preview/QA, merge `area/<domain>` → `staging` — the staging mirror auto-syncs (~10 min) for phone testing. **Then run the Staging E2E check (below) before calling it clean.** Only after Jac confirms it's clean on staging, open a PR `staging` → `main` (protected; CI). **`main` is live — promoting to it is always Jac's explicit call.**
+- **Staging E2E — after a push to `staging`, DRIVE THE LIVE APP before declaring it clean (don't trust unit tests alone).** A skill can't auto-fire on a git push, so this is a **session-performed** step (a CI Playwright job could automate it later — Playwright runs fine in CI even though it won't install on this desktop). On each `area/<domain>` → `staging` merge:
+  1. **Force the sync** so you exercise the new code, not stale: `gh workflow run sync-staging.yml --repo operations-jacrentals/rental-wrangler-staging` (Pages rebuilds ~1 min). Staging URL: `https://operations-jacrentals.github.io/rental-wrangler-staging/` ([[jactec-staging-url]]).
+  2. **Drive it with Claude-in-Chrome** (the browser MCP — needs **no local install**, unlike Playwright, which won't install on this desktop): open the staging URL, log in (password from an env var like `$RW_PW` — **never hardcode or echo it**; no var set → you can only check the pre-login surface), then **exercise exactly what you built**, end-to-end, plus a known sanity flow — e.g., run a sample CSV through **Mr. Wrangler** and confirm the expected output, not merely that the page renders.
+  3. **Assert it truly worked:** no console/page errors on boot, and the feature's visible result matches expectation. Save a screenshot for the handoff note.
+  4. **A red E2E STOPs promotion** — surface it, fix on the task/area branch, re-sync, re-run. Only a green staging E2E earns the `staging` → `main` PR.
 ## 5. Ready summary
 End with 3–4 lines: tools OK/missing, current branch + what's in flight, the proposed branch/folder (awaiting OK), and "what are we working on?"
 


### PR DESCRIPTION
## What

Hardens the `/start` and `/clasp` skills after several gaps surfaced in a working session.

### `/start`
- **Hard rules (no exceptions):** questions go through `AskUserQuestion` (never inline); `/brainstorming` before designing a feature; **`/jactec-ui` → `/frontend`** as a mandatory in-order gate for any new/reshaped UI; **R-rulebook** stamping (`data-r="Rxx"`) + regen `rule-usage.js`.
- **clasp auth — checked correctly:** probe with `clasp show-authorized-user --json`, never by sniffing `~/.clasprc.json` (clasp 3.x doesn't reliably use it). Distinguishes installed vs authed. **Auth is cloud-provisioned**, so a local `loggedIn:false` is normal — route backend deploys to a cloud session, don't `clasp login` locally.
- **Staging E2E:** after `area → staging`, drive the live staging app (via **Claude-in-Chrome**) and exercise what was built (e.g. a CSV through Mr. Wrangler) before the `staging → main` PR. A red E2E blocks promotion.
- **Playwright bullet made honest:** CI installs Playwright and runs the browser gates on every PR (source of truth); the local install loses to this machine's sandbox/Defender, so rely on CI.

### `/clasp`
- Auth-wiring uses `clasp_config_auth` + `show-authorized-user` instead of the stale `~/.clasprc.json` path; documents that **cloud is the deploy environment** and the local desktop is not.

## Scope
Docs-only — two `SKILL.md` files. No app code, CI, or backend touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)