### PR TITLE
Wrangler fix: dedup chat threads created via drag-drop onto the chat pad

### DIFF
--- a/app.js
+++ b/app.js
@@ -6332,6 +6332,8 @@ function chatStartFromDrop(p) {
   let tag;
   if (p.chatEl) tag = { id: p.chatEl.id || ('TAG' + (state.seq++)), label: p.chatEl.label, color: p.chatEl.color || 'gray', ref: p.chatEl.ref || null };
   else { const ec = p.entity, rec = p.rec; const label = ROW_META[ec] ? ROW_META[ec](rec).title : (idOf(ec, rec) || 'Item'); const m = commentMarker(rec); tag = { id: 'TAG:' + ec + ':' + p.id, label, color: m ? m.color : 'gray', ref: { card: ec, recId: p.id } }; }
+  // Dedup like startChatFromEl: a record/element already has a chat → REOPEN it, never spin a duplicate thread.
+  if (tag.ref) { const existing = chatsTagging(tag.ref.card, tag.ref.recId)[0]; if (existing) return openChat(existing.id, `Reopened the chat on this ${SINGULAR[tag.ref.card] || 'record'}.`); }
   newChat(tag); state.chat.open = true; render();
   toast(`New chat started from “${tag.label}”.`);
 }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260622j" />
+  <link rel="stylesheet" href="style.css?v=20260623a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260622j"></script>
-  <script type="module" src="app.js?v=20260622j"></script>
+  <script src="rule-usage.js?v=20260623a"></script>
+  <script type="module" src="app.js?v=20260623a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Report
In-app Mr. Wrangler issue #234 — Armando Garcia had **3 identical "WHATS UP!" chat threads** in the Chat dock.

## Root cause (proven)
The §17 team-dock chat has two paths that create a chat tagged to a record:

- `startChatFromEl` (right-click → "Start chat", app.js:6306) **dedups**: `chatsTagging(ec, recId)[0]` → reopens the record's existing chat instead of duplicating. Its own comment states the intent: *"OPEN the element's existing chat (rejoin) if it has one, else start fresh."*
- `chatStartFromDrop` (drop a record on the bottom-right pad, app.js:6331) had **no such guard** — it always called `newChat(tag)`. Dropping the same record N times spawned N identical threads tagged to it.

That inconsistency is the duplicate-create bug the report suspected. The threads weren't seed data (no "WHATS UP!"/Armando in the repo) — they're live runtime chats made via repeated drops on the pad.

## Fix
One line in `chatStartFromDrop`: before `newChat(tag)`, if the dragged record/element already has a chat (`tag.ref` + `chatsTagging`), **reopen it via `openChat`** instead of spinning a duplicate — mirroring `startChatFromEl` exactly. Minimal, matches the surrounding idiom, no UI/rule-stamp changes.

The 2 pre-existing duplicate threads on Armando are live data (never deleted by design — §17 chats are persistent); this stops new dupes. The old ones can be tidied in the backend if desired.

## Gates
All 4 pass: `node ci/smoke.mjs` · `node ci/logic-test.mjs` (177/177) · `node ci/gen-rule-usage.mjs --check` · `node ci/check-window-catalog.mjs`. Cache-bust token bumped `20260622j → 20260623a`.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)