### PR TITLE
Mobile: force phone inputs to 16px so focusing a field never zooms (iOS)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260623z11" />
+  <link rel="stylesheet" href="style.css?v=20260623z12" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -30,8 +30,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260623z11"></script>
-  <script type="module" src="app.js?v=20260623z11"></script>
+  <script src="rule-usage.js?v=20260623z12"></script>
+  <script type="module" src="app.js?v=20260623z12"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -380,6 +380,10 @@ input { font-family: inherit; }
    long-press drag + the column/Back-Fwd swipe engine are untouched (single tap still opens,
    double tap still anchors — now without the browser stealing it). */
 body.is-phone { touch-action: manipulation; }
+/* §M-touch — iOS Safari auto-zooms when you FOCUS an input whose font-size is < 16px,
+   independent of the viewport scale lock. Force every phone input to 16px so tapping a
+   field (card search, line-item fields, chat compose, login) never zooms the screen. */
+.is-phone input, .is-phone textarea, .is-phone select { font-size: 16px !important; }
 /* ── §M3 — overlays & the winpicker become bottom SHEETS on phones: full-width,
    pinned to the bottom edge, rounded top, slide up. Popups keep their ✕ and the
    backdrop closes on tap; the winpicker gets its own tap-to-close backdrop + Esc. ── */


### PR DESCRIPTION
Follow-up to #322. Tapping the card search bar (or any field) still zoomed in: iOS Safari auto-zooms when you **focus** an input whose `font-size` is **< 16px**, and it does this independently of the viewport scale lock. Every input in the app is 11–13px, so every field triggered it.

**Fix:** force all phone inputs to the 16px no-zoom threshold:
```css
.is-phone input, .is-phone textarea, .is-phone select { font-size: 16px !important; }
```
With #322's viewport lock + pinch block + `touch-action: manipulation`, focusing a field now never zooms — completing "no zoom at all."

Cache token → `v=20260623z12`. Gates: `gen-rule-usage --check` passes; `smoke`/`logic-test` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yPsRQf8VnNAcmii5Y5Kwd

---
_Generated by [Claude Code](https://claude.ai/code/session_013yPsRQf8VnNAcmii5Y5Kwd)_