### PR TITLE
Mobile improvements: touch fixes + wrench Shop toggle & 3-bar shop graph

### DIFF
--- a/app.js
+++ b/app.js
@@ -10187,7 +10187,7 @@ function render() {
   applyTitles();   // full text on hover wherever we truncate (custom ~0.5s tooltip)
   drawDispatchArrows();   // §2.3 — paint free-form route legs over the dispatch run (needs live geometry)
   scoreTick();     // §11 gamification — pop +X over any ring whose metric just rose
-  if (DRAG.active) reapplyDragDecor();   // §15c — re-stamp drop targets after ANY mid-drag rebuild (the card swap IS a render)
+  if (DRAG.active) { reapplyDragDecor(); buildZipZones(); }   // §15c — re-stamp drop targets + rebuild the §M2 zip rails after ANY mid-drag rebuild (the card swap IS a render)
   const dt = performance.now() - t0;
   renderCount++;
   if (dt > CFG.PERF_BUDGET_MS) console.warn(`[perf] render ${renderCount} took ${dt.toFixed(1)}ms (budget ${CFG.PERF_BUDGET_MS}ms)`);
@@ -10244,11 +10244,11 @@ function toast(msg) {
    Drops dispatch into the EXISTING §16 mutations — no money/safety logic here.
    Wave 2: pick mode is GONE — drag (+ customer quick-add-link) IS the link path.
    ════════════════════════════════════════════════════════════════════════ */
-const DRAG = { active: false, armed: null, payload: null, point: { x: 0, y: 0 }, ghost: null, suppressClick: false, raf: null, hot: null };
+const DRAG = { active: false, armed: null, payload: null, point: { x: 0, y: 0 }, ghost: null, suppressClick: false, raf: null, hot: null, zipHot: null };
 // units/rentals/customers/invoices link via DROP_MATRIX; categories + serviceOrders are
 // drag sources ONLY for chat-tagging (they're not in DROP_MATRIX, so no record links). §17
 const DRAG_SOURCES = new Set(['units', 'rentals', 'customers', 'invoices', 'categories', 'serviceOrders']);
-let dragLayer = null, dragArc = null, chatDropPad = null, dragEdgeDwell = null;
+let dragLayer = null, dragArc = null, chatDropPad = null, zipZones = null, zipDwell = null, zipCooldown = false;
 
 /* DROP_MATRIX — payload entity → { target entity: validator(srcRec, tgtRec) }.
    Validators are the cheap VISUAL gate (which rows/cards glow .drop-ok); the
@@ -10317,6 +10317,10 @@ function initDrag() {
   // spin up a brand-new chat seeded with that thing.
   chatDropPad = el('div', 'chat-drop', '<div class="cd-inner"><svg class="cd-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg><span class="cd-label">Drop to start a chat</span></div>');
   dragLayer.appendChild(chatDropPad);
+  // §M2 — phone "zip zones": edge rails of valid drop-target cards. Dragging onto one
+  // jumps to that card's column mid-drag (drag stays live), then you drop on the row.
+  zipZones = el('div'); zipZones.id = 'zip-zones';
+  dragLayer.appendChild(zipZones);
   document.body.appendChild(dragLayer);
   document.addEventListener('pointerdown', dragDown);
   document.addEventListener('pointermove', dragMove);
@@ -10469,6 +10473,7 @@ function startDrag() {
   // links (e.g. customer↔invoice, which share the right column) use the reverse
   // drag direction (the DROP_MATRIX is bidirectional).
   reapplyDragDecor();
+  buildZipZones();   // §M2 — phone edge rails of valid target cards
   dragFrameLoop();
 }
 
@@ -10581,19 +10586,71 @@ function dragFrameLoop() {
   };
   DRAG.raf = requestAnimationFrame(step);
 }
-// §M2 — while dragging on a phone, holding the pointer at the left/right screen edge
-// switches to the adjacent column (one column per dwell), so an item can be carried
-// across columns. The bottom edge is the chat zone (handled by the drop-pad, §17).
+// §M2 ZIP ZONES (phone) — the valid drop-target cards for the dragged item appear as
+// edge rails. Dragging onto a zone jumps to that card's column (drag stays live), then
+// you drop on the exact row. Replaces the old blind 350ms/30px edge-dwell.
+// Hazard-stripe tint per card so you aim by colour (transient drag overlay only — the
+// persistent UI keeps the one-orange rule). No status meaning is encoded here.
+const ZIP_HUE = { units: 'brown', categories: 'brown', rentals: 'blue', invoices: 'green', customers: 'purple', workOrders: 'accent', serviceOrders: 'accent', inspections: 'accent', shop: 'accent' };
+function zipTargetsFor(entity) {
+  const accept = DROP_MATRIX[entity] || {}, s = activeSession();
+  return Object.keys(accept).map((tgt) => {
+    const idx = COLUMNS.findIndex((c) => c.id === COLUMN_OF[tgt]);
+    return { entity: tgt, idx, label: MEMBER_TITLE[tgt] || tgt, icon: CARD_ICON[tgt] || '', hue: ZIP_HUE[tgt] || 'accent' };
+  }).filter((z) => {
+    if (z.idx < 0) return false;
+    const colId = COLUMNS[z.idx].id, cur = (s.cols && s.cols[colId]) || COLUMNS[z.idx].default;
+    const showing = z.idx === state.mobileCol && (cur === z.entity || (SHOP_TYPES.includes(z.entity) && SHOP_TYPES.includes(cur)));
+    return !showing;   // no zone for the card already on screen
+  });
+}
+// (re)build the edge rails for the current drag source + visible column. Phone only.
+function buildZipZones() {
+  if (!zipZones) return;
+  zipZones.innerHTML = ''; DRAG.zipHot = null; zipDwell = null;
+  if (!DRAG.active || !document.body.classList.contains('is-phone')) return;
+  const targets = zipTargetsFor(DRAG.payload.entity);
+  if (!targets.length) return;
+  const railL = el('div', 'zz-rail zz-rail-left'), railR = el('div', 'zz-rail zz-rail-right');
+  targets.forEach((z) => {
+    const left = z.idx < state.mobileCol || (z.idx === state.mobileCol && COLUMNS[z.idx].id === 'left');   // column to the left → left edge; same-column member-switch sits on its home side
+    const b = el('div', `zip-zone zip-${left ? 'left' : 'right'}`);
+    b.dataset.zip = z.entity;
+    b.style.setProperty('--zip-hue', `var(--${z.hue})`);
+    b.innerHTML = `<span class="zz-ico">${z.icon}</span><span class="zz-lbl">${esc(z.label)}</span>`;
+    (left ? railL : railR).appendChild(b);
+  });
+  if (railL.children.length) zipZones.appendChild(railL);
+  if (railR.children.length) zipZones.appendChild(railR);
+}
+// jump the phone to a target card's column (keeping the drag live) so its rows are droppable.
+function zipToCard(entity) {
+  const s = activeSession(), idx = COLUMNS.findIndex((c) => c.id === COLUMN_OF[entity]);
+  if (idx < 0) return;
+  if (s.cols) s.cols[COLUMNS[idx].id] = entity;
+  state.mobileCol = idx;
+  const mc = s.cards[SHOP_TYPES.includes(entity) ? 'shop' : entity];
+  if (mc) { mc.mode = 'list'; mc.recId = null; mc.recType = null; }   // list mode → rows to drop on
+  render();   // §15c hook re-stamps drop decor + rebuilds the zip rails for the new column
+}
 function phoneDragEdge() {
-  const EDGE = 30, DWELL = 350, w = window.innerWidth, x = DRAG.point.x;
-  const side = x <= EDGE ? -1 : x >= w - EDGE ? 1 : 0;
-  if (!side) { dragEdgeDwell = null; return; }
+  if (!zipZones) return;
+  const DWELL = 150;
+  let over = null;
+  for (const z of zipZones.querySelectorAll('.zip-zone')) {
+    const r = z.getBoundingClientRect();
+    if (DRAG.point.x >= r.left && DRAG.point.x <= r.right && DRAG.point.y >= r.top && DRAG.point.y <= r.bottom) { over = z; break; }
+  }
+  if (zipCooldown) { if (!over) zipCooldown = false; if (DRAG.zipHot) { DRAG.zipHot.classList.remove('hot'); DRAG.zipHot = null; } return; }   // after a zip, must leave the edge before another can arm (no accidental chain-zip)
+  if (DRAG.zipHot && DRAG.zipHot !== over) DRAG.zipHot.classList.remove('hot');
+  if (over && DRAG.zipHot !== over) { over.classList.add('hot'); haptic(8); }   // §M-touch — tick when a zip zone arms
+  DRAG.zipHot = over;
+  if (!over) { zipDwell = null; return; }
   const now = performance.now();
-  if (!dragEdgeDwell || dragEdgeDwell.side !== side) { dragEdgeDwell = { side, at: now }; return; }
-  if (now - dragEdgeDwell.at < DWELL) return;
-  const next = Math.max(0, Math.min(2, state.mobileCol + side));
-  dragEdgeDwell.at = now;                                    // re-arm the dwell for a possible further hop
-  if (next !== state.mobileCol) { state.mobileCol = next; render(); }   // render re-stamps drop targets mid-drag (§15c) + restores scroll to the new column
+  if (!zipDwell || zipDwell.el !== over) { zipDwell = { el: over, at: now }; return; }
+  if (now - zipDwell.at < DWELL) return;
+  zipDwell = null; zipCooldown = true;
+  zipToCard(over.dataset.zip);   // render rebuilds the rails; the rAF loop continues for the new context
 }
 
 /* ── release / cancel ───────────────────────────────────────────────────── */
@@ -10615,11 +10672,12 @@ function endDrag({ rerender } = {}) {
   if (DRAG.ghost) DRAG.ghost.remove();
   dragArc.classList.remove('show', 'hot');
   chatDropPad.classList.remove('show', 'hot');
+  if (zipZones) zipZones.innerHTML = '';   // §M2 — tear down the edge rails
   const arcLbl = dragArc.querySelector('.ca-label'); if (arcLbl) arcLbl.textContent = 'Cancel';   // reset copy so the next drag opens idle, not "Release to cancel"
   document.querySelectorAll('.drop-ok, .drop-hot').forEach((n) => n.classList.remove('drop-ok', 'drop-hot'));
   document.body.classList.remove('dragging');
   delete document.body.dataset.drag;
-  DRAG.active = false; DRAG.payload = null; DRAG.ghost = null; DRAG.hot = null; DRAG.armed = null; dragEdgeDwell = null;
+  DRAG.active = false; DRAG.payload = null; DRAG.ghost = null; DRAG.hot = null; DRAG.armed = null; DRAG.zipHot = null; zipDwell = null; zipCooldown = false;
   DRAG.suppressClick = true;   // the trailing click is swallowed once; the NEXT pointerdown clears it (no timer — see dragDown)
   if (rerender) render();
 }

--- a/app.js
+++ b/app.js
@@ -2069,6 +2069,7 @@ function totColMatch(card, rec, col, value) {
     if (value === 'on-schedule') return !s || (s.status !== 'past-due' && s.status !== 'due-soon');
     return false;
   }
+  if (col === '__wophase') return card === 'workOrders' && (rec.phase || '—') === value;   // shop front-page WO bar: match this phase AND exclude non-WO items (the normal 'phase' fallback would let them through)
   const c = cardColumns(card, activeSession()).find((x) => x.key === col);
   return c ? String(c.get(rec)) === String(value) : true;
 }
@@ -5859,24 +5860,22 @@ function colTabsEl(col, active, session) {
 /* The coltab buttons themselves (no wrapper) — shared by the desktop in-card tab row
    (colTabsEl) AND the phone footer (mobileDockEl), so a toggle looks identical in both. */
 function colTabButtonsHtml(col, active, session) {
-  // v2 (Jac call #1): the standalone Inspections + Work Orders tabs go away —
-  // they live INSIDE the Unit card now; only Service keeps a tab. The hidden
-  // tab still renders while its member is ACTIVE so deep links navigate home.
-  const HIDDEN_TABS = new Set(['inspections', 'workOrders']);
-  // "Not Ready" filter chip (Jac 2026-06-11): rides with the Service heart on the
-  // units column — clipboard-? icon + count; hidden when zero; it's just a filter.
-  const notReady = col.members.includes('units') ? DATA.units.filter((u) => u.inspectionStatus === 'Not Ready').length : 0;
-  const nrChip = notReady ? `<button class="coltab js-notready compact alert" data-tip="${notReady} Not Ready — filter the Units list"><span class="ct-ico">${CARD_ICON.inspectionsPending || CARD_ICON.inspections}</span><span class="ct-n">${notReady}</span></button>` : '';
-  return col.members.filter((m) => !HIDDEN_TABS.has(m) || m === active).map((m) => {
-    const on = m === active, compact = SHOP_TYPES.includes(m);   // shop sub-types are icon-only
-    const n = memberCount(m, session);
-    const alert = SHOP_TYPES.includes(m) && shopAlertCount(m, session) > 0;   // red = work needs doing
-    return `<button class="coltab js-coltab${on ? ' on' : ''}${compact ? ' compact' : ''}${alert ? ' alert' : ''}" data-col="${col.id}" data-member="${m}" data-tip="${esc(MEMBER_TITLE[m])}${alert ? ' — needs attention' : ''}">`
+  // The 3 shop sub-types (inspections/workOrders/serviceOrders) fold into ONE wrench
+  // "Shop" toggle that opens the shop graph; the old Service-heart toggle + Not-Ready
+  // chip are absorbed into it (the graph's Services + Not Ready bars).
+  const coltabBtn = (m, on, { alert = false, count = null } = {}) =>
+    `<button class="coltab js-coltab${on ? ' on' : ''}${alert ? ' alert' : ''}" data-col="${col.id}" data-member="${m}" data-tip="${esc(MEMBER_TITLE[m] || m)}${alert ? ' — needs attention' : ''}">`
       + `<span class="ct-ico">${memberIcon(m)}</span>`
-      + (compact ? '' : `<span class="ct-lbl">${esc(MEMBER_TITLE[m])}</span>`)
-      + `<span class="ct-n">${n}</span>`
+      + `<span class="ct-lbl">${esc(MEMBER_TITLE[m] || m)}</span>`
+      + (count != null ? `<span class="ct-n">${count}</span>` : '')
       + `</button>`;
-  }).join('') + nrChip;
+  let out = col.members.filter((m) => !SHOP_TYPES.includes(m)).map((m) => coltabBtn(m, m === active, { count: memberCount(m, session) })).join('');
+  if (col.members.some((m) => SHOP_TYPES.includes(m))) {   // this column owns the shop → append the wrench Shop toggle
+    const shopActive = active === 'shop' || SHOP_TYPES.includes(active);
+    const alertN = SHOP_TYPES.reduce((a, ty) => a + shopAlertCount(ty, session), 0);   // total items needing the crew
+    out += coltabBtn('shop', shopActive, { alert: alertN > 0, count: alertN });
+  }
+  return out;
 }
 /* Jac 2026-06-12: the nav cluster (List / Anchor / New tab) rides the TOGGLE row,
    not the title row — the item header gets room to breathe and head gates align right. */
@@ -5891,6 +5890,7 @@ function colActionsHtml(active, session) {
 }
 function memberCardEl(member, session) {
   if (member === 'calendar') return calendarCardEl(session);
+  if (member === 'shop') return shopCardEl({ id: 'shop', title: 'Shop' }, session);   // the wrench "Shop" member = the COMBINED view (segment bar + 3-bar front-page graph), no forcedSeg
   if (SHOP_TYPES.includes(member)) return shopCardEl({ id: 'shop', title: MEMBER_TITLE[member] }, session, member);
   return cardEl(GRID_CARD_BY_ID[member], session);
 }
@@ -6674,22 +6674,26 @@ function activeMobileCard() {
   const member = (s.cols && s.cols[colObj.id]) || colObj.default;
   return SHOP_TYPES.includes(member) ? 'shop' : member;
 }
-// §M1 — the card the phone is currently showing (the active column's member).
+// §M1 — the card the phone is currently showing (the active column's member). Fold the
+// shop sub-types to 'shop' (mirror activeMobileCard) so the footer toggle highlight + the
+// swipe-step index track the single Shop entry instead of failing to match.
 function currentMobileMember() {
   const colObj = COLUMNS[Math.max(0, Math.min(2, state.mobileCol))];
   const s = activeSession();
-  return (s.cols && s.cols[colObj.id]) || colObj.default;
+  const m = (s.cols && s.cols[colObj.id]) || colObj.default;
+  return SHOP_TYPES.includes(m) ? 'shop' : m;
 }
-// §M1 — the flat card list the phone toggle bar offers. On desktop, inspections + work
-// orders live INSIDE the Unit card (hidden tabs); on phone they get their own toggles too.
-const MOBILE_CARDS = ['units', 'categories', 'inspections', 'serviceOrders', 'rentals', 'calendar', 'customers', 'invoices'];
+// §M1 — the flat card list the phone toggle bar offers. The 3 shop sub-types fold into one
+// 'shop' entry (the wrench), matching desktop; it opens the 3-bar shop graph.
+const MOBILE_CARDS = ['units', 'categories', 'shop', 'rentals', 'calendar', 'customers', 'invoices'];
 // §M1 — jump straight to a card (flattens the 3-column model on phones): set the column +
-// member, flip the visible column, and show that card's LIST.
+// member, flip the visible column, and show that card's LIST (or, for Shop, its graph).
 function goToCard(member) {
   const s = activeSession(); const col = COLUMN_OF[member];
   if (s.cols && col) s.cols[col] = member;
   const idx = COLUMNS.findIndex((c) => c.id === col); if (idx >= 0) state.mobileCol = idx;
-  const mc = s.cards[member]; if (mc) { mc.mode = 'list'; mc.recId = null; mc.recType = null; }
+  if (member === 'shop') { const sc = s.cards.shop; if (sc) { sc.segment = 'all'; sc.graphView = true; sc.mode = 'list'; sc.recId = null; sc.recType = null; } }
+  else { const mc = s.cards[member]; if (mc) { mc.mode = 'list'; mc.recId = null; mc.recType = null; } }
   render();
 }
 // §M1 phone footer — ONE card-toggle bar: every card collapsed to its icon, the SELECTED
@@ -7752,6 +7756,26 @@ function graphViewsFor(card) {
       { key: 'nums', title: 'By the Numbers', kind: 'nums', segs: status.map((s) => ({ ...s })) },
     ];
   }
+  if (card === 'shop') {
+    // The Shop "front page" (wrench toggle): one stacked-bar view of what needs the
+    // crew's attention right now — Not Ready · Services · Work Orders.
+    const notReady = DATA.units.filter((u) => u.inspectionStatus === 'Not Ready').length;
+    let svcOver = 0, svcDue = 0;
+    DATA.units.forEach((u) => { if (u.washRequested) return; const s = topServiceForUnit(u); if (!s) return; if (s.status === 'past-due') svcOver++; else if (s.status === 'due-soon') svcDue++; });
+    const woByPhase = {}; DATA.workOrders.filter((w) => w.phase !== 'Complete' && !w.cancelled).forEach((w) => { const ph = w.phase || '—'; woByPhase[ph] = (woByPhase[ph] || 0) + 1; });
+    const woParts = Object.keys(STATUS.woPhase).filter((ph) => ph !== 'Complete' && woByPhase[ph]).map((ph) => ({ col: '__wophase', value: ph, label: getStatus('woPhase', ph).label || ph, count: woByPhase[ph], color: getStatus('woPhase', ph).color || 'gray' }));
+    const bars = [
+      // Not Ready reuses the established js-notready affordance (route to the Units list,
+      // filtered to Not-Ready) rather than a graph filter — same behavior the old chip had.
+      { label: 'Not Ready', count: notReady, color: 'yellow', js: 'js-notready', tip: `${notReady} Not Ready — open the Units list` },
+      { label: 'Services', parts: [
+        { col: '__svcstat', value: 'past-due', label: 'Overdue', count: svcOver, color: 'red' },
+        { col: '__svcstat', value: 'due-soon', label: 'Due', count: svcDue, color: 'yellow' },
+      ] },
+      { label: 'Work Orders', parts: woParts },
+    ];
+    return [{ key: 'shopfront', title: 'Shop', kind: 'stackbars', segs: bars }];
+  }
   return null;
 }
 // ── state transitions. The active view's selection lives in cs.filterTerms as g-tagged
