### PR TITLE
Wrangler fix: offload base64 photos + hold oversized records before sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -13136,12 +13136,47 @@ async function loadWranglerRail() {
   } catch (e) { /* offline → the refresh poll retries */ }
 }
 function saveSoon() { if (booting || !backendPassword) return; clearTimeout(saveTimer); saveTimer = setTimeout(flushSave, 1200); }
+// A Google Sheets cell is hard-capped at 50,000 chars; the backend writes each
+// record's full JSON into one cell, so an oversized record makes the write throw
+// and — with the all-or-nothing commit below — jams the WHOLE sync (#251). The
+// realistic bloat source is an inline base64 photo (~100KB–2MB) still riding an
+// inspection / WO-part record. Offload it to Drive BEFORE the JSON rides the
+// sync, the same treatment chat images already get (pushWranglerRail → 6212).
+async function offloadDirtyPhotos(upserts) {
+  if (!backendPassword) return;                 // demo/offline → can't offload; the size-guard below backstops
+  const jobs = [];
+  (upserts.inspections || []).forEach((u) => { const n = u.rec; if ((n.photo || '').startsWith('data:')) jobs.push(offloadPhotoNow(n, 'photo', 'insp_' + n.inspectionId, n, 'inspections')); });
+  (upserts.workOrders || []).forEach((u) => { const w = u.rec; (w.lineItems || []).forEach((li) => { if ((li.photo || '').startsWith('data:')) jobs.push(offloadPhotoNow(li, 'photo', 'wopart_' + w.woId + '_' + lineKey(li), w, 'workOrders')); }); });
+  if (jobs.length) { try { await Promise.all(jobs); } catch (e) {} }   // a failed offload leaves base64 → held back below, never poisons the batch
+}
+// Client-side fault isolation (#251): if a record is STILL over the cell cap after
+// offload (Drive upload failed, or non-photo bloat), hold it OUT of the batch so it
+// can't abort the sync for every other record. It stays dirty → retries; loud once.
+let _oversizeHeld = new Set();
+function holdOversized(upserts) {
+  const stillHeld = new Set();
+  Object.keys(upserts).forEach((k) => {
+    const keep = [];
+    upserts[k].forEach((u) => {
+      if (u.js.length > 49000) {
+        const tag = k + ':' + u.id; stillHeld.add(tag);
+        if (!_oversizeHeld.has(tag)) toast('⚠ A record is too large to sync (photo over the 50k cell limit) — held back so the rest save. Re-capture with a smaller photo, or reconnect to offload it to Drive.');
+      } else keep.push(u);
+    });
+    if (keep.length) upserts[k] = keep; else delete upserts[k];
+  });
+  _oversizeHeld = stillHeld;
+}
 async function flushSave() {
   if (saving) { savePending = true; return; }
   if (!lastSaved) return;                       // never loaded → nothing to diff against
-  const { upserts, deletes, n } = computeChanges();
+  let { upserts, deletes, n } = computeChanges();
   if (!n) return;                               // nothing changed
   saving = true;
+  await offloadDirtyPhotos(upserts);            // base64 photos → Drive before they can ride into a 50k cell (#251)
+  ({ upserts, deletes } = computeChanges());    // re-diff: offloaded records shrank to a ~60-byte URL
+  holdOversized(upserts);                        // keep any still-oversized record out of the batch (fault isolation)
+  if (!Object.keys(upserts).length && !Object.keys(deletes).length) { saving = false; if (savePending) { savePending = false; saveSoon(); } return; }
   const wireUp = {}; Object.keys(upserts).forEach((k) => { wireUp[k] = upserts[k].map((u) => u.rec); });
   try {
     const r = await backendCall('sync', { upserts: wireUp, deletes });

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623d" />
+  <link rel="stylesheet" href="style.css?v=20260623e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623d"></script>
-  <script type="module" src="app.js?v=20260623d"></script>
+  <script src="rule-usage.js?v=20260623e"></script>
+  <script type="module" src="app.js?v=20260623e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Verdict: report **correct** — frontend root cause fixed here; backend half flagged for Jac

**The poison-loop is real** (`app.js` `flushSave`): the dirty diff is sent in one `sync` call and committed **all-or-nothing** (`lastSaved` advances only `if (r && r.ok)`). A record over Google Sheets' 50,000-char cell cap makes the backend write throw, so **no** record commits and `computeChanges` re-derives the identical batch every flush → permanent no-advance retry (the reporter's 30/30 server-error). Root cause of the oversized record: an inline base64 photo (~100KB–2MB) still on `inspections[].photo` / `workOrders[].lineItems[].photo` — the offload (`offloadPhotoNow`) was fire-and-forget at capture time and **raced** the sync.

**Known-good sibling proves the fix:** chat/rail sync already **awaits** `wrOffloadChatImages` *before* the JSON rides the push (`pushWranglerRail`). `flushSave` was the one path missing that offload-before-sync.

## What changed (frontend only, no contract change, no money/auth touch)
1. **`offloadDirtyPhotos`** — `flushSave` now **awaits** offloading any base64 photo on a dirty record to Drive *before* the sync, so a record never carries a `data:` URL into a 50k cell. Mirrors the chat sibling.
2. **`holdOversized`** — client-side fault isolation: any record still >49k after offload (Drive upload failed / non-photo bloat) is held **out** of the batch so it can't abort the sync for every other record. It stays dirty + retries, with a loud once-per-record toast.

## Deliberately NOT in this PR
Fixes #1–#3, #5 from the report live in **`Code.gs`** (size guard + per-record fault isolation in `doSync`/`writeRecord_`/`doSeed`/`setChats_`, `rejected[]` response). That file is **gitignored / not in this checkout** (ships via the gated `/clasp` deploy), and `writeRecord_` is shared by `recordCharge_`/`recordManualPayment_`/`recordManualRefund_` — **money paths**. A server-side size-guard that silently rejects an oversized *charge* could drop a payment, and `rejected[]` is a GAS↔frontend contract change. Per CLAUDE.md that's "never weaken money logic" + cross-system + a gated deploy → flagged for Jac, not shipped unprompted.

## Gates (all green; port 9147 per CLAUDE.md, `ci/` reverted)
- `node ci/smoke.mjs` ✓
- `node ci/logic-test.mjs` ✓ 179/179
- `node ci/gen-rule-usage.mjs --check` ✓ (no stamped UI changed)
- `node ci/check-window-catalog.mjs` ✓

Cache-bust token bumped `20260623d → 20260623e`.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)