### PR TITLE
Wrangler fix: winpicker/datesearch dismiss no longer swallows the click (#263)

### DIFF
--- a/app.js
+++ b/app.js
@@ -9882,21 +9882,17 @@ function onClick(e) {
     if (r) { e.preventDefault(); e.stopPropagation(); return openInNewTab(r.card, r.recId, r.recType); }
   }
 
-  // Task C — the picker is NON-MODAL: it stays open while the operator works the
-  // Units / Categories / Customers cards (browse, toggle, open-to-inspect, drag-to-
-  // select). It closes only on a click truly OUTSIDE those cards, the picker, and the
-  // trigger. (Drags never reach here — their trailing click is swallowed at 4925.)
-  // §5.4d — the date-search picker closes on a click outside the calendar, the search
-  // bars, and the date chips (so editing a chip keeps it open).
-  if (state.datesearch && !closest('.winpicker') && !closest('.searchwrap') && !closest('.mini-searchwrap') && !closest('.js-date-edit')) {
-    state.datesearch = null; render(); return;
-  }
-  if (state.winpicker
-      && !closest('.winpicker')
-      && !closest('.js-open-winpicker')
-      && !closest('.card[data-card="units"]')
-      && !closest('.card[data-card="categories"]')
-      && !closest('.card[data-card="customers"]')) {
+  // Task C — the picker is NON-MODAL: it stays open while the operator works any
+  // card / the header / the bottom bar (browse, toggle, open-to-inspect, drag-to-
+  // select) AND every click still runs its OWN action. It dismisses ONLY on a click
+  // landing on genuine DEAD SPACE — never on an interactive target — so a click is
+  // never swallowed (the old allow-list `return`ed on pills/rows/buttons, nulling the
+  // picker AND eating the click; #263). This mirrors the §5.4 search-mode dismiss
+  // below: an interactive target never enters the block, so it falls through to its
+  // own handler. (Drags never reach here — their trailing click is swallowed at 4925.)
+  const winDeadSpace = !closest('.card') && !closest('.header') && !closest('.winpicker') && !closest('.bottombar');
+  if (state.datesearch && winDeadSpace) { state.datesearch = null; render(); return; }
+  if (state.winpicker && winDeadSpace) {
     // Must always render or the float lingers as a dead, frozen overlay (state closed,
     // DOM open). Discards a fragile rental's staged change. Jac 2026-06-13.
     state.winpicker = null;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623i" />
+  <link rel="stylesheet" href="style.css?v=20260623j" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623i"></script>
-  <script type="module" src="app.js?v=20260623i"></script>
+  <script src="rule-usage.js?v=20260623j"></script>
+  <script type="module" src="app.js?v=20260623j"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Report
#263 — clicking almost anything (a pill, row, link, button, header, bottom bar, another card) while the rental-window picker (or the date-search picker) was open **closed the picker AND swallowed the click** — its own action never fired.

## Root cause (proven)
The outside-click dismiss guard at `app.js` `onClick` ran at the **top** of the handler, before any action handler, with a narrow keep-open allow-list (`.winpicker` / `.js-open-winpicker` / the units-categories-customers cards). **Any other left-click** while a picker was open fell through to `state.winpicker = null; render(); return;` — which (1) nulled the open picker context and (2) `return`ed, so the pill/row/button's own handler never ran.

The canonical sibling — the §5.4 search-mode dismiss (`app.js:10442`) — runs **last** and is dead-space-only (`!closest('.card') && !closest('.header')`), which is exactly why it never swallows.

## Fix (minimal)
Narrow both guards (winpicker + its datesearch twin) to dismiss **only on genuine dead space** (`!.card && !.header && !.winpicker && !.bottombar`) — a strict selector superset of the §5.4 sibling. An interactive target now never enters the block, so it falls through to its own handler; only a click on empty yard dismisses. The picker stays open while you work any card/header/bottom bar (it's non-modal) and still closes via Done / the trigger toggle / Esc / a dead-space click. The dead-space condition also subsumes the datesearch keep-open cases (`.searchwrap` lives in the header, `.mini-searchwrap`/`.js-date-edit` in cards).

## Pattern pass
The other outside-click dismissers (dropdown `off` listener, ctx-menu, hover-preview) use their own non-swallowing mechanisms — the greedy-dismiss-and-`return` pattern was unique to these two guards, so "both guards" is the complete sibling set.

## Verification
- `node --check app.js` ✓
- `node ci/smoke.mjs` ✓ (full app boots clean headless with the change)
- `node ci/logic-test.mjs` ✓ 179/179
- `node ci/gen-rule-usage.mjs --check` ✓ (no rule-usage drift — logic guard, not a stamped element)
- `node ci/check-window-catalog.mjs` ✓ 28 popups

⚠ Global click handler = wide blast radius. The change is a strict narrowing that mirrors the already-shipped, proven §5.4 dead-space dismiss; dead-space dismiss still fires (clicking empty background → none of card/header/winpicker/bottombar match → dismiss).

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)