### PR TITLE
Wrangler fix: custom invoice line no longer kicks you off the invoice

### DIFF
--- a/app.js
+++ b/app.js
@@ -12663,7 +12663,9 @@ function addCustomLine(invoiceId, label, amount) {
   inv.lineItems.push({ kind: 'custom', ref: null, lid: lineLid(), label: label || 'Custom', amount });
   logAction(inv, `Added line: ${label || 'Custom'} (${money(amount)})`);
   toast(`Custom line added (${money(amount)}).`);
-  const session = activeSession(); if (session.anchor) setAnchor(session, session.anchor.card, session.anchor.recId, session.anchor.recType);
+  // plain render() — a custom line (kind 'custom', ref null) adds no cascade edge, so it
+  // must NOT re-anchor; setAnchor() here collapsed the open invoice back to the list (it
+  // reset every non-anchored card's recId), kicking you off the invoice. Matches addPartToWO.
   render();
 }
 /* Add a part / labor line to a work order; advances the WO phase sensibly. */

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623i" />
+  <link rel="stylesheet" href="style.css?v=20260623j" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623i"></script>
-  <script type="module" src="app.js?v=20260623i"></script>
+  <script src="rule-usage.js?v=20260623j"></script>
+  <script type="module" src="app.js?v=20260623j"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Reported
Jac, in-session on the live app: "When I add a custom line item it kicks me off the invoice and I have to go find it again."

## Root cause (proven)
`addCustomLine` (`app.js:12666`) called `setAnchor(session, session.anchor.card, …)` after pushing the new line. A custom line (`kind:'custom'`, `ref:null`) adds **no** edge to the cascade graph, but `setAnchor` rebuilds the cascade and resets every **non-anchored** card's `recId` to `null`. Whenever the session was anchored on another card (typically `rentals`), the open **invoice** card lost its record and collapsed back to the list — "kicking you off."

The sibling `addPartToWO` (`app.js:12683`) already documents the correct pattern: a cascade-neutral line addition uses a plain `render()`, never a re-anchor. `addCustomLine` now matches it.

## Fix
Drop the gratuitous `setAnchor` call; keep `render()`. One-line behavior change, no money/total logic touched (line push, `logAction`, `toast`, and totals recompute are unchanged).

## Gates (local, port-swapped to 9147)
- `ci/smoke.mjs` ✅ boots clean
- `ci/logic-test.mjs` ✅ **179/179** (money regression intact)
- `ci/gen-rule-usage.mjs --check` ✅ current (no rule-usage change)
- `ci/check-window-catalog.mjs` ✅ 28 popups covered

Cache token bumped to `?v=20260623j`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7ygbx4e2Sc9zs1CZbPUoS)_