### PR TITLE
Restore UI polish + neon colors (revert of accidental revert #291)

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -46,20 +46,29 @@ The app is organized into long-lived **area branches** (`area/*`), each owning a
   3. cut the task branch: `git checkout -b <domain>/<task>` and `git push -u origin <domain>/<task>`.
   4. Commit your work to the **task branch** and push there. Name it `<domain>/<task>`, NOT `area/<domain>/<task>` — git won't nest a branch under an existing branch's name.
 - **Test at the AREA level, LOCALLY — this is the primary debug loop (NOT staging).** When a feature merges to its `area/<domain>`, serve that branch and drive it on `localhost` — isolated, instant, no entanglement with anyone else's in-flight work. It's the dev-loop version of what `ci/smoke.mjs` already does (a static server), minus Playwright:
-  1. Save this tiny server to a **gitignored scratch path** (e.g. the session-output folder — never commit it) as `serve.mjs`:
+  > **Cloud session vs. local machine — read this first.** When Claude Code runs in the web/cloud environment (`CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE=cloud_default`), the static server starts inside the cloud container but the port is **NOT proxied** to Jac's browser — `http://localhost:9147` from a cloud session is unreachable. Detect with: `echo $CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE` (prints `cloud_default` = cloud, blank/other = local). **Cloud session's job: code, commit, push to the area branch.** Then Jac pulls on his **local machine** and serves there. If in doubt — the cloud session CAN start the server and confirm it responds inside the container (`curl -s http://localhost:9147 | head -3`) as a smoke-check that the code boots, but it cannot hand Jac a browser URL. The URL only works on Jac's local machine.
+  1. Save this server to a **gitignored scratch path** (e.g. the session-output folder — never commit it) as `serve.mjs`. **This runs on Jac's LOCAL machine** (or cloud, as a boot-smoke-check only — no browser URL from cloud):
      ```js
      import { createServer } from 'http';
      import { readFile } from 'fs/promises';
      import { extname, join, normalize } from 'path';
-     const T = { '.html':'text/html','.js':'text/javascript','.css':'text/css','.json':'application/json','.svg':'image/svg+xml' };
+     const MIME = { '.html':'text/html', '.js':'application/javascript', '.css':'text/css',
+       '.json':'application/json', '.png':'image/png', '.jpg':'image/jpeg',
+       '.svg':'image/svg+xml', '.ico':'image/x-icon', '.woff2':'font/woff2', '.woff':'font/woff' };
+     const ROOT = process.cwd();
      createServer(async (q, s) => {
-       try { let p = decodeURIComponent(q.url.split('?')[0]); if (p==='/') p='/index.html';
-         const b = await readFile(join('.', normalize(p)));
-         s.writeHead(200, { 'Content-Type': T[extname(p)] || 'application/octet-stream' }); s.end(b);
-       } catch { s.writeHead(404); s.end('404'); }
-     }).listen(9147, () => console.log('http://localhost:9147'));
+       try {
+         let p = decodeURIComponent(q.url.split('?')[0]);
+         if (p === '/') p = '/index.html';
+         const safe = normalize(p).replace(/^(\.\.[\/\\])+/, '');
+         const file = join(ROOT, safe);
+         const data = await readFile(file);
+         s.writeHead(200, { 'Content-Type': MIME[extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' });
+         s.end(data);
+       } catch { s.writeHead(404); s.end('Not found'); }
+     }).listen(9147, () => console.log('serving on http://localhost:9147'));
      ```
-  2. From the repo root on the area branch: `node <path>/serve.mjs` (**port 9147** — 8000 is reserved on this machine).
+  2. **On Jac's local machine:** pull the area branch (`git pull origin area/<domain>`), then from the repo root: `node <path>/serve.mjs` (**port 9147** — 8000 is reserved on this machine).
   3. Open `http://localhost:9147` and log in — password from **`$env:RW_PW`** (never hardcode or echo it; no var set → you can only check the pre-login surface). Then **exercise exactly the feature you built**, plus a sanity flow.
   - **Backend note:** local hits the SAME single GAS web app + Sheets DB that staging and main use (`app.js` → `BACKEND_URL`), gated by the team password — so local testing is **no riskier with real data than staging**. PII guard still applies: read for understanding; NEVER paste Drive/Sheets data into the repo/commits/seeds ([[jactec-real-data-migration]]).
   - Drive it with **Claude-in-Chrome** for an automated assertion (no local install needed), or just open it yourself.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,8 +34,8 @@ colors:
   track: "#22262e"
   # — Status registry: each hue means ONE thing everywhere
   ready: "#34d399"               # green  — ready / active
-  caution: "#f5c542"             # yellow — caution
-  danger: "#ff4242"              # red    — danger / overdue / failed
+  caution: "#ffe000"             # yellow — caution
+  danger: "#ff1040"              # red    — danger / overdue / failed
   link: "#5b9dff"               # blue   — link / commit action
   scheduled: "#b07cf5"           # purple — scheduled
   navy: "#6f8bdb"

--- a/app.js
+++ b/app.js
@@ -2767,7 +2767,11 @@ const FLAG_COND = {
   customers: {
     'unpaid-balance':    (c) => c.payStatus === 'Unpaid',
     'blacklisted':       (c) => /Blacklist/i.test(c.accountType || ''),
-    'no-card':           (c) => cardFlag(c) === 'none',
+    // Only flag if they have an actual business relationship — a rental (any status)
+    // or an invoice. Pure leads in the funnel with no booking don't need a card yet.
+    'no-card':           (c) => cardFlag(c) === 'none' &&
+      (DATA.rentals.some((r) => r.customerId === c.customerId) ||
+       DATA.invoices.some((i) => i.customerId === c.customerId)),
     'customer-lost':     (c) => customerActivity(c).stage === 'Lost',
     'customer-inactive': (c) => customerActivity(c).stage === 'Inactive',
     'partial-balance':   (c) => c.payStatus === 'Partial',
@@ -2841,6 +2845,17 @@ function unitPill(unitId, { x, xData } = {}) {
   const xb = x ? `<span class="x" data-x="${esc(x)}"${xData != null ? ` data-id="${esc(xData)}"` : ''}>✕</span>` : '';
   const chat = ` data-chat-el data-chat-label="${esc(u.name)}" data-chat-color="gray" data-chat-card="units" data-chat-rec="${esc(unitId)}"`;   // §17
   return `<span class="pill ref link" data-r="R2" data-pill-card="units" data-pill-rec="${esc(unitId)}"${chat}>${CARD_ICON.units}${esc(u.name)}${xb}</span>`;
+}
+/** R2e: ENTITY NAME PILL — Saira-stamped linked record. Matches the row-name look:
+ *  uppercase, flag-colored (most-urgent), card icon. Used in rental detail header/stalls. */
+function entityPill(card, rec, { x, xData } = {}) {
+  if (!rec) return '';
+  const id = idOf(card, rec);
+  const name = rec.name || '';
+  const flag = getEntityColor(card, rec) || 'gray';
+  const xb = x ? `<span class="x" data-x="${esc(x)}"${xData != null ? ` data-id="${esc(xData)}"` : ''}>✕</span>` : '';
+  const chat = ` data-chat-el data-chat-label="${esc(name)}" data-chat-color="${esc(flag)}" data-chat-card="${esc(card)}" data-chat-rec="${esc(id)}"`;
+  return `<span class="pill entity-stamp c-${flag}" data-r="R2" data-pill-card="${card}" data-pill-rec="${esc(id)}"${chat}>${CARD_ICON[card] || ''}<span class="t">${esc(name)}</span>${xb}</span>`;
 }
 /** R3b: a DATA CHIP — a plain fact (480 HRS, No GPS), independent of R3. */
 const badge = (label, color = 'gray') => `<span class="pill c-${color}" data-r="R3b"><span class="t">${esc(label)}</span></span>`;
@@ -3416,7 +3431,7 @@ function unitWoSoPill(u) {
   const wo = openWOForUnit(u.unitId);
   if (wo) return statusPill('woPhase', wo.phase, { card: 'workOrders', recId: wo.woId });
   const svc = topServiceForUnit(u);
-  return svc ? badge(svcText(svc), svc.color) : '';
+  return svc ? badge(svcText(svc), svc.color) : badge('No Orders', 'green');
 }
 
 /* ════════════════════════════════════════════════════════════════════════
@@ -3543,7 +3558,8 @@ const ROWS = {
     // Name TINTED by the customer's flag color (Jac): only red/yellow lead — a clear
     // customer keeps the calm default ink, archived/gray reads muted.
     const fc = getEntityColor('customers', c);
-    const nameColor = (fc === 'red' || fc === 'yellow') ? `var(--${fc})` : fc === 'gray' ? 'var(--txt-3)' : 'var(--txt)';
+    const isMember = c.accountType === 'Member' || c.accountType === 'Business Member';
+    const nameColor = (fc === 'red' || fc === 'yellow') ? `var(--${fc})` : fc === 'gray' ? 'var(--txt-3)' : (fc === 'green' && isMember) ? 'var(--green)' : 'var(--txt)';
     const acct = getStatus('customerAccountType', c.accountType || 'Non-Business');
     const sub = [esc(c.phone || ''), c.accountType ? esc(acct.label) : ''].filter(Boolean).join(' · ');
 
@@ -3565,7 +3581,7 @@ const ROWS = {
     const FUNNEL_RANK = { 'Inbound Lead': 1, 'Outbound Lead': 2, 'Contacted': 3, 'Not A No!': 4, 'Payment Discussed': 5, 'Paid': 6, "Don't Contact": 0.5 };
     const topStage = [c.usedSalesStage || 'N/A', c.membershipStage || 'N/A']
       .filter((s) => s && s !== 'N/A').sort((a, b) => (FUNNEL_RANK[b] || 0) - (FUNNEL_RANK[a] || 0))[0];
-    const funnelHtml = topStage ? statusPill('funnelStage', topStage) : '';
+    const funnelHtml = topStage ? statusPill('funnelStage', topStage) : badge('N/A', 'gray');
 
     // Row: name · phone·type · pay-$ ← LEFT  ·  [acct pill][funnel pill] → RIGHT.
     // Both status pills shown always; equal-width grid slots; margin-left:auto pushes them right.
@@ -3590,14 +3606,15 @@ const ROWS = {
     const hl = getEntityColor('units', u);
     // NAME tinted to the unit's flag color (Jac 2026-06-23): r/y/g lead in-color, gray reads muted.
     const nameColor = (hl === 'red' || hl === 'yellow' || hl === 'green') ? `var(--${hl})` : hl === 'gray' ? 'var(--txt-3)' : 'var(--txt)';
-    const sub = [cat ? esc(cat.name) : '', `${num(u.currentHours)} HRS`].filter(Boolean).join(' · ');
+    // Sub order (Jac): hours first, then category — left-to-right reads: hours · cat · NAME · icon · stripe
+    const sub = [`${num(u.currentHours)} HRS`, cat ? esc(cat.name) : ''].filter(Boolean).join(' · ');
     return `<div class="ur" style="--ur-hl:var(--${hl})">
       <div class="ur-pills"><div class="ur-pill-slot">${unitRentalInspPill(u)}</div><div class="ur-pill-slot">${unitWoSoPill(u)}</div></div>
-      <span class="ur-cat">${categoryIconFor(cat && cat.name)}</span>
       <div class="ur-id">
-        <span class="r-title ur-name" style="color:${nameColor}">${esc(u.name)}</span>
         <span class="ur-sub">${sub}</span>
+        <span class="r-title ur-name" style="color:${nameColor}">${esc(u.name)}</span>
       </div>
+      <span class="ur-cat">${categoryIconFor(cat && cat.name)}</span>
     </div>`;
   },
 
@@ -4534,13 +4551,14 @@ const DETAIL = {
 
     /* Header: customer + category + invoice + PO left · gate + balance right. */
     const custEl = cust
-      ? refPill('customers', r.customerId, cust.name, { x: 'cust-swap' })
+      ? entityPill('customers', cust, { x: 'cust-swap' })
       : addBtn('Customer', { link: true, js: 'js-quickadd-cust', h: 26, data: { card: 'rentals', rec: r.rentalId, slot: 'customer' } });
     const catPill = cat ? dPill(cat.name, 'orange', { card: 'categories', recId: cat.categoryId, icon: CARD_ICON.categories }) : '';
     const poField = efld('rentals', r, 'rentalId', 'po', 'Add PO', { fmt: (v) => 'PO ' + v });
+    /* Header: customer + PO left · status gate top-right, then invoice+balance below. */
     const rdHead = `<div class="rd-head">
-      <div class="rd-head-l">${custEl}${catPill}${invPill}${poField}</div>
-      <div class="rd-head-r">${masterGate(r, { truck })}${rdBal}</div>
+      <div class="rd-head-l">${custEl}${poField}</div>
+      <div class="rd-head-r">${masterGate(r, { truck })}<div class="rd-head-bal">${invPill}${rdBal}</div></div>
     </div>`;
 
     /* Not-Ready blocker — jumps to unit pills; sits above the calendar. */
@@ -4563,6 +4581,7 @@ const DETAIL = {
       ? units.map((eu) => {
           const u = IDX.unit.get(eu.unitId); if (!u) return '';
           const insp = getStatus('unitInspectionStatus', u.inspectionStatus);
+          const unitCat = IDX.category.get(u.categoryId);
           const voided = unitVoided(r, eu);
           const lref = rentalLineRefund(r, eu.unitId);   // §19b reflect the invoice's per-line refund on the rental's unit
           const multi = units.length > 1;
@@ -4573,7 +4592,7 @@ const DETAIL = {
           const splitBtn = multi ? `<button class="stall-split js-split-open" data-rec="${esc(r.rentalId)}" data-unit="${esc(u.unitId)}" data-tip="Give ${esc(u.name)} its own dates — splits to a separate rental on the same invoice"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:12px;height:12px"><rect x="3" y="4" width="18" height="17" rx="2"/><path d="M3 9h18M8 2v4M16 2v4"/></svg>dates</button>` : '';
           return `<div class="stall rd-unit${voided ? ' voided' : ''}${lref.fully ? ' stall-refunded' : ''}">
             <div class="rd-unit-top">
-              <div class="stall-id rd-unit-id">${unitPill(u.unitId, { x: 'unit-remove', xData: u.unitId })}${dPill(insp.label, insp.color, { card: 'units', recId: u.unitId, icon: CARD_ICON.inspections })}${noRates}${multi ? unitStatusGate(r, eu) : ''}</div>
+              <div class="stall-id rd-unit-id">${entityPill('units', u, { x: 'unit-remove', xData: u.unitId })}${unitCat ? dPill(unitCat.name, 'orange', { card: 'categories', recId: u.categoryId, icon: CARD_ICON.categories }) : ''}${noRates}${multi ? unitStatusGate(r, eu) : ''}</div>
               <div class="rd-unit-rate">${lref.refunded ? `<span class="stall-refund" data-tip="${lref.fully ? 'fully' : 'partially'} refunded on the invoice">↩ refunded</span> · ` : ''}${durLabel ? `<span class="rd-dur">${esc(durLabel)}</span> · ` : ''}<span class="stall-amt${lref.fully ? ' struck' : ''}">${money(up ? up.price : 0)}</span>${splitBtn}</div>
             </div>
             ${stallRouteHtml(r, eu)}
@@ -4581,7 +4600,7 @@ const DETAIL = {
         }).join('')
       : `<div class="stall stall-empty rd-unit rd-unit-empty">${pickUnitBtn}<span class="muted" style="font-size:12px">drag a unit on, or cancel the quote</span></div>`;
 
-    /* Footer: field call + Complete/Cancel left · invoice total right. */
+    /* Footer: field call left · Complete/Cancel button RIGHT (Jac spec). */
     const cancelish = ['Cancelled', 'No Show'].includes(r.status);
     const canComplete = allUnitsTerminal(r);
     const crBtn = cancelish
@@ -4589,7 +4608,7 @@ const DETAIL = {
       : actionPill('commit', 'Complete Rental', { js: `js-complete-rental${canComplete ? '' : ' locked'}`, h: 26, data: { rec: r.rentalId } });
     const fcRow = r.fieldCall ? actionPill('danger', 'Field Call active — clear', { js: 'js-clear-fc', data: { rec: r.rentalId } }) : '';
     const invTotalHtml = invT ? `<span class="rd-inv-total">${money(eventTotal)}</span>` : '';
-    const rdFoot = `<div class="rd-foot"><div class="rd-foot-l">${fcRow}${crBtn}</div><div class="rd-foot-r">${invTotalHtml}</div></div>`;
+    const rdFoot = `<div class="rd-foot"><div class="rd-foot-l">${fcRow}</div><div class="rd-foot-r">${crBtn}</div></div>`;
 
     const rentalSec = `<div class="section sec-${stColor} rentalsec">
       ${rdHead}
@@ -12732,12 +12751,17 @@ function openWinPicker(rentalId) {
   if (!r.startTime) r.startTime = nowHourLabel();   // default to the current hour (user spec)
   state.winpicker = { rentalId, monthISO: firstOfMonthISO(r.startDate || TODAY_ISO), anchor: null };
   if (rentalFragile(r)) state.winpicker.staged = { rentalId, startDate: r.startDate || '', endDate: r.endDate || '', startTime: r.startTime || '' };
-  // Task C — frame the yard on open: reveal Categories (list view) in the left column
-  // so the operator can browse what's free for this window. If the rental already has a
-  // window, light the availability lens right away (live rentals only — staged commits on Save).
+  // Task C / item #9 — frame the yard on open: reveal Categories (list view) in the
+  // left column only when the Rental Standard View is open with dates already set.
+  // If opened from a list-view mini-calendar, skip the column pivot (Jac: "Both, but
+  // only trigger the category path if the Rental Standard View is open with dates selected").
   const s = activeSession();
-  if (s.cols) s.cols.left = 'categories';
-  const cc = s.cards.categories; if (cc) { cc.mode = 'list'; cc.recId = null; cc.listLimit = undefined; }
+  const rs = s.cards.rentals;
+  if (rs && rs.mode === 'standard' && rs.recId === rentalId && r.startDate && r.endDate) {
+    if (s.cols) s.cols.left = 'categories';
+    const cc = s.cards.categories; if (cc) { cc.mode = 'list'; cc.recId = null; cc.listLimit = undefined; }
+  }
+  // Availability lens fires for both trigger paths whenever dates exist.
   if (!rentalFragile(r) && r.startDate && r.endDate) enterAvailabilitySearch(r);
   render();
 }

--- a/style.css
+++ b/style.css
@@ -858,6 +858,11 @@ select.lf-in { appearance: none; cursor: pointer; }
 .pill.ghost { background: transparent; border-color: var(--line); color: var(--txt-2); }                     /* R18: quiet action (Cancel/Close) */
 .pill.ghost:hover { color: var(--txt); border-color: var(--accent-line); }
 .pill.locked { opacity: .55; cursor: not-allowed; }                                                          /* R17 locked-gate state (no inline hacks) */
+/* R2e entity-stamp: row-name style on a linked pill — Saira caps, flag-colored, card icon. */
+.pill.entity-stamp { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 12.5px; height: 24px; border-radius: 5px; gap: 5px; }
+.pill.entity-stamp svg { width: 13px; height: 13px; }
+.pill.entity-stamp .t { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.pill.entity-stamp:hover { filter: brightness(1.1); }
 .req { display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 13px; border-radius: 10px; background: #fff; color: #16181d; border: 1px solid #fff; font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; }  /* rule 15/16/22: required-until-entered = white bg + dark ink */
 .req svg { width: 15px; height: 15px; }
 /* rule 8: notes carry a 3-color dot tag (white/red/green), picked while entering */
@@ -2351,7 +2356,8 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 /* ── RENTAL DETAIL v2 — header · calendar · unit rows · footer (rd-*, rdcal-*) ── */
 .rd-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; }
 .rd-head-l { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; min-width: 0; }
-.rd-head-r { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.rd-head-r { display: flex; flex-direction: column; align-items: flex-end; gap: 5px; flex-shrink: 0; }
+.rd-head-bal { display: flex; align-items: center; gap: 7px; }
 .rd-blocker { margin-bottom: 6px; }
 /* numbered-date window-track calendar */
 .rdcal { background: var(--panel-2); border-radius: 10px; overflow: hidden; cursor: pointer; margin-top: 2px; user-select: none; }
@@ -2639,7 +2645,7 @@ body { font-variant-numeric: tabular-nums; }
 .card[data-card="rentals"] .list .empty { grid-column: 1 / -1; }   /* +New Rental + empty states span both columns (and self-size, no tall track) */
 .row[data-card="rentals"] { padding: 0; display: flex; flex-direction: column; height: 172px; }
 .row[data-card="rentals"] .row-content { padding: 0; height: 100%; display: flex; flex-direction: column; }
-.rcc { flex: 1; display: flex; flex-direction: column; gap: 5px; padding: 8px 10px 7px; border-left: 3px solid var(--rcc-hl, var(--line)); overflow: hidden; }
+.rcc { flex: 1; display: flex; flex-direction: column; gap: 5px; padding: 8px 10px 7px; border: 2px solid var(--rcc-hl, var(--line)); border-radius: 11px; overflow: hidden; }
 /* HEADER — row 1: unit names (LEFT, colored by inspection) + status pill pinned RIGHT;
    row 2: customer + balance (Jac 2026-06-23) */
 .rcc-head { display: flex; flex-direction: column; gap: 4px; flex-shrink: 0; }
@@ -2679,7 +2685,7 @@ body { font-variant-numeric: tabular-nums; }
 .rcc-day.is-past .rcc-dot { background: var(--line); opacity: 1; }
 .rcc-day.is-win .rcc-dot { background: var(--rcc-hl, var(--green)); opacity: .7; }
 /* today = orange RING (not fill) so the dot doesn't compete with start/end markers */
-.rcc-day.is-today .rcc-dot { width: 15px; height: 15px; background: transparent; border: 2px solid var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); opacity: 1; }
+.rcc-day.is-today .rcc-dot { width: 15px; height: 15px; background: transparent; border: 2px solid var(--blue); box-shadow: 0 0 0 3px var(--blue-bg); opacity: 1; }
 /* start/end: enlarged for legibility — bigger dot, bigger icon */
 .rcc-day.is-start .rcc-dot, .rcc-day.is-end .rcc-dot { width: 24px; height: 24px; background: var(--rcc-hl, var(--green)); color: var(--card); opacity: 1; }
 .rcc-day.is-start .rcc-dot svg, .rcc-day.is-end .rcc-dot svg { width: 15px; height: 15px; }
@@ -2710,19 +2716,22 @@ body { font-variant-numeric: tabular-nums; }
    Equal-width pill slots so all rows share the same column rhythm. ── */
 .row[data-card="units"] { padding: 0; }
 .row[data-card="units"] .row-content { padding: 0; }
-.ur { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 8px; border-left: 3px solid var(--ur-hl, var(--line)); }
+.ur { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 8px; border-right: 3px solid var(--ur-hl, var(--line)); }
 .ur-cat { flex: 0 0 auto; width: 22px; height: 22px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
 .ur-cat svg { width: 19px; height: 19px; display: block; }
 .ur-id { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 1px 8px; }
 .ur-name { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }
 .ur-sub { font-size: 11.5px; color: var(--txt-2); white-space: nowrap; flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-/* two pill slots in a 2-column equal-width grid → every row's pills align to the same x-positions */
-.ur-pills { flex: 0 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; min-width: 180px; }
+/* two pill slots in a 2-column equal-width grid → every row's pills align to the same x-positions.
+   Must use a FIXED width (not min-width) — fr units in an auto-sized flex child resolve per-column,
+   producing unequal widths. A definite width makes 1fr = exactly half. */
+.ur-pills { flex: 0 0 176px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
 .ur-pill-slot { display: flex; align-items: center; justify-content: center; }
-.ur-pill-slot .pill { width: 100%; text-align: center; justify-content: center; }
+.ur-pill-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
+.ur-pill-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
 @container (max-width: 340px) {
   .ur-id { flex-direction: column; align-items: flex-start; gap: 1px; }
-  .ur-pills { grid-template-columns: 1fr; min-width: 90px; }
+  .ur-pills { flex-basis: 90px; grid-template-columns: 1fr; }
 }
 /* ── CATEGORY ROW (catr): [status badges LEFT] · [name/rate RIGHT] — mirrors units swap. ── */
 .catr { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 10px; }
@@ -2731,11 +2740,12 @@ body { font-variant-numeric: tabular-nums; }
 .catr-sub { font-size: 11.5px; color: var(--txt-2); white-space: nowrap; }
 
 /* ── CUSTOMER ROW (cr-statuses): account-type + funnel, equal-width, right-pinned. ── */
-.cr-statuses { flex: 0 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-left: auto; min-width: 160px; }
+.cr-statuses { flex: 0 0 160px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-left: auto; }
 .cr-pill-slot { display: flex; align-items: center; justify-content: center; }
-.cr-pill-slot .pill { width: 100%; text-align: center; justify-content: center; }
+.cr-pill-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
+.cr-pill-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
 @container (max-width: 340px) {
-  .cr-statuses { grid-template-columns: 1fr; min-width: 80px; }
+  .cr-statuses { flex-basis: 80px; grid-template-columns: 1fr; }
 }
 
 /* No-Preview Mode (Jac 2026-06-12): every eye — row chips + the toolbar — runs RED */

--- a/style.css
+++ b/style.css
@@ -15,8 +15,8 @@
 
   /* status colors (base = text/border tone, -bg = soft fill) */
   --green:#34d399;  --green-bg:rgba(52,211,153,.14);
-  --yellow:#f5c542; --yellow-bg:rgba(245,197,66,.14);
-  --red:#ff4242;    --red-bg:rgba(255,66,66,.18);   /* brighter, bolder (overdue / Failed) */
+  --yellow:#ffe000; --yellow-bg:rgba(255,224,0,.15);
+  --red:#ff1040;    --red-bg:rgba(255,16,64,.18);
   --blue:#5b9dff;   --blue-bg:rgba(91,157,255,.14);
   --navy:#6f8bdb;   --navy-bg:rgba(70,102,196,.18);
   --purple:#b07cf5; --purple-bg:rgba(176,124,245,.16);
@@ -2719,13 +2719,13 @@ body { font-variant-numeric: tabular-nums; }
 .ur { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 8px; border-right: 3px solid var(--ur-hl, var(--line)); }
 .ur-cat { flex: 0 0 auto; width: 22px; height: 22px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
 .ur-cat svg { width: 19px; height: 19px; display: block; }
-.ur-id { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 1px 8px; }
+.ur-id { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 1px 8px; justify-content: flex-end; }
 .ur-name { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }
 .ur-sub { font-size: 11.5px; color: var(--txt-2); white-space: nowrap; flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 /* two pill slots in a 2-column equal-width grid → every row's pills align to the same x-positions.
    Must use a FIXED width (not min-width) — fr units in an auto-sized flex child resolve per-column,
    producing unequal widths. A definite width makes 1fr = exactly half. */
-.ur-pills { flex: 0 0 176px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+.ur-pills { flex: 0 0 196px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
 .ur-pill-slot { display: flex; align-items: center; justify-content: center; }
 .ur-pill-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
 .ur-pill-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }


### PR DESCRIPTION
## Summary

- **Restores PR #268** (unit/customer rows, rental detail redesign, availability re-anchor) which was accidentally reverted by #291 during the inspections-seed rollback
- **Adds neon colors**: `--red #ff1040`, `--yellow #ffe000` — more vibrant across all status pills and flags
- **Unit row right-align**: unit name + sub-text pack toward the icon via `justify-content: flex-end`
- **Equal-width status pills**: fixed `flex: 0 0 196px` so both pill columns are exactly the same width regardless of label length

## What happened

The inspections-seed PR (#289) was reverted (#290), but the revert PR (#291) also accidentally caught and reverted PR #268 (the UI polish). This PR re-applies that work via `git revert ed026cd` (clean, no conflicts), then layers the new neon/layout polish on top.

## Test plan

- [ ] All unit row status pills are equal width — "PART NEEDED?" width matches shorter pills  
- [ ] Unit name + hours/category text flush-right toward the icon
- [ ] Red and yellow flags read as neon/vivid (`#ff1040` / `#ffe000`)
- [ ] Original PR #268 features intact: rental detail layout, customer row statuses, availability re-anchor
- [ ] CI: smoke ✅ logic 186/186 ✅ rule-usage ✅ window-catalog ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiGsZEpFXqEbbUziPakEpi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiGsZEpFXqEbbUziPakEpi)_