### PR TITLE
Mobile: fill the card-toggle bar — no dead space on the right

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260624b" />
+  <link rel="stylesheet" href="style.css?v=20260624c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260624b"></script>
-  <script type="module" src="app.js?v=20260624b"></script>
+  <script src="rule-usage.js?v=20260624c"></script>
+  <script type="module" src="app.js?v=20260624c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -340,6 +340,10 @@ input { font-family: inherit; }
 .mcard-tog .mct-ico { display: inline-flex; } .mcard-tog .mct-ico svg { width: 19px; height: 19px; }
 .mcard-tog .mct-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 13px; white-space: nowrap; }
 .mcard-tog.on { background: var(--accent); color: var(--on-orange, #1a1205); }   /* selected = ignition orange + dark ink */
+/* Fill the bar (Jac 2026-06-24): the icon toggles share the leftover width evenly so
+   there's no dead space, while the selected (labelled) toggle keeps its natural size. */
+.mcard-bar .mcard-tog { flex: 1 1 0; }
+.mcard-bar .mcard-tog.on { flex: 0 0 auto; }
 .mcard-tog:not(.on):active { background: rgba(255,255,255,.06); }
 .mdock-act { flex: 0 0 auto; position: relative; }
 /* ── §M2 Mobile drag — the chat drop-zone is the BOTTOM EDGE (full width) on phones,


### PR DESCRIPTION
The phone footer card-toggle bar had dead space on the right — the toggles were natural-width and left-packed, so 7 toggles didn't fill the bar.

**Fix:** the icon toggles now `flex-grow` to share the leftover width evenly; the selected (labeled) toggle keeps its natural size. The bar fills edge-to-edge with no empty gap.

CSS-only; cache token → `v=20260624c`. Gates: `gen-rule-usage --check` passes; `smoke`/`logic-test` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yPsRQf8VnNAcmii5Y5Kwd

---
_Generated by [Claude Code](https://claude.ai/code/session_013yPsRQf8VnNAcmii5Y5Kwd)_