### PR TITLE
Fix invoice-number leap-frog: derive running number from data, not array length

### DIFF
--- a/app.js
+++ b/app.js
@@ -1611,7 +1611,7 @@ const state = {
   invMergePick: null,         // invoiceId whose "Merge invoice" picker is open (consolidate unpaid bills)
   dashboard: false,           // §5.3/§11 Office Dispatch Time Grid (grid-swap mode)
   seq: 1,
-  invoiceSeq: DATA.invoices.length,   // monotonic invoice number (never reused after a discard)
+  invoiceSeq: maxInvoiceSeq(),   // monotonic invoice number — derived from the highest running number actually present (NOT .length: see maxInvoiceSeq)
   previewsOn: (() => { try { return localStorage.getItem('jactec.previewsOff') !== '1'; } catch (e) { return true; } })(),   // hover previews (per device)
   overbookOn: (() => { try { return localStorage.getItem('jactec.overbook') === '1'; } catch (e) { return false; } })(),   // §10 allow-overbooking policy (per device, default OFF — drag build)
   hapticsOff: (() => { try { return localStorage.getItem('jactec.hapticsOff') === '1'; } catch (e) { return false; } })(),   // §M-touch Vibration-API feedback (per device, default ON; Android-only, no-op on iOS)
@@ -1619,8 +1619,21 @@ const state = {
   settings: loadAdminSettings(),   // Settings Board admin customization (config.settings); mirrored to localStorage, applied at boot via applySettings()
 };
 const activeSession = () => (state.activeTabId ? state.tabs.find((t) => t.id === state.activeTabId)?.session : state.defaultSession) || state.defaultSession;
-/** Next unique invoice id — a monotonic counter so deleting a Quote-stage invoice can't reuse a number. */
-const nextInvoiceId = () => CFG.invoiceId(TODAY_ISO, ++state.invoiceSeq);
+/** Highest running number actually present across invoices, parsed from each id's
+ *  leading digits (e.g. '07i02Ju26' -> 7). The counter MUST come from the data, not
+ *  the array: `DATA.invoices.length` started from the seed file (4) and was never
+ *  recomputed after loadFromBackend swapped in the real invoices, so every login it
+ *  restarted low and minted 05i…/06i… numbers that already existed on the backend —
+ *  duplicate "##i" prefixes that the 18s refresh poll then leap-frogged in. `.length`
+ *  also shrinks on discard (breaking the "never reused" invariant) and doesn't grow
+ *  when the poll pushes remote invoices in. Mirrors nextUnitId/nextCategoryId. */
+function maxInvoiceSeq() {
+  return (DATA.invoices || []).reduce((m, inv) => { const n = /^(\d+)i/.exec(String(inv.invoiceId || '')); return n ? Math.max(m, +n[1]) : m; }, 0);
+}
+/** Next unique invoice id — a monotonic counter so deleting a Quote-stage invoice can't
+ *  reuse a number. Always jumps past the current max in the data, so it can't collide
+ *  with invoices loaded at login or pushed in by the live-refresh poll mid-session. */
+const nextInvoiceId = () => { state.invoiceSeq = Math.max(state.invoiceSeq || 0, maxInvoiceSeq()) + 1; return CFG.invoiceId(TODAY_ISO, state.invoiceSeq); };
 
 /* ── session actions ──────────────────────────────────────────────────────
    `recType` is only meaningful for the Shop card (which holds inspections /

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z" />
+  <link rel="stylesheet" href="style.css?v=20260623z2" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z"></script>
-  <script type="module" src="app.js?v=20260623z"></script>
+  <script src="rule-usage.js?v=20260623z2"></script>
+  <script type="module" src="app.js?v=20260623z2"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Symptom
Create or link an invoice, and ~10s later a **different** invoice with the **same first‑3‑char `##i` running‑number prefix** takes its place ("leap‑frogging").

## Root cause
`state.invoiceSeq` was seeded from `DATA.invoices.length` — a literal evaluated at **module load against the seed file (4 invoices)** and **never recomputed** after `loadFromBackend` swapped in the real backend invoices. So every login the counter restarted low and `nextInvoiceId` minted `05i…`/`06i…` — running numbers that **already existed** on the backend (the "first 3 digits match"). The 18s live‑refresh poll then adopted the colliding remote record → the "~10s later it jumps" symptom.

`.length` is doubly wrong: it **shrinks on discard** (violating the code's own "never reused after a discard" comment) and **never grows** when the poll pushes remote invoices into `DATA.invoices` mid‑session.

Every sibling minter (`nextUnitId`, `nextCategoryId`, `nextCustomerId`) already derives the next number from the **max ID present in the data** via reduce — invoice numbering was the lone outlier.

## Fix
Add `maxInvoiceSeq()` (parses the leading running number from each `invoiceId`) and make `nextInvoiceId` always jump past the current max in the data at mint time, so it can't collide with invoices loaded at login **or** polled in mid‑session. Monotonic within a session; mirrors the other minters. Pure front‑end logic — no UI change.

## Verification
- `node --check app.js`, `gen-rule-usage.mjs --check`, `check-window-catalog.mjs` all pass.
- Browser gates (`smoke`/`logic-test`) run in CI (Playwright not installable here).
- Standalone simulation: old code mints `05i23Ju26` whose `05i` prefix already exists (collision); new code jumps to `09i`/`10i`, and correctly to `16i` after a poll injects invoice #15 — no duplicate prefixes, all IDs unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01721FzeZBtE9ingu3oRWYic)_