### PR TITLE
Remove 12 verified-dead functions

### DIFF
--- a/app.js
+++ b/app.js
@@ -204,7 +204,6 @@ function rentalUnits(r) {
   return (r && r.unitId) ? [legacyUnitEntry(r)] : [];
 }
 const rentalUnitIds = (r) => rentalUnits(r).map((u) => u.unitId).filter(Boolean);
-const primaryUnit = (r) => (r && r.unitId) || (rentalUnits(r)[0] || {}).unitId || null;
 const rentalHasUnit = (r, unitId) => rentalUnitIds(r).includes(unitId);
 /* §20 the units[] entry for a unitId (or the PRIMARY when unitId is falsy), else null.
    ONE source for "this unit's entry" — replaces ~9 inlined (r.units||[]).find copies. */
@@ -447,15 +446,6 @@ function acctSnapshot(c, k) {
     email: (c && c.email) || '', industry: (c && c.industry) || '', accountType: (c && c.accountType) || '',
     requiresPO: !!(c && c.requiresPO), last4: (k && k.last4) || '' };
 }
-/* Hold a captured signing on the account (no card yet) — saddles onto the first card added.
-   Set by Save now that there's no separate "Sign & Hold" button. */
-function holdSigning(c, signature, selfie) {
-  if (!c || !signature) return;
-  const key = requiredAgreementKey(c); const ag = AGREEMENTS[key] || AGREEMENTS.rental;
-  c.pendingSigning = { key, version: AGREEMENT_CURRENT[key] || '', title: ag.title, accountType: c.accountType || '',
-    signedAt: TODAY_ISO, signerName: c.name || fullName(c), signature, selfie: selfie || '', acct: acctSnapshot(c, null) };
-  reindex('customers', c); logAction(c, `${ag.title} signed & held (no card yet)`);
-}
 /* §7.1c independent capture — each piece (card · selfie · signature) AUTO-SAVES the moment
    it's captured, in any order, and the card finalizes (one completion date) once all three
    are present. The capture target is the open card tab, or — with no card yet — a held bucket
@@ -600,9 +590,7 @@ function removeCard(custId, cardId) {
 }
 /* ── §14b multi-ACH helpers (parallel to the multi-card helpers above) ── */
 const customerBanks = (c) => (c && Array.isArray(c.achAccounts)) ? c.achAccounts.filter((k) => k.status !== 'removed') : [];
-const defaultBank = (c) => { const ks = customerBanks(c); return ks.find((k) => k.isDefault) || ks[0] || null; };
 const verifiedBanks = (c) => customerBanks(c).filter((k) => k.verified);
