### PR TITLE
Wrangler fix: reverse customer↔unit/category search (#267)

### DIFF
--- a/app.js
+++ b/app.js
@@ -638,7 +638,9 @@ function migrateInvoiceLines() {
     if (dirty) migrationDirty = true;
   });
 }
+let buildingIndexes = false;   // §5 — suppress per-rental reverse propagation during a full rebuild (units/categories are reindexed wholesale below)
 function buildIndexes() {
+  buildingIndexes = true;
   migrateCustomers();
   migrateRentals();
   migrateInvoiceLines();
@@ -667,10 +669,29 @@ function buildIndexes() {
   DATA.expenses.forEach((x) => reindex('expenses', x)); // §7.11 v2 — receipts are globally searchable
   DATA.parts.forEach((p) => reindex('parts', p));        // §7.12 v2 — parts are searchable
   DATA.companyFiles.forEach((f) => reindex('files', f)); // §7.13 v2 — files are searchable
+  buildingIndexes = false;
 }
 const idOf   = (card, rec) => rec[{ customers: 'customerId', rentals: 'rentalId', categories: 'categoryId', units: 'unitId', invoices: 'invoiceId', workOrders: 'woId', inspections: 'inspectionId', serviceOrders: 'unitId', vendors: 'vendorId', parts: 'partId', expenses: 'expenseId', files: 'fileId' }[card]];
 const recOf  = (card, id) => ({ customers: IDX.customer, rentals: IDX.rental, categories: IDX.category, units: IDX.unit, invoices: IDX.invoice, workOrders: IDX.wo, inspections: IDX.insp, serviceOrders: IDX.unit, vendors: IDX.vendor, expenses: IDX.expense, parts: IDX.part, files: IDX.file }[card])?.get(id);
 
+/* §5 reverse denormalization — the distinct customers who've ever rented this unit
+   or category, so a customer-name search surfaces the Units & Categories they rented
+   (the mirror of the rentals blob, which already denormalizes unit/category/customer
+   names — app.js rentals case). Scanned fresh off DATA.rentals each call, so a unit's
+   blob is always exact the moment it's reindexed; reindex() propagates a rental change
+   to its CURRENT unit/category (below), and a full rebuild reconciles any it moved off. */
+function rentersOf(linkField, id) {
+  if (id == null) return [];
+  const seen = new Set(); const out = [];
+  for (const r of DATA.rentals) {
+    const cid = r.customerId;
+    if (r[linkField] !== id || !cid || seen.has(cid)) continue;
+    seen.add(cid);
+    const c = IDX.customer.get(cid);
+    if (c) { if (c.name) out.push(c.name); if (c.company) out.push(c.company); }
+  }
+  return out;
+}
 /* ── §5 comprehensive search blob — ONE source of truth for what's searchable.
    Emits every raw field, foreign-key DISPLAY names, AND the getStatus(...) labels
    so the VISIBLE text ('Member', 'Bill: Yes', 'Past Due', 'Delivery') matches too. */
@@ -705,7 +726,8 @@ function searchBlob(card, rec) {
       break;
     }
     case 'categories':
-      p = [rec.name, rec.fuelType, rec.description, rec.notes];
+      p = [rec.name, rec.fuelType, rec.description, rec.notes,
+        ...rentersOf('categoryId', rec.categoryId)];   // §5 reverse — customers who've rented this category
       break;
     case 'units':
       p = [rec.name, rec.assignedMechanic, rec.serial, rec.year, rec.make, rec.model, rec.weight,
@@ -713,7 +735,8 @@ function searchBlob(card, rec) {
         rec.inspectionStatus, L('unitInspectionStatus', rec.inspectionStatus),
         rec.fleetStatus, L('unitFleetStatus', rec.fleetStatus),
         rec.gpsStatus, L('gpsStatus', rec.gpsStatus), ca(rec.categoryId)?.name,
-        rec.washRequested ? 'Wash Requested wash' : ''];
+        rec.washRequested ? 'Wash Requested wash' : '',
+        ...rentersOf('unitId', rec.unitId)];   // §5 reverse — customers who've rented this unit
       break;
     case 'invoices': {
       const cust = cu(rec.customerId); const t = invoiceTotals(rec);
@@ -757,7 +780,11 @@ function searchBlob(card, rec) {
 /** (Re)build a record's search blob in IDX.search. Call after any create/edit.
     Vendors are auto-created mid-session (savePartForm) with no IDX set at the
     call site, so reindex also keeps the IDX.vendor identity map in sync. */
-const reindex = (card, rec) => { const id = idOf(card, rec); if (id != null) { IDX.search.set(card + ':' + id, searchBlob(card, rec)); if (card === 'vendors') IDX.vendor.set(id, rec); if (card === 'expenses') IDX.expense.set(id, rec); if (card === 'parts') IDX.part.set(id, rec); if (card === 'files') IDX.file.set(id, rec); } saveSoon(); };
+const reindex = (card, rec) => { const id = idOf(card, rec); if (id != null) { IDX.search.set(card + ':' + id, searchBlob(card, rec)); if (card === 'vendors') IDX.vendor.set(id, rec); if (card === 'expenses') IDX.expense.set(id, rec); if (card === 'parts') IDX.part.set(id, rec); if (card === 'files') IDX.file.set(id, rec);
+  // §5 reverse denormalization — a rental create/re-link must refresh its linked unit's
+  // & category's blobs so a customer-name search surfaces them right away (not just after
+  // a full rebuild). Skipped mid-rebuild — buildIndexes reindexes units/categories wholesale.
+  if (card === 'rentals' && !buildingIndexes) { const u = IDX.unit.get(rec.unitId); if (u) reindex('units', u); const c = IDX.category.get(rec.categoryId); if (c) reindex('categories', c); } } saveSoon(); };
 
 /* ════════════════════════════════════════════════════════════════════════
    §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623j" />
+  <link rel="stylesheet" href="style.css?v=20260623k" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623j"></script>
-  <script type="module" src="app.js?v=20260623j"></script>
+  <script src="rule-usage.js?v=20260623k"></script>
+  <script type="module" src="app.js?v=20260623k"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Root cause
Global search is a per-record blob substring match — `rowMatches` → `blobMatches(IDX.search.get(card+':'+id), ...)` (`app.js:1950`), each record matched against its OWN precomputed `searchBlob` (`app.js:677`). The **rentals** blob denormalizes related names (`u?.name … c?.name, cust?.name, cust?.company`, `app.js:704`) — that's why a customer-name query surfaces his rentals. The **units** (`app.js:710`) and **categories** (`app.js:707`) blobs only ever emitted their own fields. The denormalization was built **one-directional** (rental → unit/category/customer), never the reverse. So "Cameron Miller" surfaced his Rentals + Customer + Invoices, but Units read "No Unit" and Categories showed 0. **Report proven correct.**

## Fix (minimal — mirrors the existing pattern, reversed)
- **`rentersOf(linkField, id)`** — distinct customers who've ever rented a given unit/category, scanned fresh off `DATA.rentals` (deduped by customer), emitting **name + company** only (exactly what the rentals blob already pulls in for a customer). Smallest blob growth; no rental names/POs (kept minimal).
- **`searchBlob`** — `units` and `categories` now append `rentersOf(...)`.
- **`reindex()`** — a rental create/re-link now also reindexes its linked unit + category, so a new rental makes the customer searchable on that unit **immediately**, not just after a full rebuild. Suppressed during `buildIndexes` (units/categories are reindexed wholesale there) via a `buildingIndexes` guard to avoid a rebuild storm.

Bidirectional bonus: searching a unit/category name now also surfaces its renters.

## Proof (failed-before / passes-after)
Headless repro against real demo data via the `__rw` seam: picked a real renter ("devin lyles"), `rowMatches('units', unit, name)` and `rowMatches('categories', cat, name)` both **true** after the fix, **false** with the `rentersOf` line removed; negative control (a non-renter's name) stays **false** — no over-matching.

## Scope / perf
Pure search-index logic — no UI element changed, so no R-rule / window-catalog / `rule-usage.js` changes. `rentersOf` is O(rentals) per unit/category blob; full rebuild ≈ (103 units + 46 categories) × ~1140 rentals ≈ 170k iterations (trivial), incremental rental change ≈ 2 scans.

Gates: `smoke` ✓ · `logic-test` 179/179 ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓. Cache-bust `?v=` → `20260623k`.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)