### PR TITLE
Rental window: inline the confirm panel + make popups draggable

### DIFF
--- a/app.js
+++ b/app.js
@@ -4130,7 +4130,7 @@ const RULE_META = {
   R13: ['History', 'historySection', 'count chips above the search bar filter inline; record-backed links only'],
   R14: ['Seg toggle', 'segCtl', '3-state segmented control (condition · wash)'],
   R15: ['Journey', 'yardToolHtml / miniJourneyHtml', 'yard +Start/+FC/+End + Jac─Site─Jac transport; white = video owed'],
-  R16: ['Window calendar', 'rdcal-edit / winPickerEl (inline)', 'the rental window — an INLINE editable month calendar in the detail (popup retired 2026-06-25); tap start→end, the left Units/Categories card shows availability live, fragile rentals stage behind a hovering Confirm card'],
+  R16: ['Window calendar', 'rdcal-edit / winPickerEl (inline)', 'the rental window — an INLINE editable month calendar in the detail (popup retired 2026-06-25); tap start→end, the left Units/Categories card shows availability live, fragile rentals stage with an inline Confirm panel below the calendar'],
   R17: ['Action pill', 'actionPill', 'commit = blue · money = green · danger = solid red; .locked = gated'],
   R18: ['Ghost', 'ghostPill', 'the ONE quiet action — Cancel / Close / Exit / Clear'],
   R19: ['Attention flash', 'attnFlash / flashOr', 'a glow that points AT the next action — replaces an error message when the fix is on screen'],
@@ -5523,7 +5523,8 @@ const DETAIL = {
     /* Calendar: the INLINE editable window calendar (popup retired — Jac 2026-06-25).
        Tap a day to set start, tap another to set end; the left Categories/Units card
        reflects availability for the window live. A fragile (invoiced/out) rental stages
-       its edits behind a hovering "Confirm new window" card with the money preview. */
+       its edits with an inline "Confirm new window" panel (below the grid, above Clear)
+       carrying the money preview — the calendar stays editable, no blocking popup. */
     if (!state.winEdit || state.winEdit.rentalId !== r.rentalId) {
       state.winEdit = { rentalId: r.rentalId, monthISO: firstOfMonthISO(r.startDate || TODAY_ISO), anchor: null };
       if (rentalFragile(r)) state.winEdit.staged = { rentalId: r.rentalId, startDate: r.startDate || '', endDate: r.endDate || '', startTime: r.startTime || '' };
@@ -8609,6 +8610,34 @@ function cardGraphBody(card) {
    APP-26 · §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups
    ════════════════════════════════════════════════════════════════════════ */
 let _ovScroll = {}, _ovLastKind = null;   // keep a popup-body's scroll across its OWN re-renders (sign/selfie)
+let _popDrag = { x: 0, y: 0 }, _popDragKind = null;   // drag offset of the open popup; persists across its own re-renders, resets on kind change / close
+/* §popup-drag — let users grab a popup by its stamped head and slide it out of the way (desktop
+   only; phone popups are bottom-sheets). The offset is a transform on the flex-centered .popup,
+   stashed in _popDrag so a re-render re-applies it, and cleared when the popup changes or closes. */
+function wirePopupDrag(overlay) {
+  if (document.body.classList.contains('is-phone')) return;   // phone popups dock as bottom-sheets — no drag
+  const pop = overlay.querySelector('.popup'); if (!pop) return;
+  const head = pop.querySelector('.popup-head'); if (!head) return;
+  const apply = () => { const m = _popDrag.x || _popDrag.y; pop.style.transform = m ? `translate(${_popDrag.x}px, ${_popDrag.y}px)` : ''; if (m) pop.style.animation = 'none'; };
+  apply();   // re-seat a dragged popup after its own re-render (without replaying the plateIn drop)
+  head.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0 || e.target.closest('button, a, input, select, textarea, label, .x')) return;   // controls keep their own behavior
+    e.preventDefault();
+    const sx = e.clientX, sy = e.clientY, ox = _popDrag.x, oy = _popDrag.y;
+    const r = pop.getBoundingClientRect(), bx = r.left - ox, by = r.top - oy, w = r.width;   // rect at zero offset
+    pop.classList.add('is-dragging');
+    try { head.setPointerCapture(e.pointerId); } catch (_) {}
+    const move = (ev) => {
+      let nx = ox + (ev.clientX - sx), ny = oy + (ev.clientY - sy);
+      const M = 40;   // keep at least M px of the popup on-screen in each direction
+      nx = Math.min(window.innerWidth - M - bx, Math.max(M - w - bx, nx));
+      ny = Math.min(window.innerHeight - M - by, Math.max(-by, ny));   // never above the top edge
+      _popDrag.x = nx; _popDrag.y = ny; apply();
+    };
+    const up = () => { pop.classList.remove('is-dragging'); head.removeEventListener('pointermove', move); head.removeEventListener('pointerup', up); head.removeEventListener('pointercancel', up); };
+    head.addEventListener('pointermove', move); head.addEventListener('pointerup', up); head.addEventListener('pointercancel', up);
+  });
+}
 /* ── §M3 — phone hardware-BACK button (Android) joins the dismiss chain. We keep at
    most ONE dummy history entry while any sheet/overlay/dock is open; pressing Back
    pops it and closes the topmost surface (same order as Esc), re-pushing if more
@@ -8638,12 +8667,14 @@ function renderOverlay() {
   if (_ovLastKind) { const _pb = root.querySelector('.set-pane') || root.querySelector('.popup-body'); if (_pb) _ovScroll[_ovLastKind] = _pb.scrollTop; }   // .set-pane is the settings scroller; .popup-body for the rest
   destroyCardElement();        // any re-render/overlay-switch tears down a mounted Stripe element
   root.innerHTML = '';
-  if (!state.overlay) { _ovLastKind = null; return; }
+  if (!state.overlay) { _ovLastKind = null; _popDragKind = null; _popDrag = { x: 0, y: 0 }; return; }
   const o = state.overlay;
+  if (o.kind !== _popDragKind) { _popDragKind = o.kind; _popDrag = { x: 0, y: 0 }; }   // a new popup opens centered; re-renders of the same one keep the dragged spot
   const overlay = el('div', 'overlay');
   overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) closeOverlay(); });
   if (buildPopupEl(o, overlay) === false) { state.overlay = null; return; }
   root.appendChild(overlay);
+  wirePopupDrag(overlay);
   { const _nb = overlay.querySelector('.set-pane') || overlay.querySelector('.popup-body'); if (_nb && _ovScroll[o.kind]) _nb.scrollTop = _ovScroll[o.kind]; }   // restore scroll on a same-overlay re-render (settings pane / sign / selfie no longer jump to top)
 
   _ovLastKind = o.kind;
@@ -14267,8 +14298,9 @@ function winPickerEl(r) {
       </div>`
     : '';
   // §inline confirm — a FRAGILE (invoiced/out) rental stages its edit; once the window
-  // actually changes, a "Confirm new rental window?" card hovers over the calendar with the
-  // money preview + a blue Save. Non-fragile rentals commit live (no staging, no confirm).
+  // actually changes, a "Confirm new rental window?" panel drops in INLINE below the calendar
+  // (above the Today/Clear foot) with the money preview + a blue Save. The calendar stays fully
+  // editable behind it — no blocking popup. Non-fragile rentals commit live (no staging).
   const stagedChanged = !!(wp.staged && winStagedChanged());
   const saveLabel = billing ? 'Bill Extension' : reducing ? 'Re-price ↓' : 'Confirm window';
   const confirmCard = stagedChanged
@@ -14284,8 +14316,8 @@ function winPickerEl(r) {
       <span class="wp-nav"><button class="js-wp-prev" data-tip="Previous month">‹</button><button class="js-wp-next" data-tip="Next month">›</button></span></div>
     <div class="wp-grid">${dows}${cells}</div>
     ${subjName ? `<div class="wp-blocknote">Greyed days are ${state.overbookOn ? 'booked' : 'unavailable'} for <b>${esc(subjName)}</b>${state.overbookOn ? ' — overbooking is on, pick to force' : ''}</div>` : ''}
-    <div class="wp-foot"><button class="pill ghost js-wp-today" data-r="R18">Today</button>${actionPill('commit', 'Clear', { js: 'js-wp-clear' })}</div>
     ${confirmCard}
+    <div class="wp-foot"><button class="pill ghost js-wp-today" data-r="R18">Today</button>${actionPill('commit', 'Clear', { js: 'js-wp-clear' })}</div>
   </div>`;
 }
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 15633 lines, 38 chapters
+## app.js — 15665 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -23,29 +23,29 @@
 | APP-13 | 4312–4422 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
 | APP-14 | 4423–4700 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
 | APP-15 | 4701–4897 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 4898–6217 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
-| APP-17 | 6218–6312 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6313–6593 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 6594–6787 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 6788–6911 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 6912–7076 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7077–7286 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7287–8055 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+67) |
-| APP-24 | 8056–8161 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8162–8607 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8608–9481 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9482–9576 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9577–9841 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
-| APP-29 | 9842–10514 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+63) |
-| APP-30 | 10515–10784 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 10785–10909 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 10910–10913 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 10914–12352 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+36) |
-| APP-34 | 12353–13263 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 13264–14291 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
-| APP-36 | 14292–14732 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 14733–14735 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 14736–15633 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-16 | 4898–6218 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
+| APP-17 | 6219–6313 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
+| APP-18 | 6314–6594 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 6595–6788 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 6789–6912 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 6913–7077 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7078–7287 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7288–8056 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+67) |
+| APP-24 | 8057–8162 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8163–8608 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 8609–9512 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9513–9607 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9608–9872 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
+| APP-29 | 9873–10545 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+63) |
+| APP-30 | 10546–10815 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 10816–10940 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 10941–10944 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 10945–12383 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+36) |
+| APP-34 | 12384–13294 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 13295–14323 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
+| APP-36 | 14324–14764 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 14765–14767 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 14768–15665 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 524 lines, 0 chapters
 

--- a/style.css
+++ b/style.css
@@ -1461,12 +1461,13 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .rdcal-edit .wp-time { margin-bottom: 7px; padding-bottom: 7px; }
 .rdcal-edit .wp-day { height: 34px; }
 .is-phone .rdcal-edit .wp-day { height: 40px; }
-/* the fragile-rental "Confirm new window" card — hovers over the calendar with the money preview */
-.rdcal-edit.staged .winpicker { filter: saturate(.85) brightness(.78); pointer-events: none; }   /* dim the calendar behind the confirm */
-.rdcal-edit.staged .winpicker .wp-grid, .rdcal-edit.staged .winpicker .wp-time, .rdcal-edit.staged .winpicker .wp-head { pointer-events: auto; }   /* keep the grid editable */
-.wp-confirm { position: absolute; left: 50%; bottom: 8px; transform: translateX(-50%); width: calc(100% - 16px); max-width: 320px; z-index: 5;
+/* the fragile-rental "Confirm new window" panel — INLINE below the calendar, above the foot
+   (hovering popup retired Jac 2026-06-26): a bordered plate carrying the money preview. The
+   calendar stays fully editable behind it — no dim, no pointer-block, no floating overlay. */
+.wp-confirm { width: 100%; margin-top: 10px;
   background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid var(--accent); border-radius: 12px;
-  box-shadow: 0 16px 36px -14px rgba(0,0,0,.75), 0 0 0 2px var(--accent-line), 0 0 22px -6px var(--accent); padding: 10px 11px; }
+  box-shadow: inset 0 0 0 1px var(--accent-line); padding: 10px 11px; }
+@media (prefers-reduced-motion: no-preference) { .wp-confirm { animation: plateIn .15s ease-out; } }
 .wp-confirm-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 11px; color: var(--txt); margin-bottom: 6px; }
 .wp-confirm .wp-ext { margin-top: 0; padding-top: 0; border-top: none; }
 .wp-confirm-foot { display: flex; gap: 7px; justify-content: flex-end; margin-top: 9px; }
