### PR TITLE
Remove card totals footer + graph-view: right-click to hide filter pills / sort

### DIFF
--- a/app.js
+++ b/app.js
@@ -2946,6 +2946,28 @@ function openCtxMenu(e, hit) {
   m.style.top = Math.min(e.clientY, window.innerHeight - m.offsetHeight - 8) + 'px';
   setTimeout(() => document.addEventListener('mousedown', ctxOutside), 0);
 }
+// §13.4/§R20 — graph-view chrome menu: hide/show the clickable filter-pill legend under the
+// charts and/or the Views & sort control, or Reset both. Reuses the R20 ctx-menu shell +
+// the ctxOutside closer; the chosen state persists per device, per card (loadGvChrome).
+let ctxGvCard = null;
+function openGvChromeMenu(e, card) {
+  closeCtxMenu();
+  ctxTarget = null; ctxGvCard = card;
+  const ch = loadGvChrome(card);
+  const m = document.createElement('div');
+  m.className = 'ctx-menu'; m.id = 'rw-ctx';
+  const item = (act, label) => `<button class="dd-item" data-ctx="${act}">${label}</button>`;
+  m.innerHTML = [
+    item('gv-pills', `🏷️ ${ch.pills ? 'Show' : 'Hide'} filter pills`),
+    item('gv-sort', `↕️ ${ch.sort ? 'Show' : 'Hide'} Views &amp; sort`),
+    '<div class="menu-sep"></div>',
+    item('gv-reset', '↺ Reset pills &amp; sort'),
+  ].join('');
+  document.body.appendChild(m);
+  m.style.left = Math.min(e.clientX, window.innerWidth - 205) + 'px';
+  m.style.top = Math.min(e.clientY, window.innerHeight - m.offsetHeight - 8) + 'px';
+  setTimeout(() => document.addEventListener('mousedown', ctxOutside), 0);
+}
 // §M3 — open the right-click/long-press menu for the element at (x,y). Shared by the
 // contextmenu handler (mouse) and the touch long-press timer (phone). Mirrors the §R20
 // logic: a real "leaf" tool opens the Wrangler menu; card dead-space → card-to-List.