@@ -7839,6 +7863,27 @@ function gvRenderView(card, src, cs, v) {
       const inner = `<div class="gv-bar-n">${esc(money(s.count))}</div>${fill}<div class="gv-bar-x">${esc(s.label)}</div>`;
       return gvSegBtn(cs, card, src, s, inner, 'gv-barcol');
     }).join('')}</div>`;
+  }
+  if (v.kind === 'stackbars') {   // bars whose fill is a STACK of clickable segments (each = a filter); a single-part bar can carry a custom action class (js)
+    const tot = (s) => s.parts ? s.parts.reduce((a, p) => a + (p.count || 0), 0) : (s.count || 0);
+    const max = Math.max(1, ...v.segs.map(tot));
+    const bars = v.segs.map((s) => {
+      const t = tot(s), h = Math.round((t / max) * 100);
+      let stack;
+      if (s.parts) {
+        stack = s.parts.filter((p) => p.count).map((p) => {
+          const on = gvSegOn(cs, p.col, p.value);
+          return `<button class="gv-bar-seg js-gv-seg${on ? ' on' : ''}" style="flex:${p.count} 1 0;background:var(--${p.color})" data-card="${card}" data-src="${esc(src)}" data-col="${esc(p.col)}" data-value="${esc(String(p.value))}" data-label="${esc(p.label)}" data-tip="${on ? 'Remove filter' : 'Filter to ' + esc(p.label)}"></button>`;
+        }).join('');
+      } else {
+        stack = t ? `<button class="gv-bar-seg ${s.js || ''}" style="flex:1;background:var(--${s.color || v.color || 'accent'})" data-tip="${esc(s.tip || s.label)}"></button>` : '';
+      }
+      return `<div class="gv-barcol"><div class="gv-bar-n">${t || ''}</div><div class="gv-bar-track"><div class="gv-bar-stack" style="height:${h}%">${stack}</div></div><div class="gv-bar-x">${esc(s.label)}</div></div>`;
+    }).join('');
+    const legParts = [];
+    v.segs.forEach((s) => { if (s.parts) s.parts.filter((p) => p.count).forEach((p) => legParts.push(gvSegBtn(cs, card, src, p, `<i style="background:var(--${p.color})"></i><span class="gl-lbl">${esc(p.label)}</span> <b>${p.count}</b>`, 'gv-leg'))); });
+    const legend = (gvPillsHidden(card) || !legParts.length) ? '' : `<div class="gv-legend gv-legend-click">${legParts.join('')}</div>`;
+    return `<div class="gv-bars gv-stackbars">${bars}</div>${legend}`;
   }
   if (v.kind === 'lead') {
     if (!v.segs.length) return '<div class="gv-empty">No data yet.</div>';
@@ -10970,13 +11015,11 @@ function onClick(e) {
   if (closest('.js-new-cat-search')) { e.stopPropagation(); return quickAddCategoryFromSearch(activeSession().cards.categories.search); }
   if (closest('.js-coltab')) {
     const ct = closest('.js-coltab'); e.stopPropagation();
-    // A1 — the Services (heart) tab filters the Units list to service-due as a removable
-    // pill, instead of switching to a stuck Service view you can't clear. (Jac 2026-06-15)
-    if (ct.dataset.member === 'serviceOrders') { const s = activeSession(); if (s.cols) s.cols.left = 'units'; s.cards.units.mode = 'list'; s.cards.units.recId = null; s.cards.units.recType = null; addColFilter('units', '__svc', 'due'); return; }
     const cs = activeSession(); if (cs.cols) cs.cols[ct.dataset.col] = ct.dataset.member;
+    if (ct.dataset.member === 'shop') { const sc = cs.cards.shop; if (sc) { sc.segment = 'all'; sc.graphView = true; sc.mode = 'list'; sc.recId = null; sc.recType = null; } }   // wrench Shop → the combined 3-bar graph front page
     // §M1 — on phones the footer toggle is the primary nav (no in-card List button): tapping a
     // card shows its LIST (the back chevron returns from a record). Desktop keeps per-member state.
-    if (document.body.classList.contains('is-phone')) { const mc = cs.cards[ct.dataset.member]; if (mc) { mc.mode = 'list'; mc.recId = null; mc.recType = null; } }
+    else if (document.body.classList.contains('is-phone')) { const mc = cs.cards[ct.dataset.member]; if (mc) { mc.mode = 'list'; mc.recId = null; mc.recType = null; } }
     return render();
   }
   // §2.3 dispatch timeline — day nav + open a stop's rental (Phase 6)
@@ -14327,6 +14370,16 @@ async function shareSession() {
     caption: tabs.length ? `Scan to open your ${tabs.length} open tab${tabs.length === 1 ? '' : 's'} on another device — sign in with the shared password.`
       : 'Scan to open Rental Wrangler on another device — sign in with the shared password.' });
 }
+// Shop roles (Mechanic / M.Tech) get the Shop card + its 3-bar graph as the landing view
+// — quick access to the crew's worklist. A default only; they can navigate anywhere after.
+function applyShopRoleLanding() {
+  if (currentRole !== 'mechanic' && currentRole !== 'mtech') return;
+  const s = activeSession(); if (!s) return;
+  if (s.cols) s.cols.left = 'shop';
+  const sc = s.cards.shop; if (sc) { sc.segment = 'all'; sc.graphView = true; sc.mode = 'list'; sc.recId = null; sc.recType = null; }
+  const li = COLUMNS.findIndex((c) => c.id === 'left'); if (li >= 0) state.mobileCol = li;   // phone: make the Shop column the active one
+  render();
+}
 async function attemptLogin() {
   const name = (document.getElementById('login-name')?.value || '').trim();
   const pw = document.getElementById('login-pw')?.value || '';
@@ -14354,6 +14407,7 @@ async function attemptLogin() {
     sessionStorage.setItem('jactec.pw', pw);
     await loadFromBackend();
     finishLoad();
+    applyShopRoleLanding();   // shop roles (Mechanic / M.Tech) land on the Shop graph
   } catch (e) {
     backendPassword = ''; sessionStorage.removeItem('jactec.pw'); sessionStorage.removeItem('jactec.role');
     renderLogin(/unauthorized/i.test(String(e && e.message)) ? 'That password wasn’t recognized.' : "Couldn't reach the database. Check your connection and try again.");

--- a/app.js
+++ b/app.js
@@ -5928,7 +5928,7 @@ function cardEl(cardDef, session) {
       : '';
     const head = el('div', 'card-head');
     head.innerHTML = `
