### PR TITLE
Wrangler fix: guard category ROI on a real acquisition cost basis

### DIFF
--- a/app.js
+++ b/app.js
@@ -1439,7 +1439,11 @@ function categoryStats(cat) {
   // derive from purchaseDate; units missing it default to ~1 year (annualize factor ≈ 1).
   const daysOwned = us.map((u) => u.purchaseDate ? Math.max(1, dayDiff(parseISO(u.purchaseDate), TODAY)) : 365);
   const avgDaysOwned = daysOwned.length ? daysOwned.reduce((a, b) => a + b, 0) / daysOwned.length : 365;
-  const lifetimeRoi = denom ? ((totalRev + (cat.bottomDollar || 0) * us.length) - denom) / denom : null;
+  // ROI needs a real ACQUISITION cost basis — repair cost alone is not an investment.
+  // Without a purchase cost (units with no trueCost/purchasePrice), revenue ÷ repair-only
+  // explodes to absurd %. Gate on `trueCost` (matches the §12.4 unit-level `invested ?`
+  // guard) so a category with no acquisition cost reads '—', not a fake 900,000%.
+  const lifetimeRoi = trueCost ? ((totalRev + (cat.bottomDollar || 0) * us.length) - denom) / denom : null;
   const roi = lifetimeRoi != null ? Math.round(lifetimeRoi * (365 / avgDaysOwned) * 100) : null;
   return {
     count: us.length,

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623c" />
+  <link rel="stylesheet" href="style.css?v=20260623d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623c"></script>
-  <script type="module" src="app.js?v=20260623c"></script>
+  <script src="rule-usage.js?v=20260623d"></script>
+  <script type="module" src="app.js?v=20260623d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Root cause

Category-card ROI read **897,918% / 696,254% / 42,906%** etc. (footer 195,920.3% avg) for imported units.

`categoryStats` (app.js §12.3) computed:
```js
const denom = trueCost + totalRepair;
const lifetimeRoi = denom ? (... - denom) / denom : null;
```
When a unit has **no acquisition cost** (`trueCost`/`purchasePrice` = 0) but a small repair cost, `denom` is small-but-nonzero, so revenue ÷ repair-cost-only **explodes**. Repair cost alone is not an investment basis.

The known-good sibling — unit-level ROI (app.js:4324-4326) — already guards correctly on the acquisition basis: `const roi = invested ? … : null`. The category calc was inconsistent.

## Fix

One-line guard change: gate category ROI on `trueCost` (acquisition basis) instead of `denom`. Categories with no purchase cost now render `'—'` (honest "unknown") instead of a fake astronomical %. The ROI **formula/definition is unchanged** when a real basis exists.

Bracket (standalone repro of the exact formula):
- imported category (trueCost 0, repair \$100, rev \$50k): **49,900% → null ('—')**
- real category (trueCost \$180k): **50% → 50% (unchanged)**

## Report premises corrected

The report's `purchaseDate=today → avgDaysOwned=1 → ×365` theory was **wrong**:
- No path stamps a unit's `purchaseDate`. The dev import (`import-real-data.ps1`) and in-app `quickAddUnitFromSearch` both leave it **undefined**; `categoryStats` defaults missing `purchaseDate` to **365 days** → annualize factor = 1.
- **Mr. Wrangler cannot import/create units** — `WR_EDITABLE.units` is `create:false`, not `importable`, and its field allowlist excludes purchase fields (app.js:8235); `applyWranglerData` creates customers only (app.js:8352). So no Wrangler import stamps unit purchase data.

The remaining DATA work (entering real purchase costs/dates) is Jac's to do via the editable Investment fields — this fix makes the display honest in the meantime, it does **not** fabricate acquisition data.

## ⚠️ Money-touching

Touches financial display logic, so flagging per the Don't list. The change only makes ROI **more conservative** (null instead of a fake number) — no dollar figure, pricing floor, margin-visibility, or auth gate is altered or weakened.

Gates: `smoke` ✓ · `logic-test` 177/177 ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓ (no rule/markup change). Cache-bust `?v=` bumped to 20260623.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)