### PR TITLE
Rapid-fire: Coming 2026 roadmap plate · hide touch row tools · click-hold = right-click

### DIFF
--- a/app.js
+++ b/app.js
@@ -10361,12 +10361,12 @@ function initDrag() {
 // move lifts a drag. A quick horizontal flick (before this fires) is a Back/Forward swipe
 // instead (see the grid swipe tracker in boot). Frees the horizontal axis for navigation.
 function armReadyTimer(arm) { return setTimeout(() => { if (DRAG.armed === arm) arm.ready = true; }, 300); }
-function armMenuTimer(arm) {   // §M3 — touch hold-still opens the context menu (not a drag)
+function armMenuTimer(arm) {   // §M3 — hold-still opens the context menu: touch long-press OR mouse click-and-hold (the right-click equivalent)
   return setTimeout(() => {
     if (DRAG.armed !== arm) return;
     const t = document.elementFromPoint(arm.x, arm.y);
     DRAG.armed = null;
-    if (t) { DRAG.suppressClick = true; lastTouchCtx = performance.now(); openCtxMenuAt(t, arm.x, arm.y); }
+    if (t) { DRAG.suppressClick = true; if (arm.touch) lastTouchCtx = performance.now(); openCtxMenuAt(t, arm.x, arm.y); }   // lastTouchCtx guards the trailing native contextmenu — touch only
   }, 500);
 }
 function dragDown(e) {
@@ -10381,7 +10381,8 @@ function dragDown(e) {
   if (chatEl) {
     DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
     const arm = { chatEl: chatElPayload(chatEl), x: e.clientX, y: e.clientY, pointerId: e.pointerId, touch: e.pointerType === 'touch', lp: null, rdy: null, ready: e.pointerType !== 'touch' };
-    if (arm.touch) { arm.lp = armMenuTimer(arm); arm.rdy = armReadyTimer(arm); }
+    arm.lp = armMenuTimer(arm);                          // §M3 — hold still → context menu (mouse + touch)
+    if (arm.touch) arm.rdy = armReadyTimer(arm);         // touch only: a hold must precede a horizontal drag (mouse drags immediately)
     DRAG.armed = arm; return;
   }
   const bail = e.target.closest('.inline-edit, .inline-input, input, textarea, select, button, .x, .pill, .seg, .add-field, .linkname, .flag, .jnode, .dropdown-menu, .overlay, .hover-preview, .winpicker-float, .ctx-menu');
@@ -10392,7 +10393,8 @@ function dragDown(e) {
   if (!src) return;
   DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;                    // seed the ghost/hit-test point — a touch long-press may fire with NO move first
   const armed = { card: src.card, rec: src.rec, x: e.clientX, y: e.clientY, pointerId: e.pointerId, touch: e.pointerType === 'touch', lp: null, rdy: null, ready: e.pointerType !== 'touch' };
-  if (armed.touch) { armed.lp = armMenuTimer(armed); armed.rdy = armReadyTimer(armed); }
+  armed.lp = armMenuTimer(armed);                        // §M3 — hold still → context menu (mouse + touch)
+  if (armed.touch) armed.rdy = armReadyTimer(armed);     // touch only: a hold must precede a horizontal drag (mouse drags immediately)
   DRAG.armed = armed;
 }
 /* Resolve what a press grabs, in priority order:

--- a/app.js
+++ b/app.js
@@ -6533,13 +6533,48 @@ function scorePop(roleId, ringIdx, delta, unit) {
   btn.appendChild(pop);                                            // floats up + fades (CSS), then removed
   setTimeout(() => pop.remove(), 760);
 }
+/* ════════════ COMING 2026 — the roadmap morale plate (Jac 2026-06-23) ════════
+   The KPI rings ride behind a blur (the metrics engine isn't wired up yet). Rather
+   than leave dead frosted glass up top, the rings wear a "Coming 2026" data-plate
+   that opens this roadmap — what's on the docket plus every area of the yard we're
+   building out. Pure morale: a glance at how much is coming. The list mirrors
+   backlog.md (the sorted task branches) + the area map; keep it in step when those
+   move. type: Feature (gray) · Fix (red) · Cleanup (gray) · Planned (yellow). */
+const ROADMAP_ITEMS = [
+  { t: 'Rental Status button',                   area: 'Rentals',       type: 'Feature' },
+  { t: 'Card-on-File no longer blocks On Rent',  area: 'Rentals',       type: 'Fix' },
+  { t: 'Retire the obsolete Window Picker',      area: 'Rentals',       type: 'Cleanup' },
+  { t: 'Invoice Card',                           area: 'Invoicing',     type: 'Feature' },
+  { t: 'Fix the “OBi” invoice link label',       area: 'Invoicing',     type: 'Fix' },
+  { t: 'Category rows — scroll by group',        area: 'Units',         type: 'Feature' },
+  { t: 'Default Services — hand over the manuals',area: 'Shop',         type: 'Feature' },
+  { t: 'Custom Fields + defaults',               area: 'Backend',       type: 'Feature' },
+  { t: 'Customer self-service portal',           area: 'Mobile',        type: 'Feature' },
+  { t: 'Notifications',                           area: 'Comms',         type: 'Feature' },
+  { t: 'Customer texts & email',                 area: 'Comms',         type: 'Feature' },
+  { t: 'Memberships — round out the details',    area: 'Members',       type: 'Planned' },
+];
+const ROADMAP_AREAS = [
+  'Rentals & Dispatch', 'Invoicing & Payments', 'Customers / CRM', 'Memberships',
+  'Units & Fleet', 'Maintenance Shop', 'Financials & KPIs', 'Backend & Data',
+  'Design System', 'Mobile & Remote', 'Comms & Notifications', 'HR & Compliance',
+  'Sales & Growth', 'Maps & Location', 'Search & Views', 'Frontend & Performance',
+  'Mr. Wrangler AI',
+];
 function headerEl() {
   const h = el('div', 'header');
   const roleRing = (id, label, vals, color) => `<button class="kpi-ring js-ring" data-role="${id}">
       <span class="ring-wrap">${ring3SVG(vals, color, { size: 64 })}</span>
       <span class="ring-label">${esc(label)}</span>
     </button>`;
-  const rings = ROLES.map((role) => roleRing(role.id, role.label, kpiFor(role.id), role.color)).join('');
+  // The blurred rings wear a "Coming 2026" plate (last child of .kpis) — taps open the roadmap.
+  const comingPlate = `<button class="coming-plate js-roadmap" data-tip="What's coming in 2026" aria-label="Coming 2026 — open the roadmap">
+      <span class="cp-haz" aria-hidden="true"></span>
+      <span class="cp-rivet tl"></span><span class="cp-rivet tr"></span><span class="cp-rivet bl"></span><span class="cp-rivet br"></span>
+      <span class="cp-stamp">Coming <b>2026</b></span>
+      <span class="cp-sub">Round up what we’re wrangling</span>
+    </button>`;
+  const rings = ROLES.map((role) => roleRing(role.id, role.label, kpiFor(role.id), role.color)).join('') + comingPlate;
   // §M1 — phone-only TOP TOOLBAR: the full tool set opened up across the top of the screen
   // (logo + rings stay on their own row above it). Notifications + Requests live here too.
   const nu = unseenNotifs();
@@ -8379,6 +8414,27 @@ function buildPopupEl(o, overlay, opts = {}) {
         ${rows.map((r) => `<div class="hk-row"><div class="hk-demo hk-${r.d}">${hkDemoInner(r.d)}</div><div class="hk-text"><div class="hk-name">${esc(r.n)}</div><div class="hk-desc">${esc(r.t)}</div></div></div>`).join('')}
         <p class="muted" style="font-size:11px;margin:6px 2px 0">These work on a list row or anywhere on a card.</p>` });
     overlay.appendChild(pop);
+  } else if (o.kind === 'roadmap') {
+    // §M2 — "Coming 2026" roadmap (the morale window behind the blurred rings).
+    const TYPE_COLOR = { Fix: 'red', Planned: 'yellow' };   // Feature/Cleanup stay gray (R3b)
+    const counts = ROADMAP_ITEMS.reduce((m, it) => (m[it.type] = (m[it.type] || 0) + 1, m), {});
+    const tally = [['Feature', 'building'], ['Fix', 'fixing'], ['Cleanup', 'cleaning up'], ['Planned', 'to scope']]
+      .filter(([t]) => counts[t]).map(([t, v]) => `${counts[t]} ${v}`).join(' · ');
+    const rows = ROADMAP_ITEMS.map((it) => `<div class="rm-row">
+        <span class="rm-badge">${badge(it.type, TYPE_COLOR[it.type] || 'gray')}</span>
+        <span class="rm-name">${esc(it.t)}</span>
+        <span class="rm-area">${esc(it.area)}</span>
+      </div>`).join('');
+    const chips = ROADMAP_AREAS.map((a) => `<span class="rm-chip">${esc(a)}</span>`).join('');
+    const pop = el('div', 'popup rm-popup');
+    pop.innerHTML = popupShell({ icon: I.horseshoe, title: 'Coming in 2026', tag: 'Roadmap · what we’re wrangling', bodyClass: 'rm-body', body: `
+        <p class="rm-intro">${ROADMAP_ITEMS.length} on the docket — ${esc(tally)}. The gauges up top light up once the metrics engine lands.</p>
+        <div class="rm-list">${rows}</div>
+        <div class="rm-stitch" aria-hidden="true"></div>
+        <div class="rm-terr-h">The whole territory — ${ROADMAP_AREAS.length} areas under the saddle</div>
+        <div class="rm-chips">${chips}</div>
+        <p class="rm-foot">Got an idea for the list? Tap <strong>🤠 Report</strong> on any card and tell Mr. Wrangler.</p>` });
+    overlay.appendChild(pop);
   } else if (o.kind === 'feedback') {
     const ctx = feedbackContext();
     const TYPES = [['Bug', 'Claude fixes it'], ['Improvement', 'needs your OK'], ['Idea', 'needs your OK'], ['Change', 'needs your OK']];
@@ -8813,6 +8869,7 @@ const WINDOW_CATALOG = [
   { kind: 'requests',      label: 'Requests inbox',          tag: 'Mr. Wrangler · approvals',  sample: () => ({}) },
   { kind: 'notifications', label: 'Notifications',           tag: 'Mr. Wrangler · resolved',   sample: () => ({}) },
   { kind: 'hotkeys',       label: 'Mouse shortcuts',         tag: 'Operator · controls',       sample: () => ({}) },
+  { kind: 'roadmap',       label: 'Coming in 2026',          tag: 'Roadmap · the docket',      sample: () => ({}) },
   { kind: 'feedback',      label: 'Report a bug or request', tag: 'Mr. Wrangler · report',     sample: () => ({}) },
   { kind: 'board',         label: 'Back-office board',       tag: 'Back office · records',     sample: () => ({ board: (BACKOFFICE_BOARDS[0] || {}).id }) },
   { kind: 'boardview',     label: 'Board View',              tag: 'Card · board view',         sample: () => ({ card: 'units', query: '', sort: {}, calc: {}, colOrder: null, extraRows: [], cellData: {}, seq: 0 }) },
@@ -10837,6 +10894,7 @@ function onClick(e) {
   if (closest('.js-lock-invoice')) { e.stopPropagation(); return lockInvoiceFlow(closest('.js-lock-invoice').dataset.rec, true); }
   if (closest('.js-unlock-invoice')) { e.stopPropagation(); return lockInvoiceFlow(closest('.js-unlock-invoice').dataset.rec, false); }
   if (closest('.js-ring')) return openOverlay({ kind: 'role', role: closest('.js-ring').dataset.role });
+  if (closest('.js-roadmap')) return openOverlay({ kind: 'roadmap' });
   if (closest('.js-close')) return closeOverlay();
   if (closest('.js-theme')) { state.theme = (THEME_NEXT[state.theme] || THEME_NEXT.dark).next; try { localStorage.setItem('jactec.theme', state.theme); } catch (e) {} if (state.overlay && state.overlay.kind !== 'addCard') renderOverlay(); render(); return; }
   if (closest('.js-qr')) return shareSession();

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z2" />
+  <link rel="stylesheet" href="style.css?v=20260623z3" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z2"></script>
-  <script type="module" src="app.js?v=20260623z2"></script>
+  <script src="rule-usage.js?v=20260623z3"></script>
+  <script type="module" src="app.js?v=20260623z3"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -878,6 +878,10 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* both row buttons share ONE floating chip (like the card-header chip), stacked + vertically centered */
 .row .r-actions { position: absolute; top: 50%; right: 7px; transform: translateY(-50%); z-index: 2; display: flex; flex-direction: column; gap: 2px; padding: 3px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); box-shadow: var(--chip-shadow); opacity: 0; transition: opacity .12s; }
 .row:hover .r-actions { opacity: 1; }                                                              /* §0.1 buttons on hover only */
+/* Hover row tools can't be reached without a real hover — hide on touch/phone so they
+   don't sit dead on a row (Jac 2026-06-23). Eye → toolbar previews toggle · + → Ctrl+click. */
+.is-phone .row .r-actions { display: none; }
+@media (hover: none) and (pointer: coarse) { .row .r-actions { display: none; } }
 .rbtn { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 8px; background: none; border: none; color: var(--txt-2); }
 .rbtn:hover { background: var(--panel-2); color: var(--accent); }
 .rbtn svg { width: 14px; height: 14px; }

--- a/style.css
+++ b/style.css
@@ -126,7 +126,7 @@ input { font-family: inherit; }
 
 /* KPI rings (§5.2/§11) — Apple-style concentric progress rings, each colored by
    its own value band; number + role label below. */
-.kpis { display: flex; align-items: center; gap: 14px; }
+.kpis { display: flex; align-items: center; gap: 14px; position: relative; }   /* position: anchor for the Coming-2026 plate */
 .kpi-ring {
   display: flex; flex-direction: column; align-items: center; gap: 3px;
   padding: 4px 6px 0; border-radius: 11px; border: 1px solid transparent; min-width: 64px;
@@ -152,6 +152,53 @@ input { font-family: inherit; }
 .big-ring .ring-fill.ring-glow { filter: drop-shadow(0 0 2.4px var(--green)) drop-shadow(0 0 5.2px var(--green)); }
 .kpi-ring .ring-label { font-size: 10px; color: var(--txt-3); font-weight: 600; text-transform: uppercase; letter-spacing: .3px; }
 .kpi-ring .ring-pct { font-size: 28px; font-weight: 700; fill: var(--txt); }   /* big popup ring only */
+
+/* ── COMING 2026 — roadmap plate over the blurred rings (Jac 2026-06-23) ──────
+   Signature = the hi-vis hazard-stripe cap ("work zone / coming soon"); the dimmed
+   gauges glow behind frosted steel. Boldness spent ONLY on the stripe; everything
+   else quiet. No orange (reserved) — caution-yellow ties to the hazard signature.
+   Themes for free off the tokens; reduced-motion freezes the lift. */
+.coming-plate {
+  position: absolute; inset: 0; z-index: 3;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 1px;
+  border: 1px solid var(--line); border-radius: var(--chip-radius); overflow: hidden;
+  padding: 7px 16px 5px; cursor: pointer; font-family: 'Saira Condensed', sans-serif;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--panel) 76%, transparent), color-mix(in srgb, var(--bg) 88%, transparent));
+  -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px);
+  transition: border-color .15s, transform .15s;
+}
+.coming-plate:hover { border-color: color-mix(in srgb, var(--yellow) 45%, var(--line)); transform: translateY(-1px); }
+.coming-plate:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.cp-haz { position: absolute; left: 0; right: 0; top: 0; height: 5px; opacity: .9;
+  background: repeating-linear-gradient(135deg, var(--yellow) 0 11px, #14181d 11px 22px); }
+.cp-rivet { position: absolute; width: 4px; height: 4px; border-radius: 50%;   /* matches .pl-rivet metal */
+  background: radial-gradient(circle at 35% 30%, #434c58, #0f1318); box-shadow: inset 0 0 0 1px rgba(0,0,0,.55); }
+.cp-rivet.tl { left: 6px; top: 9px; } .cp-rivet.tr { right: 6px; top: 9px; }
+.cp-rivet.bl { left: 6px; bottom: 6px; } .cp-rivet.br { right: 6px; bottom: 6px; }
+.cp-stamp { margin-top: 3px; font-size: 17px; font-weight: 800; letter-spacing: 2px; text-transform: uppercase; color: var(--txt); line-height: 1; }
+.cp-stamp b { color: var(--yellow); font-weight: 800; }
+.cp-sub { font-family: var(--font); font-size: 9.5px; letter-spacing: .2px; color: var(--txt-3); text-align: center; }
+.is-phone .coming-plate { padding: 2px 6px; }
+.is-phone .cp-stamp { margin-top: 2px; font-size: 12px; letter-spacing: 1px; }
+.is-phone .cp-sub, .is-phone .cp-rivet { display: none; }
+@media (prefers-reduced-motion: reduce) { .coming-plate { transition: none; } .coming-plate:hover { transform: none; } }
+
+/* ── COMING 2026 roadmap popup — the docket + the whole territory ── */
+.rm-popup { width: 460px; max-width: 94vw; }
+.rm-intro { margin: 0 2px 12px; font-size: 12.5px; line-height: 1.45; color: var(--txt-2); }
+.rm-list { display: flex; flex-direction: column; }
+.rm-row { display: grid; grid-template-columns: 80px 1fr auto; align-items: center; gap: 10px;
+  padding: 7px 2px; border-bottom: 1px solid var(--line-soft); }
+.rm-row:last-child { border-bottom: 0; }
+.rm-badge { display: flex; }
+.rm-name { font-size: 13px; font-weight: 600; color: var(--txt); }
+.rm-area { font-family: 'Saira Condensed', sans-serif; font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--txt-3); white-space: nowrap; }
+.rm-stitch { margin: 15px 0; border-top: 1.5px dashed var(--tan, #c2925a); opacity: .6; }   /* saddle-stitch — the ranch seasoning */
+.rm-terr-h { margin-bottom: 9px; text-align: center; font-family: 'Saira Condensed', sans-serif; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px; color: var(--txt-3); }
+.rm-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.rm-chip { padding: 3px 10px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel-2);
+  font-family: 'Saira Condensed', sans-serif; font-size: 11px; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-2); }
+.rm-foot { margin: 14px 2px 0; font-size: 11.5px; line-height: 1.4; color: var(--txt-3); }
 
 /* tab strip — ONE row, scrolls horizontally if many; sits above the toolbar */
 .tabstrip { display: flex; gap: 6px; overflow-x: auto; max-width: 100%; padding-bottom: 0; }


### PR DESCRIPTION
Accumulating PR for a batch of rapid-fire edits to main. Squash-merge when the batch looks good.

## 1. "Coming 2026" roadmap plate over the blurred KPI rings (morale)
The blurred rings now wear a hazard-stripe **Coming 2026** data-plate. Tap it → a roadmap popup listing what's on the docket (mirrors `backlog.md`) plus every area of the yard we're building out — a glance at how much is coming.
- New popup kind `roadmap` (+ `WINDOW_CATALOG` entry, click handler).
- Yard-data-plate language: hazard-stripe cap, rivets (matched to `.pl-rivet`), Saira Condensed stamp, caution-yellow accent (no orange — reserved), tan saddle-stitch divider.
- Type chips via `badge()` (R3b); honest registry colors (Fix=red, Planned=yellow).
- Responsive + reduced-motion safe; visible focus.

## 2. Hide the hover row tools on touch/phone
The per-row `.r-actions` (eye + open-in-new-tab) are hover-reveal (`opacity:0` → `1` on `.row:hover`), so on touch they never reliably appear and just sit dead on the row. Hidden on `.is-phone` and `(hover:none)+(pointer:coarse)`. Both functions stay reachable elsewhere (eye = toolbar previews toggle, `+` = Ctrl+click). *Scope chosen by Jac: mobile/touch only — kept on desktop.*

## 3. Mouse click-and-hold = right-click (context menu)
§M3 already gave touch a hold-still→menu gesture; extended `armMenuTimer` to the mouse so a left **click-and-hold** (~500ms, no move) opens the R20 menu. The hold-before-drag gate stays touch-only, so mouse **click+drag still drags immediately**. Quick clicks disarm the timer; a started drag clears it; `lastTouchCtx` stays touch-only so it can't swallow a real right-click.

## Gates
- ✅ `gen-rule-usage.mjs --check` · ✅ `check-window-catalog.mjs` · ✅ `node --check app.js`
- ⏳ `smoke` / `logic-test` (Playwright) run in CI — not installable in this container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3zJdbKcgCqSJcdkCyMSfr)_