### PR TITLE
fix: restore UI polish clobbered by inspections seed (#289)

### DIFF
--- a/app.js
+++ b/app.js
@@ -3927,10 +3927,11 @@ const ROWS = {
   },
 
   customers: (c) => {
-    // Name TINTED by the customer's flag color (Jac): only red/yellow lead — a clear
-    // customer keeps the calm default ink, archived/gray reads muted.
+    // Name TINTED by the customer's flag color (Jac): red/yellow lead; green for Members
+    // in good standing; a clear non-member keeps the calm default ink; archived/gray reads muted.
     const fc = getEntityColor('customers', c);
-    const nameColor = (fc === 'red' || fc === 'yellow') ? `var(--${fc})` : fc === 'gray' ? 'var(--txt-3)' : 'var(--txt)';
+    const isMember = c.accountType === 'Member' || c.accountType === 'Business Member';
+    const nameColor = (fc === 'red' || fc === 'yellow') ? `var(--${fc})` : fc === 'gray' ? 'var(--txt-3)' : (fc === 'green' && isMember) ? 'var(--green)' : 'var(--txt)';
     const acct = getStatus('customerAccountType', c.accountType || 'Non-Business');
     const sub = [esc(c.phone || ''), c.accountType ? esc(acct.label) : ''].filter(Boolean).join(' · ');
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623w" />
+  <link rel="stylesheet" href="style.css?v=20260623x" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623w"></script>
-  <script type="module" src="app.js?v=20260623w"></script>
+  <script src="rule-usage.js?v=20260623x"></script>
+  <script type="module" src="app.js?v=20260623x"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2379,7 +2379,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 /* ── RENTAL DETAIL v2 — header · calendar · unit rows · footer (rd-*, rdcal-*) ── */
 .rd-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; }
 .rd-head-l { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; min-width: 0; }
-.rd-head-r { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.rd-head-r { display: flex; flex-direction: column; align-items: flex-end; gap: 5px; flex-shrink: 0; }
 .rd-blocker { margin-bottom: 6px; }
 /* numbered-date window-track calendar */
 .rdcal { background: var(--panel-2); border-radius: 10px; overflow: hidden; cursor: pointer; margin-top: 2px; user-select: none; }
@@ -2667,7 +2667,7 @@ body { font-variant-numeric: tabular-nums; }
 .card[data-card="rentals"] .list .empty { grid-column: 1 / -1; }   /* +New Rental + empty states span both columns (and self-size, no tall track) */
 .row[data-card="rentals"] { padding: 0; display: flex; flex-direction: column; height: 172px; }
 .row[data-card="rentals"] .row-content { padding: 0; height: 100%; display: flex; flex-direction: column; }
-.rcc { flex: 1; display: flex; flex-direction: column; gap: 5px; padding: 8px 10px 7px; border-left: 3px solid var(--rcc-hl, var(--line)); overflow: hidden; }
+.rcc { flex: 1; display: flex; flex-direction: column; gap: 5px; padding: 8px 10px 7px; border: 2px solid var(--rcc-hl, var(--line)); border-radius: 11px; overflow: hidden; }
 /* HEADER — row 1: unit names (LEFT, colored by inspection) + status pill pinned RIGHT;
    row 2: customer + balance (Jac 2026-06-23) */
 .rcc-head { display: flex; flex-direction: column; gap: 4px; flex-shrink: 0; }
@@ -2706,8 +2706,8 @@ body { font-variant-numeric: tabular-nums; }
 .rcc-day.is-end .rcc-bar { right: 50%; border-radius: 0 2px 2px 0; }
 .rcc-day.is-past .rcc-dot { background: var(--line); opacity: 1; }
 .rcc-day.is-win .rcc-dot { background: var(--rcc-hl, var(--green)); opacity: .7; }
-/* today = orange RING (not fill) so the dot doesn't compete with start/end markers */
-.rcc-day.is-today .rcc-dot { width: 15px; height: 15px; background: transparent; border: 2px solid var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); opacity: 1; }
+/* today = blue RING (not fill) so the dot doesn't compete with start/end markers */
+.rcc-day.is-today .rcc-dot { width: 15px; height: 15px; background: transparent; border: 2px solid var(--blue); box-shadow: 0 0 0 3px var(--blue-bg); opacity: 1; }
 /* start/end: enlarged for legibility — bigger dot, bigger icon */
 .rcc-day.is-start .rcc-dot, .rcc-day.is-end .rcc-dot { width: 24px; height: 24px; background: var(--rcc-hl, var(--green)); color: var(--card); opacity: 1; }
 .rcc-day.is-start .rcc-dot svg, .rcc-day.is-end .rcc-dot svg { width: 15px; height: 15px; }
@@ -2738,7 +2738,7 @@ body { font-variant-numeric: tabular-nums; }
    Equal-width pill slots so all rows share the same column rhythm. ── */
 .row[data-card="units"] { padding: 0; }
 .row[data-card="units"] .row-content { padding: 0; }
-.ur { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 8px; border-left: 3px solid var(--ur-hl, var(--line)); }
+.ur { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 8px; border-right: 3px solid var(--ur-hl, var(--line)); }
 .ur-cat { flex: 0 0 auto; width: 22px; height: 22px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
 .ur-cat svg { width: 19px; height: 19px; display: block; }
 .ur-id { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 1px 8px; justify-content: flex-end; }
@@ -2749,10 +2749,11 @@ body { font-variant-numeric: tabular-nums; }
    producing unequal widths. A definite width makes 1fr = exactly half. */
 .ur-pills { flex: 0 0 196px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
 .ur-pill-slot { display: flex; align-items: center; justify-content: center; }
-.ur-pill-slot .pill { width: 100%; text-align: center; justify-content: center; }
+.ur-pill-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
+.ur-pill-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
 @container (max-width: 340px) {
   .ur-id { flex-direction: column; align-items: flex-start; gap: 1px; }
-  .ur-pills { grid-template-columns: 1fr; min-width: 90px; }
+  .ur-pills { grid-template-columns: 1fr; flex-basis: 90px; }
 }
 /* ── CATEGORY ROW (catr): [status badges LEFT] · [name/rate RIGHT] — mirrors units swap. ── */
 .catr { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 10px; }
@@ -2761,11 +2762,12 @@ body { font-variant-numeric: tabular-nums; }
 .catr-sub { font-size: 11.5px; color: var(--txt-2); white-space: nowrap; }
 
 /* ── CUSTOMER ROW (cr-statuses): account-type + funnel, equal-width, right-pinned. ── */
-.cr-statuses { flex: 0 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-left: auto; min-width: 160px; }
+.cr-statuses { flex: 0 0 160px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-left: auto; }
 .cr-pill-slot { display: flex; align-items: center; justify-content: center; }
-.cr-pill-slot .pill { width: 100%; text-align: center; justify-content: center; }
+.cr-pill-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
+.cr-pill-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
 @container (max-width: 340px) {
-  .cr-statuses { grid-template-columns: 1fr; min-width: 80px; }
+  .cr-statuses { grid-template-columns: 1fr; flex-basis: 80px; }
 }
 
 /* ── FOOTER SECTIONS: labeled chip groups separated by a rule (units/rentals/customers). ── */


### PR DESCRIPTION
## Summary

The inspections seed PR (#289) was developed before UI polish PR (#268) was finalized and accidentally overwrote several UI changes when it was originally merged. When we re-applied the inspections seed (PR #299), those regressions came back.

**Restored in `style.css`:**
- `.rcc` — full border wrap + `border-radius: 11px` (inspections seed had reverted to left-only)
- `.rcc-day.is-today` — blue ring `var(--blue)` (was reverted to orange `var(--accent)`)  
- `.ur` — `border-right` color accent (was reverted to `border-left`)
- `.ur-pill-slot .pill` — `overflow: hidden` + `.t` ellipsis (removed by seed)
- `.cr-statuses` — fixed `flex: 0 0 160px` (reverted to auto + min-width)
- `.cr-pill-slot .pill` — `overflow: hidden` + `.t` ellipsis (removed by seed)
- `@container` responsive — `flex-basis` (reverted to `min-width`)
- `.rd-head-r` — column stack + `flex-end` align (reverted to horizontal row)

**Restored in `app.js`:**
- Customer `nameColor` — green ink for Member/Business Member in good standing (removed by seed)

## Test plan

- [ ] Rental mini-calendar cards show full border wrap + rounded corners (`.rcc`)
- [ ] Today dot is blue ring, not orange
- [ ] Unit row color accent is on the RIGHT border, not left
- [ ] Member/Business Member customers in good standing show green name ink
- [ ] Status pill text truncates with ellipsis on narrow screens
- [ ] CI: smoke ✅ logic 186/186 ✅ rule-usage ✅ window-catalog ✅ design-md ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiGsZEpFXqEbbUziPakEpi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiGsZEpFXqEbbUziPakEpi)_