### PR TITLE
Comms rail: hide the horizontal scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623n" />
+  <link rel="stylesheet" href="style.css?v=20260623o" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623n"></script>
-  <script type="module" src="app.js?v=20260623n"></script>
+  <script src="rule-usage.js?v=20260623o"></script>
+  <script type="module" src="app.js?v=20260623o"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1175,9 +1175,8 @@ select.lf-in { appearance: none; cursor: pointer; }
    stays left, bell+inbox right. Tab = registry dot + Geist title; selected = the ONE
    safety-orange; a "needs your answer" tab flashes red. */
 .comms-rail { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 12px;
-  overflow-x: auto; overflow-y: hidden; scrollbar-width: thin; padding: 2px 2px; }
-.comms-rail::-webkit-scrollbar { height: 6px; }
-.comms-rail::-webkit-scrollbar-thumb { background: var(--line); border-radius: 99px; }
+  overflow-x: auto; overflow-y: hidden; scrollbar-width: none; padding: 2px 2px; }   /* hide the scrollbar (still scrolls via wheel/trackpad) — matches .header-tabs */
+.comms-rail::-webkit-scrollbar { height: 0; width: 0; }
 .crail-group { flex: 0 0 auto; display: flex; align-items: center; gap: 7px; }
 .crail-glabel { flex: 0 0 auto; font-family: 'Saira Condensed', sans-serif; text-transform: uppercase;
   letter-spacing: 1.4px; font-weight: 700; font-size: 10.5px; color: var(--txt-3); padding-right: 2px; white-space: nowrap; }


### PR DESCRIPTION
Jac didn't like the white horizontal scrollbar under the conversation rail.

Hides it the same way the header tab strip already does — `scrollbar-width: none` (Firefox) + `::-webkit-scrollbar { height: 0 }` (Chrome/Safari/Edge). The rail still scrolls via wheel/trackpad, and the cut-off last tab signals there's more.

## Verification
Headless: with 14+ tabs the rail overflows (`scrollWidth > clientWidth`) but the scrollbar height is **0** (hidden). Screenshot confirms no track. Gates: `smoke` ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓ (CSS-only). Cache token `20260623n → 20260623o`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zDJHVUQ3kqq7Vhc7jngKS

---
_Generated by [Claude Code](https://claude.ai/code/session_019zDJHVUQ3kqq7Vhc7jngKS)_