### PR TITLE
Wrangler fix: On-Rent gate + ACH consent recognize §7.1c per-card signature + selfie

### DIFF
--- a/app.js
+++ b/app.js
@@ -646,7 +646,7 @@ function cardTabBody(c) {
 }
 function achTabBody(c) {
   const banks = customerBanks(c);
-  const consent = !!(c.signature && c.selfie);
+  const consent = !!((c.signature || validCards(c).some((k) => cardCurrentSigning(c, k))) && latestCustomerSelfie(c));   // §7.1c: agreement + selfie live on the card (Drive-aware), with account-level back-compat
   const rows = banks.length ? banks.map((k) => `<div class="card-row">
       <span class="cr-brand">${esc(k.bankName || 'Bank')} ••${esc(k.last4)}</span>
       <span class="cr-exp">${esc(bankTypeLabel(k.accountType))}</span>
@@ -8685,7 +8685,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     // (confirmUsBankAccountSetup); never stored, never sent to our backend.
     const c = IDX.customer.get(o.customerId);
     if (!c) { return false; }
-    const consent = !!(c.signature && c.selfie);
+    const consent = !!((c.signature || validCards(c).some((k) => cardCurrentSigning(c, k))) && latestCustomerSelfie(c));   // §7.1c: agreement + selfie live on the card (Drive-aware), with account-level back-compat
     const pop = el('div', 'popup'); pop.style.width = '430px';
     pop.innerHTML = popupShell({ icon: CARD_ICON.customers || '', title: `Add bank account — ${c.name}`, tag: 'Customer · ACH bank',
       foot: `<button class="pill ghost js-close" data-r="R18">Cancel</button><button class="pill ignition js-ach-save" data-r="R17" ${consent ? '' : 'disabled style="opacity:.45;cursor:default"'}>Save ACH</button>`,

--- a/app.js
+++ b/app.js
@@ -11445,8 +11445,8 @@ function rentalRuleBlock(r, cust, val) {
   if (!['card', 'signature', 'selfie', 'po', 'id', 'terms'].some(req)) return null;
   const inv = r && r.invoiceId ? IDX.invoice.get(r.invoiceId) : null;
   if (req('card') && !(cust && hasValidCard(cust))) return 'Rental rule: a valid card on file is required before On Rent.';
-  if (req('signature') && !(cust && cust.signature)) return 'Rental rule: a signed agreement is required before On Rent.';
-  if (req('selfie') && !(cust && cust.selfie)) return 'Rental rule: a customer selfie is required before On Rent.';
+  if (req('signature') && !(cust && (cust.signature || validCards(cust).some((k) => cardCurrentSigning(cust, k))))) return 'Rental rule: a signed agreement is required before On Rent.';
+  if (req('selfie') && !(cust && latestCustomerSelfie(cust))) return 'Rental rule: a customer selfie is required before On Rent.';
   if (req('id') && !(cust && cust.idNumber)) return "Rental rule: a driver's license / ID is required before On Rent.";
   if (req('terms') && !(cust && cust.netDays != null && cust.netDays !== '')) return 'Rental rule: payment terms (Net days) must be set before On Rent.';
   if (req('po') && !(inv && inv.po)) return 'Rental rule: a PO number on the invoice is required before On Rent.';

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623u" />
+  <link rel="stylesheet" href="style.css?v=20260623v" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623u"></script>
-  <script type="module" src="app.js?v=20260623u"></script>
+  <script src="rule-usage.js?v=20260623v"></script>
+  <script type="module" src="app.js?v=20260623v"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Reported
Jac: "Rental status is being blocked despite customers having a card on file and contract and selfie signed." (Customer **Kodi Smith**, C1957.)

## Root cause (proven against Kodi's live data)
Two gates checked the **legacy account-level** `cust.signature` / `cust.selfie`, which are empty under **§7.1c** (the signature + selfie live on the **card** — `card.agreements[].signature`, `card.selfie`, offloaded to Drive). Kodi's card CARD-33 has a complete, signed **membership** agreement (SIG-34) — `cardComplete` and the §14 `cardGateBlocked` gate both pass — but these two gates blocked anyway:

1. **Rental Rules gate** `rentalRuleBlock` (`app.js:11448–11449`) — the "signature"/"selfie" admin toggles. Once on, blocked every §7.1c customer.
2. **ACH consent gate** (`achTabBody` `app.js:649`; addAch overlay `app.js:8688`) — `!!(c.signature && c.selfie)` disabled "Save ACH" for §7.1c customers (same bug class; swept here at Jac's go).

Both gates were simply never updated to the per-card model the rest of the app uses.

## Fix
Both now recognize a signed **card** (`validCards(cust).some(k => cardCurrentSigning(cust, k))`) and the card-level selfie (`latestCustomerSelfie`, Drive-aware), with **legacy account-level back-compat**. **Not weakened** — no signed card + selfie still blocks On Rent / disables Save ACH.

## Gates (local, port-swapped to 9147)
- smoke ✅ · logic-test **186/186** ✅ · gen-rule-usage `--check` ✅ · window-catalog ✅

Cache token bumped to `?v=20260623v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)