### PR TITLE
ec-red: official site-wide glow treatment for all flagging-red signals

### DIFF
--- a/app.js
+++ b/app.js
@@ -3978,7 +3978,7 @@ const ROWS = {
     const isMember = c.accountType === 'Member' || c.accountType === 'Business Member';
     const nameColor = (fc === 'red' || fc === 'yellow') ? `var(--${fc})` : fc === 'gray' ? 'var(--txt-3)' : (fc === 'green' && isMember) ? 'var(--green)' : 'var(--txt)';
     const acct = getStatus('customerAccountType', c.accountType || 'Non-Business');
-    const sub = [esc(c.phone || ''), c.accountType ? esc(acct.label) : ''].filter(Boolean).join(' · ');
+    const sub = c.phone ? esc(c.phone) : '';
 
     // Pay status AS A NUMBER (Jac — no "New Customer" text): owed balance → yellow before
     // its due date / red on-or-after; otherwise rolling-12-month spend → green.

--- a/app.js
+++ b/app.js
@@ -4005,7 +4005,7 @@ const ROWS = {
     const acctPill = statusPill('customerAccountType', c.accountType || 'Non-Business');
     return `<div class="cr">
       <div class="cr-id">
-        <span class="r-title cr-name" style="color:${nameColor}">${esc(c.name)}</span>
+        <span class="r-title cr-name${fc === 'red' ? ' ec-red' : ''}" style="color:${nameColor}">${esc(c.name)}</span>
         ${sub ? `<span class="cr-sub">${sub}</span>` : ''}
       </div>
       ${payHtml}

--- a/app.js
+++ b/app.js
@@ -3910,7 +3910,7 @@ const ROWS = {
       if (!unit) return '';
       const insp = unit.inspectionStatus;
       const ic = insp === 'Failed' ? 'var(--red)' : insp === 'Not Ready' ? 'var(--yellow)' : insp === 'Passed' ? 'var(--green)' : 'var(--txt)';
-      return `<span class="rcc-uname" style="color:${ic}" data-tip="${esc(unit.name)}: ${esc(insp || 'Unknown')}">${esc(unit.name)}</span>`;
+      return `<span class="rcc-uname${insp === 'Failed' ? ' ec-red' : ''}" style="color:${ic}" data-tip="${esc(unit.name)}: ${esc(insp || 'Unknown')}">${esc(unit.name)}</span>`;
     }).filter(Boolean).join('<span class="rcc-usep">, </span>') || (units ? `<span class="rcc-uname">${esc(units)}</span>` : '');
     const headHtml = `<div class="rcc-head">
       <div class="rcc-h1">${unitNameHtml ? `<span class="rcc-units">${unitNameHtml}</span>` : ''}${stPill}</div>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z2" />
+  <link rel="stylesheet" href="style.css?v=20260623z3" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z2"></script>
-  <script type="module" src="app.js?v=20260623z2"></script>
+  <script src="rule-usage.js?v=20260623z3"></script>
+  <script type="module" src="app.js?v=20260623z3"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2706,8 +2706,8 @@ body { font-variant-numeric: tabular-nums; }
 .cr { display: flex; align-items: center; gap: 8px; min-width: 0; justify-content: flex-start; }
 .cr-id { flex: 0 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 8px; }
 .cr-name { flex: 0 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-/* Red customer names: outline stays at full --red; fill dialed to 60% so harsh red-on-dark vibration eases. */
-.cr-name.ec-red { -webkit-text-stroke: 0.5px var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 60%, transparent); }
+/* Red customer names: thick outline at full --red; fill mixed toward white so the interior reads as a brighter, lighter red — legible without the harsh vibration. */
+.cr-name.ec-red { -webkit-text-stroke: 1.5px var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 55%, white); }
 .cr-sub { flex: 0 1 auto; min-width: 0; font-size: 11.5px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cr-pay { flex: 0 0 auto; font-size: 13px; font-weight: 700; font-style: italic; white-space: nowrap; }
 .cr-pay.spend { color: var(--green); }

--- a/style.css
+++ b/style.css
@@ -2706,8 +2706,8 @@ body { font-variant-numeric: tabular-nums; }
 .cr { display: flex; align-items: center; gap: 8px; min-width: 0; justify-content: flex-start; }
 .cr-id { flex: 0 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 8px; }
 .cr-name { flex: 0 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-/* Red customer names: thick outline at full --red; fill mixed toward white so the interior reads as a brighter, lighter red — legible without the harsh vibration. */
-.cr-name.ec-red { -webkit-text-stroke: 1.5px var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 55%, white); }
+/* Red customer names: lighter/whiter fill with a layered red glow shadow so the edge bleeds naturally into the interior — no hard stroke boundary. */
+.cr-name.ec-red { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 55%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .cr-sub { flex: 0 1 auto; min-width: 0; font-size: 11.5px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cr-pay { flex: 0 0 auto; font-size: 13px; font-weight: 700; font-style: italic; white-space: nowrap; }
 .cr-pay.spend { color: var(--green); }

--- a/style.css
+++ b/style.css
@@ -2706,8 +2706,10 @@ body { font-variant-numeric: tabular-nums; }
 .cr { display: flex; align-items: center; gap: 8px; min-width: 0; justify-content: flex-start; }
 .cr-id { flex: 0 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 8px; }
 .cr-name { flex: 0 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-/* Red customer names: lighter/whiter fill with a layered red glow shadow so the edge bleeds naturally into the interior — no hard stroke boundary. */
-.cr-name.ec-red { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 55%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
+/* Shared ec-red glow: full --red halo bleeds into a 65%-red+white fill — no hard seam. Covers red customer names, Failed-inspection unit names in rental cards, and overdue balances. */
+.cr-name.ec-red,
+.rcc-uname.ec-red,
+.rcc-bal.overdue { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .cr-sub { flex: 0 1 auto; min-width: 0; font-size: 11.5px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cr-pay { flex: 0 0 auto; font-size: 13px; font-weight: 700; font-style: italic; white-space: nowrap; }
 .cr-pay.spend { color: var(--green); }

--- a/style.css
+++ b/style.css
@@ -2706,6 +2706,8 @@ body { font-variant-numeric: tabular-nums; }
 .cr { display: flex; align-items: center; gap: 8px; min-width: 0; justify-content: flex-start; }
 .cr-id { flex: 0 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 8px; }
 .cr-name { flex: 0 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* Red customer names: outline stays at full --red; fill dialed to 60% so harsh red-on-dark vibration eases. */
+.cr-name.ec-red { -webkit-text-stroke: 0.5px var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 60%, transparent); }
 .cr-sub { flex: 0 1 auto; min-width: 0; font-size: 11.5px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cr-pay { flex: 0 0 auto; font-size: 13px; font-weight: 700; font-style: italic; white-space: nowrap; }
 .cr-pay.spend { color: var(--green); }

--- a/style.css
+++ b/style.css
@@ -408,8 +408,8 @@ input { font-family: inherit; }
 .coltab .ct-n { font-size: 11px; font-weight: 700; color: var(--txt-3); background: var(--bg-2); padding: 1px 8px; border-radius: 999px; }
 .coltab.on .ct-n { color: var(--on-orange); background: rgba(0,0,0,.16); }
 /* red "needs work" alert on a Shop tab (pending inspections / open WOs / overdue service) */
-.coltab.alert:not(.on) { color: var(--txt); background: var(--bg-2); box-shadow: inset 0 0 0 1px var(--red); }   /* rule 1: red border + red icon + light ink + dark bg */
-.coltab.alert:not(.on) .ct-ico { color: var(--red); }
+.coltab.alert:not(.on) { color: var(--txt); background: var(--bg-2); box-shadow: inset 0 0 0 1px var(--red), 0 0 5px color-mix(in srgb, var(--red) 30%, transparent); }   /* rule 1: red border + red icon + light ink + dark bg */
+.coltab.alert:not(.on) .ct-ico { color: var(--red); filter: drop-shadow(0 0 3px color-mix(in srgb, var(--red) 55%, transparent)); }
 .coltab.alert .ct-n { color: var(--txt); background: transparent; }
 /* prominent orange action button — mirrors the Select-rental-window button */
 /* R5b (the real one) at CTA size: empty-search "+New X" + the +New Rental row use the
@@ -563,7 +563,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .disp-addr { color: var(--blue); text-decoration: underline; cursor: pointer; }
 .disp-deadline { flex: 0 0 auto; font-size: 10.5px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .4px; }
 .disp-deadline.today { color: var(--accent); }
-.disp-deadline.over { color: var(--red); }
+.disp-deadline.over { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .disp-home { padding: 4px 11px; }
 .disp-home .disp-unit { font-size: 12px; color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; }
 .disp-home .disp-sub { font-size: 10.5px; }
@@ -1168,7 +1168,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* request lifecycle state (Needs your OK / Needs your answer / Building) */
 .req-head .spacer { flex: 1 1 auto; }
 .req-state { height: 20px; font-size: 9.5px; letter-spacing: .3px; flex: 0 0 auto; align-self: center; }
-.req-card.req-needs { border-color: var(--red); box-shadow: 0 0 0 1px rgba(255, 66, 66, .25); }
+.req-card.req-needs { border-color: var(--red); box-shadow: 0 0 0 1px color-mix(in srgb, var(--red) 50%, transparent), 0 0 7px color-mix(in srgb, var(--red) 30%, transparent); }
 
 /* §18e/f the round bell + Requests inbox — now ride the right of the bottom comms band
    (.bb-utils); the old floating fab-stack + its reserved right lane are retired. */
@@ -1202,14 +1202,14 @@ select.lf-in { appearance: none; cursor: pointer; }
 .crail-t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* registry dot follows the team thread's flag color */
 .crail-tab.c-green .crail-dot { background: var(--green); } .crail-tab.c-yellow .crail-dot { background: var(--yellow); }
-.crail-tab.c-red .crail-dot { background: var(--red); } .crail-tab.c-blue .crail-dot { background: var(--blue); }
+.crail-tab.c-red .crail-dot { background: var(--red); box-shadow: 0 0 4px color-mix(in srgb, var(--red) 50%, transparent); } .crail-tab.c-blue .crail-dot { background: var(--blue); }
 .crail-tab.c-purple .crail-dot { background: var(--purple); } .crail-tab.c-gray .crail-dot { background: var(--txt-3); }
 /* Actionable request tabs read via a STEADY tinted edge + colored dot — needs-answer
    (red) · needs-your-OK (yellow). NO perpetual glow: a wall of pulsing tabs was a
    strobe; motion is reserved for the one transient attnFlash beat elsewhere. */
 .crail-needs .crail-dot { background: var(--red); }
 .crail-ok .crail-dot { background: var(--yellow); }
-.crail-tab.crail-needs:not(.is-active) { border-color: color-mix(in srgb, var(--red) 55%, var(--line)); }
+.crail-tab.crail-needs:not(.is-active) { border-color: var(--red); box-shadow: 0 0 5px color-mix(in srgb, var(--red) 30%, transparent); }
 .crail-tab.crail-ok:not(.is-active) { border-color: color-mix(in srgb, var(--yellow) 50%, var(--line)); }
 .crail-tab.is-unseen { border-color: var(--accent-line); }
 .crail-tab.is-unseen .crail-dot { box-shadow: 0 0 0 3px var(--accent-soft); }
@@ -1630,7 +1630,7 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gv-lead-n { color: var(--txt-3); font-weight: 700; font-size: 11px; }
 .gv-lead-name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .gv-lead-mech { font-size: 11px; color: var(--txt-3); }
-.gv-lead-c { font-weight: 800; color: var(--red); }
+.gv-lead-c { font-weight: 800; color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .gv-pie { display: flex; flex-direction: column; align-items: center; }
 .gv-pie svg { display: block; }
 .gv-legend { display: flex; flex-wrap: wrap; gap: 4px 10px; margin-top: 10px; justify-content: center; }
@@ -1644,7 +1644,7 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gv-bar-track { flex: 1; width: 70%; display: flex; align-items: flex-end; }
 .gv-bar-fill { position: relative; width: 100%; min-height: 2px; border-radius: 4px 4px 0 0; }
 /* §13.4 Revenue-by-Status: a red cap on the bar = the uncollected (unpaid + refunded) share */
-.gv-bar-red { position: absolute; top: 0; left: 0; right: 0; min-height: 2px; background: var(--red); border-radius: 4px 4px 0 0; }
+.gv-bar-red { position: absolute; top: 0; left: 0; right: 0; min-height: 2px; background: var(--red); border-radius: 4px 4px 0 0; box-shadow: 0 0 8px color-mix(in srgb, var(--red) 45%, transparent); }
 .gv-bars .gv-barcol.on .gv-bar-red { background: var(--red); }   /* stay red even when the bar is the active filter (orange) */
 .gv-revbars .gv-bar-n { color: var(--txt); font-weight: 700; }
 .gv-bar-x { font-size: 10px; color: var(--txt-3); margin-top: 5px; text-transform: uppercase; letter-spacing: .4px; }
@@ -1701,7 +1701,7 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gv-lead-list .gv-lead-row:hover { background: var(--panel); }
 .gv-lead-list .gv-lead-row.on { background: var(--accent-soft); }
 .gv-lead-list .gv-lead-row.on .gv-lead-name { color: var(--accent); }
-.gv-lead-list .gv-lead-row .gv-lead-c { color: var(--txt-2); }
+.gv-lead-list .gv-lead-row .gv-lead-c { color: var(--txt-2); -webkit-text-fill-color: var(--txt-2); text-shadow: none; }
 .gv-lead-list .gv-lead-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 /* clickable number tiles */
 .gv-numrow { display: flex; flex-wrap: wrap; gap: 8px; }
@@ -1866,17 +1866,17 @@ select.nc-in { cursor: pointer; }
 .ag-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
 .ag-dot.ok { background: var(--green); }
 .ag-dot.mid { background: var(--yellow); box-shadow: 0 0 0 3px var(--yellow-bg); }   /* §7.1c in-progress */
-.ag-dot.bad { background: var(--red); box-shadow: 0 0 0 3px var(--red-bg); }
+.ag-dot.bad { background: var(--red); box-shadow: 0 0 0 3px var(--red-bg), 0 0 6px color-mix(in srgb, var(--red) 40%, transparent); }
 /* short status banner — a thin red hazard rail, calm body */
 .ag-banner { position: relative; padding: 9px 13px 9px 20px; border-radius: 10px; margin: 2px 0 16px; font-size: 12.5px; font-weight: 600; }
-.ag-banner.bad { background: var(--red-bg); border: 1px solid var(--accent-line); border-color: rgba(255,66,66,.34); color: var(--red); }
+.ag-banner.bad { background: var(--red-bg); border: 1px solid var(--accent-line); border-color: var(--red); color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); box-shadow: 0 0 6px color-mix(in srgb, var(--red) 25%, transparent); }
 .ag-banner.bad::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 8px; border-radius: 10px 0 0 10px;
   background: repeating-linear-gradient(135deg, var(--red) 0 7px, #14181d 7px 14px); }
 /* per-card meta line + states */
 .ag-meta { display: flex; align-items: center; gap: 9px; margin: 2px 0 14px; font-size: 12.5px; color: var(--txt-2); }
 .ag-metasep { margin-left: auto; }
 .ag-gate { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin: 0 0 15px; font-size: 12.5px; }
-.ag-gate .lead { color: var(--red); font-weight: 600; }
+.ag-gate .lead { color: var(--red); font-weight: 600; -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .ag-gate .sub { color: var(--txt-3); }
 .ag-readref { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 10px 13px; border-radius: 10px;
   background: var(--panel); border: 1px solid var(--line); margin: 0 0 14px; font-size: 13px; color: var(--txt-2); }
@@ -2257,7 +2257,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .flag:hover { text-decoration: underline; }
 .flag.c-green { background: none; color: var(--green); border: none; }
 .flag.c-yellow { background: none; color: var(--yellow); border: none; }
-.flag.c-red { background: none; color: var(--red); border: none; }
+.flag.c-red { background: none; color: var(--red); border: none; -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .flag.c-blue { background: none; color: var(--blue); border: none; }
 .flag.c-purple { background: none; color: var(--purple); border: none; }
 .flag.c-gray { background: none; color: var(--gray); border: none; }
@@ -2267,8 +2267,8 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .section.sec-green > h4 { color: var(--green); }
 .section.sec-yellow { border-color: color-mix(in srgb, var(--yellow) 45%, transparent); }
 .section.sec-yellow > h4 { color: var(--yellow); }
-.section.sec-red { border-color: color-mix(in srgb, var(--red) 80%, transparent); }
-.section.sec-red > h4 { color: var(--red); }
+.section.sec-red { border-color: var(--red); box-shadow: 0 0 8px color-mix(in srgb, var(--red) 30%, transparent); }
+.section.sec-red > h4 { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 
 /* NOTES = heading-only line, no panel box, no label (filled→top, empty→bottom) */
 .nsec { display: flex; align-items: center; gap: 9px; padding: 1px 2px; }
@@ -2706,10 +2706,14 @@ body { font-variant-numeric: tabular-nums; }
 .cr { display: flex; align-items: center; gap: 8px; min-width: 0; justify-content: flex-start; }
 .cr-id { flex: 0 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 8px; }
 .cr-name { flex: 0 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-/* Shared ec-red glow: full --red halo bleeds into a 65%-red+white fill — no hard seam. Covers red customer names, Failed-inspection unit names in rental cards, and overdue balances. */
+/* ec-red: official flagging-red text treatment — --red halo bleeds into 65%-red+white fill, no hard seam. */
 .cr-name.ec-red,
 .rcc-uname.ec-red,
-.rcc-bal.overdue { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
+.rcc-bal.overdue,
+.cr-pay.over,
+.pill.c-red .t { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
+/* ec-red border glow on red status pills */
+.pill.c-red { border-color: color-mix(in srgb, var(--red) 55%, transparent); box-shadow: 0 0 4px color-mix(in srgb, var(--red) 25%, transparent); }
 .cr-sub { flex: 0 1 auto; min-width: 0; font-size: 11.5px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cr-pay { flex: 0 0 auto; font-size: 13px; font-weight: 700; font-style: italic; white-space: nowrap; }
 .cr-pay.spend { color: var(--green); }


### PR DESCRIPTION
## Summary

Implements the "ec-red" glow as the new official design for every red flagging signal across the app — per Jac: *"anything that's red for the purpose of flagging should use this: text, statuses, highlights, borders, etc."*

The treatment: `color: var(--red)` → `-webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white)` + `text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent)`. Full `--red` halo bleeds into a lighter 65%/35% fill with no hard seam.

**Text / icons rolled out to:**
- `.cr-name.ec-red` — red customer names (existing)
- `.rcc-uname.ec-red` — Failed-inspection unit names in rental cards (existing)
- `.rcc-bal.overdue` — overdue balance amounts in rental cards (existing)
- `.cr-pay.over` — overdue payment totals in customer rows (new)
- `.pill.c-red .t` — text label in every red status/gate/badge pill (new)
- `.flag.c-red` — title mini-flags with red severity (new)
- `.section.sec-red > h4` — section headers for red-status sections (new)
- `.disp-deadline.over` — overdue deadline stamps (new)
- `.gv-lead-c` — gate-view lead customer name (new; reset in list context via more-specific rule)
- `.ag-gate .lead` — agent gate lead text (new)
- `.ag-banner.bad` — agent status banner text (new)
- `.coltab.alert:not(.on) .ct-ico` — column tab alert icon, gets `filter: drop-shadow()` glow (new)

**Borders rolled out to:**
- `.pill.c-red` — border strengthened to 55% + outer box-shadow glow (new)
- `.coltab.alert:not(.on)` — inset ring gains outer glow (new)
- `.section.sec-red` — bumped to full `var(--red)` + box-shadow (new)
- `.req-card.req-needs` — glow strengthened (new)
- `.crail-tab.crail-needs:not(.is-active)` — border now full `var(--red)` + glow (new)
- `.ag-banner.bad` — border now full `var(--red)` + glow (new)

**Fill / dot elements:**
- `.crail-tab.c-red .crail-dot` — red dot gains box-shadow glow (new)
- `.ag-dot.bad` — existing ring + new outer glow (new)
- `.gv-bar-red` — gate-view red bar gains glow (new)

## Test plan
- [x] Smoke CI passes (`node ci/smoke.mjs`)
- [x] Logic suite 186/186 (`node ci/logic-test.mjs`)
- [x] Rule-usage current (`node ci/gen-rule-usage.mjs --check`)
- [x] Window catalog current (`node ci/check-window-catalog.mjs`)
- [x] Screenshot verified — 4 ec-red customer names visible with correct glow/fill treatment
- [ ] Visual review: confirm glow reads well across customers, status pills, sections, and borders in dark + light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiGsZEpFXqEbbUziPakEpi