### PR TITLE
Phone gaps: unify header + dock spacing to the 8/12 rhythm (first pass)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z5" />
+  <link rel="stylesheet" href="style.css?v=20260623z6" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -22,8 +22,8 @@
   <div id="toast" class="toast"></div>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z5"></script>
-  <script type="module" src="app.js?v=20260623z5"></script>
+  <script src="rule-usage.js?v=20260623z6"></script>
+  <script type="module" src="app.js?v=20260623z6"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -326,7 +326,7 @@ input { font-family: inherit; }
 .is-phone .mdock-searchslot .mini-searchwrap { min-height: 44px; }   /* match the graph/sort buttons so the row is one height */
 .is-phone .mdock-searchslot .mini-search { height: 44px; }
 /* the card-toggle BAR: every card as an icon; the selected one expands to icon + label */
-.mdock-row { display: flex; align-items: center; gap: 8px; padding: 6px 8px; }
+.mdock-row { display: flex; align-items: center; gap: 8px; padding: 8px; }   /* unified dock padding to 8 (Jac 2026-06-23) */
 .mcard-bar { display: flex; align-items: center; gap: 6px; flex: 1 1 auto; min-width: 0; overflow-x: auto; scrollbar-width: none;
   background: none; border: none; padding: 0; box-shadow: none; }   /* no wrapper panel — card-toggle chips float; the active one is the orange chip (Jac 2026-06-23) */
 .mcard-bar::-webkit-scrollbar { display: none; }
@@ -382,7 +382,7 @@ input { font-family: inherit; }
 @media (prefers-reduced-motion: reduce) { .is-phone .popup, .is-phone .winpicker { animation: none; } }
 /* ── §M4 — phone header: logo + ALL FIVE KPI rings share the TOP row (rings shrunk to
    fit), and the global search wraps to its own full-width row underneath. ── */
-.is-phone .header { flex-wrap: wrap; align-items: center; gap: 6px 8px; padding: 10px 10px 0; }
+.is-phone .header { flex-wrap: wrap; align-items: center; gap: 8px; padding: 12px 12px 0; }   /* unified to the 8/12 rhythm (Jac 2026-06-23) */
 .is-phone .logo { width: 58px; height: 58px; order: 1; }
 .is-phone .kpis { order: 1; flex: 1 1 auto; min-width: 0; display: flex; justify-content: space-around; gap: 2px; }   /* logo + rings share a row, below the tool bar */
 .is-phone .kpi-ring { min-width: 0; flex: 0 1 auto; padding: 1px 0 0; }


### PR DESCRIPTION
First conservative pass at the inconsistent phone gaps (#7).

**Unified toward the 8/12 rhythm:**
- `.is-phone .header` — gap `6px 8px` → `8px`, padding `10px 10px 0` → `12px 12px 0` (matches the desktop header).
- `.mdock-row` — padding `6px 8px` → `8px` (matches the dock search slot).

**Left alone (deliberate):**
- `.tabrow` margin `13px` — it's `8 + 5` to clear the 6px hazard stripe so the gaps above/below the toggle read even.
- `.is-phone .kpis` gap `2px` — intentionally tight so all rings fit the top row.
- `.list` row gap `7px` — the documented list rhythm.

This is a **first pass to verify on local serve** — pull `claude/phone-gaps-2qd3iw`, serve, and point me at any specific gaps that still look off and I'll tune against the real render. Combined with #319's flattened backgrounds, the stack should read much cleaner.

Cache-bust `?v=` → `20260623z6`. Gates: ✅ rule-usage · ✅ window-catalog. smoke/logic-test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3zJdbKcgCqSJcdkCyMSfr)_