### PR TITLE
Wrangler fix: extension preview must equal what Bill Extension posts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1040,35 +1040,73 @@ function reconcileChunkRetro(inv, r, ns, ne) {
   });
   return { delta: Math.round(delta * 100) / 100, count };
 }
-/** PURE preview of extending r to a staged window (no mutation) — drives the picker
- *  banner. Series-aware; honors the retroactive-pricing setting. */
+/** PURE mirror of billExtension's per-step math — returns the subtotal delta billExtension
+ *  WOULD post for lengthening r from prevEnd → newEnd, with ZERO mutation. Kept in lockstep
+ *  with billExtension by logic-test (the preview MUST equal what's actually billed). Walks the
+ *  same fill→spill chunk model: grow the open active chunk (retro reconcile vs OFF standalone),
+ *  then — once that chunk is closed/locked/full — spill ≤28-day standalone segments onto fresh
+ *  continuation invoices. This is why a PAID invoice (its segment spills) or one whose prior
+ *  charge isn't a matched rental line no longer overstates the charge: the preview now reflects
+ *  the real posting, not a blind "full window − matched-billed". */
+function previewExtensionDelta(r, prevEnd, newEnd) {
+  if (!r || !r.invoiceId) return 0;
+  const active = rentalActiveInvoice(r); if (!active) return 0;
+  const targetEnd = newEnd;
+  let coveredEnd = active.covEnd || prevEnd || r.startDate;
+  if (!targetEnd || !coveredEnd || dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) <= 0) return 0;   // no net lengthening → bills nothing (matches billExtension)
+  const retro = retroPricingOn();
+  const units = rentalUnits(r).filter((eu) => !unitVoided(r, eu) && IDX.unit.get(eu.unitId));
+  const priceOf = (eu, s, e) => { const p = rentalPrice({ categoryId: IDX.unit.get(eu.unitId).categoryId, startDate: s, endDate: e, customerId: r.customerId }); return p ? Math.round(p.price * 100) / 100 : 0; };
+  let delta = 0, onReal = true, guard = 0;
+  while (dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) > 0 && guard++ < 80) {
+    if (onReal) {
+      const t = invoiceTotals(active);
+      const closed = t.paid > 0 && t.balance <= 0;
+      const room = INV_CAP_DAYS - invCoveredDays(active, r);
+      if (active.locked || closed || room <= 0) { onReal = false; continue; }   // active sealed/full → spill
+      const grow = Math.min(room, dayDiff(parseISO(coveredEnd), parseISO(targetEnd)));
+      const newCovEnd = addDaysISO(coveredEnd, grow);
+      if (retro) {                                                // reconcileChunkRetro: re-price to cheapest(covStart→newEnd) − billed
+        const cs = invCovStart(active, r);
+        units.forEach((eu) => {
+          const target = priceOf(eu, cs, newCovEnd);
+          const mine = (active.lineItems || []).filter((li) => (li.kind === 'rental' || li.kind === 'extension') && li.ref === r.rentalId && li.unitId === eu.unitId);
+          const paid = mine.reduce((a, li) => a + itemPaid(active, li), 0);
+          const billed = Math.round(mine.reduce((a, li) => a + (Number(li.amount) || 0), 0) * 100) / 100;
+          const d = target - billed;
+          if (Math.abs(d) <= 0.005) return;
+          if (paid > 0.005) { if (d > 0.005) delta += d; } else { delta += d; }   // paid can only top up (refund-first); unpaid re-prices either way
+        });
+      } else {                                                    // OFF: bill the added segment standalone
+        units.forEach((eu) => { const d = priceOf(eu, coveredEnd, newCovEnd); if (d > 0.005) delta += d; });
+      }
+      coveredEnd = newCovEnd; onReal = false;                     // real active is now full/at-target; any remainder spills
+    } else {                                                      // spilled: fresh ≤28-day continuation chunk, billed standalone
+      const chunkEnd = minISO(addDaysISO(coveredEnd, INV_CAP_DAYS), targetEnd);
+      units.forEach((eu) => { const d = priceOf(eu, coveredEnd, chunkEnd); if (d > 0.005) delta += d; });
+      coveredEnd = chunkEnd;
+    }
+  }
+  return Math.round(delta * 100) / 100;
+}
+/** PURE preview of extending r to a staged window (no mutation) — drives the picker banner.
+ *  The added charge is EXACTLY what billExtension will post (via previewExtensionDelta), so a
+ *  paid invoice (spills the added segment to a continuation invoice) or a manually-lined one
+ *  can never overstate it. Series-aware; honors the retroactive-pricing setting. */
 function extensionPreview(r, stagedStart, stagedEnd) {
   if (!r || !r.invoiceId) return null;
   const invs = rentalInvoices(r); if (!invs.length) return null;
   const ns = stagedStart || r.startDate, ne = stagedEnd || r.endDate;
   if (!ns || !ne) return null;
   const retro = retroPricingOn();
-  let subtotalDelta = 0; const perUnit = [];
-  const unitPaidSeries = (uId) => invs.reduce((a, inv) => a + (inv.lineItems || []).filter((li) => (li.kind === 'rental' || li.kind === 'extension') && li.ref === r.rentalId && li.unitId === uId).reduce((s, li) => s + itemPaid(inv, li), 0), 0);
-  rentalUnits(r).forEach((eu) => {
-    if (unitVoided(r, eu)) return;
-    const u = IDX.unit.get(eu.unitId); if (!u) return;
-    let d;
-    if (retro) {
-      const p = rentalPrice({ categoryId: u.categoryId, startDate: ns, endDate: ne, customerId: r.customerId });
-      d = Math.round(((p ? p.price : 0) - unitBilledSeries(r, eu.unitId)) * 100) / 100;
-      if (d < 0 && unitPaidSeries(eu.unitId) > 0.005) d = 0;   // paid lines can't drop (refund-first), matching billExtension
-    } else { const p = (r.endDate && ne > r.endDate) ? rentalPrice({ categoryId: u.categoryId, startDate: r.endDate, endDate: ne, customerId: r.customerId }) : null; d = p ? Math.round(p.price * 100) / 100 : 0; }
-    if (retro ? Math.abs(d) > 0.005 : d > 0.005) { subtotalDelta += d; perUnit.push({ unitId: eu.unitId, name: u.name, delta: d }); }   // retro counts reductions too
-  });
-  subtotalDelta = Math.round(subtotalDelta * 100) / 100;
+  const subtotalDelta = previewExtensionDelta(r, r.endDate, ne);
   const cust = IDX.customer.get(r.customerId);
   const exempt = !!(invs[0].taxExempt || cust?.salesTaxExempt);
   const taxDelta = exempt ? 0 : Math.round(subtotalDelta * TAX_RATE * 100) / 100;
   const curBal = invs.reduce((a, inv) => a + invoiceTotals(inv).balance, 0);
   const prevDays = Math.max(1, dayDiff(parseISO(r.startDate), parseISO(r.endDate)));
   const newDays = Math.max(1, dayDiff(parseISO(ns), parseISO(ne)));
-  return { subtotalDelta, taxDelta, perUnit, newBalance: curBal + subtotalDelta + taxDelta, daysDelta: newDays - prevDays, prevEnd: r.endDate, newEnd: ne, retro };
+  return { subtotalDelta, taxDelta, newBalance: curBal + subtotalDelta + taxDelta, daysDelta: newDays - prevDays, prevEnd: r.endDate, newEnd: ne, retro };
 }
 /** Bill a lengthened window across the rental's invoice series — fill the active open
  *  chunk toward its 28-day cap, then spill into fresh ≤28-day invoices (closed/locked

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -756,6 +756,42 @@ try {
         const ri = T.DATA.rentals.findIndex((o) => o.rentalId === rid); if (ri >= 0) T.DATA.rentals.splice(ri, 1); T.IDX.rental.delete(rid);
       });
     }
+
+    // 32b) EXTENSION PREVIEW == ACTUAL POSTING (regression for the reported bug — the inline
+    //      confirm panel's "Added charge" must equal EXACTLY what Bill Extension posts, even when
+    //      the invoice is PAID (spills the added segment to a continuation invoice) or its prior
+    //      charge is a MANUAL line, not an auto rental line. The old preview blindly did
+    //      `price(full window) − matched-billed`, which overstated both cases.)
+    {
+      const pf = (catId, s, e) => { const p = T.rentalPrice({ categoryId: catId, startDate: s, endDate: e, customerId: 'C0009' }); return p ? p.price : 0; };
+      const S0 = '2099-08-01', E0 = '2099-08-03', E1 = '2099-08-04';   // 2 days → +1 (mirrors the reported screenshot)
+      const af3 = T.DATA.units.filter((u) => u.fleetStatus === 'Active');
+      const cu = af3.find((u) => pf(u.categoryId, S0, E1) > pf(u.categoryId, S0, E0) && pf(u.categoryId, S0, E0) > 0) || af3[0];
+      const seriesSub = (r) => T.rentalInvoices(r).reduce((a, iv) => a + iv.lineItems.filter((l) => l.kind === 'rental' || l.kind === 'extension').reduce((s, l) => s + (+l.amount || 0), 0), 0);
+      const scenario = (label, paid, matched) => {
+        const rid = 'R-PVEQ', iid = 'I-PVEQ';
+        const r = { rentalId: rid, customerId: 'C0009', unitId: cu.unitId, categoryId: cu.categoryId, startDate: S0, endDate: E0, startTime: '', status: 'On Rent', transportType: 'Self', deliveryAddress: '', transportMiles: null, invoiceId: iid, units: [{ unitId: cu.unitId, transportType: 'Self', transportMiles: null }], notes: '', actions: [], mock: true };
+        T.DATA.rentals.push(r); T.IDX.rental.set(rid, r);
+        const inv = { invoiceId: iid, customerId: 'C0009', rentalIds: [rid], date: T.TODAY_ISO, dueDate: T.TODAY_ISO, po: '', amountPaid: 0, lineItems: [], covOf: rid, covStart: S0, covEnd: E0, mock: true };
+        if (matched) T.rentalLineItems(r).forEach((li) => inv.lineItems.push(li));
+        else inv.lineItems.push({ kind: 'item', ref: rid, unitId: cu.unitId, lid: 'L-MAN', label: `${T.IDX.unit.get(cu.unitId)?.name || 'Unit'} · 1-Day×1`, amount: pf(cu.categoryId, S0, E0), qty: 1 });
+        T.DATA.invoices.push(inv); T.IDX.invoice.set(iid, inv);
+        if (paid) { inv.amountPaid = T.invoiceTotals(inv).total; const l0 = inv.lineItems[0]; inv.allocations = { [T.lineKey(l0)]: l0.amount }; }
+        const pv = T.extensionPreview(r, S0, E1);
+        const before = seriesSub(r);
+        r.endDate = E1; T.billExtension(r, E0);
+        const actual = Math.round((seriesSub(r) - before) * 100) / 100;
+        ok(pv && Math.abs(pv.subtotalDelta - actual) < 0.01, `preview == actual posting — ${label} (preview ${pv ? pv.subtotalDelta : 'null'} vs billed ${actual})`);
+        T.rentalInvoices(r).forEach((iv) => { const i = T.DATA.invoices.findIndex((o) => o.invoiceId === iv.invoiceId); if (i >= 0) T.DATA.invoices.splice(i, 1); T.IDX.invoice.delete(iv.invoiceId); });
+        const ri = T.DATA.rentals.findIndex((o) => o.rentalId === rid); if (ri >= 0) T.DATA.rentals.splice(ri, 1); T.IDX.rental.delete(rid);
+        return pv ? pv.subtotalDelta : null;
+      };
+      scenario('unpaid · auto rental line', false, true);
+      scenario('PAID · auto rental line', true, true);
+      const pvManual = scenario('PAID · manual ×1 line (the reported bug)', true, false);
+      // headline regression: a paid manual-lined invoice must preview the ADDED segment, NOT the full new window
+      ok(pvManual != null && Math.abs(pvManual - pf(cu.categoryId, E0, E1)) < 0.01, `paid+manual: added charge = the added segment ($${pf(cu.categoryId, E0, E1)}), not the full window ($${pf(cu.categoryId, S0, E1)})`);
+    }
     // === F1 — membership fee math (spec §2): no proration; protection = 15% of BASE only; 10.75% tax ===
     {
       const PR = { monthlyBase: 299, annualBase: 2691, monthlyTransport: 500, annualTransport: 4500, protectionPct: 15, protectionCapMonthly: 2000 };

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 15798 lines, 38 chapters
+## app.js — 15836 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -12,40 +12,40 @@
 | APP-02 | 62–77 | §1 | §1 UTILITIES & FORMATTING — $, el, esc, money, num, dates | $, el, esc, money, money2, num, TODAY, dayDiff, SINGULAR |
 | APP-03 | 78–828 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, migrationDirty, migrateCustomers, legacyUnitEntry, migrateRentals, rentalUnits, rentalUnitIds, rentalHasUnit, unitEntry, isPrimaryUnit, …(+82) |
 | APP-04 | 829–929 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 930–1203 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, invoiceChunks, unitBilledSeries, …(+13) |
-| APP-06 | 1204–1777 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+48) |
-| APP-07 | 1778–2414 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, state, activeSession, maxInvoiceSeq, nextInvoiceId, setAnchor, anchorRecord, …(+60) |
-| APP-08 | 2415–2422 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 2423–3748 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+86) |
-| APP-10 | 3749–3769 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 3770–4236 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
-| APP-12 | 4237–4404 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 4405–4515 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
-| APP-14 | 4516–4793 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 4794–4990 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 4991–6312 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
-| APP-17 | 6313–6407 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6408–6688 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 6689–6882 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 6883–7006 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7007–7171 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7172–7381 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7382–8150 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+67) |
-| APP-24 | 8151–8256 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8257–8702 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8703–9618 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9619–9713 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9714–9978 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
-| APP-29 | 9979–10651 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+63) |
-| APP-30 | 10652–10921 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 10922–11046 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11047–11050 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11051–12499 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+36) |
-| APP-34 | 12500–13421 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 13422–14450 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
-| APP-36 | 14451–14897 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 14898–14900 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 14901–15798 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-05 | 930–1241 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, invoiceChunks, unitBilledSeries, …(+14) |
+| APP-06 | 1242–1815 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+48) |
+| APP-07 | 1816–2452 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, state, activeSession, maxInvoiceSeq, nextInvoiceId, setAnchor, anchorRecord, …(+60) |
+| APP-08 | 2453–2460 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 2461–3786 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+86) |
+| APP-10 | 3787–3807 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 3808–4274 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
+| APP-12 | 4275–4442 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 4443–4553 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
+| APP-14 | 4554–4831 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 4832–5028 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 5029–6350 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
+| APP-17 | 6351–6445 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
+| APP-18 | 6446–6726 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 6727–6920 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 6921–7044 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7045–7209 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7210–7419 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7420–8188 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+67) |
+| APP-24 | 8189–8294 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8295–8740 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 8741–9656 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9657–9751 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9752–10016 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
+| APP-29 | 10017–10689 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+63) |
+| APP-30 | 10690–10959 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 10960–11084 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11085–11088 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11089–12537 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+36) |
+| APP-34 | 12538–13459 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 13460–14488 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
+| APP-36 | 14489–14935 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 14936–14938 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 14939–15836 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 524 lines, 0 chapters
 


### PR DESCRIPTION
## The report
The inline "Confirm new rental window" panel's **Added charge** didn't match what an extension actually adds to the invoice. In the screenshot: a fully-**paid** invoice (`Outlaw · 1-Day×1 $320`), extending +1 day, showed **Added charge $960** (the full new window) instead of the real delta.

## Root cause (proven, not guessed)
`extensionPreview` computed the added charge as `rentalPrice(full new window) − unitBilledSeries`, where `unitBilledSeries` only counts **auto rental/extension lines matched to the rental's current unit**. That formula breaks for exactly what the screenshot hit:

- **Paid/closed invoice** — per yesterday's 28-day-series design (§2.2), `billExtension` never re-blends a settled invoice; it **spills the added segment onto a continuation invoice**. So the real charge is just the added days, not full-window-minus-billed.
- **Manually-created line** (the `Outlaw · 1-Day×1` item) — not an auto rental line, so it credited **$0** and the preview billed the full window.

`billExtension` (the actual posting) was already correct — only the **preview** overstated. Verified with a throwaway sandbox harness (no PII):

| Scenario | Preview (old) | Actually posted | 
|---|---|---|
| Paid + auto rental line | $660 | $440 |
| **Paid + manual `×1` line** (screenshot) | **$1320** | **$440** |

## The fix
`extensionPreview` now derives its delta from a new **`previewExtensionDelta()`** — a pure, zero-mutation mirror of `billExtension`'s fill→spill chunk walk (grow the open active chunk via retro-reconcile / OFF-standalone, then spill ≤28-day standalone segments once it's paid/locked/full). The preview can no longer diverge from the posting, for any case.

## Why it can't regress
New **`ci/logic-test.mjs §32b`** asserts `extensionPreview.subtotalDelta == the actual series delta from billExtension` across unpaid / paid / paid-with-manual-line. This assertion **fails on the old code** (paid+manual: preview 1320 vs billed 440) and **passes on the fix** — the failed-before/passes-after bracket.

## Gates
All green: `smoke` ✅ · `logic-test` **259/259** ✅ · `gen-rule-usage --check` ✅ · `check-window-catalog` ✅ · `gen-code-map --check` ✅. No UI/markup change (logic only); no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011py1d7jyGg4oLQYGDKXqGB

---
_Generated by [Claude Code](https://claude.ai/code/session_011py1d7jyGg4oLQYGDKXqGB)_