@@ -1523,6 +1524,13 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .popup { background: var(--panel); border: 1px solid var(--accent); border-radius: var(--radius); box-shadow: var(--shadow), 0 0 0 2px var(--accent-line), 0 0 32px -6px rgba(255,122,26,.5); max-width: 92vw; max-height: 86vh; overflow: hidden; display: flex; flex-direction: column; }
 .popup { position: relative; }   /* anchor the hazard cap + corner rivets (the plate signature) */
 .popup-head { display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid var(--line); }
+/* §popup-drag — grab the stamped head to slide the popup aside (desktop; wired in app.js).
+   Controls inside the head keep the pointer cursor; phone sheets aren't draggable. */
+.overlay .popup-head { cursor: grab; touch-action: none; }
+.overlay .popup-head button, .overlay .popup-head a, .overlay .popup-head input, .overlay .popup-head select, .overlay .popup-head label { cursor: pointer; }
+.overlay .popup.is-dragging { cursor: grabbing; user-select: none; }
+.overlay .popup.is-dragging .popup-head { cursor: grabbing; }
+.is-phone .overlay .popup-head { cursor: default; touch-action: auto; }
 .popup-head h3 { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 800; font-size: 16px; color: var(--txt); line-height: 1.05; }
 .popup-head .x { margin-left: auto; width: 30px; height: 30px; flex: 0 0 auto; border-radius: 9px; display: inline-flex; align-items: center; justify-content: center; color: var(--txt-2); }
 .popup-head .x:hover { background: var(--panel-2); color: var(--txt); }


