### PR TITLE
Wrangler fix: dismiss floating tooltip on popup switch

### DIFF
--- a/app.js
+++ b/app.js
@@ -7119,6 +7119,7 @@ function syncBackGuard() {
 }
 
 function renderOverlay() {
+  hideTip();   // a tooltip floats on <body>, OUTSIDE #overlay-root — tearing down/switching a popup destroys its source element with no mouseout, so dismiss it here too (mirrors render())
   syncBackGuard();
   const root = $('#overlay-root');
   if (_ovLastKind) { const _pb = root.querySelector('.set-pane') || root.querySelector('.popup-body'); if (_pb) _ovScroll[_ovLastKind] = _pb.scrollTop; }   // .set-pane is the settings scroller; .popup-body for the rest


### PR DESCRIPTION
## Report
In-app Mr. Wrangler issue #226 — hovering a metric in one role's KPI scorecard popup leaves the tooltip visible when switching to another role's scorecard (all roles affected).

## Root cause (cited)
- Clicking a role ring (`.js-ring`, app.js:9926) calls `openOverlay({kind:'role', ...})`.
- `openOverlay` (app.js:7889) calls **only** `renderOverlay()`, never `render()`.
- `renderOverlay()` (app.js:7121) wipes/rebuilds `#overlay-root`, destroying the hovered `.kpi-line` with no `mouseout` firing.
- The tooltip element `tipEl` lives on `document.body`, **outside** `#overlay-root` (app.js:9263). Its `.show` class is cleared by a `mouseout` on the source element or by `hideTip()` — which `render()` calls (app.js:9170) but `renderOverlay()` did not.

Result: the floating tooltip stays `.show` over the freshly-built popup. Exactly the reporter's suspected cause (tooltip positioned outside the popup subtree; dismissal only fires on mouseout from the current popup).

## Fix
Add `hideTip()` to the top of `renderOverlay()`, mirroring `render()`. Minimal, one line, matches the established pattern.

## Gates
All green: `node ci/smoke.mjs`, `node ci/logic-test.mjs` (177/177), `node ci/gen-rule-usage.mjs --check` (current), `node ci/check-window-catalog.mjs` (28/28). No rule-usage or popup-kind changes.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)