### PR TITLE
Restore #260: anchor card ids to the Stripe PM id + fingerprint dedupe

### DIFF
--- a/app.js
+++ b/app.js
@@ -12142,13 +12142,24 @@ async function saveCardFlow(btn) {
     c.stripeId = r.stripeId || c.stripeId;
     if (!Array.isArray(c.cards)) c.cards = [];
     const firstCard = customerCards(c).length === 0;
-    const newCardId = 'CARD-' + (state.seq++);
+    const newCardId = 'CARD-' + setupIntent.payment_method;   // anchor to the globally-unique Stripe PM id (was 'CARD-'+state.seq, which reset per session and collided across sessions/devices → wrong-card charges / can't-delete / signature bleed)
     // §7.1c a card lands IN PROGRESS — chargeable immediately, but the account can't go On Rent /
     // log deliveries until the card is COMPLETE (card + selfie + signature). Any selfie/signature
     // captured in this panel were held on c.pendingCapture and now saddle onto the new card.
-    const newCard = { id: newCardId, stripePmId: setupIntent.payment_method, brand: s.card.brand, last4: s.card.last4,
+    const newCard = { id: newCardId, stripePmId: setupIntent.payment_method, fingerprint: s.card.fingerprint || '', brand: s.card.brand, last4: s.card.last4,
       expMonth: s.card.expMonth, expYear: s.card.expYear, nickname: o.nickname || '', notes: '', isDefault: firstCard, status: 'active',
       selfie: '', driveSelfieUrl: '', draftSignature: null, agreements: [] };
+    // Stripe attaches the SAME physical card as a NEW pm every time it's saved. If this card's
+    // fingerprint matches one already on file, SUPERSEDE that entry in place — carry its signed
+    // agreement/selfie onto the fresh pm, retire the old pm — so one physical card never piles up
+    // as duplicate chips. (Functional now that stripeSaveCard returns card.fingerprint.)
+    const _dup = newCard.fingerprint ? customerCards(c).find((k) => k.fingerprint === newCard.fingerprint) : null;
+    if (_dup) {
+      newCard.agreements = _dup.agreements || []; newCard.selfie = _dup.selfie || ''; newCard.driveSelfieUrl = _dup.driveSelfieUrl || '';
+      newCard.isDefault = newCard.isDefault || _dup.isDefault;
+      _dup.status = 'removed';
+      if (backendPassword && _dup.stripePmId && _dup.stripePmId !== setupIntent.payment_method) backendCall('stripeRemoveCard', { customerId: c.customerId, paymentMethodId: _dup.stripePmId }).catch(() => {});
+    }
     c.cards.push(newCard);
     c.cardBrand = s.card.brand; c.cardLast4 = s.card.last4; c.cardExpMonth = s.card.expMonth; c.cardExpYear = s.card.expYear;   // legacy mirror (default card)
     saddlePendingCapture(c, newCard);                                                            // held selfie/signature → this card, then finalize if all three are present

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623p" />
+  <link rel="stylesheet" href="style.css?v=20260623q" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623p"></script>
-  <script type="module" src="app.js?v=20260623p"></script>
+  <script src="rule-usage.js?v=20260623q"></script>
+  <script type="module" src="app.js?v=20260623q"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Why
#260's front-end card fixes (which Jac verified by feel, but which only collide *across* sessions) were **lost in an earlier merge-conflict resolution** — the live front-end still used `'CARD-' + (state.seq++)` and had no fingerprint dedupe. The backend `fingerprint` field is live, but the front-end never read it.

## What
1. **Card id = Stripe PM id** — `newCardId = 'CARD-' + setupIntent.payment_method`. `state.seq` is a per-session counter that resets and collides across sessions/devices — the root of wrong-card charges, can't-delete, and per-card signature bleed. The PM id is globally unique.
2. **Fingerprint on each saved card** — `fingerprint: s.card.fingerprint || ''`.
3. **Supersede-on-fingerprint** — saving the SAME physical card twice (Stripe issues a new pm each time) now retires the old pm and carries its signed agreement/selfie onto the fresh one, instead of piling up duplicate chips.

## Companion (separate, via clasp)
`stripeSaveCard_` now also returns `card.fingerprint` so (2)/(3) are functional — deploying through the clasp STOP-gate.

## Gates (local, port-swapped to 9147)
- `ci/smoke.mjs` ✅ · `ci/logic-test.mjs` ✅ **180/180** · `ci/gen-rule-usage.mjs --check` ✅ · `ci/check-window-catalog.mjs` ✅

Cache token bumped to `?v=20260623q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7ygbx4e2Sc9zs1CZbPUoS)_