### PR TITLE
Comms rail: calm the flashing + retire the desktop Requests inbox

### DIFF
--- a/app.js
+++ b/app.js
@@ -6164,31 +6164,35 @@ function bottomBarEl() {
     + `<div class="bb-utils">${commsUtilsEl()}</div>`;
   return bar;
 }
-// The right-hand utilities of the comms band — notification bell + the Requests inbox.
+// The right-hand utility of the comms band — just the notification bell now. The
+// Requests inbox is retired on desktop: every open request is a tab in the rail (open
+// it to Approve/Dismiss). The inbox still exists for phones (top toolbar), which have
+// no rail. (resolved-fix feed = the bell.)
 function commsUtilsEl() {
-  const reqBadge = wranglerRequests.length ? `<span class="fab-badge">${wranglerRequests.length > 9 ? '9+' : wranglerRequests.length}</span>` : '';
   const nu = unseenNotifs();
   const notifBadge = nu ? `<span class="fab-badge">${nu > 9 ? '9+' : nu}</span>` : '';
-  return `<button class="fab js-notifications" data-tip="Notifications — resolved fixes">${I.bell}${notifBadge}</button>
-    <button class="fab js-requests" data-tip="Requests for your OK — review what Mr. Wrangler filed">${I.inbox}${reqBadge}</button>`;
+  return `<button class="fab js-notifications" data-tip="Notifications — resolved fixes">${I.bell}${notifBadge}</button>`;
 }
 // The conversation rail: channels grouped + stamped, each conversation a SEPARATE
