### PR TITLE
Rentals list: sink completed/cancelled rentals to the bottom

### DIFF
--- a/app.js
+++ b/app.js
@@ -5753,7 +5753,12 @@ function sortRows(card, rows, sort) {
     }
   };
   const dir = sort.dir === 'desc' ? -1 : 1;
-  return [...rows].sort((a, b) => { const va = val(a), vb = val(b); return va < vb ? -dir : va > vb ? dir : 0; });
+  return [...rows].sort((a, b) => {
+    // Completed/cancelled rentals always sink to the bottom so the active queue leads —
+    // they stay searchable/viewable, just below the live ones (Jac 2026-06-24).
+    if (card === 'rentals') { const ac = a.completed ? 1 : 0, bc = b.completed ? 1 : 0; if (ac !== bc) return ac - bc; }
+    const va = val(a), vb = val(b); return va < vb ? -dir : va > vb ? dir : 0;
+  });
 }
 
 const VIRT_CAP = 60;   // first-paint cap (SPEC §3 windowing)

--- a/app.js
+++ b/app.js
@@ -5754,9 +5754,14 @@ function sortRows(card, rows, sort) {
   };
   const dir = sort.dir === 'desc' ? -1 : 1;
   return [...rows].sort((a, b) => {
-    // Completed/cancelled rentals always sink to the bottom so the active queue leads —
-    // they stay searchable/viewable, just below the live ones (Jac 2026-06-24).
-    if (card === 'rentals') { const ac = a.completed ? 1 : 0, bc = b.completed ? 1 : 0; if (ac !== bc) return ac - bc; }
+    // Genuinely-completed rentals sink to the bottom so the active queue leads — they stay
+    // searchable/viewable, just below. Cancelled/No-Show are NOT counted: they're not
+    // "completed" until the Complete button is clicked, so they stay up where they can be
+    // worked (mirrors the cancelish check in the rental footer). (Jac 2026-06-24)
+    if (card === 'rentals') {
+      const done = (r) => r.completed && r.status !== 'Cancelled' && r.status !== 'No Show';
+      const ac = done(a) ? 1 : 0, bc = done(b) ? 1 : 0; if (ac !== bc) return ac - bc;
+    }
     const va = val(a), vb = val(b); return va < vb ? -dir : va > vb ? dir : 0;
   });
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260624c" />
+  <link rel="stylesheet" href="style.css?v=20260624d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260624c"></script>
-  <script type="module" src="app.js?v=20260624c"></script>
+  <script src="rule-usage.js?v=20260624d"></script>
+  <script type="module" src="app.js?v=20260624d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Behavior
The rentals card wasn't hiding completed rentals — it showed them all (greyed) mixed into the list. This sinks **genuinely-completed** rentals to the bottom (active queue leads); they stay fully searchable/viewable, just below.

**Cancelled / No-Show are NOT sunk** (per Jac): both Complete and the "Cancel Rental" close button set `r.completed=true`, and that close button only appears for Cancelled/No-Show status — but those aren't "completed" until the Complete button is clicked, so they stay up in the active queue where they can be worked. Predicate: `r.completed && status ∉ {Cancelled, No Show}` (mirrors the `cancelish` check in the rental footer, app.js:5049).

Applies in normal list view and search results. Pure sort logic — no UI element changed (no R-rule / rule-usage / window-catalog impact).

Cache-bust `?v=` → `20260624d`. Gates: ✅ `node --check` · ✅ rule-usage · ✅ window-catalog. smoke/logic-test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)