-const hasChargeableBank = (c) => verifiedBanks(c).length > 0;
 const bankTypeLabel = (t) => (t === 'savings' ? 'Savings' : 'Checking');
 const bankOneLabel = (k) => k ? `${k.bankName || 'Bank'} ••${k.last4} · ${bankTypeLabel(k.accountType)}${k.verified ? '' : ' · unverified'}` : '';
 function setBankDefault(custId, bankId) {   // app-level default among banks (NOT Stripe's single default PM — that stays the card's, for auto-charge)
@@ -1572,11 +1560,6 @@ function rentalRevStatus(r) {
   const base = rentalDisplayStatus(r);
   if (base === 'Reserved') { const n = dayDiff(TODAY, parseISO(r.startDate)); if (n === 0) return 'Today'; if (n === 1) return 'Tomorrow'; }
   return base;
-}
-function relDate(iso) {
-  const d = parseISO(iso); if (!d) return '';
-  const n = dayDiff(TODAY, d);
-  return n === 0 ? 'Today' : n === 1 ? 'Tomorrow' : fmtShortDate(iso);
 }
 function activeRentalForUnit(unitId) {
   // §20 judge by the UNIT's OWN status, not the rental roll-up — a No-Show /
@@ -3176,12 +3159,6 @@ const MEMBERSHIP_MONTHS = 12;
 const memberAccountType = (c) => (c.company && c.company.trim()) ? 'Business Member' : 'Non-Business Member';
 const addMonthsISO = (iso, n) => { const d = parseISO(iso) || new Date(); return isoOf(new Date(d.getFullYear(), d.getMonth() + n, d.getDate())); };
 const monthsRemaining = (toISO) => { const a = new Date(), b = parseISO(toISO); if (!b) return 0; return Math.max(0, (b.getFullYear() - a.getFullYear()) * 12 + (b.getMonth() - a.getMonth())); };
-// Live → real Stripe; demo/offline (no backend password) → simulate a cleared charge so the flow completes locally.
-function membershipChargeResult(invId, amountCents, pick) {
-  const isDemo = (typeof backendPassword === 'undefined' || !backendPassword);
-  if (isDemo) return Promise.resolve({ ok: true, status: 'succeeded', amountPaid: amountCents / 100, fullyPaid: true, paymentMethod: 'Card (demo)', _demo: true });
-  return backendCall('stripeChargeInvoice', { invoiceId: invId, amountCents, paymentMethodId: pick?.stripePmId || undefined });
-}
 function markInvoicePaidLocal(inv, method) { const t = invoiceTotals(inv); inv.amountPaid = t.total; inv.paid = true; inv.paymentMethod = method || 'Card'; inv.paidAt = new Date().toISOString(); reindex('invoices', inv); }
 // Build a membership invoice (kind:'membership' lines so it's identifiable for the §7 economics + revenue rollup).
 function buildMembershipInvoice(c, lines, { cancellation = false, date = TODAY_ISO, due } = {}) {
@@ -5360,41 +5337,6 @@ function rentalLineRefund(r, unitId) {
 /* Jac ─ Site ─ Jac transport journey under an invoice rental line. +Log Delivery /
    +Log Recovery ARE the same captures as the yard tool's +Start/+End (one event,
    shared fields, so both views stay in sync). Self-pickup collapses to one line. */
-/** Action-column transport affordance (under +Unit): a blue +Transport button
- *  when none is set, or a compact type+price chip (per unit on multi-unit). */
-function transportActionHtml(r) {
-  const units = rentalUnits(r);
-  const one = (eu, u) => {
-    const du = eu ? ` data-unit="${esc(eu.unitId)}"` : '';
-    const T = eu || r;
-    const hasT = T.transportType && T.transportType !== 'Self';
-    const nameSfx = (units.length > 1 && u) ? ` · ${esc(u.name)}` : '';
-    if (!hasT) return `<button class="add-field anchor js-tedit-open" data-r="R5b" data-rec="${esc(r.rentalId)}"${du} data-leg="delivery" style="height:26px">+Transport${nameSfx}</button>`;
-    const st = getStatus('transportType', T.transportType);
-    const tr = eu ? unitTransport(r, eu) : rentalTransport(r);
-    const oneWay = (tr && tr.perLeg != null) ? tr.perLeg : (tr && tr.price != null ? tr.price : null);
-    return `<span class="pill c-${st.color} js-tedit-open" data-r="R4" data-rec="${esc(r.rentalId)}"${du} data-leg="delivery" style="cursor:pointer">${CARD_ICON.rentals}${esc(st.label)}${nameSfx}${oneWay ? ` · ${money(oneWay)}` : ''}</span>`;
-  };
-  if (!units.length) return one(null, null);
-  return units.map((eu) => { const u = IDX.unit.get(eu.unitId); return u ? one(eu, u) : ''; }).join('');
-}
-/** The Transport section shown on rentals with no invoice yet (with an invoice,
- *  the per-unit journeys ride the invoice lines). Renders a journey per unit that
- *  has transport, plus the inline editor for whichever leg is being edited. */
-function transportSectionHtml(r) {
-  const te = state.transportEdit;
-  const units = rentalUnits(r);
-  const list = units.length ? units : [null];
-  const rows = list.map((eu) => {
-    const hasT = (eu || r).transportType && (eu || r).transportType !== 'Self';
-    const editing = te && te.rentalId === r.rentalId && (te.unitId || null) === (eu ? eu.unitId : null);
-    if (!hasT && !editing) return '';
-    const u = eu ? IDX.unit.get(eu.unitId) : null; if (eu && !u) return '';
-    return `<div class="tjrow">${units.length > 1 && u ? `<span class="stamp tjname">${esc(u.name)}</span>` : ''}${miniJourneyHtml(r, eu)}</div>`;
-  }).filter(Boolean).join('');
-  if (!rows) return '';
-  return `<div class="tsec"><span class="muted tsec-label">Transport</span>${rows}</div>`;
-}
 function miniJourneyHtml(r2, eu) {
   const T = eu || r2;   // §20 per-unit transport + captures (fallback to the rental for legacy)
   const uId = eu ? eu.unitId : (r2.unitId || '');
@@ -7093,11 +7035,6 @@ function wrValidateKpi(act) {
   return { ok: !issues.length, ring, issues, value, role: act.role, idx };
 }
 
-/** §11 Team ring — per-position average across the 5 roles (skips null placeholders). */
-function kpiTeam() {
-  const all = ROLES.map((r) => kpiFor(r.id));
-  return [0, 1, 2].map((i) => { const vals = all.map((v) => v[i]).filter((x) => x != null); return vals.length ? Math.round(vals.reduce((a, b) => a + b, 0) / vals.length) : null; });
-}
 
 /* §11 GAMIFICATION (Jac 2026-06-13) — when an action raises a ring's underlying
    metric, pop the raw delta over that ring (natural unit: +$X on money rings, +N
@@ -7363,7 +7300,6 @@ function chatComments() {
 function chatUnreadCount() { const u = commentUserKey(); return chatComments().filter((c) => !(c.ack || []).includes(u)).length; }
 const chatById = (id) => state.chat.chats.find((c) => c.id === id) || null;
 const activeChat = () => chatById(state.chat.activeId);
-const chatLive = () => { const c = activeChat(); return !!c && c.participants.length > 0; };
 function chatRoleOn(id) { const c = activeChat(); return !!c && c.participants.includes(id); }
 function chatsTagging(card, recId) { return state.chat.chats.filter((c) => (c.tags || []).some((t) => t.ref && t.ref.card === card && String(t.ref.recId) === String(recId))); }
 function chatMarkSeen() { const c = activeChat(); if (c) c.seen[commentUserKey()] = Date.now(); }
@@ -7852,7 +7788,6 @@ function dispatchEvents() {
    yard and back. D = Deliver, R = Recover, 🏠 = JAC. Drag a stop to reorder the
    run; type a time; the date rides as a bold-red deadline. Order + times are
    per-device (localStorage). */
-const DISPATCH_HOME = 'JAC · 102 S Huntington';
 const dispatchStopId = (ev) => `${ev.rentalId}|${ev.unitId || ''}|${ev.task}`;
 const _lsJSON = (k) => { try { return JSON.parse(localStorage.getItem(k) || '{}'); } catch (e) { return {}; } };
 const _lsSave = (k, o) => { try { localStorage.setItem(k, JSON.stringify(o)); } catch (e) {} };
@@ -10558,16 +10493,6 @@ function boardViewTable(o, session) {
   const hasExtra = order.some((co) => co.kind === 'extra');
   const hint = hasExtra ? `<div class="bv-fieldhint"><b>Fields:</b> ${cols.map((c) => esc(c.key)).join(', ')} &nbsp;·&nbsp; <b>functions:</b> sum() avg() min() max() count() &nbsp;·&nbsp; e.g. <code>=price*0.9</code> · <code>=total-paid</code> · <code>=hours/count(name)</code></div>` : '';
   return hint + `<table class="board-table bv-table"><thead>${head}</thead><tbody>${body}</tbody><tfoot>${summary}</tfoot></table>`;
-}
-/** Seed a Board View from a card's current sort + search, then open the popup. */
-function openBoardView(card) {
-  const session = activeSession();
-  const cs = session.cards[card] || {};
-  const cols = cardColumns(card, session);
-  const seedField = cs.sort?.field;
-  const sortCol = cols.find((c) => c.sortField === seedField || c.key === seedField) || cols[0];
-  const query = (state.searchMode && state.query) ? state.query : (cs.search || '');
-  openOverlay({ kind: 'boardview', card, query, sort: { key: sortCol?.key, dir: cs.sort?.dir || 'asc' }, calc: {}, colOrder: null, extraRows: [], cellData: {}, seq: 0 });
 }
 /** The "List rows" customiser inside Board View: choose which registry columns
  *  appear in List-View row 1 (details) vs row 2 (badges). Saved per device. */

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,48 +4,48 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 15708 lines, 38 chapters
+## app.js — 15633 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
 | APP-01 | 29–61 | §0.7 | §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you | ERR_LOG, logErr, WRANGLER_REPO, wranglerIssueUrl |
 | APP-02 | 62–77 | §1 | §1 UTILITIES & FORMATTING — $, el, esc, money, num, dates | $, el, esc, money, money2, num, TODAY, dayDiff, SINGULAR |
-| APP-03 | 78–840 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, migrationDirty, migrateCustomers, legacyUnitEntry, migrateRentals, rentalUnits, rentalUnitIds, primaryUnit, rentalHasUnit, unitEntry, …(+86) |
-| APP-04 | 841–941 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 942–1215 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, invoiceChunks, unitBilledSeries, …(+13) |
-| APP-06 | 1216–1794 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+49) |
-| APP-07 | 1795–2431 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, state, activeSession, maxInvoiceSeq, nextInvoiceId, setAnchor, anchorRecord, …(+60) |
-| APP-08 | 2432–2439 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 2440–3678 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+83) |
-| APP-10 | 3679–3699 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 3700–4166 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
-| APP-12 | 4167–4334 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 4335–4445 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
-| APP-14 | 4446–4723 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 4724–4920 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 4921–6275 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+40) |
-| APP-17 | 6276–6370 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6371–6651 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 6652–6845 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 6846–6969 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 6970–7139 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+12) |
-| APP-22 | 7140–7349 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7350–8120 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatLive, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, …(+69) |
-| APP-24 | 8121–8226 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8227–8672 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8673–9546 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9547–9641 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9642–9906 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
-| APP-29 | 9907–10589 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+64) |
-| APP-30 | 10590–10859 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 10860–10984 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 10985–10988 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 10989–12427 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+36) |
-| APP-34 | 12428–13338 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 13339–14366 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
-| APP-36 | 14367–14807 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 14808–14810 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 14811–15708 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-03 | 78–828 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, migrationDirty, migrateCustomers, legacyUnitEntry, migrateRentals, rentalUnits, rentalUnitIds, rentalHasUnit, unitEntry, isPrimaryUnit, …(+82) |
+| APP-04 | 829–929 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
+| APP-05 | 930–1203 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, invoiceChunks, unitBilledSeries, …(+13) |
+| APP-06 | 1204–1777 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+48) |
+| APP-07 | 1778–2414 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, state, activeSession, maxInvoiceSeq, nextInvoiceId, setAnchor, anchorRecord, …(+60) |
+| APP-08 | 2415–2422 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 2423–3655 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+82) |
+| APP-10 | 3656–3676 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 3677–4143 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
+| APP-12 | 4144–4311 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 4312–4422 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
+| APP-14 | 4423–4700 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 4701–4897 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 4898–6217 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
+| APP-17 | 6218–6312 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
+| APP-18 | 6313–6593 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 6594–6787 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 6788–6911 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 6912–7076 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7077–7286 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7287–8055 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+67) |
+| APP-24 | 8056–8161 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8162–8607 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 8608–9481 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9482–9576 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9577–9841 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
+| APP-29 | 9842–10514 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+63) |
+| APP-30 | 10515–10784 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 10785–10909 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 10910–10913 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 10914–12352 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+36) |
+| APP-34 | 12353–13263 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 13264–14291 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
+| APP-36 | 14292–14732 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 14733–14735 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 14736–15633 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 524 lines, 0 chapters
 

