### PR TITLE
Wrangler fix: graceful "Coming soon" for unwired KPI placeholders

### DIFF
--- a/app.js
+++ b/app.js
@@ -7393,7 +7393,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     const lines = role.kpis.map((k, i) => {
       const raw = vals[i];
       const b = bandColor(raw == null ? 0 : raw);
-      const valTxt = raw == null ? '<span class="muted">— backend</span>' : `<span style="color:var(--${b.color})">${raw}%</span>`;
+      const valTxt = raw == null ? '<span class="muted">Coming soon</span>' : `<span style="color:var(--${b.color})">${raw}%</span>`;
       return `<div class="kpi-line" data-tip="${esc(KPI_HELP[k] || '')}"><span class="ring-no" style="border-color:var(--${raw == null ? 'line' : b.color});color:var(--${raw == null ? 'txt-3' : b.color})">${i + 1}</span><span class="k-name">${esc(k)}<span class="muted" style="font-size:10px;margin-left:6px">${ringTag[i]}</span></span><span class="k-val">${valTxt}</span></div>`;
     }).join('');
     const pop = el('div', 'popup kpi-popup');

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260622j" />
+  <link rel="stylesheet" href="style.css?v=20260623a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260622j"></script>
-  <script type="module" src="app.js?v=20260622j"></script>
+  <script src="rule-usage.js?v=20260623a"></script>
+  <script type="module" src="app.js?v=20260623a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Verdict: report **proven correct** (#225, `wrangler-request`)

The Driver **Driving Score** and Office **Reputation** KPIs render the literal string **`— backend`** to end users.

### Root cause
- `kpiFor()` returns `null` for these two metrics by design — their data sources aren't wired: Driving Score = GPS telematics backend (`app.js:5578`), Reputation = email-reviews backend (`app.js:5585`).
- The role scorecard popup renders that `null` as `<span class="muted">— backend</span>` (`app.js:7396`) — developer shorthand that reads as broken and leaks an internal implementation detail.

### Fix (report's option b — the minimal one)
Option (a), wiring real GPS/email providers, is out of scope (no provider, credentials, or contract). Swapped the user-facing string to a muted **"Coming soon"**, matching the existing empty-state idiom and the `KPI_HELP` tooltips that already frame both as placeholders awaiting their backend (`app.js:5612`, `5615`).

Pure copy change inside an existing span — no `data-r` stamp or popup added/removed, so the R-rulebook and `WINDOW_CATALOG` are unchanged. Cache-bust token bumped `20260622j → 20260623a`.

### Gates
- ✅ `node ci/smoke.mjs`
- ✅ `node ci/logic-test.mjs` (177/177)
- ✅ `node ci/gen-rule-usage.mjs --check`
- ✅ `node ci/check-window-catalog.mjs` (28 popups)

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)