### PR TITLE
Wrangler fix: defer persistence of empty Quote drafts (#227)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1614,20 +1614,32 @@ function closeAll() { state.tabs = []; state.activeTabId = null; state.searchMod
    (slot buttons, window trigger) — the §18b sync persists mock records as-is. */
 
 /** Click a row → standard mode in that card (push back-stack). §0.2 */
+// #227 (Jac 2026-06-23) — a bare "+New Rental/Invoice" click used to mint a mock draft
+// AND write it straight to the Sheet (reindex/logAction → saveSoon), so an abandoned
+// empty Quote left junk behind (no nav = no #8 sweep, but the 1.2s save already fired).
+// This predicate is the single source of truth for "content-free throwaway draft": such
+// records self-destruct on navigation (#8 sweep below) AND are held out of the §18b sync
+// (computeChanges) so they never reach the backend until they earn real content.
+function isEmptyMockDraft(card, rec) {
+  if (!rec || !rec.mock) return false;
+  if (card === 'invoices') return !(rec.lineItems || []).length && !(Number(rec.amountPaid) || 0);
+  if (card === 'rentals')  return !(rentalUnits(rec) || []).length && !rec.customerId && !rec.startDate && !rec.invoiceId;
+  return false;
+}
 // #8 — an abandoned empty draft self-destructs the moment you leave it: a mock invoice
 // with no line items, or a mock rental still totally blank. keepId = the record you're
 // navigating TO (never swept). Called from every record-open + anchor. Jac 2026-06-13.
 function sweepEmptyDrafts(keepId) {
   for (let i = DATA.invoices.length - 1; i >= 0; i--) {
     const inv = DATA.invoices[i];
-    if (inv.mock && inv.invoiceId !== keepId && !(inv.lineItems || []).length && !(Number(inv.amountPaid) || 0)) {
+    if (inv.invoiceId !== keepId && isEmptyMockDraft('invoices', inv)) {
       (inv.rentalIds || []).forEach((rid) => { const r = IDX.rental.get(rid); if (r && r.invoiceId === inv.invoiceId) r.invoiceId = ''; });
       IDX.invoice.delete(inv.invoiceId); DATA.invoices.splice(i, 1);
     }
   }
   for (let i = DATA.rentals.length - 1; i >= 0; i--) {
     const r = DATA.rentals[i];
-    if (r.mock && r.rentalId !== keepId && !(rentalUnits(r) || []).length && !r.customerId && !r.startDate && !r.invoiceId) {
+    if (r.rentalId !== keepId && isEmptyMockDraft('rentals', r)) {
       IDX.rental.delete(r.rentalId); DATA.rentals.splice(i, 1);
     }
   }
@@ -12923,7 +12935,7 @@ function computeChanges() {
   PERSIST_KEYS.forEach((k) => {
     const idf = PERSIST_ID[k]; const prev = (lastSaved && lastSaved[k]) || new Map(); const seen = new Set();
     const ups = [];
-    (DATA[k] || []).forEach((r) => { const id = String(r[idf]); seen.add(id); const js = JSON.stringify(r); if (prev.get(id) !== js) ups.push({ id, js, rec: r }); });
+    (DATA[k] || []).forEach((r) => { const id = String(r[idf]); seen.add(id); if (isEmptyMockDraft(k, r)) return; const js = JSON.stringify(r); if (prev.get(id) !== js) ups.push({ id, js, rec: r }); });   // #227 — a content-free mock draft is held out of the sync until it earns content
     const dels = []; prev.forEach((_, id) => { if (!seen.has(id)) dels.push(id); });
     if (ups.length) { upserts[k] = ups; n += ups.length; }
     if (dels.length) { deletes[k] = dels; n += dels.length; }

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -265,6 +265,20 @@ try {
     ok(wrDiff.upserts.units && wrDiff.upserts.units.some((u) => u.id === 'U003'), 'the applied unit note is queued for persistence too');
     T.DATA.customers.length = custBefore; u3.notes = noteBefore;   // restore
 
+    // #227 — a bare "+New Rental" click must NOT leave an empty Quote in the Sheet. The
+    // mock draft is held out of the §18b sync until it earns real content (a unit, a
+    // customer, a window) — so abandoning it leaves zero backend junk — yet a Quote WITH
+    // content still persists and survives (Wave 2). Baseline first so the draft is "new".
+    window.JT.snapshotSaved();
+    const q227 = { rentalId: 'R-NEW227x', customerId: null, unitId: null, categoryId: null, rentalName: 'New Quote', startDate: '', endDate: '', startTime: '', status: 'Quote', transportType: 'Self', deliveryAddress: '', po: '', invoiceId: null, startHours: null, returnHours: null, notes: '', mock: true };
+    T.DATA.rentals.push(q227); T.IDX.rental.set(q227.rentalId, q227);
+    const d227a = window.JT.computeChanges();
+    ok(!(d227a.upserts.rentals || []).some((u) => u.id === 'R-NEW227x'), '#227: a content-free mock Quote is held OUT of the sync (a bare +New click leaves no backend junk)');
+    q227.customerId = 'C0009';   // now it has real content → it must persist (Quotes survive)
+    const d227b = window.JT.computeChanges();
+    ok((d227b.upserts.rentals || []).some((u) => u.id === 'R-NEW227x'), '#227: once the Quote earns content (a customer) it DOES sync — content-bearing Quotes survive');
+    const qi227 = T.DATA.rentals.findIndex((r) => r.rentalId === 'R-NEW227x'); if (qi227 >= 0) T.DATA.rentals.splice(qi227, 1); T.IDX.rental.delete('R-NEW227x'); window.JT.snapshotSaved();   // restore baseline
+
     // #152 a big import reply can be TRUNCATED by the model's output limit (no closing ```);
     // parseWranglerAction must salvage the complete rows so the preview still opens.
     const wrTrunc = '```wrangler-action\n{"action":"data","title":"Import leads","ops":[{"op":"import","entity":"customers","rows":[\n{"firstName":"Aaa","lastName":"One","phone":"337-555-0101"},\n{"firstName":"Bbb","lastName":"Two","email":"b@x.com"},\n{"firstName":"Ccc","lastName":"Tr';   // cut off mid-row, no closing fence


### PR DESCRIPTION
## Verdict: report is **correct**

Clicking **+ New Rental** minted a `mock:true` Quote and persisted it immediately. `startNewRental` (app.js) calls `reindex()` (→`saveSoon()`) and `logAction(draft,'Quote created')` (→`saveSoon()`), so the 1.2 s `flushSave` debounce upserted an **empty** draft — no unit, customer, or window — to the Sheet. The `#8` `sweepEmptyDrafts` self-destruct only runs on *navigation* (`setAnchor`/`openStandard`), so abandoning via tab-close / sign-out / browser-close left a live empty Quote behind. Root of the "56+ Quote" clutter (finding G10).

## Root cause
Persistence is triggered on the create **click**, not deferred to a meaningful draft state — exactly as the report claims.

## Fix (minimal, canon-faithful)
- New shared predicate `isEmptyMockDraft(card, rec)` — the same emptiness test `sweepEmptyDrafts` already used, now the single source of truth so the sweep and the sync can't drift.
- `computeChanges` (§18b sync) holds content-free mock drafts **out of the upsert** until they earn a unit / customer / window / invoice. The draft still lives in memory and still self-destructs on navigation (`#8`).
- Honors **Wave 2 "Quotes survive"**: a Quote *with* content persists and survives tab-close exactly as before. No new sweep added. No change to the "no hard delete" flow (that's intended — Quotes live until Completed/Cancelled).

Bonus: a bare +New click no longer trips the `beforeunload` "unsaved changes" prompt.

## Proof
Bracket test added to `ci/logic-test.mjs`: **fails before** the fix (the empty draft is upserted), **passes after**. A second assertion confirms a Quote that earns a customer still syncs.

```
✗ FAIL: #227: a content-free mock Quote is held OUT of the sync   ← before fix
  ✓     #227: a content-free mock Quote is held OUT of the sync   ← after fix
  ✓     #227: once the Quote earns content it DOES sync — Quotes survive
✅ Logic suite: 179/179 checks passed.
```

All gates green: `smoke` · `logic-test` (179/179) · `gen-rule-usage --check` · `check-window-catalog`. No UI/rule change — R-rulebook + window catalog untouched.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)