### PR TITLE
Wrangler fix: gate card-on-file add screen to Office/Owner/Admin

### DIFF
--- a/app.js
+++ b/app.js
@@ -642,7 +642,7 @@ function cardTabBody(c) {
     </div>`;
   }).join('') : '<span class="muted" style="font-size:12px">No cards on file.</span>';
   return `<div class="cards-list">${rows}</div>
-    <div style="margin-top:10px">${addBtn('Card', { link: true, js: 'js-add-card', data: { rec: c.customerId } })}</div>`;
+    ${canMoney() ? `<div style="margin-top:10px">${addBtn('Card', { link: true, js: 'js-add-card', data: { rec: c.customerId } })}</div>` : ''}`;
 }
 function achTabBody(c) {
   const banks = customerBanks(c);
@@ -655,7 +655,8 @@ function achTabBody(c) {
       <button class="x js-bank-remove" data-rec="${c.customerId}" data-bank="${k.id}" data-tip="Remove bank account">${I.x}</button>
     </div>`).join('') : '<span class="muted" style="font-size:12px">No bank accounts on file.</span>';
   return `<div class="cards-list">${rows}</div>
-    ${consent ? `<div style="margin-top:10px">${addBtn('ACH', { link: true, js: 'js-add-ach', data: { rec: c.customerId } })}</div>`
+    ${!canMoney() ? ''
+      : consent ? `<div style="margin-top:10px">${addBtn('ACH', { link: true, js: 'js-add-ach', data: { rec: c.customerId } })}</div>`
               : '<span class="muted" style="font-size:11px">Capture a selfie + signature (Edit account) before adding a bank account.</span>'}`;
 }
 
@@ -8649,7 +8650,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     const railTabs = `<div class="ag-tabs" role="tablist">
       <button type="button" class="ag-tab js-nc-tab${tab === 'account' ? ' on' : ''}" data-tab="account">Account</button>
       ${cards.map((k) => `<button type="button" class="ag-tab js-nc-tab${tab === k.id ? ' on' : ''}" data-tab="${esc(k.id)}"><span class="ag-dot ${{ complete: 'ok', 'in-progress': 'mid', stale: 'bad' }[cardCaptureState(custRec, k)]}"></span>${esc(brandName(k.brand))} ••${esc(k.last4)}</button>`).join('')}
-      ${addBtn('Card', { link: true, js: 'js-add-card', data: { rec: o.editId || '' } })}
+      ${canMoney() ? addBtn('Card', { link: true, js: 'js-add-card', data: { rec: o.editId || '' } }) : ''}
     </div>`;
     const headRail = `${railTabs}<span class="spacer"></span>${isEdit ? `<button class="iconbtn iconbtn-bare js-nc-qr" data-tip="Open on phone">${I.qr}</button>` : ''}`;
     let body;
@@ -11046,6 +11047,7 @@ function onClick(e) {
   if (closest('.js-print-magreement')) { e.stopPropagation(); openMembershipAgreementPdf(closest('.js-print-magreement').dataset.rec); return; }
   if (closest('.js-add-card')) {
     e.stopPropagation();
+    if (!canMoney()) return;   // card-on-file is Office/Owner/Admin only — guards the inline cardSub panel path too
     const rec = closest('.js-add-card').dataset.rec;
     // From the onboarding form: persist the draft (incl. signature/selfie) first, add the card,
     // then RETURN to the form (card now on file) — no save-close-reopen. Elsewhere: normal add.
@@ -12776,8 +12778,8 @@ function friendlyPayErr(r) {
   })[code] || 'Payment failed — try again or use another card.';
 }
 
-async function openAddCard(customerId, opts) { await ensurePubKey(); openOverlay({ kind: 'addCard', customerId, returnTo: (opts && opts.returnTo) || '', invoiceId: (opts && opts.invoiceId) || '' }); }
-async function openAddBank(customerId, opts) { await ensurePubKey(); openOverlay({ kind: 'addAch', customerId, returnTo: (opts && opts.returnTo) || '', invoiceId: (opts && opts.invoiceId) || '' }); }
+async function openAddCard(customerId, opts) { if (!canMoney()) return; await ensurePubKey(); openOverlay({ kind: 'addCard', customerId, returnTo: (opts && opts.returnTo) || '', invoiceId: (opts && opts.invoiceId) || '' }); }   // card-on-file is a money action → Office/Owner/Admin only (roles.md · canMoney)
+async function openAddBank(customerId, opts) { if (!canMoney()) return; await ensurePubKey(); openOverlay({ kind: 'addAch', customerId, returnTo: (opts && opts.returnTo) || '', invoiceId: (opts && opts.invoiceId) || '' }); }   // same gate — bank/ACH on file is the same payment-instrument class
 async function openVerifyBank(customerId, bankId) { await ensurePubKey(); openOverlay({ kind: 'verifyAch', customerId, bankId }); }
 async function openPayInvoice(invoiceId) { await ensurePubKey(); openOverlay({ kind: 'payment', invoiceId, busy: false, error: '' }); }
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260625b" />
+  <link rel="stylesheet" href="style.css?v=20260625c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260625b"></script>
-  <script type="module" src="app.js?v=20260625b"></script>
+  <script src="rule-usage.js?v=20260625c"></script>
+  <script type="module" src="app.js?v=20260625c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Report
#334 — *Card-on-file screen accessible to non-admin/office roles* (`wrangler-fix`). Non-Office/non-Admin roles could navigate to the add-card-on-file capture screen.

## Verdict — confirmed, with a cited root cause
**You're right.** Per the role canon (`.claude/skills/role/references/roles.md`), **card-on-file management is a money/payment action reserved to Office Manager / Owner / Admin** — every other role's "Restricted from" list explicitly excludes card-on-file/Stripe data.

**Root cause:** the add-card screen had **no role guard**. The `+Card` / `+ACH` add buttons (`addBtn` in `cardTabBody` / `achTabBody` / the new-customer rail), their click handler (`js-add-card`, incl. the inline `cardSub` panel path that bypasses the opener), and the openers `openAddCard` / `openAddBank` all rendered/ran for any role.

## Fix (minimal, at the cause)
Reuse the **existing `canMoney()`** predicate — the same gate the payment UI already uses (`!currentRole || Admin || Owner || Office`). This guarantees *exactly the roles that can take payments can add a payment instrument*, matching the canon's "Admin and Office only".

- Hide the `+Card` / `+ACH` add buttons for non-money roles (screen unreachable, not just blocked).
- No-op `openAddCard` / `openAddBank` and the `js-add-card` handler for non-money roles (defense-in-depth; covers the `js-pay-addcard` path too).
- **Pattern sweep:** the sibling bank/ACH add-screen had the identical missing guard — same class, swept in this fix.

## Verification (failed-before / passes-after)
Headless browser, per role:

| Role | +Card buttons |
|------|---------------|
| Driver / Mechanic / Sales (non-money) | **0** — screen unreachable |
| Office / Owner / Admin (money) | **1** — reachable |

This role-dependent split is impossible under the old unconditional render. All 4 CI gates pass (`smoke`, `logic-test` 186/186, `gen-rule-usage --check`, `check-window-catalog`); rule usage unchanged (the `R5b` stamp stays in source).

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)