@@ -2955,6 +2977,13 @@ function openCtxMenuAt(target, x, y) {
   if (!target || !target.closest) return;
   if (target.closest('input, textarea, .inline-input')) return;
   const card = target.closest('.card'); if (!card && !target.closest('.overlay .popup')) return;
+  // §13.4 — inside an OPEN graph view, right-click/long-press the panel (or the Views & sort
+  // control above it) opens the graph-chrome menu instead of the per-element Wrangler menu,
+  // so the filter pills / sort can be hidden and Reset.
+  if (card && !state.winpicker) {
+    const cid = card.dataset.card, gcs = cid && activeSession().cards[cid];
+    if (gcs && gcs.graphView && (target.closest('.gv-panel') || target.closest('.sort'))) return openGvChromeMenu({ clientX: x, clientY: y }, cid);
+  }
   // While the rental-window picker is open, keep right-click → BACK working; just suppress
   // the element context menu (it gets in the way of picking). (Jac B5, 2026-06-15)
   const leaf = state.winpicker ? null : target.closest('.pill, .add-field, .flag, .linkname, .inv-line-link, .req, .seg, button, .inline-edit, .jnode, .x, a, .d-title, .r-title, .derived');
@@ -2972,6 +3001,14 @@ function ctxOutside(e) {
   closeCtxMenu();
 }
 function runCtxAction(act) {
+  if (act.startsWith('gv-')) {   // §13.4 graph-chrome menu — no leaf target, just the card
+    const card = ctxGvCard; closeCtxMenu(); document.removeEventListener('mousedown', ctxOutside); ctxGvCard = null;
+    if (!card) return;
+    if (act === 'gv-pills') saveGvChrome(card, { pills: !gvPillsHidden(card) });
+    else if (act === 'gv-sort') saveGvChrome(card, { sort: !gvSortHidden(card) });
+    else if (act === 'gv-reset') saveGvChrome(card, { pills: false, sort: false });
+    return render();
+  }
   const tg = ctxTarget; closeCtxMenu(); document.removeEventListener('mousedown', ctxOutside);
   if (!tg) return;
   const el = tg.el;
@@ -3066,7 +3103,7 @@ const RULE_META = {
   R17: ['Action pill', 'actionPill', 'commit = blue · money = green · danger = solid red; .locked = gated'],
   R18: ['Ghost', 'ghostPill', 'the ONE quiet action — Cancel / Close / Exit / Clear'],
   R19: ['Attention flash', 'attnFlash / flashOr', 'a glow that points AT the next action — replaces an error message when the fix is on screen'],
-  R20: ['Context menu', 'openCtxMenu (right-click · long-press)', 'right-click/long-press any element: Cut · Copy · Paste · Search · Replace · Add Comment · Ask Mr. Wrangler'],
+  R20: ['Context menu', 'openCtxMenu (right-click · long-press)', 'right-click/long-press any element: Cut · Copy · Paste · Search · Replace · Add Comment · Ask Mr. Wrangler — or, inside an open graph view, hide the filter pills / Views & sort (Reset restores)'],
   R21: ['File drop', 'fileDrop', 'the MASSIVE popup add-file zone — R5b blue dashed at full size'],
   R22: ['Date picker', 'dateField', 'the ONE app-styled calendar for a single date/time (NOT the rental-window timeline)'],
   R23: ['Tooltip', 'data-tip → the one styled tip', 'every hover hint goes through data-tip — a native title attribute is a violation'],
@@ -5442,10 +5479,10 @@ function listView(cardDef, session) {
       ${cascChip}${cterms.map((ft, i) => filterTermPill(ft, i, card)).join('')}
       <input class="mini-search" placeholder="${cterms.length ? 'Add filter — Enter to pin…' : `Search ${esc(cardDef.title.toLowerCase())}…`}" value="${esc(cs.search)}" data-card="${card}" />
     </div>
-    <div class="sort">
+    ${(cs.graphView && gvSortHidden(card)) ? '' : `<div class="sort">
       <button class="sortbtn js-sortmenu${av ? ' viewing' : ''}" data-card="${card}" data-tip="Views &amp; sort">${esc(av ? av.name : curField.label)} ${I.chev}</button>
       <button class="dir js-sortdir" data-card="${card}"><span class="${cs.sort.dir === 'asc' ? 'on' : ''}">▲</span><span class="${cs.sort.dir === 'desc' ? 'on' : ''}">▼</span></button>
-    </div>`;
+    </div>`}`;
   wrap.appendChild(bar);
   // §13.4 — Graph carousel: an interactive panel ABOVE the list (the list renders below,
   // filtered by the chart's g-tagged search terms). Legacy cards still full-replace the list.
@@ -7194,6 +7231,26 @@ function gvRestore(src, cs, idx) {
 }
 function gvOpen(card, src) { const cs = activeSession().cards[card]; cs.graphView = true; gvRestore(src, cs, cs.graphIdx || 0); cs.listLimit = undefined; render(); }
 function gvChevron(card, src, dir) { const cs = activeSession().cards[card]; gvSaveCurrent(src, cs); gvRestore(src, cs, (cs.graphIdx || 0) + dir); cs.listLimit = undefined; render(); }
+// §13.4 — per-device, per-card graph-chrome prefs: hide the clickable filter-pill legend
+// under the chart (pie slices stay clickable) and/or the Views & sort control. Toggled from
+// the §R20 right-click menu (Reset restores both). Persisted like the list layout; default
+// shows everything, and the key is dropped once nothing is hidden.
+const GV_CHROME_KEY = (card) => `jactec.gvChrome.${card}`;
+const GV_CHROME = Object.create(null);
+function loadGvChrome(card) {
+  if (card in GV_CHROME) return GV_CHROME[card];
+  let v = null;
+  try { const raw = localStorage.getItem(GV_CHROME_KEY(card)); if (raw) v = JSON.parse(raw); } catch (e) { v = null; }
+  v = (v && typeof v === 'object') ? { pills: !!v.pills, sort: !!v.sort } : { pills: false, sort: false };
+  GV_CHROME[card] = v; return v;
+}
+function saveGvChrome(card, patch) {
+  const next = { ...loadGvChrome(card), ...patch };
+  GV_CHROME[card] = next;
+  try { if (next.pills || next.sort) localStorage.setItem(GV_CHROME_KEY(card), JSON.stringify(next)); else localStorage.removeItem(GV_CHROME_KEY(card)); } catch (e) {}
+}
+const gvPillsHidden = (card) => loadGvChrome(card).pills;
+const gvSortHidden = (card) => loadGvChrome(card).sort;
 // Idempotent close-sync: any path that flips graphView off (record open, invoice surface,
 // switch to Shop 'all') leaves g-terms behind — save them to memory + strip them.
 function gvSyncClosed(src, cs) { if (cs.graphView) return; if (!(cs.filterTerms || []).some((t) => t.g)) return; gvSaveCurrent(src, cs); gvStripTerms(cs); }
@@ -7238,8 +7295,10 @@ function gvPieClickable(card, src, cs, segs, size = 116) {
 }
 function gvRenderView(card, src, cs, v) {
   if (v.kind === 'pie') {
-    const legend = v.segs.map((s) => gvSegBtn(cs, card, src, s, `<i style="background:var(--${s.color})"></i><span class="gl-lbl">${esc(s.label)}</span> <b>${s.count}</b>`, 'gv-leg')).join('');
-    return `<div class="gv-pie">${gvPieClickable(card, src, cs, v.segs)}<div class="gv-legend gv-legend-click">${legend}</div></div>`;
+    // the legend chips are the clickable "filter pills" under the donut — hideable via the
+    // §R20 graph-chrome menu (the donut slices stay clickable as the pointer path).
+    const legend = gvPillsHidden(card) ? '' : `<div class="gv-legend gv-legend-click">${v.segs.map((s) => gvSegBtn(cs, card, src, s, `<i style="background:var(--${s.color})"></i><span class="gl-lbl">${esc(s.label)}</span> <b>${s.count}</b>`, 'gv-leg')).join('')}</div>`;
+    return `<div class="gv-pie">${gvPieClickable(card, src, cs, v.segs)}${legend}</div>`;
   }
   if (v.kind === 'bars') {
     const max = Math.max(1, ...v.segs.map((s) => s.count));

--- a/app.js
+++ b/app.js
@@ -1977,7 +1977,7 @@ function rowMatches(card, rec, query, terms) {
   }
   const q2 = (query || '').replace(/\b(?:un)?available\b/gi, '').replace(/\s+/g, ' ').trim();
   const terms2 = (terms || []).filter((t) => !/^(?:un)?available$/.test(t.t));
-  // A1 — col-scoped terms (from footer chips / graph slices) do an EXACT column match so
+  // A1 — col-scoped terms (from graph slices / the Not-Ready chip) do an EXACT column match so
   // "Ready" can't also catch "Not Ready"; plain text terms fall to the blob substring match.
   // §13.4 — a NOT term excludes on its own; positive terms of the SAME column OR together
   // (toggle several graph slices = match any), while different columns still AND.
@@ -1991,7 +1991,7 @@ function rowMatches(card, rec, query, terms) {
   for (const col in byCol) { if (!byCol[col].some((v) => totColMatch(card, rec, col, v))) return false; }
   return blobMatches(IDX.search.get(card + ':' + idOf(card, rec)), q2, terms2b.filter((t) => !t.col));
 }
-// A1 — exact match for a footer-chip's {col, value}, per record (mirrors applyTotalFilter).
+// A1 — exact match for a graph slice / filter term's {col, value}, per record.
 function totColMatch(card, rec, col, value) {
   if (col === '__date') return dateTermHits(card, rec, value);   // §5.4d date-picker filter term
   if (col === '__wo') return DATA.workOrders.some((w) => w.unitId === rec.unitId && w.phase !== 'Complete' && !w.cancelled && (value === 'open' || w.phase === 'Part Ordered' || (w.lineItems || []).some((l) => l.phase === 'Part Ordered')));
@@ -2028,8 +2028,8 @@ function afterFilterChange(scope) {
   render();
   document.querySelector(scope === 'global' ? '#globalsearch' : `.mini-search[data-card="${scope}"]`)?.focus();
 }
-// A1 — a footer chip adds an EXACT, removable filter pill to the card's search bar (one
-// filtering pathway, cleared from the search bar) instead of a separate sticky footer filter.
+// A1 — adds an EXACT, removable filter pill to the card's search bar (the Not-Ready chip and
+// other col-scoped filters route through here, so there's ONE filtering pathway: the search bar).
 function addColFilter(scope, col, value) {
   const arr = termsFor(scope);
   if (!arr.some((ft) => ft.col === col && String(ft.value) === String(value))) arr.push({ t: colFilterLabel(scope, col, value), value, col, neg: false });
@@ -2194,7 +2194,6 @@ function pageDefaultSlice(tab) {
     case 'kpis': return { key: 'kpis', value: {} };
     case 'general': return { key: 'company', value: {} };
     case 'requirements': return { key: 'rentalRules', value: {} };
-    case 'layout': return { key: 'layout', value: { footers: {} } };
     case 'fields': return { key: 'customFields', value: { customers: [], units: [], rentals: [], invoices: [] } };
     case 'inspections': return { key: 'inspections', value: Object.fromEntries([...new Set((DATA.categories || []).map((c) => inspFamilyKey(c)))].map((k) => [k, { required: false, items: [] }])) };
     default: return null;   // Logins / planned tabs have no resettable slice
@@ -2238,9 +2237,6 @@ async function undoLastSettings() {
 // Company identity (Settings → Company). Read-through with shipped fallbacks, so an empty
 // config keeps every surface exactly as it ships today.
 const companyCfg = () => (state.settings && state.settings.company) || {};
-// Layout prefs (Settings → Layout & Footers). Read-through; default keeps every footer shown.
-const layoutCfg = () => (state.settings && state.settings.layout) || {};
-const footerHidden = (card) => (layoutCfg().footers || {})[card] === 'off';
 // Admin-defined custom fields per entity (Settings → Custom Fields). Values live schema-less
 // on the record (rec.custom[fieldId]); an empty config means no extra fields anywhere.
 const customFieldsFor = (entity) => ((state.settings && state.settings.customFields) || {})[entity] || [];
@@ -2303,7 +2299,6 @@ const SETTINGS_TABS = [
   { id: 'requirements',  label: 'Rental Rules',     icon: STATUS_ICONS.shield,    v1: true },
   { id: 'kpis',          label: 'KPIs & Rings',     icon: STATUS_ICONS.gauge,     v1: true },
   { id: 'notifications', label: 'Notifications',    icon: I.bell,                 note: 'Team chat on/off, driver dispatch alerts, customer reminders & cadence.' },
-  { id: 'layout',        label: 'Layout & Footers', icon: I.grid,                 v1: true },
   { id: 'integrations',  label: 'Integrations',     icon: STATUS_ICONS.zap,       note: 'Stripe, Maps, telematics feed — references & toggles (secrets stay server-side).' },
 ];
 const draftStatusOv = (o, set, val) => (((o.draftSettings || {}).status || {})[set] || {})[val] || {};
@@ -2329,7 +2324,6 @@ function settingsBoardHtml(o) {
   else if (o.tab === 'kpis') pane = settingsKpisPane(o);
   else if (o.tab === 'general') pane = settingsCompanyPane(o);
   else if (o.tab === 'requirements') pane = settingsRulesPane(o);
-  else if (o.tab === 'layout') pane = settingsLayoutPane(o);
   else if (o.tab === 'fields') pane = settingsFieldsPane(o);
   else if (o.tab === 'inspections') pane = settingsInspectionsPane(o);
   else pane = settingsPlannedPane(SETTINGS_TABS.find((t) => t.id === o.tab));
@@ -2402,27 +2396,6 @@ function settingsRulesPane(o) {
     <div class="rule-list">${rows}</div>
     <div class="rule-planned-head">Coming once their capture field exists</div>
     <div class="rule-list">${planned}</div>`;
-}
-// Cards that carry a totals footer (the highlighted roll-up row beneath the list).
-const LAYOUT_FOOTER_CARDS = [
-  { key: 'rentals', label: 'Rentals' }, { key: 'units', label: 'Units' }, { key: 'customers', label: 'Customers' },
-  { key: 'categories', label: 'Categories' }, { key: 'invoices', label: 'Invoices' }, { key: 'workOrders', label: 'Work Orders' },
-  { key: 'inspections', label: 'Inspections' },
-];
-function settingsLayoutPane(o) {
-  const draft = (o.draftSettings && o.draftSettings.layout && o.draftSettings.layout.footers) || (state.settings && state.settings.layout && state.settings.layout.footers) || {};
-  const rows = LAYOUT_FOOTER_CARDS.map((c) => {
-    const shown = draft[c.key] !== 'off';
-    return `<div class="rule-row">
-      <div class="rule-main"><span class="rule-label">${CARD_ICON[c.key] || ''}${esc(c.label)} footer</span><span class="rule-desc">The totals roll-up beneath the ${esc(c.label.toLowerCase())} list.</span></div>
-      ${segCtl([{ label: 'Hide', js: 'js-layout-footer', data: { card: c.key, val: 'off' }, on: shown ? null : 'red' }, { label: 'Show', js: 'js-layout-footer', data: { card: c.key, val: 'on' }, on: shown ? 'green' : null }])}
-    </div>`;
-  }).join('');
-  return `
-    <div class="set-pane-head"><h4>Layout &amp; Footers</h4><p>Show or hide each card's <strong>totals footer</strong> — the highlighted roll-up row beneath its list. Everything defaults to shown.</p></div>
-    <div class="rule-list">${rows}</div>
-    <div class="rule-planned-head">More layout controls coming</div>
-    <div class="rule-list"><div class="rule-row rule-soon"><div class="rule-main"><span class="rule-label">Columns · sort · grid order</span><span class="rule-desc">Builds on the existing List-View column picker — a focused follow-on so the two don't fight.</span></div><span class="rule-soon-tag">Planned</span></div></div>`;
 }
 // Entities that can carry custom fields. v1 wires the Customers form; others store defs but
 // their forms aren't wired yet (shown as 'form coming').
@@ -3756,108 +3729,6 @@ function fmtAggValue(col, a, calc) {
   const v = a[calc] != null ? a[calc] : a.sum;
   return col.type === 'money' ? money(v) : col.type === 'pct' ? num(v) + '%' : num(v);
 }
-/* Footer chips Jac pruned as noise (2026-06-16): whole numeric roll-ups dropped
-   per card, plus a few badge VALUES. No Show is a rental-card-only signal. */
-const FOOT_DROP_NUM = { units: ['service'], rentals: ['price'], customers: ['rentals'] };
-const footDropNum = (card, key) => (FOOT_DROP_NUM[card] || []).includes(key);
-const footDropBadge = (card, value) =>
-  (value === 'No Show' && card !== 'rentals') ||      // No Show = rental card only
-  (value === 'Refunded' && card !== 'invoices') ||    // Refunded = invoice card only
-  value === 'Returned' || value === 'Card OK';
-/** The highlighted summary row beneath a card's List View: badge value-counts +
- *  numeric roll-ups (e.g. "6 Tomorrow · 900 HRS avg · 12 Part Needed"). */
-function listTotalsEl(card, rows, session) {
-  if (!rows || !rows.length) return null;
-  if (footerHidden(card)) return null;   // Settings → Layout & Footers: this card's totals footer is hidden
-  const cols = cardColumns(card, session);
-  const sel = loadListTotals(card);                 // null = every aggregatable column
-  const allowed = sel ? new Set(sel) : null;
-  const totCard = (session.cards && session.cards[card]) ? card : 'shop';   // shop sub-types route to the shop card
-  const tf = session.cards[totCard] && session.cards[totCard].totalFilter;
-  const chips = [];   // { k: col.key, html } — buckets let rentals split Billing/Status rows
-  for (const col of cols) {
-    if (allowed && !allowed.has(col.key)) continue;
-    if (footDropNum(card, col.key)) continue;            // Jac-pruned numeric roll-up
-    const a = aggColumn(col, rows);
-    if (a.kind === 'badge') {
-      // each value-count is a button → filters the list to that value.
-      // Registry-set columns order by the SET's canonical order (Jac: faster to use),
-      // ad-hoc badges keep count-desc.
-      const ord = col.set ? Object.keys(STATUS[col.set] || {}) : null;
-      Object.entries(a.counts).sort((x, y) => ord ? ord.indexOf(x[0]) - ord.indexOf(y[0]) : y[1] - x[1]).forEach(([key, n]) => {
-        if (footDropBadge(card, key)) return;            // Jac-pruned badge value
-        const m = col.meta ? col.meta(key) : { label: key, color: 'gray' };
-        const on = tf && tf.col === col.key && String(tf.value) === String(key);
-        chips.push({ k: col.key, html: `<button class="tot-chip c-${m.color} js-tot-chip${on ? ' on' : ''}" data-r="R4" data-tot-card="${totCard}" data-tot-col="${col.key}" data-tot-val="${esc(String(key))}">${n} ${esc(m.label)}</button>` });
-      });
-    } else if (a.kind === 'num' && a.count) {
-      const calc = col.agg === 'sum' ? 'sum' : 'avg';
-      const val = col.type === 'money' ? money(a[calc]) : num(a[calc]);
-      chips.push({ k: col.key, html: `<span class="tot-chip" data-r="R4">${val} ${esc(col.label)} ${calc}</span>` });
-    }
-  }
-  // v2: the units footer carries the SHOP — open-WO + parts-ordered counts
-  // (the standalone Inspections/WO tabs went away; Jac call #1)
-  if (card === 'units') {
-    const openBy = new Set(DATA.workOrders.filter((w) => w.phase !== 'Complete' && !w.cancelled).map((w) => w.unitId));
-    const ordBy = new Set(DATA.workOrders.filter((w) => w.phase !== 'Complete' && !w.cancelled && (w.phase === 'Part Ordered' || (w.lineItems || []).some((l) => l.phase === 'Part Ordered'))).map((w) => w.unitId));
-    const nOpen = rows.filter((u) => openBy.has(u.unitId)).length;
-    const nOrd = rows.filter((u) => ordBy.has(u.unitId)).length;
-    if (nOpen) { const on = tf && tf.col === '__wo' && tf.value === 'open'; chips.push({ k: '__wo', html: `<button class="tot-chip c-red js-tot-chip${on ? ' on' : ''}" data-r="R4" data-tot-card="units" data-tot-col="__wo" data-tot-val="open">${nOpen} WOs Open</button>` }); }
-    if (nOrd) { const on = tf && tf.col === '__wo' && tf.value === 'ordered'; chips.push({ k: '__wo', html: `<button class="tot-chip c-yellow js-tot-chip${on ? ' on' : ''}" data-r="R4" data-tot-card="units" data-tot-col="__wo" data-tot-val="ordered">${nOrd} Parts Ordered</button>` }); }
-  }
-  if (!chips.length) return null;
-  const node = el('div', 'list-totals');
-  // Footer sections (Jac 2026-06-23): group chips into labeled sections so Fleet · Rental ·
-  // Shop (units), Billing · Status (rentals), and Type · Finance (customers) read as one shop.
-  const totSec = (label, ks) => { const h = chips.filter((c) => ks.has(c.k)).map((c) => c.html).join(''); return h ? `<span class="tot-sec"><span class="tot-label">${label}</span>${h}</span>` : ''; };
-  if (card === 'units') {
-    node.classList.add('sectioned');
-    node.innerHTML = [
-      totSec('Fleet', new Set(['inspection', 'fleet', 'hours'])),
-      totSec('Rental', new Set(['rental'])),
-      totSec('Shop', new Set(['service', 'wash', '__wo'])),
-    ].filter(Boolean).join('') || chips.map((c) => c.html).join('');
-  } else if (card === 'rentals') {
-    node.classList.add('sectioned');
-    node.innerHTML = [
-      totSec('Billing', new Set(['invoice', 'price'])),
-      totSec('Status', new Set(['status', 'window', 'customer'])),
-    ].filter(Boolean).join('') || chips.map((c) => c.html).join('');
-  } else if (card === 'customers') {
-    node.classList.add('sectioned');
-    node.innerHTML = [
-      totSec('Type', new Set(['account'])),
-      totSec('Finance', new Set(['pay', 'card'])),
-      totSec('Activity', new Set(['rentals', 'email', 'company'])),
-    ].filter(Boolean).join('') || chips.map((c) => c.html).join('');
-  } else {
-    node.innerHTML = chips.map((c) => c.html).join('');
-  }
-  return node;
-}
-/** Filter a card's list rows by an active footer-chip filter (col === value). */
-function applyTotalFilter(card, rows, session) {
-  const cs = session.cards[card]; if (!cs || !cs.totalFilter) return rows;
-  if (cs.totalFilter.col === '__wo') {           // v2 synthetic footer chips: units with shop work
-    const want = cs.totalFilter.value;
-    const ids = new Set(DATA.workOrders.filter((w) => w.phase !== 'Complete' && !w.cancelled && (want === 'open' || w.phase === 'Part Ordered' || (w.lineItems || []).some((l) => l.phase === 'Part Ordered'))).map((w) => w.unitId));
-    return rows.filter((rec) => ids.has(rec.unitId));
-  }
-  if (cs.totalFilter.col === '__cond') return rows.filter((rec) => rec.inspectionStatus === cs.totalFilter.value);   // the Not Ready tab chip
-  const col = cardColumns(card, session).find((c) => c.key === cs.totalFilter.col);
-  return col ? rows.filter((rec) => String(col.get(rec)) === String(cs.totalFilter.value)) : rows;
-}
-/** A removable "Filtered to X" chip when a footer-chip filter is active. */
-function totalFilterChip(card, session) {
-  const cs = session.cards[card]; if (!cs || !cs.totalFilter) return null;
-  const col = cardColumns(card, session).find((c) => c.key === cs.totalFilter.col);
-  const m = (col && col.meta) ? col.meta(cs.totalFilter.value) : { label: cs.totalFilter.value };
-  const chip = el('div', 'fleet-chip');
-  chip.innerHTML = `<span class="muted">Filtered to</span> <b>${esc(m.label)}</b> <button class="x js-clear-totfilter" data-card="${card}" data-tip="Clear">${I.x}</button>`;
-  return chip;
-}
-
 /* ── §13.3 LIST-VIEW LAYOUT — per-device choice of which registry columns show in
    row 1 (details, non-badge, Name always first) vs row 2 (badges). Saved to
    localStorage; when absent a card uses its hand-tuned ROWS renderer. ── */
@@ -3888,22 +3759,6 @@ function loadListLayout(card) {
 function saveListLayout(card, layout) {
   LIST_LAYOUTS[card] = layout || undefined;
   try { if (layout) localStorage.setItem(LIST_LAYOUT_KEY(card), JSON.stringify(layout)); else localStorage.removeItem(LIST_LAYOUT_KEY(card)); } catch (e) { /* private mode */ }
-}
-/* Which columns roll up in the card's totals footer — chosen per device, independent
-   of the row layout. null = the default (every aggregatable column). */
-const LIST_TOTALS_KEY = (card) => `jactec.listTotals.${card}`;
-const LIST_TOTALS = Object.create(null);
-const isAggCol = (c) => c.badge || c.type === 'money' || c.type === 'num' || c.type === 'pct';
-function loadListTotals(card) {
-  if (card in LIST_TOTALS) return LIST_TOTALS[card];
-  let v = null;
-  try { const raw = localStorage.getItem(LIST_TOTALS_KEY(card)); if (raw) v = JSON.parse(raw); } catch (e) { v = null; }
-  if (Array.isArray(v)) { const keys = new Set((CARD_COLUMNS[card] || []).map((c) => c.key)); v = v.filter((k) => keys.has(k)); } else v = null;
-  LIST_TOTALS[card] = v; return v;
-}
-function saveListTotals(card, keys) {
-  LIST_TOTALS[card] = keys || undefined;
-  try { if (keys) localStorage.setItem(LIST_TOTALS_KEY(card), JSON.stringify(keys)); else localStorage.removeItem(LIST_TOTALS_KEY(card)); } catch (e) {}
 }
 /** A list row's inner HTML from a saved layout: Name is the locked title, the
  *  rest of row 1 are non-badge values, row 2 are badge pills. */
@@ -5458,14 +5313,10 @@ function columnEl(col, session) {
   const cs = card.dataset.card && session.cards ? session.cards[card.dataset.card] : null;
   card.dataset.view = (cs && cs.mode === 'standard' && cs.recId != null) ? `${cs.recType || ''}:${cs.recId}` : 'list';
   if (!document.body.classList.contains('is-phone')) card.insertBefore(colTabsEl(col, active, session), card.firstChild);   // toggles live INSIDE the card top on desktop; on phones they move to the footer dock (§M1)
-  const tot = card.querySelector('.card-body .list-totals');             // freeze the totals out of the scroll
-  // §M1 — phones invert the desktop layout: the card "footer" (totals) sits at the TOP,
-  // while the toggles + search live in the bottom dock. Desktop keeps it as a footer.
-  if (tot) { if (document.body.classList.contains('is-phone')) card.insertBefore(tot, card.firstChild); else card.appendChild(tot); }
-  // Desktop: freeze the search/sort bar out of the scroll too — a full-width card
+  // Desktop: freeze the search/sort bar out of the scroll — a full-width card
   // header so the card-body scrollbar runs ONLY through the list below it, never in
-  // a gutter alongside the bar (the "funny" gap). Mirrors the .list-totals footer
-  // freeze; on phones render() relocates the bar to the bottom dock instead.
+  // a gutter alongside the bar (the "funny" gap). On phones render() relocates the
+  // bar to the bottom dock instead.
   if (!document.body.classList.contains('is-phone')) {
     const lb = card.querySelector('.card-body .listbar'), body = card.querySelector('.card-body');
     if (lb && body) card.insertBefore(lb, body);
@@ -5632,9 +5483,6 @@ function listView(cardDef, session) {
   } else if (availWin && card === 'categories') {
     rows = [...rows].sort((a, b) => (availUnavailable('categories', a) ? 1 : 0) - (availUnavailable('categories', b) ? 1 : 0));
   }
-  rows = applyTotalFilter(card, rows, session);          // a clicked footer-chip narrows the list
-  const tfChip = totalFilterChip(card, session); if (tfChip) wrap.appendChild(tfChip);
-
   const list = el('div', 'list');
   // §0.2 — Rentals always lead with a +New Rental row, no matter the search (obsoletes
   // the old toolbar Rental button). INSIDE the list so it shares the row inset — was
@@ -5668,8 +5516,6 @@ function listView(cardDef, session) {
     appendWindowed(list, rows, cs, card, (rec) => list.appendChild(rowEl(card, rec)));
   }
   wrap.appendChild(list);
-  const totals = listTotalsEl(card, rows, session);   // highlighted roll-up row at the card's foot
-  if (totals) wrap.appendChild(totals);
   return wrap;
 }
 const PLUS_NEW = new Set(['rentals', 'invoices', 'customers']);
@@ -5832,18 +5678,6 @@ function shopListView(session, byType, forcedSeg) {
   }
   items = shopSort(items, cs.sort);
 
-  // a clicked footer-chip narrows the shop list (filter is stored on the shop card)
-  if (cs.totalFilter && segActive !== 'all') {
-    const fcol = (CARD_COLUMNS[segActive] || []).find((c) => c.key === cs.totalFilter.col);
-    if (fcol) {
-      items = items.filter((it) => String(fcol.get(it.rec)) === String(cs.totalFilter.value));
-      const m = fcol.meta ? fcol.meta(cs.totalFilter.value) : { label: cs.totalFilter.value };
-      const chip = el('div', 'fleet-chip');
-      chip.innerHTML = `<span class="muted">Filtered to</span> <b>${esc(m.label)}</b> <button class="x js-clear-totfilter" data-card="shop" data-tip="Clear">${I.x}</button>`;
-      wrap.appendChild(chip);
-    }
-  }
-
   const list = el('div', 'list');
   if (!items.length) {
     // creation lives in ONE place — the header + New menu (no per-card +New)
@@ -5852,10 +5686,6 @@ function shopListView(session, byType, forcedSeg) {
     appendWindowed(list, items, cs, 'shop', (it) => list.appendChild(shopRowEl(it.type, it.rec)));
   }
   wrap.appendChild(list);
-  if (segActive !== 'all') {   // a single shop segment has one record shape → roll it up
-    const tot = listTotalsEl(segActive, items.map((it) => it.rec), session);
-    if (tot) wrap.appendChild(tot);
-  }
   return wrap;
 }
 
@@ -9357,16 +9187,11 @@ function bvCustomizePanel(card) {
   const nonBadge = cols.filter((c) => !c.pill && c.key !== nameKey);
   const badges = cols.filter((c) => c.pill);
   const box = (c, row, on, locked) => `<label class="bv-pick${locked ? ' locked' : ''}"><input type="checkbox" class="js-bv-pick" data-card="${card}" data-row="${row}" data-col="${c.key}"${on ? ' checked' : ''}${locked ? ' disabled' : ''}/> ${esc(c.label)}</label>`;
-  const aggCols = cols.filter(isAggCol);
-  const totSel = loadListTotals(card);                  // null = all
-  const totBox = (c) => `<label class="bv-pick"><input type="checkbox" class="js-bv-tot" data-card="${card}" data-col="${c.key}"${(totSel ? totSel.includes(c.key) : true) ? ' checked' : ''}/> ${esc(c.label)}</label>`;
   return `<div class="bv-customize">
     <div class="bv-pick-group"><h4>List row 1 — details <span class="muted">(${(layout.row1 || []).length}/6)</span></h4>
       ${box(cols[0], 'row1', true, true)}${nonBadge.map((c) => box(c, 'row1', layout.row1.includes(c.key), false)).join('')}</div>
     <div class="bv-pick-group"><h4>List row 2 — badges <span class="muted">(${(layout.row2 || []).length}/6)</span></h4>
       ${badges.length ? badges.map((c) => box(c, 'row2', layout.row2.includes(c.key), false)).join('') : '<span class="muted">No badge columns on this card.</span>'}</div>
-    <div class="bv-pick-group"><h4>Card totals <span class="muted">(footer)</span></h4>
-      ${aggCols.length ? aggCols.map(totBox).join('') : '<span class="muted">Nothing to total.</span>'}</div>
     <button class="pill ghost js-bv-resetlayout" data-r="R18" data-card="${card}">Reset to defaults</button>
   </div>`;
 }
@@ -10323,8 +10148,6 @@ function onClick(e) {
   if (closest('.js-kpi-refine')) { e.stopPropagation(); const b = closest('.js-kpi-refine'); openWranglerForKpi(b.dataset.role, Number(b.dataset.i)); return; }
   // Rental Rules tab
   if (closest('.js-rule-set')) { e.stopPropagation(); const o = state.overlay, b = closest('.js-rule-set'); if (o) { o.draftSettings = o.draftSettings || {}; o.draftSettings.rentalRules = o.draftSettings.rentalRules || { ...((state.settings && state.settings.rentalRules) || {}) }; o.draftSettings.rentalRules[b.dataset.rule] = b.dataset.val === 'required' ? 'required' : 'off'; renderOverlay(); } return; }
-  // Layout & Footers tab
-  if (closest('.js-layout-footer')) { e.stopPropagation(); const o = state.overlay, b = closest('.js-layout-footer'); if (o) { o.draftSettings = o.draftSettings || {}; o.draftSettings.layout = o.draftSettings.layout || { ...((state.settings && state.settings.layout) || {}) }; o.draftSettings.layout.footers = { ...(o.draftSettings.layout.footers || {}), [b.dataset.card]: b.dataset.val === 'off' ? 'off' : 'on' }; renderOverlay(); } return; }
   // Custom Fields tab
   if (closest('.js-cf-entity')) { e.stopPropagation(); const o = state.overlay; if (o) { o.cfEntity = closest('.js-cf-entity').dataset.ent; renderOverlay(); } return; }
   if (closest('.js-cf-type')) { e.stopPropagation(); const o = state.overlay; if (o) { o.cfDraft = { ...(o.cfDraft || { label: '', type: 'text', required: false }), type: closest('.js-cf-type').dataset.type }; renderOverlay(); } return; }
@@ -10530,7 +10353,7 @@ function onClick(e) {
   if (closest('.js-bv-insrow')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { o.extraRows = o.extraRows || []; o.extraRows.push({ id: 'xr' + (++o.seq), pos: Number(closest('.js-bv-insrow').dataset.pos), cells: {} }); renderOverlay(); } return; }
   if (closest('.js-bv-rmrow')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { const id = closest('.js-bv-rmrow').dataset.row; o.extraRows = (o.extraRows || []).filter((er) => er.id !== id); renderOverlay(); } return; }
   if (closest('.js-bv-customize')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { o.customize = !o.customize; renderOverlay(); } return; }
-  if (closest('.js-bv-resetlayout')) { e.stopPropagation(); const card = closest('.js-bv-resetlayout').dataset.card; saveListLayout(card, null); saveListTotals(card, null); render(); renderOverlay(); return; }
+  if (closest('.js-bv-resetlayout')) { e.stopPropagation(); const card = closest('.js-bv-resetlayout').dataset.card; saveListLayout(card, null); render(); renderOverlay(); return; }
   if (closest('.js-new-cust-search')) { e.stopPropagation(); const cs = activeSession().cards.customers; return startNewCustomer(parseCustomerSearch(cs.search)); }
   if (closest('.js-new-unit-search')) { e.stopPropagation(); return quickAddUnitFromSearch(activeSession().cards.units.search); }
   if (closest('.js-new-cat-search')) { e.stopPropagation(); return quickAddCategoryFromSearch(activeSession().cards.categories.search); }
@@ -10756,17 +10579,6 @@ function onClick(e) {
   if (closest('.js-addview')) { if (!adminUnlocked()) { document.querySelectorAll('.dropdown-menu').forEach((n) => n.remove()); return; } const b = closest('.js-addview'); const card = b.dataset.card; const cs = activeSession().cards[card]; const search = (cs.search || '').trim(); const terms = (cs.filterTerms || []).map((t) => ({ ...t })); const suggested = viewLabel(search, terms); const name = (typeof prompt === 'function' ? prompt('Name this view:', suggested) : suggested); document.querySelectorAll('.dropdown-menu').forEach((n) => n.remove()); if (name && name.trim()) { const views = loadViews(card); if (!views.some((v) => v.name.toLowerCase() === name.trim().toLowerCase())) { views.push({ name: name.trim(), search, terms }); saveViews(card, views); } } render(); return; }
   if (closest('.js-sortfield')) { const b = closest('.js-sortfield'); const cs = activeSession().cards[b.dataset.card]; const f = SORT_FIELDS[b.dataset.card].find((x) => x.field === b.dataset.field); if (f) { cs.sort = { ...f }; saveSort(b.dataset.card, cs.sort); } document.querySelectorAll('.dropdown-menu').forEach((n) => n.remove()); render(); return; }
   if (closest('.js-sortdir')) { const card = closest('.js-sortdir').dataset.card; const cs = activeSession().cards[card]; cs.sort.dir = cs.sort.dir === 'asc' ? 'desc' : 'asc'; saveSort(card, cs.sort); render(); return; }
-
-  // footer-totals badge → filter the list to that value (click the active chip to clear)
-  if (closest('.js-tot-chip')) {
-    const b = closest('.js-tot-chip'); const card = b.dataset.totCard; const cs = activeSession().cards[card];
-    if (cs) {
-      if (cs.mode === 'standard') { cs.mode = 'list'; cs.recId = null; cs.recType = null; }   // footers show the filtered list, not a record detail
-      addColFilter(card, b.dataset.totCol, b.dataset.totVal);   // A1 — route into the card's search bar as a removable, exact-match pill
-    }
-    return;
-  }
-  if (closest('.js-clear-totfilter')) { e.stopPropagation(); const cs = activeSession().cards[closest('.js-clear-totfilter').dataset.card]; if (cs) cs.totalFilter = null; render(); return; }
 
   // inline edit (click a value → input)
   if (closest('.inline-edit')) { e.stopPropagation(); const _ie = closest('.inline-edit'); if (_ie.dataset.admin === '1' && !adminUnlocked()) return requireAdmin('Categories and pricing are Admin-only.', () => startInlineEdit(_ie)); return startInlineEdit(_ie); }
@@ -11707,17 +11519,6 @@ function onChange(e) {
     const nameKey = (CARD_COLUMNS[card] || [])[0]?.key;   // Name stays as the locked title
     if (nameKey && !layout.row1.includes(nameKey)) layout.row1.unshift(nameKey);
     saveListLayout(card, layout);
-    render(); renderOverlay();
-    return;
-  }
-  // Board View "Card totals" picker → toggle a column in/out of the footer roll-up.
-  if (e.target.classList.contains('js-bv-tot')) {
-    const card = e.target.dataset.card, col = e.target.dataset.col;
-    const aggKeys = (CARD_COLUMNS[card] || []).filter(isAggCol).map((c) => c.key);
-    let sel = loadListTotals(card); sel = (sel ? sel.slice() : aggKeys.slice());   // start from "all"
-    if (e.target.checked) { if (!sel.includes(col)) sel.push(col); }
-    else { const i = sel.indexOf(col); if (i >= 0) sel.splice(i, 1); }
-    saveListTotals(card, sel);
     render(); renderOverlay();
     return;
   }
@@ -14205,7 +14006,7 @@ function exposeTestApi() {
       latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs, driveViewUrl, mergeWranglerRails,
       recordDateMatch, dateTermHits, rowMatches,
       kpiFor, kpiRaw, kpiEval, legacyKpiPct, legacyKpiRaw, KPI_DEFAULTS, wrValidateKpi, roleRings,
-      companyRevenueGoal, companyName, companyTagline, rentalRuleBlock, dueForCustomer, footerHidden, customFieldsFor, checklistFor, checklistRequired, inspFamilyKey, inspKeyOfCat, applySettings, getStatus, pageDefaultSlice, previewOverlayFor, WINDOW_CATALOG, setRole: (r) => { currentRole = r || ''; render(); },
+      companyRevenueGoal, companyName, companyTagline, rentalRuleBlock, dueForCustomer, customFieldsFor, checklistFor, checklistRequired, inspFamilyKey, inspKeyOfCat, applySettings, getStatus, pageDefaultSlice, previewOverlayFor, WINDOW_CATALOG, setRole: (r) => { currentRole = r || ''; render(); },
       openCustomerForm, renderOverlay, render, cardComplete, cardCaptureState, cardHasSelfie, cardHasSignature, captureSelfie, captureSignature, __state: state };   // UI drivers for headless screenshot/e2e tests
 
   } catch (e) { /* no window (non-browser) */ }

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -523,14 +523,6 @@ try {
     st.settings.company = { maxNetDays: 60 }; const dueCap60 = T.dueForCustomer(tc.customerId); ok(dueCap60 > due30b, 'raising the system max to 60 lets the same Net 999 customer go further out');
     tc.netDays = savedNd; st.settings.company = savedCo2;   // restore
 
-    // 24) Layout & Footers — per-card footer visibility (default shown = zero change)
-    const savedLayout = st.settings.layout;
-    st.settings.layout = undefined;
-    ok(T.footerHidden('rentals') === false, 'no layout config → footers shown (default)');
-    st.settings.layout = { footers: { rentals: 'off' } };
-    ok(T.footerHidden('rentals') === true && T.footerHidden('units') === false, 'a card footer can be hidden without affecting others');
-    st.settings.layout = savedLayout;   // restore
-
     // 25) Custom Fields — admin-defined fields per entity (default none = forms unchanged)
     const savedCF = st.settings.customFields;
     st.settings.customFields = undefined;
@@ -569,7 +561,6 @@ try {
     ok(T.pageDefaultSlice('statuses').key === 'status' && T.pageDefaultSlice('kpis').key === 'kpis', 'each tab resets only its own settings slice');
     const cfReset = T.pageDefaultSlice('fields').value;
     ok(Array.isArray(cfReset.customers) && cfReset.customers.length === 0 && Array.isArray(cfReset.units), 'Reset page (Custom Fields) empties every entity, not just the active one');
-    ok(JSON.stringify(T.pageDefaultSlice('layout').value) === JSON.stringify({ footers: {} }), 'Reset page (Layout) restores all footers shown');
     ok(T.pageDefaultSlice('logins') === null && T.pageDefaultSlice('notifications') === null, 'tabs with no settings slice (Logins/planned) have no Reset page');
 
     // 29) §5.4d DATE SEARCH — overlap (rentals), point-in-range (dated cards), invoice

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623s" />
+  <link rel="stylesheet" href="style.css?v=20260623t" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623s"></script>
-  <script type="module" src="app.js?v=20260623s"></script>
+  <script src="rule-usage.js?v=20260623t"></script>
+  <script type="module" src="app.js?v=20260623t"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -384,8 +384,6 @@ input { font-family: inherit; }
 /* Give the scroll content clearance below the floating bottom-right FAB cluster so the
    History / notes don't sit under the notification + inbox buttons. */
 .is-phone .card-body { padding-bottom: 10px; }   /* FABs are folded into the footer Tools menu now, so no big clearance needed */
-/* phone inverts the layout — the totals strip is a card HEADER now (border + shadow flip down) */
-.is-phone .list-totals { border-top: none; border-bottom: 1px solid var(--accent-line); box-shadow: 0 5px 11px -7px rgba(0,0,0,.45); }
 /* Card tabs = a SEGMENTED NAV BAR (one container, flat segments) — now sit INSIDE
    the card at its top, centered, so the card's height/glow includes the toggles. */
 .col-tabs { display: inline-flex; gap: 3px; flex: 0 0 auto; align-self: center; max-width: calc(100% - 16px); overflow: hidden;
@@ -1712,26 +1710,12 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .board-table tbody tr.js-board-row { cursor: pointer; }
 .board-detail { max-width: 820px; margin: 0 auto; }
 
-/* §13 — Board-View icon (left of each card's search) + List-View totals row */
+/* §13 — Board-View icon (left of each card's search) */
 .listbar { display: flex; align-items: center; gap: 8px; }
 .bv-btn { flex: 0 0 auto; width: 32px; height: 32px; display: inline-flex; align-items: center; justify-content: center;
   border-radius: 9px; background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); }
 .bv-btn:hover { color: var(--accent); border-color: var(--accent-line); background: var(--panel-2); }
 .bv-btn svg { width: 16px; height: 16px; }
-/* the value totals, frozen as a real Card Footer below the scrolling body */
-.list-totals { flex: 0 0 auto; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; padding: 9px 12px;
-  background: var(--card-head); border-top: 1px solid var(--accent-line); box-shadow: 0 -5px 11px -7px rgba(0,0,0,.45); }
-/* R4 (Jac 2026-06-12): footer chips wear the DERIVED-pill treatment — no
-   background, no border, no icon; colored ink + underline on hover/active. */
-.tot-chip { font-size: 11px; font-weight: 700; padding: 2px 2px; background: none; color: var(--txt-2);
-  border: none; white-space: nowrap; }
-.tot-chip.c-green { color: var(--green); } .tot-chip.c-red { color: var(--red); } .tot-chip.c-yellow { color: var(--yellow); }
-.tot-chip.c-blue { color: var(--blue); } .tot-chip.c-purple { color: var(--purple); } .tot-chip.c-orange { color: var(--orange); }
-.tot-chip.c-navy { color: var(--navy); } .tot-chip.c-pink { color: var(--pink); } .tot-chip.c-brown { color: var(--brown); }
-/* badge-value chips are clickable → filter the list to that value */
-button.tot-chip { cursor: pointer; font-family: inherit; }
-button.tot-chip:hover { text-decoration: underline; text-underline-offset: 3px; }
-button.tot-chip.on { text-decoration: underline; text-underline-offset: 3px; filter: brightness(1.18); }
 
 /* §13.2 — Board View spreadsheet popup */
 .bv-popup { width: 92vw; height: 86vh; max-width: 1400px; }
@@ -2752,16 +2736,6 @@ body { font-variant-numeric: tabular-nums; }
 @container (max-width: 340px) {
   .cr-statuses { grid-template-columns: 1fr; min-width: 80px; }
 }
-
-/* ── FOOTER SECTIONS: labeled chip groups separated by a rule (units/rentals/customers). ── */
-.list-totals.sectioned { gap: 0; padding: 6px 0; }
-.tot-sec { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; padding: 3px 12px; border-right: 1px solid var(--line); }
-.tot-sec:last-child { border-right: none; }
-.tot-label { font-size: 9px; font-weight: 700; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .9px; color: var(--txt-3); margin-right: 2px; flex: 0 0 auto; }
-
-/* rentals footer: Billing row over Rental-Status row (Jac) — kept for non-sectioned fallback */
-.list-totals.two-row { flex-direction: column; align-items: stretch; gap: 4px; }
-.list-totals.two-row .tot-row { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
 
 /* No-Preview Mode (Jac 2026-06-12): every eye — row chips + the toolbar — runs RED */
 .rbtn.js-roweye.off, .iconbtn.js-previews.off { color: var(--red); opacity: 1; }


### PR DESCRIPTION
Two changes (separable by commit).

## 1 — Remove the card totals footer (`a110e6f`)
Jac's call: the per-card totals footer (the frozen roll-up strip under each list) now duplicates the **graph view's** pie/mix counts — both click-to-filter — so it's dropped entirely. The graph view owns breakdowns/trends/leaders; the search pills cover ad-hoc filtering; the column reclaims the vertical space for list rows.

Removed:
- `listTotalsEl` + the `FOOT_DROP_*` prune helpers + the sectioned chips
- the **dead** `totalFilter` machinery (`applyTotalFilter` / `totalFilterChip` / `js-tot-chip` / `js-clear-totfilter`) — `totalFilter` was only ever set to `null`; the live chip-click already routed through `addColFilter` (search pills)
- the `LIST_TOTALS` store (`loadListTotals`/`saveListTotals`) + `isAggCol`
- the **Settings → "Layout & Footers"** tab + handler
- the Board View **"Card totals (footer)"** picker + `js-bv-tot` handler
- the §M1 mobile footer-at-top relocation + all footer CSS (`.list-totals`/`.tot-chip`/`.tot-sec`/`.tot-label`); `.fleet-chip` kept (reused by the unit-pick chip)

`totColMatch` stays — it powers graph-slice + Not-Ready-chip filtering, not the footer. `rule-usage.js` unchanged (R4 still lives on derived pills).

## 2 — Graph view: right-click to hide the filter pills / Views & sort (`930c5a1`)
In an **open graph view**, right-click (or long-press) the panel or the Views & sort control to open an **R20 context menu** that can hide:
- the clickable **filter-pill legend** under the charts (the donut slices stay clickable as the pointer filter path), and/or
- the **Views & sort** control (omitted from the listbar while the graph view is open; list view keeps it)

…with a **Reset** that restores both. The choice persists per device, per card (`localStorage` `jactec.gvChrome.<card>`; the key is removed once nothing is hidden). Reuses the existing `openCtxMenu` shell (new `openGvChromeMenu`) — no new menu CSS, themes for free. R20 `RULE_META` updated to note the variant.

## Test plan
- [ ] No totals footer under any card's list; no "Layout & Footers" Settings tab; Board View customise no longer shows the "Card totals" group; nothing references the removed symbols
- [ ] The **Not Ready** chip on Units still filters (it uses the search-pill path, not the footer)
- [ ] Open a card's **Graph view** → right-click the panel → menu offers **Hide filter pills** / **Hide Views & sort** / **Reset**; toggles persist across reload; Reset restores
- [ ] With pills hidden, the **pie donut slices still filter** the list; with sort hidden, the **graph toggle + search remain** so you can leave the graph
- [ ] CI green: smoke + logic-test + `gen-rule-usage --check` + `check-window-catalog`

> **a11y note:** hiding the pie legend removes the keyboard-focusable filter path for the donut (SVG slices aren't focusable) — it's opt-in and reversible via Reset, and filtering stays reachable through the search bar. Flag if you'd rather keep a keyboard path.

> Cache token bumped to `?v=20260623t`. Playwright (smoke/logic-test) runs in CI — not installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WRE9rweDsyZ8zRDpgsHKL

---
_Generated by [Claude Code](https://claude.ai/code/session_013WRE9rweDsyZ8zRDpgsHKL)_