### PR TITLE
Wrangler fix: surface real backend errors instead of generic "Network error"

### DIFF
--- a/app.js
+++ b/app.js
@@ -12886,7 +12886,15 @@ async function backendCall(action, extra) {
   // text/plain avoids a CORS preflight that GAS web apps can't answer
   const payload = Object.assign({ action, password: backendPassword }, extra || {});
   const res = await fetch(BACKEND_URL, { method: 'POST', headers: { 'Content-Type': 'text/plain;charset=utf-8' }, body: JSON.stringify(payload) });
-  return res.json();
+  // GAS returns server-side failures (quota / auth / unhandled exception) as a NON-JSON
+  // HTML error page or a non-2xx status. The old `res.json()` THREW on those, so every
+  // backend/Stripe failure was caught upstream as a generic "Network error" — masking the
+  // real reason (#172-class card/charge failures). Parse defensively instead and hand the
+  // caller a clean { ok:false, error } so friendlyPayErr() can surface the actual cause.
+  const text = await res.text();
+  let body; try { body = JSON.parse(text); } catch { body = { ok: false, error: res.ok ? 'bad-json' : ('http-' + res.status) }; }
+  if (!res.ok && body && body.ok === undefined) body = { ok: false, error: 'http-' + res.status };
+  return body;
 }
 const dataSnapshot = () => { const s = {}; PERSIST_KEYS.forEach((k) => { s[k] = DATA[k] || []; }); return s; };
 async function loadFromBackend() {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260622j" />
+  <link rel="stylesheet" href="style.css?v=20260623a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260622j"></script>
-  <script type="module" src="app.js?v=20260622j"></script>
+  <script src="rule-usage.js?v=20260623a"></script>
+  <script type="module" src="app.js?v=20260623a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Root cause (proven)

`backendCall` (app.js:12885) did `return res.json()`. GAS returns its server-side failures — quota, auth, unhandled exception — as a **non-JSON HTML error page** or a **non-2xx status**, on which `res.json()` **throws**. In `saveCardFlow` that throw is swallowed by the catch at app.js:11787 → surfaces as the generic **"Network error — try again."** The dedicated `friendlyPayErr(r)` mapper only fires on the `if (!r || !r.ok) return fail(friendlyPayErr(r))` branch (11751/11761), which is **never reached** when `res.json()` throws. Result: every server-side card/charge failure was mislabeled "Network error" — the #172-class masking that report M1 (#220) named.

## Fix

Parse the response defensively: read `res.text()`, `JSON.parse` it, and on non-JSON or non-ok hand the caller a clean `{ ok:false, error:'bad-json'|'http-NNN' }`. The existing `!r.ok` branches + `friendlyPayErr()` then surface the actual cause instead of "Network error".

- Strictly additive — **weakens no money/card/auth gate**. Every caller already checks `!r.ok`; the happy path (`200` + valid JSON) is byte-identical to before.
- No UI element changed → `rule-usage.js` unchanged; window catalog unchanged.

## Gates
`node ci/smoke.mjs` ✅ · `node ci/logic-test.mjs` (177/177) ✅ · `node ci/gen-rule-usage.mjs --check` ✅ · `node ci/check-window-catalog.mjs` (28 popups) ✅ · cache-bust token bumped to `20260623a`.

Part of #220. The remaining epic items — (b) Jac verifies ONE real card end-to-end and (c) confirming the #172 charge path actually posts to Stripe — are live-card / live-Stripe / gitignored-backend verifications only Jac can perform, so #220 stays open + routed to Jac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)