--- a/docs/dead-code-report.md
+++ b/docs/dead-code-report.md
@@ -4,38 +4,7 @@
 
 ## app.js
 
-**APP-03** — §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke)
-
-- `primaryUnit` — app.js:207
-- `holdSigning` — app.js:452
-- `defaultBank` — app.js:603
-- `hasChargeableBank` — app.js:605
-
-**APP-06** — INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15)
-
-- `relDate` — app.js:1576
-
-**APP-09** — SETTINGS BOARD — admin customization (config.settings).
-
-- `membershipChargeResult` — app.js:3180
-
-**APP-16** — §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections,
-
-- `transportActionHtml` — app.js:5365
-- `transportSectionHtml` — app.js:5384
-
-**APP-21** — §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings).
-
-- `kpiTeam` — app.js:7097
-
-**APP-23** — §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6
-
-- `chatLive` — app.js:7366
-- `DISPATCH_HOME` — app.js:7855
-
-**APP-29** — Mr. Wrangler ACTS on your data (Jac 2026-06-16)
-
-- `openBoardView` — app.js:10563
+_No unreferenced top-level symbols found._
 
 ## config.js
 
@@ -63,7 +32,7 @@ _No unreferenced top-level symbols found._
 
 ---
 
-_Scanned 1184 module-scope definitions; 12 unreferenced candidate(s)._
+_Scanned 1172 module-scope definitions; 0 unreferenced candidate(s)._
 
 ## Future: real execution coverage (follow-up)
 


