### PR TITLE
Wrangler fix: invoice-display pass — payment history on print + honest pay-panel charge label

### DIFF
--- a/app.js
+++ b/app.js
@@ -12117,7 +12117,17 @@ function printInvoice(invoiceId) {
         <div><span>Subtotal</span><span>${money2(t.subtotal)}</span></div>
         <div><span>Tax${t.exempt ? ' (exempt)' : ` (${(TAX_RATE * 100).toFixed(2)}%)`}</span><span>${t.exempt ? '—' : money2(t.tax)}</span></div>
         <div class="pr-big"><span>Total</span><span>${money2(t.total)}</span></div>
-        <div><span>Paid${inv.paymentMethod ? ' · ' + esc(inv.paymentMethod) : ''}</span><span>${money2(t.paid)}</span></div>
+        ${(inv.payments || []).length
+          ? (inv.payments || []).map((p) => {
+              const when = p.at ? esc(fmtShortDate(p.at)) : '';
+              const method = p.type === 'cash' ? 'Cash'
+                : p.type === 'check' ? ('Check' + (p.checkNum ? ' #' + esc(String(p.checkNum)) : ''))
+                : p.type === 'ach-pending' ? 'ACH (pending)'
+                : p.type === 'charge' ? 'Card'
+                : esc(String(p.type || 'Payment'));
+              return `<div><span>Paid${when ? ' · ' + when : ''} · ${method}</span><span>${money2((Number(p.amountCents) || 0) / 100)}</span></div>`;
+            }).join('')
+          : (t.paid ? `<div><span>Paid${inv.paymentMethod ? ' · ' + esc(inv.paymentMethod) : ''}</span><span>${money2(t.paid)}</span></div>` : '')}
         <div class="pr-due"><span>Balance due</span><span>${money2(t.balance)}</span></div>
       </div>
       <div class="pr-foot">Thank you for your business — much obliged. Questions on this ticket? Give the yard a holler.</div>

--- a/app.js
+++ b/app.js
@@ -11767,7 +11767,12 @@ function setupPayAlloc() {
     const charge = body.querySelector('.js-alloc-charge');
     const btn = body.querySelector('.js-charge-invoice');
     if (counter) counter.innerHTML = after <= 0.005 ? `<b style="color:var(--good,#1a9f57)">Pays in full ✓</b>` : `Balance after <b>${money2(after)}</b>`;
-    if (charge) charge.innerHTML = pre > 0 ? `${money2(pre)}${tax ? ` + ${money2(tax)} tax` : ''} = <b>${money2(gross)}</b>` : '<span class="muted">nothing assigned</span>';
+    if (charge) {
+      if (pre <= 0) charge.innerHTML = '<span class="muted">nothing assigned</span>';
+      else { const lineGross = pre + tax;   // honest line total; gross caps at the remaining balance when a prior payment already covered part
+        const eq = `${money2(pre)}${tax ? ` + ${money2(tax)} tax` : ''} = <b>${money2(lineGross)}</b>`;
+        charge.innerHTML = lineGross > bal + 0.005 ? `${eq} · charge <b>${money2(gross)}</b> (balance)` : eq; }
+    }
     if (btn) { btn.disabled = !(gross > 0) || !!o.busy; if (!o.busy) btn.textContent = gross > 0 ? `Charge ${money2(gross)}` : 'Charge'; }
   };
   ins.forEach((inp) => inp.addEventListener('input', recompute));

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623j" />
+  <link rel="stylesheet" href="style.css?v=20260623k" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623j"></script>
-  <script type="module" src="app.js?v=20260623j"></script>
+  <script src="rule-usage.js?v=20260623k"></script>
+  <script type="module" src="app.js?v=20260623k"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Two invoice-display fixes from Jac's QA pass (both display-only — no money/total logic touched).

## #6 — Payment history on printed invoice
**Reported:** "No payment history on Print invoice." A mixed cash+card invoice printed as a single `Paid · visa ••2261 $6.90` line.
**Root cause:** `printInvoice` (`app.js:12120`) rendered one line from `inv.paymentMethod` (last method only) + `t.paid` (total); never walked `inv.payments[]`.
**Fix:** iterate `inv.payments[]` into one row per payment (`Paid · {date} · {method} … {amount}`), labeled by type (Cash / Check #n / Card / ACH). Falls back to the old single line when there are no payment entries.

## #4 — Misleading pay-panel charge label
**Reported:** "$6.23 + $0.67 tax = $5.90" — math that doesn't add up.
**Root cause:** the allocation preview (`app.js:11770`) printed `{pre} + {tax} = {gross}`, but `gross` is capped at the remaining balance (line 11764), so on an invoice with a prior partial payment the right side ≠ the left.
**Fix:** the `=` now shows the true line total (`pre + tax`); when that exceeds the balance it appends `· charge $X (balance)` so the capped charge is explicit and honest.

## Gates (local, port-swapped to 9147)
- `ci/smoke.mjs` ✅ · `ci/logic-test.mjs` ✅ **179/179** · `ci/gen-rule-usage.mjs --check` ✅ · `ci/check-window-catalog.mjs` ✅

Cache token bumped to `?v=20260623k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)