### PR TITLE
Category mini-cards: move Weekend rate to the bottom

### DIFF
--- a/app.js
+++ b/app.js
@@ -4105,7 +4105,7 @@ const ROWS = {
         <div class="catr-slot js-cat-avail" data-cat="${esc(c.categoryId)}" data-tip="${esc(availTip)} — tap to open these units">${badge(`${availN} Avail`, availN > 0 ? 'green' : 'red')}</div>
         <div class="catr-slot" data-tip="${r.rentable} of ${r.total} units rentable — in-yard, inspection not failed">${badge(`${r.rentable}/${r.total}`, tallyColor)}</div>
       </div>
-      <div class="catr-rates">${rate('1-Day', c.rate1Day)}${rate('Weekend', c.weekend)}${rate('7-Day', c.rate7Day)}${rate('4-Week', c.rate4Wk)}</div>
+      <div class="catr-rates">${rate('1-Day', c.rate1Day)}${rate('7-Day', c.rate7Day)}${rate('4-Week', c.rate4Wk)}${rate('Weekend', c.weekend)}</div>
     </div>`;
   },
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260625a" />
+  <link rel="stylesheet" href="style.css?v=20260625b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260625a"></script>
-  <script type="module" src="app.js?v=20260625a"></script>
+  <script src="rule-usage.js?v=20260625b"></script>
+  <script type="module" src="app.js?v=20260625b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Reorders the category mini-card's stacked rate card to **1-Day · 7-Day · 4-Week · Weekend** (Weekend moved to the bottom, after 4-Week), per Jac.

Shared `?v=` cache token bumped `20260625a → 20260625b` so the live deploy loads fresh. Gates green locally (`gen-rule-usage --check`, `check-window-catalog`, `node --check`); verified headless — renders clean, Weekend now last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVhmrso4mG8GU2fU6tVyKL)_