### PR TITLE
Wrangler fix: sweep abandoned empty Quotes on click-away

### DIFF
--- a/app.js
+++ b/app.js
@@ -1684,7 +1684,7 @@ function cardRecordAt(target) {
 // the prior view so the Back chevron can return to it.
 function cardToList(card) {
   const cs = activeSession().cards[card]; if (!cs) return;   // 'calendar' has no card state → no-op
-  if (cs.mode === 'standard' && cs.recId != null) { pushCardHistory(cs); cs.mode = 'list'; cs.recId = null; cs.recType = null; render(); return; }
+  if (cs.mode === 'standard' && cs.recId != null) { pushCardHistory(cs); cs.mode = 'list'; cs.recId = null; cs.recType = null; sweepEmptyDrafts(); render(); return; }   // #8 — click-away from a record drops any abandoned empty draft
   cs.mode = 'list'; render();
 }
 // Double right-click = drop the session's anchor entirely (anchor-less = no cascade).
@@ -1693,6 +1693,7 @@ function clearAnchor() {
   if (!s.anchor) return;
   s.anchor = null; s.cascade = null;
   for (const c of GRID_CARDS) { const cs = s.cards[c.id]; cs.mode = 'list'; cs.recId = null; cs.recType = null; cs.backStack = []; cs.fwdStack = []; }
+  sweepEmptyDrafts();   // #8 — dropping the anchor leaves every record → sweep any abandoned empty draft
   render();
 }
 /* ── Per-card view history (Phase 1, Task 1) ───────────────────────────────────
@@ -1723,6 +1724,7 @@ function cardBack(card) {
     if (cs.mode === 'standard' && cs.recId != null) {
       cs.fwdStack.push(cardSnap(cs));
       cs.mode = 'list'; cs.recId = null; cs.recType = null; cs.graphView = false;
+      sweepEmptyDrafts();   // #8 — stepping back off a record sweeps any abandoned empty draft
       render();
     }
     return;
@@ -1730,6 +1732,7 @@ function cardBack(card) {
   cs.fwdStack.push(cardSnap(cs));
   applySnap(cs, cs.backStack.pop());
   if (cs.mode === 'standard' && cs.recId != null) ackComments(recOf(entityCardOf(card, cs.recType), cs.recId));
+  sweepEmptyDrafts(cs.recId);   // #8 — sweep the abandoned empty draft we stepped away from (keep the one we land on)
   render();
 }
 function cardFwd(card) {


### PR DESCRIPTION
## Verdict
The report is **correct** — clicking "+ New Rental" persists an empty Quote, and abandoning it leaves junk.

## Root cause
SPEC §7 #8 promises *"empty mock drafts self-delete on click-away"*, implemented by `sweepEmptyDrafts()` (app.js:1620). But that sweep was only called from the **open-another-record** paths (`setAnchor`, `openStandard`). The in-session **click-away** paths that leave a record for a list view never called it:

- `cardBack()` — the Back chevron
- `cardToList()` — the to-list header button
- `clearAnchor()` — drop-anchor (double right-click)

So a Quote created by "+ New Rental" and then abandoned via Back / to-list persisted forever — the 56+ empty Quotes the sweep observed.

The report's *alternative* suggestion (defer persistence until a unit is added) would contradict canon: in Wave 2 linking happens by **drag**, so the Quote must exist on click to be a drag target (app.js:12096, 12111). The canon already has the right mechanism (#8) — it just wasn't wired into every leave path.

## Fix
Call `sweepEmptyDrafts()` from those three click-away paths. Only truly-empty mock drafts (no unit, no customer, no date, no invoice) are swept; Quotes with any content still survive. Tab-close / session-switch are deliberately left alone (canon: *"Quotes persist across sessions"*).

## Proof (fail-before / pass-after)
A headless Playwright bracket: click "+ New Rental" → empty mock Quote created (+1); click the to-list / Back control → **before:** still +1 (persists); **after:** back to baseline (swept). Both paths PASS.

## Gates
`smoke` ✓ · `logic-test` 177/177 ✓ · `gen-rule-usage --check` ✓ (logic-only, no rule change) · `check-window-catalog` 28/28 ✓

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)