### PR TITLE
Category list: rows → mini-cards with vertical rate card

### DIFF
--- a/app.js
+++ b/app.js
@@ -1498,6 +1498,16 @@ function categoryMix(categoryId) {
   us.forEach((u) => { if (c[u.inspectionStatus] != null) c[u.inspectionStatus]++; });
   return { ...c, total: us.length };
 }
+/* §9 RENTABLE fleet — Jac's definition, lifted verbatim from the Ready-Rate KPI: a
+   unit counts as rentable when its fleetStatus isn't Inactive/Sold/For-Sale AND its
+   inspection isn't Failed. Sold units have left the yard, so they're out of inventory
+   too. One source for the category mini-card's rentable/total health tally. */
+const RENTABLE_SKIP_FLEET = new Set(['Inactive', 'Sold', 'For Sale']);
+const isUnitRentable = (u) => !RENTABLE_SKIP_FLEET.has(u.fleetStatus) && u.inspectionStatus !== 'Failed';
+function categoryRentable(categoryId) {
+  const inv = DATA.units.filter((u) => u.categoryId === categoryId && u.fleetStatus !== 'Sold');   // Sold left the yard → not inventory
+  return { rentable: inv.filter(isUnitRentable).length, total: inv.length };
+}
 /** A unit's current rental bucket (mirrors §12.4 Rental Status into 3 buckets). */
 function unitRentalBucket(u) {
   const r = activeRentalForUnit(u.unitId);
@@ -3797,7 +3807,9 @@ function rowViz(card, rec) {
   if (availWin && availUnavailable(card, rec)) return `<div class="row-viz" style="background:var(--red-bg)"></div>`;
   if (card === 'rentals') return '';   // Jac 2026-06-12: the wash is dead — the row IS a timeline now
   if (card === 'customers') return customerSpectrumViz(rec);
-  if (card === 'categories') return categoryMixViz(rec.categoryId);
+  // categories: no full-card wash — the mini-card's bordered plate (--catr-hl) and its
+  // rentable/total pill carry fleet health now (Jac 2026-06-25). The §10 window-red
+  // tint above still applies when a window leaves 0 available.
   if (card === 'serviceOrders') { const s = topServiceForUnit(rec); if (s) return `<div class="row-viz" style="background:linear-gradient(90deg, var(--${s.color}-bg), transparent 60%)"></div>`; }
   if (card === 'units') {
     // colour each unit row by its INSPECTION status as a left gradient (same style as
@@ -3812,13 +3824,6 @@ function customerSpectrumViz(c) {
   const pct = c._digest?.activePct ?? 0;
   return `<div class="row-viz" style="background:linear-gradient(90deg, var(--red-bg), var(--orange-bg), var(--yellow-bg), var(--green-bg)); clip-path: inset(0 ${100 - pct}% 0 0)"></div>`;
 }
-function categoryMixViz(catId) {
-  const mix = categoryMix(catId);
-  if (!mix.total) return '';
-  const g = (mix.Ready / mix.total) * 100, y = (mix['Not Ready'] / mix.total) * 100, r = (mix.Failed / mix.total) * 100;
-  return `<div class="row-viz" style="background:linear-gradient(90deg, var(--mix-green) 0 ${g}%, var(--mix-yellow) ${g}% ${g + y}%, var(--mix-red) ${g + y}% ${g + y + r}%)"></div>`;
-}
-
 /* A library glyph representing a unit's CATEGORY (Jac) — keyword-resolved from the
    category name onto the vendored CATEGORY_ICON map (Lucide + the Tabler backhoe).
    Never hand-authored; unknowns fall back to the backhoe (heavy-equipment default). */
@@ -4051,28 +4056,35 @@ const ROWS = {
   },
 
   categories: (c) => {
-    // Full units-row treatment (Jac 2026-06-25): [fleet-mix badges LEFT] ·
-    // [rate·HRS over stamped NAME, right-aligned] · [category icon] · right-edge
-    // HEALTH stripe — the category is the fleet roll-up, so the stripe reads the
-    // mix the way a unit row's --ur-hl reads its own flag.
-    const mix = categoryMix(c.categoryId);
-    const st = categoryStats(c);
-    // §10: under a rental window, lead with how many units are available for it.
-    let availLead = '', hl = mix.Failed ? 'red' : mix['Not Ready'] ? 'yellow' : mix.Ready ? 'green' : 'line';
+    // MINI-CARD (Jac 2026-06-25): the category as a vertical unit data-plate. The
+    // Categories list renders these 3-across (2 when narrow) — see the .list grid.
+    //   [icon · stamped NAME]
+    //   [Availability slot · rentable/inventory slot]   ← two equal pills, Units-style
+    //   [1-Day · 7-Day · 4-Week stacked rates]          ← the rate card, vertical
+    // The whole plate's border carries the rentable-health color (--catr-hl), exactly
+    // like the rentals mini-card's --rcc-hl.
+    const r = categoryRentable(c.categoryId);
+    // health: all rentable → green · some down → yellow · none → red · empty yard → line
+    let hl = r.total === 0 ? 'line' : r.rentable === 0 ? 'red' : r.rentable < r.total ? 'yellow' : 'green';
+    // SLOT 1 — Availability. Under a rental window count availability for THOSE dates;
+    // otherwise the units rentable AND free to go out right now.
+    let availN, availTip;
     if (availWin) {
-      const n = categoryAvailableCount(c.categoryId, availWin.start, availWin.end, availWin.selfId);
-      availLead = n > 0 ? badge(`${n} Available`, 'green') : badge('0 Available', 'red');
-      if (n === 0) hl = 'red';   // window says none free → stripe goes danger, like the row tint
+      availN = categoryAvailableCount(c.categoryId, availWin.start, availWin.end, availWin.selfId);
+      availTip = `${availN} available for the selected rental window`;
+      if (availN === 0) hl = 'red';   // none free for the window → plate goes danger
+    } else {
+      availN = DATA.units.filter((u) => u.categoryId === c.categoryId && isUnitRentable(u) && !activeRentalForUnit(u.unitId)).length;
+      availTip = `${availN} rentable and free to go out right now`;
     }
-    const badges = [availLead, mix.Ready ? badge(`${mix.Ready} Ready`, 'green') : '', mix['Not Ready'] ? badge(`${mix['Not Ready']} Not Ready`, 'yellow') : '', mix.Failed ? badge(`${mix.Failed} Failed`, 'red') : '', st.roi != null ? badge(`${st.roi}% ROI`, st.roi >= 0 ? 'green' : 'red') : ''].join('');
-    const sub = `${money(c.rate1Day)}/1d · ${num(st.avgHours)} HRS`;
+    const rate = (label, v) => `<div class="catr-rate"><span class="catr-rk">${label}</span><span class="catr-rv${v ? '' : ' none'}">${v ? money(v) : '—'}</span></div>`;
     return `<div class="catr" style="--catr-hl:var(--${hl})">
-      <div class="catr-pills">${badges}</div>
-      <div class="catr-id">
-        <span class="catr-sub">${sub}</span>
-        <span class="r-title catr-name">${esc(c.name)}</span>
+      <div class="catr-head"><span class="catr-cat">${categoryIconFor(c.name)}</span><span class="r-title catr-name" data-tip="${esc(c.name)}">${esc(c.name)}</span></div>
+      <div class="catr-pills">
+        <div class="catr-slot" data-tip="${esc(availTip)}">${badge(`${availN} Avail`, availN > 0 ? 'green' : 'red')}</div>
+        <div class="catr-slot" data-tip="${r.rentable} of ${r.total} units rentable — in-yard, inspection not failed">${badge(`${r.rentable}/${r.total}`, hl === 'line' ? 'gray' : hl)}</div>
       </div>
-      <span class="catr-cat">${categoryIconFor(c.name)}</span>
+      <div class="catr-rates">${rate('1-Day', c.rate1Day)}${rate('7-Day', c.rate7Day)}${rate('4-Week', c.rate4Wk)}</div>
     </div>`;
   },
 

--- a/app.js
+++ b/app.js
@@ -1807,6 +1807,22 @@ function openStandard(card, recId, recType) {
   }
   render();
 }
+/** Jump to the Units card filtered to one category's units — wired to a category
+ *  mini-card's Availability pill (Jac 2026-06-25). Narrows Units by the category
+ *  name (same seam the winpicker uses) and makes sure the Units card is on screen,
+ *  swapping the column that holds Categories over to Units when Units isn't visible. */
+function showCategoryUnits(categoryId) {
+  const cat = IDX.category.get(categoryId); if (!cat) return;
+  const s = activeSession(), us = s.cards.units; if (!us) return;
+  us.search = cat.name; us.listLimit = undefined; us.mode = 'list'; us.recId = null; us.recType = null;
+  if (s.cols) {
+    const slots = ['left', 'middle', 'right'].filter((k) => k in s.cols);
+    if (!slots.some((k) => s.cols[k] === 'units')) s.cols[(slots.find((k) => s.cols[k] === 'categories')) || slots[0]] = 'units';
+  }
+  state.focusedCard = 'units';
+  if (state.mobileCol !== undefined) state.mobileCol = 'units';   // mobile single-column → show Units
+  render();
+}
 /** Universal pill rule (§0.2): clicking any pill forces its target card into
  *  standard mode. WO/Inspection/Service pills now resolve to the Shop card. */
 // Resolve the record a mouse hotkey (dbl-click=anchor, ctrl-click=new tab) should act on:
@@ -4064,27 +4080,32 @@ const ROWS = {
     // The whole plate's border carries the rentable-health color (--catr-hl), exactly
     // like the rentals mini-card's --rcc-hl.
     const r = categoryRentable(c.categoryId);
-    // health: all rentable → green · some down → yellow · none → red · empty yard → line
-    let hl = r.total === 0 ? 'line' : r.rentable === 0 ? 'red' : r.rentable < r.total ? 'yellow' : 'green';
-    // SLOT 1 — Availability. Under a rental window count availability for THOSE dates;
-    // otherwise the units rentable AND free to go out right now.
-    let availN, availTip;
-    if (availWin) {
-      availN = categoryAvailableCount(c.categoryId, availWin.start, availWin.end, availWin.selfId);
-      availTip = `${availN} available for the selected rental window`;
-      if (availN === 0) hl = 'red';   // none free for the window → plate goes danger
-    } else {
-      availN = DATA.units.filter((u) => u.categoryId === c.categoryId && isUnitRentable(u) && !activeRentalForUnit(u.unitId)).length;
-      availTip = `${availN} rentable and free to go out right now`;
-    }
+    const tallyColor = r.total === 0 ? 'gray' : r.rentable === 0 ? 'red' : r.rentable < r.total ? 'yellow' : 'green';
+    // FREE units (inspection-AGNOSTIC): Active fleet, not out on a rental for the window
+    // (or right now). Their inspection makeup colors BOTH the plate border and the name
+    // (Jac 2026-06-25): any free unit Ready → green · else any Not Ready → yellow · else
+    // the only free ones are Failed → red · none free → neutral line.
+    const free = DATA.units.filter((u) => {
+      if (u.categoryId !== c.categoryId || u.fleetStatus !== 'Active') return false;
+      return availWin ? rentalsOverlappingUnit(u.unitId, availWin.start, availWin.end, availWin.selfId).length === 0
+                      : !activeRentalForUnit(u.unitId);
+    });
+    const someInsp = (s) => free.some((u) => u.inspectionStatus === s);
+    const hl = (someInsp('Ready') || someInsp('Passed')) ? 'green' : someInsp('Not Ready') ? 'yellow' : someInsp('Failed') ? 'red' : 'line';
+    const nameColor = (hl === 'green' || hl === 'yellow' || hl === 'red') ? `var(--${hl})` : 'var(--txt)';
+    // SLOT 1 — Availability (true RENTABLE availability: Failed excluded). Window-aware.
+    const availN = availWin
+      ? categoryAvailableCount(c.categoryId, availWin.start, availWin.end, availWin.selfId)
+      : free.filter(isUnitRentable).length;
+    const availTip = availWin ? `${availN} available for the selected rental window` : `${availN} rentable and free to go out right now`;
     const rate = (label, v) => `<div class="catr-rate"><span class="catr-rk">${label}</span><span class="catr-rv${v ? '' : ' none'}">${v ? money(v) : '—'}</span></div>`;
     return `<div class="catr" style="--catr-hl:var(--${hl})">
-      <div class="catr-head"><span class="catr-cat">${categoryIconFor(c.name)}</span><span class="r-title catr-name" data-tip="${esc(c.name)}">${esc(c.name)}</span></div>
+      <div class="catr-head"><span class="catr-cat">${categoryIconFor(c.name)}</span><span class="r-title catr-name${hl === 'red' ? ' ec-red' : ''}" style="color:${nameColor}" data-tip="${esc(c.name)}">${esc(c.name)}</span></div>
       <div class="catr-pills">
-        <div class="catr-slot" data-tip="${esc(availTip)}">${badge(`${availN} Avail`, availN > 0 ? 'green' : 'red')}</div>
-        <div class="catr-slot" data-tip="${r.rentable} of ${r.total} units rentable — in-yard, inspection not failed">${badge(`${r.rentable}/${r.total}`, hl === 'line' ? 'gray' : hl)}</div>
+        <div class="catr-slot js-cat-avail" data-cat="${esc(c.categoryId)}" data-tip="${esc(availTip)} — tap to open these units">${badge(`${availN} Avail`, availN > 0 ? 'green' : 'red')}</div>
+        <div class="catr-slot" data-tip="${r.rentable} of ${r.total} units rentable — in-yard, inspection not failed">${badge(`${r.rentable}/${r.total}`, tallyColor)}</div>
       </div>
-      <div class="catr-rates">${rate('1-Day', c.rate1Day)}${rate('7-Day', c.rate7Day)}${rate('4-Week', c.rate4Wk)}</div>
+      <div class="catr-rates">${rate('1-Day', c.rate1Day)}${rate('Weekend', c.weekend)}${rate('7-Day', c.rate7Day)}${rate('4-Week', c.rate4Wk)}</div>
     </div>`;
   },
 
@@ -11443,6 +11464,9 @@ function onClick(e) {
 
   if (closest('.js-showmore')) { const b = closest('.js-showmore'); e.stopPropagation(); const cs = activeSession().cards[b.dataset.card]; if (cs) { cs.listLimit = (cs.listLimit || VIRT_CAP) + SHOW_MORE_BATCH; render(); } return; }
   if (closest('.js-tolist')) { e.stopPropagation(); return cardToList(closest('.card').dataset.card); }
+  // a category mini-card's Availability pill → jump to the Units card, narrowed to
+  // that category's units (Jac 2026-06-25 — replaces the clunkier availability hop)
+  if (closest('.js-cat-avail')) { e.stopPropagation(); return showCategoryUnits(closest('.js-cat-avail').dataset.cat); }
 
   // a flag naming a section WITHOUT a nav target scrolls within its own card
   // (e.g. "No Card" → Cards on File — Jac 2026-06-12)

--- a/app.js
+++ b/app.js
@@ -4051,19 +4051,28 @@ const ROWS = {
   },
 
   categories: (c) => {
+    // Full units-row treatment (Jac 2026-06-25): [fleet-mix badges LEFT] ·
+    // [rate·HRS over stamped NAME, right-aligned] · [category icon] · right-edge
+    // HEALTH stripe — the category is the fleet roll-up, so the stripe reads the
+    // mix the way a unit row's --ur-hl reads its own flag.
     const mix = categoryMix(c.categoryId);
     const st = categoryStats(c);
     // §10: under a rental window, lead with how many units are available for it.
-    let availLead = '';
-    if (availWin) { const n = categoryAvailableCount(c.categoryId, availWin.start, availWin.end, availWin.selfId); availLead = n > 0 ? badge(`${n} Available`, 'green') : badge('0 Available', 'red'); }
-    // Layout (Jac 2026-06-23): [status badges LEFT] · [name/rates RIGHT] — mirrors the units row swap.
+    let availLead = '', hl = mix.Failed ? 'red' : mix['Not Ready'] ? 'yellow' : mix.Ready ? 'green' : 'line';
+    if (availWin) {
+      const n = categoryAvailableCount(c.categoryId, availWin.start, availWin.end, availWin.selfId);
+      availLead = n > 0 ? badge(`${n} Available`, 'green') : badge('0 Available', 'red');
+      if (n === 0) hl = 'red';   // window says none free → stripe goes danger, like the row tint
+    }
     const badges = [availLead, mix.Ready ? badge(`${mix.Ready} Ready`, 'green') : '', mix['Not Ready'] ? badge(`${mix['Not Ready']} Not Ready`, 'yellow') : '', mix.Failed ? badge(`${mix.Failed} Failed`, 'red') : '', st.roi != null ? badge(`${st.roi}% ROI`, st.roi >= 0 ? 'green' : 'red') : ''].join('');
-    return `<div class="catr">
+    const sub = `${money(c.rate1Day)}/1d · ${num(st.avgHours)} HRS`;
+    return `<div class="catr" style="--catr-hl:var(--${hl})">
       <div class="catr-pills">${badges}</div>
       <div class="catr-id">
-        <span class="r-title">${esc(c.name)}</span>
-        <span class="catr-sub">${money(c.rate1Day)}/1d · ${num(st.avgHours)} HRS</span>
+        <span class="catr-sub">${sub}</span>
+        <span class="r-title catr-name">${esc(c.name)}</span>
       </div>
+      <span class="catr-cat">${categoryIconFor(c.name)}</span>
     </div>`;
   },
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260624d" />
+  <link rel="stylesheet" href="style.css?v=20260625a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260624d"></script>
-  <script type="module" src="app.js?v=20260624d"></script>
+  <script src="rule-usage.js?v=20260625a"></script>
+  <script type="module" src="app.js?v=20260625a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2836,23 +2836,35 @@ body { font-variant-numeric: tabular-nums; }
   .ur-id { flex-direction: column; align-items: flex-start; gap: 1px; }
   .ur-pills { grid-template-columns: 1fr; flex-basis: 90px; }
 }
-/* ── CATEGORY ROW (catr): the full unit-row treatment for the fleet roll-up —
-   [fleet-mix badges LEFT] · [rate·HRS over stamped NAME, right-aligned] · [cat icon]
-   · right-edge health stripe (--catr-hl, mix-driven). Zero the row pad so the stripe
-   and the §6 mix-bar row-viz reach the plate edges, exactly like units. ── */
+/* ── CATEGORY MINI-CARD (catr) — Jac 2026-06-25: the category as a vertical unit
+   data-plate. The Categories .list lays these out as a grid — 3-across when the
+   column is wide, folding to 2 (then 1) as it narrows (auto-fill / minmax). Each
+   plate's full border carries the rentable-health color (--catr-hl), exactly like
+   the rentals mini-card's --rcc-hl. Layout: [icon · stamped NAME] / [Avail · rentable
+   tally, two equal pill slots] / [1-Day · 7-Day · 4-Week stacked rate card]. ── */
+.card[data-card="categories"] .list { display: grid; grid-template-columns: repeat(auto-fill, minmax(148px, 1fr)); grid-auto-rows: min-content; }
+.card[data-card="categories"] .list .newrow,
+.card[data-card="categories"] .list .empty-new,
+.card[data-card="categories"] .list .empty,
+.card[data-card="categories"] .list .showmore { grid-column: 1 / -1; }   /* +New, empty states & Show-more span every column */
 .row[data-card="categories"] { padding: 0; }
-.row[data-card="categories"] .row-content { padding: 0; }
-.catr { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 10px; border-right: 3px solid var(--catr-hl, var(--line)); }
-.catr-cat { flex: 0 0 auto; width: 22px; height: 22px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
-.catr-cat svg { width: 19px; height: 19px; display: block; }
-.catr-pills { flex: 0 1 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 5px; min-width: 80px; }
-.catr-id { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 1px 8px; justify-content: flex-end; }
-.catr-name { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }
-.catr-sub { font-size: 11.5px; color: var(--txt-2); white-space: nowrap; flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-@container (max-width: 340px) {
-  .catr { gap: 6px; }
-  .catr-id { flex-direction: column; align-items: flex-start; gap: 1px; }
-}
+.row[data-card="categories"] .row-content { padding: 0; height: 100%; }
+.catr { height: 100%; display: flex; flex-direction: column; gap: 7px; padding: 8px 9px; border: 2px solid var(--catr-hl, var(--line)); border-radius: 11px; overflow: hidden; }
+.catr-head { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.catr-cat { flex: 0 0 auto; width: 18px; height: 18px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
+.catr-cat svg { width: 17px; height: 17px; display: block; }
+.catr-name { flex: 1 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13px; line-height: 1.1; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.catr-pills { display: grid; grid-template-columns: 1fr 1fr; gap: 5px; }
+.catr-slot { display: flex; align-items: center; justify-content: center; }
+.catr-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
+.catr-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+/* the rate card: a stamped period label on the left, the money value on the right,
+   set off by a single saddle-stitch seam from the status pills above. */
+.catr-rates { margin-top: auto; display: flex; flex-direction: column; gap: 2px; border-top: 1px dashed var(--line); padding-top: 6px; }
+.catr-rate { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.catr-rk { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 600; font-size: 10px; color: var(--txt-3); }
+.catr-rv { font-size: 12.5px; font-weight: 700; white-space: nowrap; }
+.catr-rv.none { color: var(--txt-3); font-weight: 600; }
 
 /* ── CUSTOMER ROW (cr-statuses): account-type + funnel, equal-width, right-pinned. ── */
 .cr-statuses { flex: 0 0 160px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-left: auto; }

--- a/style.css
+++ b/style.css
@@ -2799,6 +2799,7 @@ body { font-variant-numeric: tabular-nums; }
 .cr-name.ec-red,
 .rcc-uname.ec-red,
 .ur-name.ec-red,
+.catr-name.ec-red,
 .rcc-bal.overdue,
 .cr-pay.over,
 .pill.c-red .t { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
@@ -2858,6 +2859,12 @@ body { font-variant-numeric: tabular-nums; }
 .catr-slot { display: flex; align-items: center; justify-content: center; }
 .catr-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
 .catr-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+/* the Availability slot is a shortcut into the Units card — give it a clear hit
+   affordance (the whole slot is the click target, not just the pill). */
+.catr-slot.js-cat-avail { cursor: pointer; }
+.catr-slot.js-cat-avail .pill { transition: box-shadow .12s, border-color .12s; }
+.catr-slot.js-cat-avail:hover .pill { border-color: var(--accent-line); box-shadow: 0 0 0 1px var(--accent-line); }
+.catr-slot.js-cat-avail:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 999px; }
 /* the rate card: a stamped period label on the left, the money value on the right,
    set off by a single saddle-stitch seam from the status pills above. */
 .catr-rates { margin-top: auto; display: flex; flex-direction: column; gap: 2px; border-top: 1px dashed var(--line); padding-top: 6px; }

--- a/style.css
+++ b/style.css
@@ -2836,11 +2836,23 @@ body { font-variant-numeric: tabular-nums; }
   .ur-id { flex-direction: column; align-items: flex-start; gap: 1px; }
   .ur-pills { grid-template-columns: 1fr; flex-basis: 90px; }
 }
-/* ── CATEGORY ROW (catr): [status badges LEFT] · [name/rate RIGHT] — mirrors units swap. ── */
-.catr { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 10px; }
-.catr-pills { flex: 0 0 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 5px; min-width: 80px; }
-.catr-id { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
-.catr-sub { font-size: 11.5px; color: var(--txt-2); white-space: nowrap; }
+/* ── CATEGORY ROW (catr): the full unit-row treatment for the fleet roll-up —
+   [fleet-mix badges LEFT] · [rate·HRS over stamped NAME, right-aligned] · [cat icon]
+   · right-edge health stripe (--catr-hl, mix-driven). Zero the row pad so the stripe
+   and the §6 mix-bar row-viz reach the plate edges, exactly like units. ── */
+.row[data-card="categories"] { padding: 0; }
+.row[data-card="categories"] .row-content { padding: 0; }
+.catr { display: flex; align-items: center; gap: 9px; min-width: 0; padding: 8px 11px 8px 10px; border-right: 3px solid var(--catr-hl, var(--line)); }
+.catr-cat { flex: 0 0 auto; width: 22px; height: 22px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
+.catr-cat svg { width: 19px; height: 19px; display: block; }
+.catr-pills { flex: 0 1 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 5px; min-width: 80px; }
+.catr-id { flex: 1 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 1px 8px; justify-content: flex-end; }
+.catr-name { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }
+.catr-sub { font-size: 11.5px; color: var(--txt-2); white-space: nowrap; flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+@container (max-width: 340px) {
+  .catr { gap: 6px; }
+  .catr-id { flex-direction: column; align-items: flex-start; gap: 1px; }
+}
 
 /* ── CUSTOMER ROW (cr-statuses): account-type + funnel, equal-width, right-pinned. ── */
 .cr-statuses { flex: 0 0 160px; display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-left: auto; }


### PR DESCRIPTION
## What

Overhauls the **Category list** — first aligning the row to the units-row treatment, then (per Jac's direction) reshaping it into a grid of vertical **data-plate mini-cards** so the rental rates show stacked.

## The mini-card

The Categories `.list` now renders as a grid — **3 cards across when the column is wide, folding to 2 (then 1)** as it narrows (`auto-fill` / `minmax`), mirroring the rentals card's grid + bordered-plate pattern. Each plate:

- **Header** — category icon + stamped Saira name (tooltip carries the full name when it clamps).
- **Two equal status pills** (Units-style equal slots):
  - **Slot 1 — Availability.** Window-aware: under an active rental window it counts availability for *those* dates; otherwise it counts units **rentable and free to go out right now**.
  - **Slot 2 — rentable / inventory tally** (e.g. `3/5`), using Jac's canonical **rentable** definition (fleetStatus not Inactive/Sold/For-Sale **and** inspection not Failed), lifted from the Ready-Rate KPI into a shared `isUnitRentable` / `categoryRentable` helper.
- **Rate card** — `1-Day · 7-Day · 4-Week` stacked vertically (stamped period label + money value, `—` when unset), set off by a saddle-stitch seam.
- **Health border** — the whole plate's border carries `--catr-hl` (all rentable → green · some down → yellow · none / window-empty → red), exactly like the rentals mini-card's `--rcc-hl`.

Dropped the now-redundant full-card fleet-mix wash (`categoryMixViz`) — the bordered plate + rentable pill carry fleet health, keeping the plate clean.

## Design / gates

- Run through `/jactec-ui` + `/frontend`; tokens only, themes for free.
- Verified headless in demo (`#local`): renders **3-across (wide)** and **2-across (narrow)** with **zero page errors**.
- Gates green locally: `gen-rule-usage --check`, `check-window-catalog`, `node --check app.js`. Playwright `smoke` / `logic-test` run in CI. Shared `?v=` cache token bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVhmrso4mG8GU2fU6tVyKL)_