### PR DESCRIPTION
## What & why

Two UX fixes to the rental-window editor, both from in-session feedback.

### 1. The "Confirm new rental window?" card is now inline (popup retired)
On a **fragile** (invoiced/out) rental, changing the dates staged the edit behind an absolutely-positioned card that *hovered over* the calendar. While it was up, the calendar behind it was dimmed and `pointer-events: none` — so **Cancel / click-away felt stuck**, and it **popped the instant a start date was clicked**.

The card's contents now drop in **inline, below the calendar grid and above the Today/Clear foot**. The calendar stays fully editable behind it — no dim, no pointer-block, no floating overlay. It appears as soon as the staged window differs from the saved one (non-blocking, so that's fine inline). The money preview, Cancel, and Bill Extension / Confirm window / Re-price actions are unchanged.

### 2. All centered popup windows are draggable
Grab a popup by its stamped `.popup-head` to slide it out of the way (desktop only; phone popups stay bottom-sheets). The offset is a transform on the flex-centered `.popup`, persisted across the popup's own re-renders and cleared when the popup changes or closes. Controls in the head keep their own behavior (the close ✕, tabs, inputs), and the popup is clamped so it can't be dragged off-screen.

## Design / rulebook
- Reshaped UI run through `/jactec-ui` + `/frontend`: tokens only (`--accent`, `--accent-line`, `--panel`, `--panel-2`), Saira Condensed heading kept, the named `plateIn` keyframe reused, `prefers-reduced-motion` respected, `grab`/`grabbing` cursors, no new hardcoded hex and no new drop shadow on a dark surface (inset accent-line ring only).
- R16 RULE_META text updated to describe the inline panel; Code-Atlas index regenerated.

## Gates
All green: `smoke` ✅ · `logic-test` 255/255 ✅ · `gen-rule-usage --check` ✅ · `check-window-catalog` (30 kinds) ✅ · `gen-code-map --check` ✅.

> Note: not verified end-to-end in a live browser (the confirm panel needs login + a fragile rental, which touches real backend data). The local area-test / staging-E2E pass is the place to drive it for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011py1d7jyGg4oLQYGDKXqGB

---
_Generated by [Claude Code](https://claude.ai/code/session_011py1d7jyGg4oLQYGDKXqGB)_