### PR TITLE
Rentals: list-row status gate (R1) + standard calendar month-1st label

### DIFF
--- a/app.js
+++ b/app.js
@@ -3930,7 +3930,7 @@ const ROWS = {
     const stColor = rentalStatusDisplay(r).color;   // border-left highlight follows rental status
     const units = rentalUnitsLabel(r);               // comma-separated unit names (empty on a bare quote)
     const s = parseISO(r.startDate), e = parseISO(r.endDate);
-    const stPill = statusPill('rentalStatus', rentalDisplayStatus(r), { card: 'rentals', recId: r.rentalId });
+    const stPill = masterGate(r);   // R1 gate — advance rental status straight from the list row (Jac 2026-06-24)
 
     // ── Balance (R8 derived): Paid green · upcoming yellow · past-due red ───
     let bal = '', balCls = '';
@@ -4992,6 +4992,7 @@ function rentalDetailCal(r, stColor) {
   const lastSat = new Date(e.getFullYear(), e.getMonth(), e.getDate() + lastSatDelta);
   const totalDays = Math.round((lastSat - firstSun) / 86400000) + 1;
   const DOW = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+  const RDCAL_MON = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
   const dowRow = DOW.map((l) => `<span>${l}</span>`).join('');
   const cells = [];
   for (let i = 0; i < totalDays; i++) {
@@ -5000,12 +5001,16 @@ function rentalDetailCal(r, stColor) {
     const isToday = iso === TODAY_ISO, isStart = iso === r.startDate, isEnd = iso === r.endDate;
     const inWin = iso >= r.startDate && iso <= r.endDate;
     const elapsed = inWin && d <= TODAY;
+    // 1st of a month (not a start/end cell) shows the month abbrev so the boundary reads —
+    // matches the mini calendars' mon1st marker (Jac 2026-06-24).
+    const isMon1st = !isStart && !isEnd && d.getDate() === 1;
     const cls = ['rdcal-day', isToday && 'is-today', isStart && 'is-start', isEnd && 'is-end',
       inWin && 'is-win', inWin && (elapsed ? 'elapsed' : 'fut'),
-      (!isToday && !inWin && d < TODAY) && 'is-past'].filter(Boolean).join(' ');
+      (!isToday && !inWin && d < TODAY) && 'is-past', isMon1st && 'is-mon1st'].filter(Boolean).join(' ');
     const time = isStart ? (r.startTime || '') : '';
     const icon = isStart ? startIcon : (isEnd ? endIcon : '');
-    cells.push(`<div class="${cls}">${inWin ? '<span class="rdcal-bar"></span>' : ''}${time ? `<span class="rdcal-t">${esc(time)}</span>` : ''}<span class="rdcal-n">${d.getDate()}</span>${icon ? `<span class="rdcal-ico">${icon}</span>` : ''}</div>`);
+    const nLabel = isMon1st ? RDCAL_MON[d.getMonth()] : String(d.getDate());
+    cells.push(`<div class="${cls}">${inWin ? '<span class="rdcal-bar"></span>' : ''}${time ? `<span class="rdcal-t">${esc(time)}</span>` : ''}<span class="rdcal-n${isMon1st ? ' mon1st' : ''}">${esc(nLabel)}</span>${icon ? `<span class="rdcal-ico">${icon}</span>` : ''}</div>`);
   }
   return `<div class="rdcal js-open-winpicker" data-rec="${esc(r.rentalId)}" style="--rdcal-hl:var(--${stColor})">
     <div class="rdcal-dow">${dowRow}</div>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260625a" />
+  <link rel="stylesheet" href="style.css?v=20260625b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260625a"></script>
-  <script type="module" src="app.js?v=20260625a"></script>
+  <script src="rule-usage.js?v=20260625b"></script>
+  <script type="module" src="app.js?v=20260625b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2474,6 +2474,8 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rdcal-day.is-today .rdcal-n { color: var(--accent); font-weight: 800; }
 .rdcal-day.is-start .rdcal-n { background: var(--rdcal-hl, var(--green)); color: var(--card); font-weight: 800; }
 .rdcal-day.is-end .rdcal-n { outline: 1.5px solid var(--rdcal-hl, var(--green)); color: var(--rdcal-hl, var(--green)); font-weight: 800; border-radius: 50%; }
+/* 1st-of-month → month abbrev marker (matches the mini calendars' .rcc-n.mon1st) */
+.rdcal-n.mon1st { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 11px; font-weight: 800; letter-spacing: .5px; color: var(--txt-2); padding: 0; }
 /* unit rows beneath calendar */
 .rd-units { margin-top: 6px; }
 .rd-unit-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; }

--- a/style.css
+++ b/style.css
@@ -2451,7 +2451,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 /* ── RENTAL DETAIL v2 — header · calendar · unit rows · footer (rd-*, rdcal-*) ── */
 .rd-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; }
 .rd-head-l { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; min-width: 0; }
-.rd-head-r { display: flex; flex-direction: column; align-items: flex-end; gap: 5px; flex-shrink: 0; }
+.rd-head-r { display: flex; flex-direction: column; align-items: flex-end; gap: 5px; flex-shrink: 0; margin-left: auto; }   /* stay right-aligned even when the header wraps on a narrow card (Jac 2026-06-24) */
 .rd-blocker { margin-bottom: 6px; }
 /* numbered-date window-track calendar */
 .rdcal { background: var(--panel-2); border-radius: 10px; overflow: hidden; cursor: pointer; margin-top: 2px; user-select: none; }


### PR DESCRIPTION
All three rental-card items from the screenshots.

## 1. List-row rental status → R1 gate
The QUOTE/RETURNED status on rental list rows was display-only (`statusPill`, R3). Now `masterGate(r)` (R1) — tap to open the status dropdown and advance the rental straight from the list (`openStatusDropdown` → `setRentalStatus`, by `data-rec`). Mixed multi-unit stays locked with the existing tip.

## 2. Standard calendar labels the 1st of the month
`rentalDetailCal` showed every day as a number, so a window crossing months read "…30, 1, 2…". Now the 1st shows the month abbrev ("JUL"), matching the mini calendars' `mon1st` marker. New `.rdcal-n.mon1st` mirrors `.rcc-n.mon1st`.

## 3. Why some rental headers are clunky (and the fix)
Same renderer — the difference is reflow. `.rd-head` is `flex-wrap: wrap` + `justify-content: space-between`, so on a narrow card when the right cluster (gate + invoice + balance) can't sit beside the left cluster (customer + PO), it **wraps to its own line and lands left/center** (clunky, e.g. when there's a wide `+Invoice` add button and no invoice yet). Lelemeca looked clean only because its content fit on one line. Fix: `margin-left:auto` on `.rd-head-r` so it pins right whether it fits beside or wraps below.

Cache-bust `?v=` → `20260624e`. Gates: ✅ `node --check` · ✅ rule-usage · ✅ window-catalog. smoke/logic-test in CI. **Items 2 & 3 are layout — worth an eyeball on a phone before/after merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)