### PR TITLE
Card capture: selfie + signature inline in the Add-card panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -451,9 +451,9 @@ function holdSigning(c, signature, selfie) {
    are present. The capture target is the open card tab, or — with no card yet — a held bucket
    on the account (c.pendingCapture) that saddles onto the first card added. */
 function captureCtx(o) {
-  const c = o && o.editId ? IDX.customer.get(o.editId) : null;
+  const c = o && o.editId ? IDX.customer.get(o.editId) : (o && o.kind === 'addCard' ? IDX.customer.get(o.customerId) : null);
   if (!c) return { c: null, k: null };
-  if (o.cardSub) return { c, k: null };                                            // the +Card panel (no card yet) → held
+  if (o.cardSub || o.kind === 'addCard') return { c, k: null };                     // +Card / Add-card panel → held on pendingCapture, saddles onto the new card on save
   const k = (o.tab && o.tab !== 'account') ? customerCards(c).find((x) => x.id === o.tab) || null : null;
   return { c, k };
 }
@@ -7563,7 +7563,7 @@ function renderOverlay() {
   if (o.kind === 'partform') document.querySelector('.overlay .js-pf2-desc')?.focus();   // Jac: Part/Task field focused by default
   if (o.kind === 'newCustomer') setupSignaturePad();
   if (o.kind === 'payment') { setupPayAlloc(); setupRefundAlloc(); }   // live counters for the §19 pay + §19b refund allocation rows
-  if (o.kind === 'addCard') { const cc = IDX.customer.get(o.customerId); if (cc) mountCardElement(); }   // §7.1b card saved first, signed after
+  if (o.kind === 'addCard') { const cc = IDX.customer.get(o.customerId); if (cc) { mountCardElement(); setupSignaturePad(); } }   // §7.1c capture (selfie + signature) now lives IN the Add-card panel; the live cam is wired by the generic ag-cam-feed hook below
   if (o.kind === 'newCustomer' && o.cardSub) { const cc = IDX.customer.get(o.editId); if (cc) mountCardElement(); }   // §14 the side-by-side Add-card panel
   { const _agFeed = overlay.querySelector('.ag-cam-feed'); if (_agFeed) startAgCam(_agFeed); else stopAgCam(); }   // live selfie camera follows the capture block
 }
@@ -8215,11 +8215,13 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.customers || '', title: `Add card — ${c.name}`, tag: 'Customer · card on file',
       foot: `<button class="pill ghost js-close" data-r="R18">Cancel</button><button class="pill ignition js-card-save" data-r="R17">Save card</button>`,
       body: `
-        <p class="muted" style="font-size:11px;margin:0 0 10px">Saved cards can be charged right away. The account can't go On Rent or log deliveries until the card is signed (next step).</p>
+        <p class="muted" style="font-size:11px;margin:0 0 10px">Saved cards can be charged right away. Capture the selfie + signature below to authorize On-Rent &amp; deliveries — or just save the card and sign it later.</p>
         <div class="pay-cap">Card number</div>
         <div class="pay-card-field" id="sl-card-element"></div>
         <div class="pay-err" id="sl-card-error"></div>
-        <p class="muted" style="font-size:11px;margin:10px 0 0">Entered securely via Stripe. We store only the brand + last 4 digits — never the full number. Sign the agreement on this card to authorize On-Rent &amp; deliveries.</p>` });
+        <p class="muted" style="font-size:11px;margin:10px 0 0">Entered securely via Stripe. We store only the brand + last 4 digits — never the full number.</p>
+        <div class="ag-cardsplit"></div>
+        ${heldSignBlock(o, c, {})}` });
     overlay.appendChild(pop);
   } else if (o.kind === 'addAch') {
     // §14b ACH — raw routing/account live ONLY in these inputs → straight to Stripe

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623r" />
+  <link rel="stylesheet" href="style.css?v=20260623s" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623r"></script>
-  <script type="module" src="app.js?v=20260623r"></script>
+  <script src="rule-usage.js?v=20260623s"></script>
+  <script type="module" src="app.js?v=20260623s"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Reported
Jac: "Add-card flow — merge selfie/signature into the Add-card panel." The standalone Add-card overlay was card-number-only; selfie + signature were a disjointed "save → sign next step."

## What
The `addCard` overlay now renders the **same `heldSignBlock`** the new-customer onboarding panel already uses for the first card, so **card + selfie + signature are captured in one screen**. Copy updated so it no longer reads "sign next step" (you can still save and sign later).

## Wiring (reuses existing machinery — no new UI authored)
- **render:** `heldSignBlock(o, c, {})` below the card field, with the same `ag-cardsplit` divider the onboarding `cardSub` panel uses.
- **open hook:** `setupSignaturePad()` for `addCard` — the live selfie camera is already wired generically by the `ag-cam-feed` hook.
- **captureCtx:** resolve the customer via `o.customerId` and route `addCard` captures to `c.pendingCapture`, which `saddlePendingCapture()` already carries onto the new card on save (and the restored #260 dedupe/PM-id id apply).

## Verification boundary — needs your real-device test ⚠️
Gates pass (smoke ✅, **logic-test 189/189** ✅, gen-rule-usage `--check` ✅, window-catalog ✅), and this reuses the **proven, in-language onboarding capture block verbatim** — so layout/design risk is low. But the **interactive parts — live camera + signature pad + capture routing — can't be verified in CI or headless** (no camera device, no human signing). Those need a real-device pass before/after merge:
1. Open a customer → payment methods → **Add card**.
2. Confirm the selfie cam + signature pad appear under the card field.
3. Capture both + enter a card → **Save card** → confirm the new card lands **Complete** (card + selfie + signature all ✓), not "in progress."

Cache token bumped to `?v=20260623s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7ygbx4e2Sc9zs1CZbPUoS)_