### PR TITLE
Membership: gate enroll/cancel/charge behind canMoney (Office/Admin)

### DIFF
--- a/app.js
+++ b/app.js
@@ -2954,9 +2954,13 @@ function membershipSectionHtml(c) {
   const paidUntil = (isMem && c.paidUntil) ? kv(yrFull(c.paidUntil), { sfx: c.prepaid ? 'prepaid through' : 'paid until' }) : '';
   const planBadges = c.paidCadence ? kvPills(`${badge('Paid ' + c.paidCadence, 'green')}${c.unlimitedTransport ? badge('Unlimited Transport', 'purple') : ''}${c.rentalProtection ? badge('Protected', 'blue') : ''}${c.autoRenew ? badge('Auto-Renew', 'navy') : ''}`) : '';
   const cxlInv = membershipCancellationInvoice(c);
-  const enrollBtn = !isMem ? actionPill('commit', status === 'Incomplete' ? 'Complete Enrollment' : 'Saddle Up — Enroll', { js: 'js-mem-enroll', h: 26, data: { rec: c.customerId } }) : '';
-  const cancelBtn = isMem ? actionPill('danger', 'Cancel Membership', { js: 'js-mem-cancel', h: 26, data: { rec: c.customerId } }) : '';
-  const payCxlBtn = cxlInv ? actionPill('money', 'Pay Cancellation ' + money2(invoiceTotals(cxlInv).balance), { js: 'js-mem-paycxl', h: 26, data: { rec: c.customerId } }) : '';
+  // Enroll / Cancel / Pay-Cancellation are MONEY actions → Office/Admin only, same gate as the
+  // invoice Pay/Charge/Refund row (5868) and Add-Card (canMoney). Print Agreement is not a money
+  // action, so it stays visible to every role. (Handlers re-check canMoney() as defence-in-depth.)
+  const mayMoney = canMoney();
+  const enrollBtn = (!isMem && mayMoney) ? actionPill('commit', status === 'Incomplete' ? 'Complete Enrollment' : 'Saddle Up — Enroll', { js: 'js-mem-enroll', h: 26, data: { rec: c.customerId } }) : '';
+  const cancelBtn = (isMem && mayMoney) ? actionPill('danger', 'Cancel Membership', { js: 'js-mem-cancel', h: 26, data: { rec: c.customerId } }) : '';
+  const payCxlBtn = (cxlInv && mayMoney) ? actionPill('money', 'Pay Cancellation ' + money2(invoiceTotals(cxlInv).balance), { js: 'js-mem-paycxl', h: 26, data: { rec: c.customerId } }) : '';
   const printBtn = stageSet ? actionPill('commit', 'Print Agreement', { js: 'js-print-magreement', h: 26, data: { rec: c.customerId } }) : '';
   const actions = [enrollBtn, cancelBtn, payCxlBtn, printBtn].filter(Boolean).join('');
   return `<div class="section"><h4>Membership</h4><div class="fieldstack centered">
@@ -11482,14 +11486,14 @@ function onClick(e) {
   if (closest('.js-view-agreement')) { e.stopPropagation(); const cust = IDX.customer.get(closest('.js-view-agreement').dataset.rec); if (cust) openOverlay({ kind: 'agreement', recId: cust.customerId }); return; }
   if (closest('.js-print-magreement')) { e.stopPropagation(); openMembershipAgreementPdf(closest('.js-print-magreement').dataset.rec); return; }
   // F5 — membership enroll / cancel / reactivate + the enrollment dialog controls
-  if (closest('.js-mem-enroll')) { e.stopPropagation(); return openMembershipEnroll(closest('.js-mem-enroll').dataset.rec); }
-  if (closest('.js-mem-cancel')) { e.stopPropagation(); return membershipCancel(closest('.js-mem-cancel').dataset.rec); }
-  if (closest('.js-mem-paycxl')) { e.stopPropagation(); return membershipReactivate(closest('.js-mem-paycxl').dataset.rec); }
+  if (closest('.js-mem-enroll')) { e.stopPropagation(); if (!canMoney()) { toast('Membership billing is Office/Admin only.'); return; } return openMembershipEnroll(closest('.js-mem-enroll').dataset.rec); }
+  if (closest('.js-mem-cancel')) { e.stopPropagation(); if (!canMoney()) { toast('Membership billing is Office/Admin only.'); return; } return membershipCancel(closest('.js-mem-cancel').dataset.rec); }
+  if (closest('.js-mem-paycxl')) { e.stopPropagation(); if (!canMoney()) { toast('Membership billing is Office/Admin only.'); return; } return membershipReactivate(closest('.js-mem-paycxl').dataset.rec); }
   if (closest('.js-me-plan')) { e.stopPropagation(); const o = state.overlay; if (o) { o.plan = closest('.js-me-plan').dataset.val; renderOverlay(); } return; }
   if (closest('.js-me-transport')) { e.stopPropagation(); const o = state.overlay; if (o) { o.addOns.transport = closest('.js-me-transport').dataset.val === '1'; renderOverlay(); } return; }
   if (closest('.js-me-protection')) { e.stopPropagation(); const o = state.overlay; if (o) { o.addOns.protection = closest('.js-me-protection').dataset.val === '1'; renderOverlay(); } return; }
   if (closest('.js-me-autorenew')) { e.stopPropagation(); const o = state.overlay; if (o) { o.autoRenew = closest('.js-me-autorenew').dataset.val === '1'; renderOverlay(); } return; }
-  if (closest('.js-me-commit')) { e.stopPropagation(); return membershipEnrollCommit(); }
+  if (closest('.js-me-commit')) { e.stopPropagation(); if (!canMoney()) { toast('Membership billing is Office/Admin only.'); return; } return membershipEnrollCommit(); }
   if (closest('.js-add-card')) {
     e.stopPropagation();
     if (!canMoney()) { toast('Cards on file are Office/Admin only.'); return; }   // §14 card-on-file is Office/Admin only — same gate as Pay/Charge/Refund (canMoney)

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260625f" />
+  <link rel="stylesheet" href="style.css?v=20260625g" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260625f"></script>
-  <script type="module" src="app.js?v=20260625f"></script>
+  <script src="rule-usage.js?v=20260625g"></script>
+  <script type="module" src="app.js?v=20260625g"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Why

Code review of the Membership system (#338) found one real gate gap: the membership card's **money actions weren't behind `canMoney()`** (Office/Admin/Owner), unlike every other money surface in the app.

- The membership section renders unconditionally (`app.js:5749`) and the four handlers (`js-mem-enroll`, `js-mem-cancel`, `js-mem-paycxl`, `js-me-commit`) never re-checked the role gate — contrast `js-add-card` right beside them, which does (`app.js:11495`), and the invoice Pay/Charge/Refund row gated at `app.js:5868`.
- **Sharpest case:** `membershipCancel` (`app.js:3036`) does only local field mutations + drops a cancellation invoice — it never calls a server-money-gated action, so it had **no backstop at all**. A signed-in non-money role (Sales / Yard / Driver) could cancel anyone's membership and generate a cancellation invoice. Enroll / Pay-Cancellation hit the server-gated `stripeChargeInvoice` (the charge itself would be refused), but still exposed the buttons and mutated member fields.

This contradicts spec §10.1 — membership money actions are "server-side gated to Office + Owner, like every other `stripe*` action."

## What changed (1 file, `app.js`)

- **Render gate:** the three money pills (Enroll, Cancel, Pay Cancellation) only render when `canMoney()` — mirroring the invoice pillrow. **Print Agreement is left ungated** (it's not a money action, so all roles keep it).
- **Handler gate (defence-in-depth):** each of the four money handlers now re-checks `canMoney()` and toasts + returns otherwise, mirroring `js-add-card`.

No new UI elements, no restyle, no rule/popup changes — pure role-visibility gating of existing pills.

## Confirmed correct in the same review (no change needed)
- Entitlement gating (member rates + `$0` transport) already checks `isActiveMember`, not the raw flag (`app.js:854,921,927`) — no leak on lapse.
- Client fee total is not trusted; backend recomputes at charge time.
- The `$2,000/mo` protection cap being unused in fee math is by-spec (§2.1/§8 — informational in v1).

## Gates (all green locally)
- `node --check app.js` ✅
- `node ci/smoke.mjs` ✅
- `node ci/logic-test.mjs` ✅ 227/227
- `node ci/gen-rule-usage.mjs --check` ✅ current
- `node ci/check-window-catalog.mjs` ✅ 30/30
- Cache-bust token bumped `20260625f → 20260625g`

## Not included (separate, per your call)
- Finding 2 — recurring-billing backend (`membership-billing-additions.gs`) is tracked but not yet deployed via `/clasp` (RAPT-blocked), so server-side renewals/lapse aren't live yet.
- Finding 3 — the cancellation-invoice **amount** is only asserted as `balance > 0`; a value-pinning test + making `monthsRemaining` deterministic is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzHBCdPZvWHZrR4NPLSc1N)_