### PR TITLE
Comms rail: drop the channel section-title labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -6183,12 +6183,13 @@ function commsUtilsEl() {
   const notifBadge = nu ? `<span class="fab-badge">${nu > 9 ? '9+' : nu}</span>` : '';
   return `<button class="fab js-notifications" data-tip="Notifications — resolved fixes">${I.bell}${notifBadge}</button>`;
 }
-// The conversation rail: channels grouped + stamped, each conversation a SEPARATE
-// tab. 🤠 Wrangler — one tab per OPEN request (needs-answer = red · needs-your-OK =
-// yellow; both open the dock, which carries Approve/Dismiss), the live chat, and every
-// past chat. 💬 Team — one tab per active thread. Tabs read as actionable via a STEADY
-// tinted edge (no perpetual glow). The rail REPLACES the old Requests inbox on desktop;
-// each opens ONLY its own thread (data-wrc-needs / data-wrc-open / data-team-open).
+// The conversation rail: Wrangler + Team channels (split by a thin divider, no section
+// labels), each conversation a SEPARATE tab. 🤠 Wrangler — one tab per OPEN request
+// (needs-answer = red · needs-your-OK = yellow; both open the dock, which carries
+// Approve/Dismiss), the live chat, and every past chat. 💬 Team — one tab per active
+// thread. Tabs read as actionable via a STEADY tinted edge (no perpetual glow). The rail
+// REPLACES the old Requests inbox on desktop; each opens ONLY its own thread
+// (data-wrc-needs / data-wrc-open / data-team-open).
 function commsRailEl() {
   const trim = (t, n = 24) => { t = String(t || '').replace(/\s+/g, ' ').trim(); return esc(t.length > n ? t.slice(0, n - 1) + '…' : t); };
   // ── 🤠 WRANGLER ── every open request is its own tab (the inbox lived here before)
@@ -6225,8 +6226,8 @@ function commsRailEl() {
     return `<button class="crail-tab c-${(tag && tag.color) || 'gray'}${active ? ' is-active' : ''}${unseen ? ' is-unseen' : ''}" data-team-open="${esc(c.id)}" role="tab" aria-selected="${active}" data-tip="${esc(label)}"><span class="crail-dot"></span><span class="crail-t">${trim(label)}</span></button>`;
   }).join('');
   const groups = [];
-  if (wrTabs) groups.push(`<div class="crail-group"><span class="crail-glabel">🤠 Wrangler</span>${wrTabs}</div>`);
-  if (teamTabs) groups.push(`<div class="crail-group"><span class="crail-glabel">💬 Team</span>${teamTabs}</div>`);
+  if (wrTabs) groups.push(`<div class="crail-group">${wrTabs}</div>`);
+  if (teamTabs) groups.push(`<div class="crail-group">${teamTabs}</div>`);
   return groups.length ? groups.join('<span class="crail-div" aria-hidden="true"></span>')
     : '<span class="crail-empty">No conversations yet — start one from the tools on the left.</span>';
 }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623p" />
+  <link rel="stylesheet" href="style.css?v=20260623q" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623p"></script>
-  <script type="module" src="app.js?v=20260623p"></script>
+  <script src="rule-usage.js?v=20260623q"></script>
+  <script type="module" src="app.js?v=20260623q"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1191,8 +1191,6 @@ select.lf-in { appearance: none; cursor: pointer; }
   overflow-x: auto; overflow-y: hidden; scrollbar-width: none; padding: 2px 2px; }   /* hide the scrollbar (still scrolls via wheel/trackpad) — matches .header-tabs */
 .comms-rail::-webkit-scrollbar { height: 0; width: 0; }
 .crail-group { flex: 0 0 auto; display: flex; align-items: center; gap: 7px; }
-.crail-glabel { flex: 0 0 auto; font-family: 'Saira Condensed', sans-serif; text-transform: uppercase;
-  letter-spacing: 1.4px; font-weight: 700; font-size: 10.5px; color: var(--txt-3); padding-right: 2px; white-space: nowrap; }
 .crail-div { flex: 0 0 auto; width: 1px; align-self: stretch; margin: 5px 2px; background: var(--line); }
 .crail-empty { color: var(--txt-3); font-size: 12px; font-style: italic; white-space: nowrap; }
 .crail-tab { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; max-width: 190px; padding: 6px 12px;


### PR DESCRIPTION
Jac: the "🤠 Wrangler" / "💬 Team" section-title labels on the comms rail aren't needed.

Removes the `crail-glabel` labels (and their CSS). The tabs are self-explanatory — red/yellow dots for requests, named tabs for team — and the thin divider still separates the two channels.

Gates: `smoke` ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓ (CSS/markup only). Verified headless: 0 `crail-glabel` in the DOM. Cache token `20260623p → 20260623q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zDJHVUQ3kqq7Vhc7jngKS

---
_Generated by [Claude Code](https://claude.ai/code/session_019zDJHVUQ3kqq7Vhc7jngKS)_