### PR TITLE
Wrangler fix: Save Account no longer re-anchors the grid to the customer

### DIFF
--- a/app.js
+++ b/app.js
@@ -11905,7 +11905,7 @@ function saveNewCustomer() {
     const lt = applyCustomerLink(o, c.customerId) || o.linked;   // quick-add-link → land back on the Quote/invoice
     closeOverlay();
     if (lt) { anchorRecord(lt.card, lt.recId); toast(`${c.name} saved and linked.`); }
-    else { anchorRecord('customers', c.customerId); toast(`${c.name} updated.`); }
+    else { render(); toast(`${c.name} updated.`); }   // plain Save Account stays put — don't re-anchor the grid to this customer (sibling of the #262 re-anchor-on-mutation class)
     return;
   }
   const id = nextCustomerId();                       // ── new customer ──

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623m" />
+  <link rel="stylesheet" href="style.css?v=20260623n" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623m"></script>
-  <script type="module" src="app.js?v=20260623m"></script>
+  <script src="rule-usage.js?v=20260623n"></script>
+  <script type="module" src="app.js?v=20260623n"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Reported
Jac, in-session: "When I click 'Save Account' it anchors the customer. I didn't want that."

## Root cause
`saveNewCustomer`'s edit path (`app.js:11908`) ended a plain save with `anchorRecord('customers', c.customerId)`, which re-anchors the grid to that customer — moving you off whatever you were viewing. Same defect class as #262: a mutation that shouldn't change your view, changing it.

## Fix
A plain "Save Account" edit changes no cascade membership, so it now uses `render()` to stay put (matches the #262 / `addPartToWO` pattern). Unchanged:
- the **link-target** branch right above it (when you saved a customer *from* a Quote/invoice → you correctly land back on that Quote/invoice);
- the **new-customer create** path (`Create customer`) still anchors the just-created record — you reported the edit case, and showing a brand-new customer is the sensible default.

## Gates (local, port-swapped to 9147)
- `ci/smoke.mjs` ✅ · `ci/logic-test.mjs` ✅ **180/180** · `ci/gen-rule-usage.mjs --check` ✅ · `ci/check-window-catalog.mjs` ✅

Cache token bumped to `?v=20260623n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7ygbx4e2Sc9zs1CZbPUoS)_