-// tab. 🤠 Wrangler — one tab per needs-answer request (flashing), the live chat, and
-// every past chat; 💬 Team — one tab per active thread. (Customer SMS/email channels
-// slot in here later.) Tabs reuse the wrangler open handlers (data-wrc-needs /
-// data-wrc-open) and a dedicated data-team-open for team threads, so each opens
-// ONLY its own thread.
+// tab. 🤠 Wrangler — one tab per OPEN request (needs-answer = red · needs-your-OK =
+// yellow; both open the dock, which carries Approve/Dismiss), the live chat, and every
+// past chat. 💬 Team — one tab per active thread. Tabs read as actionable via a STEADY
+// tinted edge (no perpetual glow). The rail REPLACES the old Requests inbox on desktop;
+// each opens ONLY its own thread (data-wrc-needs / data-wrc-open / data-team-open).
 function commsRailEl() {
   const trim = (t, n = 24) => { t = String(t || '').replace(/\s+/g, ' ').trim(); return esc(t.length > n ? t.slice(0, n - 1) + '…' : t); };
-  // ── 🤠 WRANGLER ──
-  const needs = (wranglerRequests || []).filter((rq) => (rq.labels || []).includes('wrangler-needs-jac'));
-  const needsNums = new Set(needs.map((rq) => rq.number));
+  // ── 🤠 WRANGLER ── every open request is its own tab (the inbox lived here before)
+  const reqStateKey = (rq) => { const L = rq.labels || []; return L.includes('wrangler-needs-jac') ? 'needs' : L.includes('wrangler-fix') ? 'building' : 'ok'; };
+  const open = (wranglerRequests || []);
+  const reqNums = new Set(open.map((rq) => rq.number));
   const wrOpen = state.wrangler.open;
-  const needTabs = needs.map((rq) => {
+  const reqTabs = open.filter((rq) => reqStateKey(rq) !== 'building').map((rq) => {   // building = Mr. Wrangler working; not actionable, surfaces via the bell when done
+    const st = reqStateKey(rq), cls = st === 'needs' ? 'crail-needs' : 'crail-ok';
+    const tip = st === 'needs' ? `Mr. Wrangler needs your answer — #${rq.number}` : `Needs your OK — #${rq.number}`;
     const active = wrOpen && (state.wrangler.reqNumber === rq.number || state.wrangler.id === 'req' + rq.number);
-    return `<button class="crail-tab crail-needs wr-flash${active ? ' is-active' : ''}" data-wrc-needs="${rq.number}" role="tab" aria-selected="${active}" data-tip="Mr. Wrangler needs your answer — #${rq.number}"><span class="crail-dot"></span><span class="crail-t">${trim(rq.title || ('Request #' + rq.number))}</span></button>`;
+    return `<button class="crail-tab ${cls}${active ? ' is-active' : ''}" data-wrc-needs="${rq.number}" role="tab" aria-selected="${active}" data-tip="${tip}"><span class="crail-dot"></span><span class="crail-t">${trim(rq.title || ('Request #' + rq.number))}</span></button>`;
   }).join('');
-  const snaps = (state.wranglerRail || []).filter((c) => !(c.reqNumber && needsNums.has(c.reqNumber)));
+  const snaps = (state.wranglerRail || []).filter((c) => !(c.reqNumber && reqNums.has(c.reqNumber)));
   // the live chat first if it's a brand-new one not yet snapshotted onto the rail
   let liveTab = '';
   if (wrOpen && state.wrangler.id && !state.wrangler.reqNumber && !snaps.some((c) => c.id === state.wrangler.id) && (state.wrangler.messages || []).length) {
@@ -6198,7 +6202,7 @@ function commsRailEl() {
     const active = wrOpen && state.wrangler.id === c.id;
     return `<button class="crail-tab${active ? ' is-active' : ''}" data-wrc-open="${esc(c.id)}" role="tab" aria-selected="${active}" data-tip="Reopen this chat with Mr. Wrangler"><span class="crail-dot"></span><span class="crail-t">${trim(c.title || 'Chat')}</span></button>`;
   }).join('');
-  const wrTabs = needTabs + liveTab + snapTabs;
+  const wrTabs = reqTabs + liveTab + snapTabs;
   // ── 💬 TEAM ──
   const u = commentUserKey();
   const teamChats = (state.chat.chats || []).filter((c) => c.participants.length && c.messages.length)

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623m" />
+  <link rel="stylesheet" href="style.css?v=20260623n" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623m"></script>
-  <script type="module" src="app.js?v=20260623m"></script>
+  <script src="rule-usage.js?v=20260623n"></script>
+  <script type="module" src="app.js?v=20260623n"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1196,17 +1196,19 @@ select.lf-in { appearance: none; cursor: pointer; }
 .crail-tab.c-green .crail-dot { background: var(--green); } .crail-tab.c-yellow .crail-dot { background: var(--yellow); }
 .crail-tab.c-red .crail-dot { background: var(--red); } .crail-tab.c-blue .crail-dot { background: var(--blue); }
 .crail-tab.c-purple .crail-dot { background: var(--purple); } .crail-tab.c-gray .crail-dot { background: var(--txt-3); }
+/* Actionable request tabs read via a STEADY tinted edge + colored dot — needs-answer
+   (red) · needs-your-OK (yellow). NO perpetual glow: a wall of pulsing tabs was a
+   strobe; motion is reserved for the one transient attnFlash beat elsewhere. */
 .crail-needs .crail-dot { background: var(--red); }
+.crail-ok .crail-dot { background: var(--yellow); }
+.crail-tab.crail-needs:not(.is-active) { border-color: color-mix(in srgb, var(--red) 55%, var(--line)); }
+.crail-tab.crail-ok:not(.is-active) { border-color: color-mix(in srgb, var(--yellow) 50%, var(--line)); }
 .crail-tab.is-unseen { border-color: var(--accent-line); }
 .crail-tab.is-unseen .crail-dot { box-shadow: 0 0 0 3px var(--accent-soft); }
 /* selected conversation = solid safety-orange + dark ink (the one accent use for a tab) */
 .crail-tab.is-active { background: var(--accent); border-color: var(--accent); color: var(--on-orange, #1a1205); }
 .crail-tab.is-active .crail-dot { background: var(--on-orange, #1a1205); box-shadow: none; }
-.crail-tab.wr-flash:not(.is-active) { animation: attnGlow 1.6s ease-in-out infinite; border-color: var(--accent-line); }
-@media (prefers-reduced-motion: reduce) {
-  .crail-tab:hover { transform: none; }
-  .crail-tab.wr-flash:not(.is-active) { animation: none; box-shadow: 0 0 0 2px var(--accent-soft), inset 0 1px 0 rgba(255,255,255,.06); }
-}
+@media (prefers-reduced-motion: reduce) { .crail-tab:hover { transform: none; } }
 
 /* §17 INTERNAL TEAM DOCK (Jac, Phase 7) — headerless: tagged-element pill rail on top,
    chat bubbles, role tab-bar at the bottom. Floats bottom-right. Yard data-plate steel. */


### PR DESCRIPTION
Follow-up to #270, fixing two "annoying Mr. Wrangler" reports from Jac in-session.

## 1. Too much flashing
14+ perpetually-glowing "needs answer" tabs was a strobe — the exact anti-pattern the design language warns about (motion is for one transient beat, not always-on chrome). Tabs now read as actionable via a **steady tinted edge + colored dot**:
- **needs answer** → red dot + steady red edge
- **needs your OK** → yellow dot + steady yellow edge

No animation. The one-orange accent is still reserved for the *selected* tab.

## 2. The Requests inbox is redundant with the tab rail — removed (desktop)
Every **open** request is now its own tab in the rail — both *needs-answer* and *needs-your-OK* (the latter used to live **only** in the inbox). Opening a tab opens the dock, which carries **Approve / Dismiss**, so approvals stay reachable — nothing orphaned. The inbox button is dropped from the desktop comms band (the **bell** stays for resolved-fix notifications).

Phones are unchanged: they have no rail, so they keep the inbox in the top toolbar. The requests overlay itself is untouched, so `WINDOW_CATALOG` doesn't change.

## Verification
Headless (Playwright): **0** flashing tabs · inbox **absent** from the band · bell present · a *needs-OK* tab opens the dock **with the Approve/Dismiss reqBar** (approvals intact). Screenshot reviewed: steady red/yellow edges, no glow.

Gates: `smoke` ✓ · `logic-test` **180/180** ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓. Cache token `20260623m → 20260623n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zDJHVUQ3kqq7Vhc7jngKS

---
_Generated by [Claude Code](https://claude.ai/code/session_019zDJHVUQ3kqq7Vhc7jngKS)_