### PR TITLE
Wrangler fix: picker outside-click guard only dismisses on dead space (#263)

### DIFF
--- a/app.js
+++ b/app.js
@@ -9888,20 +9888,21 @@ function onClick(e) {
   // trigger. (Drags never reach here — their trailing click is swallowed at 4925.)
   // §5.4d — the date-search picker closes on a click outside the calendar, the search
   // bars, and the date chips (so editing a chip keeps it open).
-  if (state.datesearch && !closest('.winpicker') && !closest('.searchwrap') && !closest('.mini-searchwrap') && !closest('.js-date-edit')) {
-    state.datesearch = null; render(); return;
-  }
-  if (state.winpicker
-      && !closest('.winpicker')
-      && !closest('.js-open-winpicker')
-      && !closest('.card[data-card="units"]')
-      && !closest('.card[data-card="categories"]')
-      && !closest('.card[data-card="customers"]')) {
+  // #263 — a non-modal picker (date-search or rental-window) dismisses ONLY on a click in
+  // genuine DEAD SPACE: not a card, the header, the bottom bar, or the picker itself. The
+  // old guards nulled the picker AND `return`ed on ANY click outside a narrow allow-list,
+  // so clicking a pill / row / button / link both vanished the picker AND swallowed that
+  // click (its own handler never ran). Mirror the §5.4 dead-space test (the `clearSearch`
+  // line below) so an interactive click keeps the picker's context and still fires — the
+  // picker stays open until true dead space. (Both floats render from state and re-render,
+  // and self-hide if their anchor scrolls off; the global search bar lives in `.header` and
+  // the per-card search/date chips live in `.card`, so the old datesearch exclusions hold.)
+  if (state.datesearch || state.winpicker) {
+    const pickerDeadSpace = !closest('.card') && !closest('.header') && !closest('.bottombar') && !closest('.winpicker');
+    if (state.datesearch && pickerDeadSpace) { state.datesearch = null; render(); return; }
     // Must always render or the float lingers as a dead, frozen overlay (state closed,
     // DOM open). Discards a fragile rental's staged change. Jac 2026-06-13.
-    state.winpicker = null;
-    render();
-    return;
+    if (state.winpicker && pickerDeadSpace) { state.winpicker = null; render(); return; }
   }
 
   // header / chrome

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623i" />
+  <link rel="stylesheet" href="style.css?v=20260623j" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623i"></script>
-  <script type="module" src="app.js?v=20260623i"></script>
+  <script src="rule-usage.js?v=20260623j"></script>
+  <script type="module" src="app.js?v=20260623j"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What broke (#263)

With the rental-window picker (or the date-search picker) open, clicking almost anything — a status pill, a row, a link, a button, the header, the bottom bar, another card — **closed the picker AND swallowed the click** (its own action never fired). Reads as "I clicked an option, the window vanished, and nothing happened."

## Root cause — `app.js:9891-9905`

Both outside-click dismiss guards nulled the picker and `return`ed on **any** click outside a narrow allow-list:

- the **winpicker** guard spared only `.winpicker`, `.js-open-winpicker`, and the units/categories/customers cards;
- the **datesearch** twin spared even less.

Every other left-click fell through to `state.X = null; render(); return;` — dropping the picker context **and** returning before the click's own handler could run.

## Fix (minimal, one pass for both guards)

Dismiss **only** on genuine dead space, mirroring the §5.4 dead-space test already used for `clearSearch`:

```js
const pickerDeadSpace = !closest('.card') && !closest('.header') && !closest('.bottombar') && !closest('.winpicker');
```

and **never `return` on an interactive click** — it falls through so its own handler still fires while the picker stays open. The floats render from state and self-hide if their anchor scrolls off (`positionWinPicker`/`positionDateSearch`). The old datesearch exclusions still hold: the global search bar lives in `.header`, per-card search bars and date chips live in `.card`.

## Verification

Drove the **real** document `onClick` in a headless `#local` browser run — **failed-before / passes-after**:
- pre-fix: a header click dismissed the winpicker; a datesearch row click was swallowed (`.selected` never applied)
- post-fix: picker stays open on interactive clicks (row gets `.selected` → click acted), dismisses only on true dead space, clicking inside the picker keeps it open

Gates: `node ci/smoke.mjs` ✅ · `node ci/logic-test.mjs` (179/179) ✅ · `node ci/gen-rule-usage.mjs --check` ✅ (no stamp/DOM change) · `node ci/check-window-catalog.mjs` ✅. Cache-bust token bumped to `20260623j`.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)