-      ${cardJog(card, cs)}
+      ${document.body.classList.contains('is-phone') ? '' : cardJog(card, cs)}${/* §M — on phones the jog rides the bottom dock (where List view keeps it), not the card header */ ''}
       <span class="c-titlecard"><span class="c-icon">${CARD_ICON[card] || ''}</span>${titleHtml}</span>
       ${commentMarkerHtml(card, stdRec)}
       ${headFlagsHtml(card, stdRec)}`;
@@ -10204,6 +10204,15 @@ function render() {
     // no listbar, so the slot stays empty (CSS hides it).
     const lb = grid.querySelector('.listbar');
     if (lb) dock.querySelector('.mdock-searchslot').appendChild(lb);
+    else {   // §M — Standard (record) view has no listbar; keep the Back/Fwd jog in the SAME
+      // bottom-dock spot List view uses, instead of letting it sit up in the card header.
+      const cardNode = grid.querySelector('.card[data-card]');
+      const dc = cardNode && cardNode.dataset.card, cs = dc && activeSession().cards[dc];
+      if (cs && cs.mode === 'standard') {
+        const jog = cardJog(dc, cs);
+        if (jog) { const bar = el('div', 'listbar mdock-jogbar'); bar.innerHTML = jog; dock.querySelector('.mdock-searchslot').appendChild(bar); }
+      }
+    }
   }
   // restore scroll by VIEW: same view → keep your spot; back to a list → return to the
   // row you left; opened a record → top of Standard view (a targeted link scrolls itself after).

--- a/app.js
+++ b/app.js
@@ -1669,6 +1669,15 @@ function anchorRecord(card, recId, recType) {
   // per-card searches (don't reset them).
   openInTab(card, recId, recType, { inheritFrom: activeSession() });
 }
+// Double-tap/dbl-click anchor TOGGLE (Jac): double-tapping the record that's already
+// THIS session's anchor drops the anchor (clearAnchor) instead of opening a duplicate
+// anchored tab. Any other record anchors as usual. Used by the gesture paths only —
+// the ⊞ button keeps its always-open-a-new-tab behavior.
+function anchorOrToggle(card, recId, recType) {
+  const a = activeSession().anchor;
+  if (a && a.card === card && String(a.recId) === String(recId) && (a.recType || null) === (recType || null)) return clearAnchor();
+  return anchorRecord(card, recId, recType);
+}
 
 /* Phase 1 shared path — freeze the current session and open card/recId in a NEW
    FOREGROUND tab. Serves anchor / global-search pick / standard-view overtake /
@@ -1904,7 +1913,7 @@ function rowOpen(card, recId, recType) {
 function deferOrAnchor(key, singleFn, anchor) {
   if (pendingRowClick && pendingRowClick.key === key) {
     clearTimeout(pendingRowClick.timer); pendingRowClick = null;
-    return anchorRecord(anchor.card, anchor.recId, anchor.recType);
+    return anchorOrToggle(anchor.card, anchor.recId, anchor.recType);   // 2nd tap on the anchored record un-anchors (toggle)
   }
   if (pendingRowClick) clearTimeout(pendingRowClick.timer);
   pendingRowClick = { key, timer: setTimeout(() => { pendingRowClick = null; singleFn(); }, DBL_MS) };
@@ -14728,9 +14737,9 @@ function boot() {
   document.addEventListener('dblclick', (e) => {
     if (hotkeyGuard(e)) return;
     if (e.target.closest('.row')) return;                 // rows are handled by the click discriminator (#10)
-    const r = cardRecordAt(e.target); if (!r) return;     // dbl-click on a card's open detail → anchor it
+    const r = cardRecordAt(e.target); if (!r) return;     // dbl-click on a card's open detail → anchor it (or un-anchor if it's already the anchor)
     e.preventDefault(); window.getSelection()?.removeAllRanges();
-    anchorRecord(r.card, r.recId, r.recType);
+    anchorOrToggle(r.card, r.recId, r.recType);
   });
   // right-click = send the card to its List View; double right-click = drop the anchor.
   document.addEventListener('contextmenu', (e) => {

--- a/app.js
+++ b/app.js
@@ -10392,6 +10392,11 @@ function dragDown(e) {
    2. a list ROW of a draggable entity;
    3. empty space on a STANDARD-view card (Task 2) → that card's open record. */
 function dragSourceAt(target) {
+  const tab = target.closest('.tab[data-tab]');                              // §M2 — an open-record item tab is a draggable record: navigate freely, then carry the tab to the target (no sustained cross-column hold). WO tabs included (DROP_MATRIX gate), so workOrders→invoice works even though WO isn't in DRAG_SOURCES.
+  if (tab) {
+    const t = (state.tabs || []).find((x) => x.id === tab.dataset.tab);
+    if (t) { const ent = entityCardOf(t.card, t.recType); if (DROP_MATRIX[ent]) return { card: ent, rec: t.recId }; }
+  }
   const upill = target.closest('[data-pill-card="units"]');                  // a unit pill drags as that unit → link to a rental (Jac B4)
   if (upill && upill.dataset.pillRec) return { card: 'units', rec: upill.dataset.pillRec };
   const woSect = target.closest('.section[data-wo]');

--- a/config.js
+++ b/config.js
@@ -352,7 +352,7 @@ export const COLUMNS = [
   { id: 'right',  default: 'customers', members: ['customers', 'invoices'] },
 ];
 export const COLUMN_OF = {
-  units: 'left', categories: 'left', inspections: 'left', serviceOrders: 'left', workOrders: 'left',
+  units: 'left', categories: 'left', inspections: 'left', serviceOrders: 'left', workOrders: 'left', shop: 'left',
   rentals: 'middle', invoices: 'right', customers: 'right',
 };
 

--- a/docs/superpowers/specs/2026-06-23-mobile-drag-zip-zones-design.md
+++ b/docs/superpowers/specs/2026-06-23-mobile-drag-zip-zones-design.md
@@ -1,0 +1,135 @@
+# Mobile drag — zip-zones + draggable item-tabs
+
+**Date:** 2026-06-23
+**Branch:** `claude/mobile-app-improvements-xunrtg`
+**Status:** approved (design); spec pending Jac's review
+
+## Goal
+
+Make cross-card drag-linking usable on a phone. Two complementary mechanisms,
+both built on the existing drag engine + `DROP_MATRIX`:
+
+1. **Zip-zones** — during a live drag, side zones let you jump to another card's
+   column without releasing, then drop precisely on the target row.
+2. **Draggable item-tabs** — open-record tabs become drag handles you can carry to
+   any column, so you can navigate first (no sustained hold) and drag a short hop.
+
+## Root cause (confirmed — this is a reachability problem, not a missing link)
+
+The link targets Jac hit are all already wired: **Work Order → invoice** is in
+`DROP_MATRIX` (`app.js:10276`, `woDroppableToInvoice`), as are unit↔rental,
+invoice↔rental, etc. The pain is **reach**: on a phone only one column shows at a
+time, so the source and target cards aren't both visible, and the only way across
+mid-drag is `phoneDragEdge` (`app.js:10587`) — a **350ms dwell in a 30px screen-edge
+zone while holding the drag**. That dwell is invisible, narrow, and slow, so
+unit→rental, invoice→rental, and (deepest of all) WO→invoice feel broken.
+
+## Current state (what we build on)
+
+- **Drag engine §15c** (`app.js` ~10310–10720): `initDrag`, `dragDown/Move/Up`,
+  `cancelDrag`, a single rAF hit-test loop (`elementFromPoint` per frame →
+  `updateHot`), and the `DRAG` state object. Mid-drag re-render re-stamps targets
+  via `reapplyDragDecor` (`app.js:10542`).
+- **`DROP_MATRIX`** (`app.js:10256`): bidirectional source→target validators
+  (specific `srcRec`/`tgtRec`). `dropTargetAt` (`app.js:10489`) resolves a row/card
+  target; valid targets get `.drop-ok`, the one under the pointer gets `.drop-hot`.
+- **Affordance pattern to mirror:** `cancel-arc` and `chat-drop` — fixed elements,
+  slide in via transform, a hazard-stripe signature (`::before`), a `.hot` armed
+  state, and a haptic tick on arm (`app.js:10520`, CSS `style.css:1288`, `2795`).
+- **Phone specifics:** `cancel-arc` is hidden on phone; releasing in empty space
+  already cancels (`§M2`). `state.mobileCol` (0/1/2) picks the visible column;
+  `COLUMNS` order is left→middle→right.
+- **Item tabs:** `tabStrip(state.tabs)` renders open-record tabs in `.header-tabs`
+  (`app.js:6555`); on phone `.hr-top` is collapsed (`§M5`, `style.css:371`).
+
+## Design
+
+### Mechanism 1 — Zip-zones (primary)
+
+When a drag is active on a phone, show a zone per **valid target card** (derived
+from `DROP_MATRIX[source]`). Dragging onto a zone **zips** the view to that card's
+column (sets `state.mobileCol` + the column's member) **without ending the drag**;
+the zones then update for the new context and you drop on the precise target row.
+Release on a row = link (existing path); release in empty space = cancel.
+
+- **Trigger to zip:** the zone arms (`.hot` + haptic tick) when the drag pointer
+  enters it, and fires the column jump after a **short dwell (~150ms)** — long
+  enough to avoid accidental fires when dragging toward a near-edge row, far shorter
+  and far more visible than today's 350ms/30px dwell. (Dwell tunable on device.)
+- **Which zones:** only the source's valid targets. Unit → {Rentals, Invoices};
+  Work Order → {Invoices}; invoice → {Rentals, Customers}; etc. A target already in
+  the current column (e.g. Invoices when you're on Customers — both right column) is
+  a member switch, not a column jump — same zone mechanism, just sets the member.
+- **Side placement (by the target's column position):** left-column targets dock to
+  the **left** edge, right-column to the **right** edge, middle-column (Rentals)
+  docks to the side with room (default left). Multiple same-side zones stack
+  vertically. Each zone is a steel tab (cancel-arc body language) bearing the target
+  card's **icon + stamped Saira label**.
+- **Color:** the only color is a thin per-card **hazard stripe** on each zone (the
+  signature device), so you can aim by color: Units = leather-tan (`--tan`), Rentals
+  = `--blue`, Invoices = `--green`, Customers = `--purple`, Shop = `--accent`. Zone
+  bodies stay steel; orange stays reserved for selection/ignition/links in
+  persistent UI. **This thin-stripe tint is a deliberate, documented exception to
+  "one orange," scoped only to these transient drag overlays** (hue values tunable).
+- **Replaces** `phoneDragEdge`'s blind dwell on phone (desktop unchanged — it shows
+  all 3 columns already).
+
+### Mechanism 2 — Draggable item-tabs (complementary)
+
+Make the open-record **item tabs** draggable handles. Because a tab is always at the
+top regardless of which column you're viewing, you can **navigate freely first** (no
+held drag), open the target card, then drag the source record's tab a short hop onto
+the target row/card — avoiding the sustained cross-column hold entirely.
+
+- The tab carries the same `[data-chat-el]`-style drag payload (card + recId) and
+  flows through the same `DROP_MATRIX` validation + drop link path.
+- On phone the tab strip is currently collapsed (`§M5`); this mechanism needs the
+  tabs **reachable while dragging** — surface the strip (or a compact tab handle)
+  when there are open tabs, so a tab is grabbable. (Exact phone tab-bar treatment
+  tuned during build + `/jactec-ui`.)
+- Long-press a tab = arm drag (same gesture model as rows); tap a tab = its existing
+  switch action (unchanged).
+
+### Shared
+
+- Both feed the existing `dragUp` → link dispatch; no change to `DROP_MATRIX`
+  semantics or the validators.
+- Let-go-anywhere-but-a-target cancels (existing). Haptic tick on zone arm + on a
+  committed drop (existing vocabulary).
+- Desktop behavior is unchanged by both.
+
+## Files touched (anticipated)
+
+- `app.js`: the drag engine (zip-zone elements built in `initDrag`; zone hit-test +
+  arm/zip in the rAF loop alongside `updateHot`/`phoneDragEdge`; gate zip-zones to
+  `is-phone`), a `zipTargetsFor(source)` helper off `DROP_MATRIX`, making `tabStrip`
+  tabs draggable sources, and the phone tab-strip surfacing.
+- `style.css`: `§M` zone styles (steel tab + per-card hazard stripe + `.hot`),
+  reduced-motion, focus; phone tab-strip tweak.
+- No backend change. No new popup window → no `WINDOW_CATALOG` change.
+
+## R-rulebook / gates
+
+- New interactive elements follow the existing drag-affordance pattern (cancel-arc /
+  chat-drop carry no `data-r`; the zones match). If any stamped lint-family element
+  is added, stamp it + regen `rule-usage.js`. Gates: `smoke`, `logic-test`,
+  `gen-rule-usage --check`, `check-window-catalog` (Playwright in CI).
+- Run the zones + tab-drag through `/jactec-ui` then `/frontend`.
+
+## Out of scope (YAGNI)
+
+- No changes to `DROP_MATRIX` link rules or what links to what.
+- No desktop drag changes.
+- No new link types.
+
+## Open questions / tune on device (cloud session can't drive touch)
+
+- **Zip dwell timing** (~150ms) and zone **edge widths/sizes** — tune for thumb
+  reach on a real phone.
+- **Middle-column (Rentals) zone side** — default left; confirm it doesn't crowd.
+- **Per-card hue values** — the proposed tan/blue/green/purple/orange set is a
+  starting point; adjust for legibility against the steel body.
+- **Phone tab-strip surfacing** for Mechanism 2 — how prominent the tab handles are
+  while dragging vs. normally (must not crowd the `§M4` header).
+- **Build order:** zip-zones first (the core fix), then item-tabs — they're
+  independent and can land in separate commits.

--- a/docs/superpowers/specs/2026-06-23-shop-wrench-graph-design.md
+++ b/docs/superpowers/specs/2026-06-23-shop-wrench-graph-design.md
@@ -1,0 +1,151 @@
+# Shop wrench toggle + 3-bar shop graph — design
+
+**Date:** 2026-06-23
+**Branch:** `claude/mobile-app-improvements-xunrtg`
+**Status:** approved (design); spec pending Jac's review
+
+## Goal
+
+Give the shop crew a one-glance "what's on my plate" front page. Replace the
+left-column **Service-heart toggle** and the **Not-Ready clipboard chip** with a
+single wrench **"Shop"** toggle that opens a focused **3-bar graph**
+(Not Ready · Services · Work Orders) over the shop list. Make that graph the
+default landing view for the shop roles, on desktop **and** phone. Fold the phone
+footer's shop sub-types into the one Shop entry (which also fixes a highlight/swipe
+bug).
+
+## Current state (what already exists)
+
+- **Graph machinery:** `cs.graphView` flips a card between list and graph;
+  `graphViewsFor(card)` returns view descriptors (`pie` / `bars` / `lead` / `nums`)
+  rendered as a carousel by `graphPanelHtml`; `gvOpen` / `gvChevron` drive it; bar
+  segments carry `{col, value, label, count, color}` and clicking a segment filters
+  the list via the segment-match switch `totColMatch` (`app.js:2049`, the
+  `col === '__…'` cases + a fallback to the normal column match).
+  **No shop view is defined today** — the shop card falls back to a legacy combined
+  `cardGraphBody('shop')` dashboard (`app.js:6191-6193`).
+- **Shop card:** `shopCardEl` renders the three `SHOP_SEGMENTS`
+  (`inspections` / `workOrders` / `serviceOrders`) as a segment bar; `SHOP_TYPES`
+  fold to the single `'shop'` engine card; `shopAlertCount` already computes the
+  "needs work" count per segment.
+- **Desktop toggles:** `colTabButtonsHtml` (`app.js:5861`) builds the left column's
+  `coltab` row. Today it shows **Units · Categories · Service(heart)** plus a
+  **Not-Ready clipboard chip** (`nrChip`, `js-notready`, count of
+  `inspectionStatus === 'Not Ready'`). `inspections` / `workOrders` are
+  `HIDDEN_TABS` (render only while active).
+- **Phone footer:** `MOBILE_CARDS` (`app.js:6685`) =
+  `['units','categories','inspections','serviceOrders','rentals','calendar','customers','invoices']`
+  — note **`workOrders` is absent**, and `currentMobileMember()` (used for the
+  footer highlight + swipe-step) does **not** fold shop-types the way
+  `activeMobileCard()` does. So landing on a shop sub-type leaves the footer with no
+  active toggle and mis-indexes the swipe. (Bug — fixed here.)
+- **Roles:** `ROLES` = mechanic, mtech, driver, office, sales. `currentRole` is set
+  at login (`app.js:14350`). **No per-role default landing exists today.**
+- **Service urgency:** `topServiceForUnit(rec).status` is `'past-due'` (overdue),
+  `'due-soon'` (due), else on-schedule. Already filterable via the `__svcstat`
+  segment (`app.js:2063-2071`).
+- **Icons:** `wrench` → `CARD_ICON.workOrders` (Lucide wrench, `app.js:2168`),
+  `serviceOrders` = heart, `inspections` = clipboard. The wrench is the natural
+  Shop mark.
+
+## Design
+
+### 1. The wrench "Shop" toggle
+
+- Introduce a single **`'shop'` toggle** in the left column's `coltab` row, using
+  the wrench icon and label "Shop". It **replaces** the `serviceOrders` (Service
+  heart) toggle and the `nrChip` Not-Ready chip. `inspections` / `workOrders` /
+  `serviceOrders` are no longer standalone toggles — they are reached *through* Shop
+  (via the bars or the in-card segment bar).
+- Tapping the Shop toggle activates the shop card **with the graph showing**
+  (`graphView = true`), defaulting to the 3-bar view.
+- The toggle carries the existing **alert** treatment (red) when any of the three
+  buckets is non-zero, so the crew sees "work waiting" at a glance even before
+  opening it. Count badge = total needs-attention items across the three bars.
+- **Phone footer:** in `MOBILE_CARDS`, replace the `inspections` + `serviceOrders`
+  entries with one `'shop'` entry → `['units','categories','shop','rentals','calendar','customers','invoices']`.
+  Fix `currentMobileMember()` to fold `SHOP_TYPES → 'shop'` (mirror
+  `activeMobileCard`) so the footer highlight and the swipe-step index track
+  correctly. `goToCard('shop')` opens the shop card in graph view.
+
+### 2. The 3-bar graph (shop "front page")
+
+A new **`graphViewsFor('shop')`** returning a single `bars` view, `key: 'shopfront'`,
+title "Shop", with three bars (needs-attention only — on-schedule/complete excluded):
+
+| Bar | Stacking | Count = | Drill target (tap a segment) |
+|---|---|---|---|
+| **Not Ready** | single (yellow) | units with `inspectionStatus === 'Not Ready'` | shop → inspections segment, scoped to Not-Ready (reuse the existing Not-Ready filter) |
+| **Services** | **stacked** — red `past-due`, yellow `due-soon` | units whose `topServiceForUnit().status` is `past-due` **or** `due-soon` | shop → serviceOrders segment, filtered to that `__svcstat` value |
+| **Work Orders** | **stacked by Journey (`woPhase`)** — one segment per open phase, each in its phase color | open WOs (`phase !== 'Complete' && !cancelled`) | shop → workOrders segment, filtered to that phase |
+
+- **Stacked bars are a core requirement.** Both Services and Work Orders are
+  multi-segment stacks; only Not Ready is a single bar. The `bars` renderer (today
+  single-color) gets a small extension to draw a stacked bar from an array of
+  `{value, label, count, color}` sub-segments, with the segment total as the bar
+  height. Tapping a sub-segment drills to that exact value; tapping the bar body
+  (or its label) drills to the whole segment.
+- **Services** stacks two sub-segments — overdue (`past-due`, **red**) and due
+  (`due-soon`, **yellow**) — so overdue load reads at a glance.
+- **Work Orders** stacks by **journey phase** using the live `woPhase` set
+  (`config.js:283`), Complete excluded: e.g. `Part Needed` (red), `Part Ordered`
+  (blue), `Part is Local` / `No Part Needed` (yellow), `Part in Stock` (green),
+  `Part Needed?` (purple) — each in its status color, so the journey bottleneck
+  distribution (what's stuck waiting on parts vs ready to work) is visible at a
+  glance. Order the stack by the journey sequence.
+- Tapping a segment reuses the existing segment-click → list-filter path
+  (`totColMatch`): `__svcstat` already covers Services; `woPhase` is a normal
+  workOrders column so the fallback column-match already filters WOs by phase; only
+  the Not-Ready case may need a small `col` addition.
+
+### 3. Shop-role default
+
+- On login as **Mechanic** or **M.Tech**, land on the Shop card with the graph up:
+  - Desktop: set the left column's active member to `'shop'` and `graphView = true`.
+  - Phone: make `'shop'` the active footer card with `graphView = true`.
+- All other roles land normally; the wrench toggle is available to everyone.
+- Implemented as a small post-login hook keyed off `currentRole ∈ {mechanic, mtech}`
+  — a default only (the crew can navigate away freely; not a lock).
+
+### 4. Visual language (`/jactec-ui` + `/frontend`)
+
+- Wrench Shop toggle = a standard `coltab` (icon-only `compact`), wrench glyph,
+  keeping the existing on/alert states. No new component shape.
+- Bars use the yard palette: caution-yellow (`--yellow`), safety-orange where an
+  accent reads best, danger-red (`--red`); stamped Saira Condensed bar labels;
+  reduced-motion respected (no bar-grow animation when set). Run the toggle + graph
+  through `/jactec-ui` then `/frontend` before finalizing.
+
+## Files touched
+
+- `app.js`: `colTabButtonsHtml` (swap Service+nrChip → wrench Shop), `MOBILE_CARDS`,
+  `currentMobileMember` (fold shop-types), `graphViewsFor` (+`'shop'` case),
+  `memberCardEl`/`memberIcon` (handle the `'shop'` pseudo-member), the `bars`
+  renderer (stacked multi-segment support for Services + WO journey), `totColMatch`
+  (drill targets — Not-Ready case), the post-login hook.
+- `style.css`: stacked-bar segment styling; wrench toggle is an existing `coltab`.
+- No backend (`Code.js`) change. No new popup window → no `WINDOW_CATALOG` change.
+
+## R-rulebook / gates
+
+- New/changed UI elements get/keep their `data-r` stamps; regenerate
+  `node ci/gen-rule-usage.mjs` (no `--check`) if rule usage changes, then
+  `--check` must pass.
+- Gates before push: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
+  `node ci/gen-rule-usage.mjs --check`, `node ci/check-window-catalog.mjs`
+  (Playwright gates run in CI).
+
+## Out of scope (YAGNI)
+
+- No changes to the existing units/rentals graph carousels.
+- No new service/WO/inspection data model or backend fields.
+- No role-based locking — the shop-role default is a landing default only.
+- No reordering of the other columns' toggles.
+
+## Open questions / verify on-device
+
+- **Not Ready drill target:** units-list filtered to Not-Ready (the established
+  `js-notready` affordance) vs the inspections segment. Defaulting to the existing
+  Not-Ready filter; confirm during build.
+- Touch double-tap-to-anchor timing (`DBL_MS = 220`) may want widening for touch —
+  tracked separately from this feature.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z3" />
+  <link rel="stylesheet" href="style.css?v=20260623z4" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z3"></script>
-  <script type="module" src="app.js?v=20260623z3"></script>
+  <script src="rule-usage.js?v=20260623z4"></script>
+  <script type="module" src="app.js?v=20260623z4"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z2" />
+  <link rel="stylesheet" href="style.css?v=20260623z3" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z2"></script>
-  <script type="module" src="app.js?v=20260623z2"></script>
+  <script src="rule-usage.js?v=20260623z3"></script>
+  <script type="module" src="app.js?v=20260623z3"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z4" />
+  <link rel="stylesheet" href="style.css?v=20260623z5" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z4"></script>
-  <script type="module" src="app.js?v=20260623z4"></script>
+  <script src="rule-usage.js?v=20260623z5"></script>
+  <script type="module" src="app.js?v=20260623z5"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z6" />
+  <link rel="stylesheet" href="style.css?v=20260623z7" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z6"></script>
-  <script type="module" src="app.js?v=20260623z6"></script>
+  <script src="rule-usage.js?v=20260623z7"></script>
+  <script type="module" src="app.js?v=20260623z7"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z8" />
+  <link rel="stylesheet" href="style.css?v=20260623z9" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z8"></script>
-  <script type="module" src="app.js?v=20260623z8"></script>
+  <script src="rule-usage.js?v=20260623z9"></script>
+  <script type="module" src="app.js?v=20260623z9"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -319,11 +319,10 @@ input { font-family: inherit; }
 .is-phone .mdot { width: 38px; height: 22px; }                                  /* column indicator dots (column also changes by toggle tap / footer swipe) */
 .is-phone .chat-tag .x { position: relative; }                                  /* tag remove ✕ keeps its 14px look… */
 .is-phone .chat-tag .x::before { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 40px; height: 40px; }   /* …but a 40px hit box */
-/* §M-touch — hover-only affordances are UNREACHABLE on touch (a phone has no :hover, so
-   these never reveal). Force the card/row action chips + the hover-reveal close ✕ on so
-   every action stays tappable — the 44px hit-area sizing above already assumes they show
-   (e.g. .is-phone .rbtn). The :empty guard still hides empty action chips. */
-.is-phone .c-actions, .is-phone .row .r-actions { opacity: 1; }
+/* §M-touch — the hover-reveal tab close ✕ has no touch alternative, so force it visible
+   on phones (a phone has no :hover). The card-header / row hover TOOLS are deliberately
+   HIDDEN on touch instead (PR #316) — their actions have touch paths (double-tap anchor,
+   long-press menu, back chevron) — so they are not revealed here. */
 .is-phone .close-x.hoveronly { opacity: 1; }
 /* §M-touch — kill the browser's accidental double-tap-to-ZOOM on phones. It fires on any
    surface still at touch-action:auto (card bodies, the open detail/standard view, text,

--- a/style.css
+++ b/style.css
@@ -324,6 +324,14 @@ input { font-family: inherit; }
    (e.g. .is-phone .rbtn). The :empty guard still hides empty action chips. */
 .is-phone .c-actions, .is-phone .row .r-actions { opacity: 1; }
 .is-phone .close-x.hoveronly { opacity: 1; }
+/* §M-touch — kill the browser's accidental double-tap-to-ZOOM on phones. It fires on any
+   surface still at touch-action:auto (card bodies, the open detail/standard view, text,
+   pills) and hijacked the double-tap-to-ANCHOR gesture, "zooming WAY in" instead. Setting
+   manipulation at the document level disables double-tap-zoom everywhere while KEEPING
+   intentional pinch-zoom + native scroll. Rows/grid/dock keep their explicit pan-y, so the
+   long-press drag + the column/Back-Fwd swipe engine are untouched (single tap still opens,
+   double tap still anchors — now without the browser stealing it). */
+body.is-phone { touch-action: manipulation; }
 /* ── §M3 — overlays & the winpicker become bottom SHEETS on phones: full-width,
    pinned to the bottom edge, rounded top, slide up. Popups keep their ✕ and the
    backdrop closes on tap; the winpicker gets its own tap-to-close backdrop + Esc. ── */

--- a/style.css
+++ b/style.css
@@ -1662,6 +1662,15 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gv-bars .gv-barcol.on .gv-bar-red { background: var(--red); }   /* stay red even when the bar is the active filter (orange) */
 .gv-revbars .gv-bar-n { color: var(--txt); font-weight: 700; }
 .gv-bar-x { font-size: 10px; color: var(--txt-3); margin-top: 5px; text-transform: uppercase; letter-spacing: .4px; }
+/* Shop front-page STACKED bars: each bar's fill is a column of clickable segments
+   (Services = overdue/due, Work Orders = woPhase journey). Registry colors per segment;
+   a 1.5px gap shows the track behind them as a clean separator. */
+.gv-stackbars .gv-bar-stack { width: 100%; display: flex; flex-direction: column-reverse; gap: 1.5px; border-radius: 4px 4px 0 0; overflow: hidden; }
+.gv-bar-seg { width: 100%; min-height: 4px; border: none; padding: 0; cursor: pointer; transition: filter .12s; }
+.gv-bar-seg:hover { filter: brightness(1.15); }
+.gv-stackbars .gv-bar-seg.on { background: var(--accent) !important; }
+.gv-bar-seg:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) { .gv-bar-seg { transition: none; } .gv-bar-seg:hover { filter: none; } }
 .gv-units-scroll { max-height: 240px; overflow-y: auto; border: 1px solid var(--line); border-radius: 10px; }
 .gv-soon { padding: 52px 24px; text-align: center; color: var(--txt-2); }
 .gv-soon-ic { display: inline-flex; width: 40px; height: 40px; color: var(--accent); opacity: .7; }

--- a/style.css
+++ b/style.css
@@ -318,6 +318,12 @@ input { font-family: inherit; }
 .is-phone .mdot { width: 38px; height: 22px; }                                  /* column indicator dots (column also changes by toggle tap / footer swipe) */
 .is-phone .chat-tag .x { position: relative; }                                  /* tag remove ✕ keeps its 14px look… */
 .is-phone .chat-tag .x::before { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 40px; height: 40px; }   /* …but a 40px hit box */
+/* §M-touch — hover-only affordances are UNREACHABLE on touch (a phone has no :hover, so
+   these never reveal). Force the card/row action chips + the hover-reveal close ✕ on so
+   every action stays tappable — the 44px hit-area sizing above already assumes they show
+   (e.g. .is-phone .rbtn). The :empty guard still hides empty action chips. */
+.is-phone .c-actions, .is-phone .row .r-actions { opacity: 1; }
+.is-phone .close-x.hoveronly { opacity: 1; }
 /* ── §M3 — overlays & the winpicker become bottom SHEETS on phones: full-width,
    pinned to the bottom edge, rounded top, slide up. Popups keep their ✕ and the
    backdrop closes on tap; the winpicker gets its own tap-to-close backdrop + Esc. ── */

--- a/style.css
+++ b/style.css
@@ -2785,6 +2785,29 @@ body { font-variant-numeric: tabular-nums; }
 .drag-ghost { position: fixed; left: 0; top: 0; z-index: 9500; display: flex; align-items: center; gap: 7px; max-width: 240px; padding: 7px 12px; border-radius: 999px; background: var(--panel); border: 1px solid var(--accent); box-shadow: 0 0 0 2px var(--accent-line), 0 14px 34px -10px rgba(0,0,0,.65); color: var(--accent); font-size: 12.5px; font-weight: 700; pointer-events: none; will-change: transform; }
 .drag-ghost svg { width: 14px; height: 14px; flex: 0 0 auto; }
 .drag-ghost .dg-t { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+/* §M2 ZIP ZONES (phone) — edge rails of valid drop-target cards during a drag. Steel
+   data-plate tabs with a per-card hazard stripe (the ONLY colour — a transient drag
+   overlay, so the one-orange rule holds for persistent UI). Drag onto one to jump to
+   that card's column; hot = armed, about to zip. Mirrors the cancel-arc language. */
+#zip-zones { position: fixed; inset: 0; pointer-events: none; }
+.zz-rail { position: fixed; top: 0; bottom: 0; display: flex; flex-direction: column; justify-content: center; gap: 12px; padding: 8px 0; }
+.zz-rail-left { left: 0; align-items: flex-start; padding-left: env(safe-area-inset-left); }
+.zz-rail-right { right: 0; align-items: flex-end; padding-right: env(safe-area-inset-right); }
+.zip-zone { position: relative; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px;
+  width: 78px; min-height: 92px; padding: 12px 8px; color: var(--txt-2);
+  background: linear-gradient(180deg, #1b2129, #0c0e11); border: 1px solid var(--line); box-shadow: 0 14px 34px -12px #000; }
+.zip-left  { border-left: 0; border-radius: 0 15px 15px 0; animation: zipInL .18s cubic-bezier(.2,.7,.2,1); }
+.zip-right { border-right: 0; border-radius: 15px 0 0 15px; animation: zipInR .18s cubic-bezier(.2,.7,.2,1); }
+.zip-zone::before { content: ''; position: absolute; top: 0; bottom: 0; width: 7px;   /* hi-vis hazard stripe in the card's hue */
+  background: repeating-linear-gradient(135deg, var(--zip-hue, var(--accent)) 0 13px, #14181d 13px 26px); }
+.zip-left::before  { right: 0; } .zip-right::before { left: 0; }
+.zip-zone .zz-ico { display: inline-flex; color: var(--zip-hue, var(--accent)); } .zip-zone .zz-ico svg { width: 22px; height: 22px; }
+.zip-zone .zz-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 11px; line-height: 1.05; text-align: center; }
+.zip-zone.hot { color: var(--zip-hue, var(--accent)); border-color: var(--zip-hue, var(--accent));
+  box-shadow: 0 14px 44px -12px #000, inset 0 0 34px -10px var(--zip-hue, var(--accent)); }
+@keyframes zipInL { from { transform: translateX(-100%); } to { transform: none; } }
+@keyframes zipInR { from { transform: translateX(100%); } to { transform: none; } }
+@media (prefers-reduced-motion: reduce) { .zip-zone { animation: none; } }
 /* THE CANCEL ARC — "the abort bay" (frontend-design pass, Jac 2026-06-13).
    A heavy steel half-ellipse rising from the bottom: drop the dragged chip in
    here to ABORT the link. Idle = steel bay with a caution HAZARD-STRIPE lip (the

--- a/style.css
+++ b/style.css
@@ -314,6 +314,7 @@ input { font-family: inherit; }
 .is-phone .iconbtn { min-height: 44px; }
 .is-phone .bv-btn { min-width: 44px; min-height: 44px; }                         /* per-card graph toggle (was 32) */
 .is-phone .coltab { min-height: 44px; }                                         /* card view tabs (was 30) */
+.is-phone .tab { min-height: 40px; }                                            /* §M2 open-record item tabs are draggable handles — give them a touch grab target */
 .is-phone .popup-head .x { width: 40px; height: 40px; }                         /* sheet close ✕ (was 30) */
 .is-phone .mdot { width: 38px; height: 22px; }                                  /* column indicator dots (column also changes by toggle tap / footer swipe) */
 .is-phone .chat-tag .x { position: relative; }                                  /* tag remove ✕ keeps its 14px look… */


### PR DESCRIPTION
Draft — mobile-app improvement session on `claude/mobile-app-improvements-xunrtg`.

### 1. Touch fix — hover-only actions reachable on phone
Card-header action chip (`.c-actions`), row action chip (`.row .r-actions`), and the hover-reveal tab close ✕ (`.close-x.hoveronly`) were `opacity:0` until `:hover` — invisible on touch even though `§M-touch` sizes them to 44×44. Added `is-phone` overrides forcing them visible.

### 2. Touch fix — stop accidental double-tap zoom
Native double-tap-to-zoom fired on surfaces still at `touch-action:auto` and hijacked the double-tap-to-anchor gesture. Set `touch-action:manipulation` at the phone document level — kills double-tap-zoom while **keeping pinch-zoom + scroll**; single-tap-open / double-tap-anchor preserved. (`DBL_MS=220` row-double-tap window may want widening for touch — verify on device.)

### 3. Feature — wrench "Shop" toggle + 3-bar stacked shop graph
Spec: `docs/superpowers/specs/2026-06-23-shop-wrench-graph-design.md`. One wrench **Shop** toggle (replacing the Service-heart toggle + Not-Ready chip) opens a 3-bar needs-attention graph: Not Ready (yellow → Units list) · Services (stacked red overdue / yellow due) · Work Orders (stacked by `woPhase` journey). New `stackbars` renderer kind + `__wophase` drill col; phone footer folds the shop sub-types into one Shop entry (fixes the `currentMobileMember` highlight/swipe mismatch). Shop roles (Mechanic / M.Tech) land here on login.

### 4. Feature — mobile drag fix: zip-zones + draggable item-tabs
Spec: `docs/superpowers/specs/2026-06-23-mobile-drag-zip-zones-design.md`. Root cause of "can't drag WO→invoice / unit→rental" was reachability (the 350ms/30px edge-dwell), not a missing link.
- **Zip-zones:** during a phone drag, the dragged item's valid `DROP_MATRIX` targets appear as steel edge tabs (per-card hazard-stripe hue + icon + Saira label). Drag onto one → after a 150ms dwell it **zips** to that card's column (drag stays live) → drop on the exact row. Cooldown prevents chain-zips; let-go-anywhere cancels. Replaces the blind edge-dwell. Desktop unchanged.
- **Draggable item-tabs:** open-record tabs are now drag handles (navigate first, then carry the tab to the target) — gated on `DROP_MATRIX[entity]` so WO tabs reach invoices. Works on desktop too.
- The per-card stripe hue is a deliberate, documented exception to "one orange," scoped only to the transient drag overlay.

**Gates:** `gen-rule-usage --check`, `check-window-catalog`, `node --check` pass locally; `smoke` + `logic-test` (Playwright) run in CI. Built through `/jactec-ui` + `/frontend` (tokens-only, registry colors, `:focus-visible`/reduced-motion where applicable). **Not yet driven on a real device** — local/staging E2E + touch tuning (zip dwell, zone sizes/sides, per-card hues, phone tab-strip prominence) pending on Jac's end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yPsRQf8VnNAcmii5Y5Kwd