### PR TITLE
Wrangler fix: gate card-on-file screen to Office/Admin

### DIFF
--- a/app.js
+++ b/app.js
@@ -642,7 +642,7 @@ function cardTabBody(c) {
     </div>`;
   }).join('') : '<span class="muted" style="font-size:12px">No cards on file.</span>';
   return `<div class="cards-list">${rows}</div>
-    <div style="margin-top:10px">${addBtn('Card', { link: true, js: 'js-add-card', data: { rec: c.customerId } })}</div>`;
+    ${canMoney() ? `<div style="margin-top:10px">${addBtn('Card', { link: true, js: 'js-add-card', data: { rec: c.customerId } })}</div>` : ''}`;
 }
 function achTabBody(c) {
   const banks = customerBanks(c);
@@ -8649,7 +8649,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     const railTabs = `<div class="ag-tabs" role="tablist">
       <button type="button" class="ag-tab js-nc-tab${tab === 'account' ? ' on' : ''}" data-tab="account">Account</button>
       ${cards.map((k) => `<button type="button" class="ag-tab js-nc-tab${tab === k.id ? ' on' : ''}" data-tab="${esc(k.id)}"><span class="ag-dot ${{ complete: 'ok', 'in-progress': 'mid', stale: 'bad' }[cardCaptureState(custRec, k)]}"></span>${esc(brandName(k.brand))} ••${esc(k.last4)}</button>`).join('')}
-      ${addBtn('Card', { link: true, js: 'js-add-card', data: { rec: o.editId || '' } })}
+      ${canMoney() ? addBtn('Card', { link: true, js: 'js-add-card', data: { rec: o.editId || '' } }) : ''}
     </div>`;
     const headRail = `${railTabs}<span class="spacer"></span>${isEdit ? `<button class="iconbtn iconbtn-bare js-nc-qr" data-tip="Open on phone">${I.qr}</button>` : ''}`;
     let body;
@@ -11046,6 +11046,7 @@ function onClick(e) {
   if (closest('.js-print-magreement')) { e.stopPropagation(); openMembershipAgreementPdf(closest('.js-print-magreement').dataset.rec); return; }
   if (closest('.js-add-card')) {
     e.stopPropagation();
+    if (!canMoney()) { toast('Cards on file are Office/Admin only.'); return; }   // §14 card-on-file is Office/Admin only — same gate as Pay/Charge/Refund (canMoney)
     const rec = closest('.js-add-card').dataset.rec;
     // From the onboarding form: persist the draft (incl. signature/selfie) first, add the card,
     // then RETURN to the form (card now on file) — no save-close-reopen. Elsewhere: normal add.
@@ -12776,7 +12777,7 @@ function friendlyPayErr(r) {
   })[code] || 'Payment failed — try again or use another card.';
 }
 
-async function openAddCard(customerId, opts) { await ensurePubKey(); openOverlay({ kind: 'addCard', customerId, returnTo: (opts && opts.returnTo) || '', invoiceId: (opts && opts.invoiceId) || '' }); }
+async function openAddCard(customerId, opts) { if (!canMoney()) { toast('Cards on file are Office/Admin only.'); return; } await ensurePubKey(); openOverlay({ kind: 'addCard', customerId, returnTo: (opts && opts.returnTo) || '', invoiceId: (opts && opts.invoiceId) || '' }); }
 async function openAddBank(customerId, opts) { await ensurePubKey(); openOverlay({ kind: 'addAch', customerId, returnTo: (opts && opts.returnTo) || '', invoiceId: (opts && opts.invoiceId) || '' }); }
 async function openVerifyBank(customerId, bankId) { await ensurePubKey(); openOverlay({ kind: 'verifyAch', customerId, bankId }); }
 async function openPayInvoice(invoiceId) { await ensurePubKey(); openOverlay({ kind: 'payment', invoiceId, busy: false, error: '' }); }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260625b" />
+  <link rel="stylesheet" href="style.css?v=20260625c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260625b"></script>
-  <script type="module" src="app.js?v=20260625b"></script>
+  <script src="rule-usage.js?v=20260625c"></script>
+  <script type="module" src="app.js?v=20260625c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Report
[#334](https://github.com/operations-jacrentals/rental-wrangler/issues/334) — non-admin/non-office roles can navigate to the add-card-on-file screen.

## Verdict — correct
The card-on-file open paths were never wired to the canonical money/card gate `canMoney()` (`app.js:12738` — `!currentRole || Admin || Owner || Office`), which already guards every other card/money action (Pay / Refund / Lock-price / Merge — `app.js:5534, 5544, 5549`). So a non-money role (Mechanic / M.Tech / Driver / Sales) could click **+Card** and reach the screen.

## Root cause + fix
- `openAddCard()` (`app.js:12779`) — the chokepoint for the customer-form **+Card** and the invoice pay-panel **+Card** — now returns early with a toast when `!canMoney()`.
- The new-customer `cardSub` branch (via the `js-add-card` handler) gets the same gate, so onboarding can't reach the card panel either.
- The two **+Card** buttons (customer card + new-customer rail) are hidden for non-money roles, matching how the invoice flow hides Pay/Refund.

⚠️ Touches **card/auth** — this only *adds* a gate (matching the existing `canMoney` contract); it never weakens money/card logic. Owner/Admin/Office/no-role behaviour is unchanged.

## Gates
All green: `smoke` ✓ · `logic-test` 186/186 ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓. Cache-bust `?v=` bumped to `20260625c`.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)