### PR DESCRIPTION
Acts on the dead-code report from the Code Atlas work — removes code that is provably never reached.

## What's removed (12 module-scope definitions)
`primaryUnit`, `holdSigning`, `defaultBank`, `hasChargeableBank`, `relDate`, `membershipChargeResult`, `transportActionHtml`, `transportSectionHtml`, `kpiTeam`, `chatLive`, `DISPATCH_HOME`, `openBoardView`

## Why it's safe (not a behavior change)
- Each name appears **exactly once** in the entire frontend — its own definition — confirmed by explicit grep across every `.js` file **and** `index.html` (0 references anywhere).
- `app.js` has **no dynamic dispatch** (`grep` for `window[…]` / `eval` / `new Function` → none), so an unreferenced name is genuinely uncallable. Dead, not merely hard-to-find.
- **Re-scan after removal = 0 candidates** — nothing else was only used by these, so no orphaned helpers were exposed.
- `app.js` parses clean; `gen-rule-usage --check`, `check-window-catalog`, and `gen-code-map --check` all green. The atlas index + dead-code report are regenerated. Defs 1184 → 1172.
- CI `smoke` + `logic-test` (money + multi-unit regression) are the runtime backstop — auto-merge is gated on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJJfoMaWuf4fKKqkSfgFjx)_