### PR TITLE
Phone card chrome: flatten nested backgrounds so chips float free

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z4" />
+  <link rel="stylesheet" href="style.css?v=20260623z5" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z4"></script>
-  <script type="module" src="app.js?v=20260623z4"></script>
+  <script src="rule-usage.js?v=20260623z5"></script>
+  <script type="module" src="app.js?v=20260623z5"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -322,13 +322,13 @@ input { font-family: inherit; }
 /* the card's search/sort row, relocated here — a FULL-WIDTH band (edge to edge) */
 .mdock-searchslot:empty { display: none; }
 .is-phone .mdock-searchslot .listbar { position: static; margin: 0; padding: 8px; gap: 8px;
-  background: var(--bg-2); border-bottom: 1px solid var(--line); box-shadow: 0 5px 11px -7px rgba(0,0,0,.45); }
+  background: none; border: none; box-shadow: none; }   /* no wrapper band — search/graph/sort chips float on the dock (Jac 2026-06-23) */
 .is-phone .mdock-searchslot .mini-searchwrap { min-height: 44px; }   /* match the graph/sort buttons so the row is one height */
 .is-phone .mdock-searchslot .mini-search { height: 44px; }
 /* the card-toggle BAR: every card as an icon; the selected one expands to icon + label */
 .mdock-row { display: flex; align-items: center; gap: 8px; padding: 6px 8px; }
-.mcard-bar { display: flex; align-items: center; gap: 3px; flex: 1 1 auto; min-width: 0; overflow-x: auto; scrollbar-width: none;
-  background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; padding: 3px; box-shadow: var(--chip-shadow); }
+.mcard-bar { display: flex; align-items: center; gap: 6px; flex: 1 1 auto; min-width: 0; overflow-x: auto; scrollbar-width: none;
+  background: none; border: none; padding: 0; box-shadow: none; }   /* no wrapper panel — card-toggle chips float; the active one is the orange chip (Jac 2026-06-23) */
 .mcard-bar::-webkit-scrollbar { display: none; }
 .mcard-tog { display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto; min-height: 44px; min-width: 44px; justify-content: center;
   padding: 0 9px; border: none; background: none; cursor: pointer; border-radius: 9px; color: var(--txt-2); transition: background .12s, color .12s; }


### PR DESCRIPTION
## Multi/nested backgrounds → free-floating chips
The phone dock's search/sort row (`.mdock-searchslot .listbar`) and the card-toggle bar (`.mcard-bar`) each had their own panel **background + border + shadow**, while the chips inside (search box, sort, graph, toggles) also carry backgrounds — a background-on-background "multi background" look. This drops the wrapper bg/border/shadow so the chips float directly on the dock surface; the active toggle stays the orange chip. Matches your "free floating chips/cards."

This should also calm the "gaps look weird" perception, since the nested panels were a big part of the visual noise.

## Notes
- Cache-bust `?v=` → `20260623z5`.
- Gates: ✅ `gen-rule-usage --check` · ✅ `check-window-catalog`. `smoke`/`logic-test` run in CI.
- **Still open — gap normalization (#7):** holding that for a render-in-the-loop pass (see PR discussion) — some "odd" gaps are deliberate (e.g. the 13px tabrow margin clears the 6px hazard stripe), so unifying them safely needs eyes on the live layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3zJdbKcgCqSJcdkCyMSfr)_