### PR TITLE
Wrangler fix: 'terms' rental rule treats a blank Net-days as COD (no longer blocks On Rent)

### DIFF
--- a/app.js
+++ b/app.js
@@ -11551,7 +11551,9 @@ function rentalRuleBlock(r, cust, val) {
   if (req('signature') && !(cust && (cust.signature || validCards(cust).some((k) => cardCurrentSigning(cust, k))))) return 'Rental rule: a signed agreement is required before On Rent.';
   if (req('selfie') && !(cust && latestCustomerSelfie(cust))) return 'Rental rule: a customer selfie is required before On Rent.';
   if (req('id') && !(cust && cust.idNumber)) return "Rental rule: a driver's license / ID is required before On Rent.";
-  if (req('terms') && !(cust && cust.netDays != null && cust.netDays !== '')) return 'Rental rule: payment terms (Net days) must be set before On Rent.';
+  // §9 'terms' rule (relaxed Jac 2026-06-23): a BLANK Net-days counts as COD (0) and is accepted —
+  // it no longer blocks On Rent; only a present, non-numeric value would (normNetDays prevents that).
+  if (req('terms') && cust && cust.netDays != null && cust.netDays !== '' && !Number.isFinite(Number(cust.netDays))) return 'Rental rule: payment terms (Net days) must be a valid number before On Rent.';
   if (req('po') && !(inv && inv.po)) return 'Rental rule: a PO number on the invoice is required before On Rent.';
   return null;
 }

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -509,7 +509,7 @@ try {
     st.settings.rentalRules = { id: 'required' };
     ok(/ID/i.test(T.rentalRuleBlock({}, { name: 'X' }, 'On Rent') || '') && T.rentalRuleBlock({}, { name: 'X', idNumber: 'LA-12345' }, 'On Rent') === null, 'ID Required: blocks without an ID #, allows with one');
     st.settings.rentalRules = { terms: 'required' };
-    ok(/terms/i.test(T.rentalRuleBlock({}, { name: 'X' }, 'On Rent') || '') && T.rentalRuleBlock({}, { name: 'X', netDays: 0 }, 'On Rent') === null, 'Payment-terms Required: blocks until Net days entered (0/COD counts)');
+    ok(T.rentalRuleBlock({}, { name: 'X' }, 'On Rent') === null && T.rentalRuleBlock({}, { name: 'X', netDays: 0 }, 'On Rent') === null && /terms/i.test(T.rentalRuleBlock({}, { name: 'X', netDays: 'abc' }, 'On Rent') || ''), 'Payment-terms Required: blank Net days counts as COD (passes), 0 passes, only a non-numeric value blocks');
     st.settings.rentalRules = savedRules;   // restore
 
     // 23) Net-days terms → invoice due date, capped by the system max (Settings → Company)

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623x" />
+  <link rel="stylesheet" href="style.css?v=20260623y" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623x"></script>
-  <script type="module" src="app.js?v=20260623x"></script>
+  <script src="rule-usage.js?v=20260623y"></script>
+  <script type="module" src="app.js?v=20260623y"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Context
Follow-up to #300 (the On-Rent gate fix). After signature/selfie cleared, Kodi Smith's rental still blocked on **"payment terms (Net days) must be set."** That rule (`rentalRuleBlock`, the `terms` case) correctly checks the account-level `netDays` — but new customers default to **blank** (`normNetDays('')` → `undefined`), so the rule caught everyone who hadn't explicitly set terms.

## Change (per Jac)
A **blank** Net-days now counts as **COD (0)** and is accepted — the rule no longer blocks on blank. `0` = COD and explicit Net-X still pass exactly as before; only a *present, non-numeric* value would block (which `normNetDays` already prevents upstream).

## Test
Updated the `ci/logic-test.mjs` assertion that encoded the old *"blocks until Net days entered"* behavior to match the deliberate relax: blank passes, `0` passes, a non-numeric value blocks. **Logic suite 186/186.**

## Gates (local, port-swapped to 9147)
- smoke ✅ · logic-test **186/186** ✅ · gen-rule-usage `--check` ✅ · window-catalog ✅

Cache token bumped to `?v=20260623y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7ygbx4e2Sc9zs1CZbPUoS)_