### PR TITLE
Mobile: adding a filter chip no longer pops the keyboard / jumps the view

### DIFF
--- a/app.js
+++ b/app.js
@@ -2091,10 +2091,15 @@ function termsFor(scope) {
   return (cs.filterTerms = cs.filterTerms || []);
 }
 function afterFilterChange(scope) {
+  const sel = scope === 'global' ? '#globalsearch' : `.mini-search[data-card="${scope}"]`;
+  // Only KEEP focus on the search box if the user was already typing in it (Enter-to-pin a
+  // term → let them add another). A chip / graph-segment / Not-Ready tap must NOT grab focus
+  // — on a phone that pops the keyboard + scroll-jumps the layout out from under you (Jac).
+  const wasTyping = !!(document.activeElement && document.activeElement.matches && document.activeElement.matches(sel));
   if (scope === 'global') recomputeSearchMode();           // sets searchMode + resets list limits
   else activeSession().cards[scope].listLimit = undefined;  // re-window this card from the top
   render();
-  document.querySelector(scope === 'global' ? '#globalsearch' : `.mini-search[data-card="${scope}"]`)?.focus();
+  if (wasTyping) document.querySelector(sel)?.focus();
 }
 // A1 — a footer chip adds an EXACT, removable filter pill to the card's search bar (one
 // filtering pathway, cleared from the search bar) instead of a separate sticky footer filter.

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260624a" />
+  <link rel="stylesheet" href="style.css?v=20260624b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260624a"></script>
-  <script type="module" src="app.js?v=20260624a"></script>
+  <script src="rule-usage.js?v=20260624b"></script>
+  <script type="module" src="app.js?v=20260624b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Tapping a chip that adds a filter pill (e.g. the **Not Ready** chip, a graph segment) auto-focused the card/global search input. On a phone that pops the keyboard + the iOS accessory bar and scroll-jumps the layout — disorienting, since you tapped a button, not the search box.

**Fix:** `afterFilterChange()` now only re-focuses the search input when the user was *already typing* in it (Enter-to-pin, so they can add another term). A chip / segment / Not-Ready tap adds the pill without grabbing focus → no keyboard, no jump. Desktop unaffected.

One-line behavioral change in `afterFilterChange`; cache token → `v=20260624b`. Gates: `gen-rule-usage --check` passes; `smoke`/`logic-test` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yPsRQf8VnNAcmii5Y5Kwd

---
_Generated by [Claude Code](https://claude.ai/code/session_013yPsRQf8VnNAcmii5Y5Kwd)_