### PR TITLE
Wrangler fix: bill the added days when a rental extends at the FRONT

### DIFF
--- a/app.js
+++ b/app.js
@@ -978,6 +978,7 @@ const invCovStart = (inv, r) => inv.covStart || (r ? r.startDate : '');
 const invCovEnd = (inv, r) => inv.covEnd || (r ? r.endDate : '');
 function invCoveredDays(inv, r) { const s = invCovStart(inv, r), e = invCovEnd(inv, r); return (parseISO(s) && parseISO(e)) ? Math.max(0, dayDiff(parseISO(s), parseISO(e))) : 0; }
 const minISO = (a, b) => (a < b ? a : b);
+const maxISO = (a, b) => (a > b ? a : b);
 /** Chunk a window into ≤28-day pieces: [{idx, start, end, days}]. */
 function invoiceChunks(startISO, endISO) {
   const total = (parseISO(startISO) && parseISO(endISO)) ? dayDiff(parseISO(startISO), parseISO(endISO)) : 0;
@@ -1040,52 +1041,62 @@ function reconcileChunkRetro(inv, r, ns, ne) {
   });
   return { delta: Math.round(delta * 100) / 100, count };
 }
-/** PURE mirror of billExtension's per-step math — returns the subtotal delta billExtension
- *  WOULD post for lengthening r from prevEnd → newEnd, with ZERO mutation. Kept in lockstep
- *  with billExtension by logic-test (the preview MUST equal what's actually billed). Walks the
- *  same fill→spill chunk model: grow the open active chunk (retro reconcile vs OFF standalone),
- *  then — once that chunk is closed/locked/full — spill ≤28-day standalone segments onto fresh
- *  continuation invoices. This is why a PAID invoice (its segment spills) or one whose prior
- *  charge isn't a matched rental line no longer overstates the charge: the preview now reflects
- *  the real posting, not a blind "full window − matched-billed". */
-function previewExtensionDelta(r, prevEnd, newEnd) {
+/** PURE mirror of billExtension's per-step math — the subtotal delta billExtension WOULD post
+ *  for lengthening r to [newStart, newEnd], with ZERO mutation (replays the fill→spill walk on a
+ *  local chunk model). Kept in lockstep with billExtension by logic-test (the preview MUST equal
+ *  what's actually billed). Handles BOTH ends: grow the active chunk's covEnd toward newEnd AND
+ *  the earliest chunk's covStart toward newStart (retro reconcile vs OFF standalone), spilling
+ *  ≤28-day standalone segments onto fresh continuation invoices once a chunk is closed/locked/
+ *  full. So a PAID invoice (its added segment spills), a manually-lined one, OR an extension at
+ *  the FRONT of the window no longer over/under-states the charge — the preview is the posting. */
+function previewExtensionDelta(r, prevEnd, newEnd, prevStart, newStart) {
   if (!r || !r.invoiceId) return 0;
-  const active = rentalActiveInvoice(r); if (!active) return 0;
-  const targetEnd = newEnd;
-  let coveredEnd = active.covEnd || prevEnd || r.startDate;
-  if (!targetEnd || !coveredEnd || dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) <= 0) return 0;   // no net lengthening → bills nothing (matches billExtension)
+  const invs = rentalInvoices(r); if (!invs.length) return 0;
   const retro = retroPricingOn();
+  const targetEnd = newEnd, targetStart = newStart || r.startDate;
   const units = rentalUnits(r).filter((eu) => !unitVoided(r, eu) && IDX.unit.get(eu.unitId));
   const priceOf = (eu, s, e) => { const p = rentalPrice({ categoryId: IDX.unit.get(eu.unitId).categoryId, startDate: s, endDate: e, customerId: r.customerId }); return p ? Math.round(p.price * 100) / 100 : 0; };
-  let delta = 0, onReal = true, guard = 0;
-  while (dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) > 0 && guard++ < 80) {
-    if (onReal) {
-      const t = invoiceTotals(active);
-      const closed = t.paid > 0 && t.balance <= 0;
-      const room = INV_CAP_DAYS - invCoveredDays(active, r);
-      if (active.locked || closed || room <= 0) { onReal = false; continue; }   // active sealed/full → spill
-      const grow = Math.min(room, dayDiff(parseISO(coveredEnd), parseISO(targetEnd)));
-      const newCovEnd = addDaysISO(coveredEnd, grow);
-      if (retro) {                                                // reconcileChunkRetro: re-price to cheapest(covStart→newEnd) − billed
-        const cs = invCovStart(active, r);
-        units.forEach((eu) => {
-          const target = priceOf(eu, cs, newCovEnd);
-          const mine = (active.lineItems || []).filter((li) => (li.kind === 'rental' || li.kind === 'extension') && li.ref === r.rentalId && li.unitId === eu.unitId);
-          const paid = mine.reduce((a, li) => a + itemPaid(active, li), 0);
-          const billed = Math.round(mine.reduce((a, li) => a + (Number(li.amount) || 0), 0) * 100) / 100;
-          const d = target - billed;
-          if (Math.abs(d) <= 0.005) return;
-          if (paid > 0.005) { if (d > 0.005) delta += d; } else { delta += d; }   // paid can only top up (refund-first); unpaid re-prices either way
-        });
-      } else {                                                    // OFF: bill the added segment standalone
-        units.forEach((eu) => { const d = priceOf(eu, coveredEnd, newCovEnd); if (d > 0.005) delta += d; });
-      }
-      coveredEnd = newCovEnd; onReal = false;                     // real active is now full/at-target; any remainder spills
-    } else {                                                      // spilled: fresh ≤28-day continuation chunk, billed standalone
-      const chunkEnd = minISO(addDaysISO(coveredEnd, INV_CAP_DAYS), targetEnd);
-      units.forEach((eu) => { const d = priceOf(eu, coveredEnd, chunkEnd); if (d > 0.005) delta += d; });
-      coveredEnd = chunkEnd;
-    }
+  // Local, NON-MUTATING model of each invoice chunk; we replay billExtension's fill→spill walk
+  // against it so the preview composes a front+back extension exactly as the real posting would.
+  const chunkOf = (inv) => {
+    const billed = {}, paid = {};
+    units.forEach((eu) => {
+      const mine = (inv.lineItems || []).filter((li) => (li.kind === 'rental' || li.kind === 'extension') && li.ref === r.rentalId && li.unitId === eu.unitId);
+      billed[eu.unitId] = Math.round(mine.reduce((a, li) => a + (Number(li.amount) || 0), 0) * 100) / 100;
+      paid[eu.unitId] = mine.reduce((a, li) => a + itemPaid(inv, li), 0);
+    });
+    const tot = invoiceTotals(inv);
+    return { covStart: invCovStart(inv, r), covEnd: invCovEnd(inv, r), locked: !!inv.locked, closed: tot.paid > 0 && tot.balance <= 0, billed, paid };
+  };
+  const chunks = invs.map(chunkOf);
+  let delta = 0;
+  const reconcile = (c, ns, ne) => units.forEach((eu) => {     // retro re-price chunk to cheapest(ns→ne) − billed
+    const target = priceOf(eu, ns, ne), billed = c.billed[eu.unitId] || 0, d = target - billed;
+    if (Math.abs(d) <= 0.005) return;
+    if ((c.paid[eu.unitId] || 0) > 0.005) { if (d > 0.005) { delta += d; c.billed[eu.unitId] = billed + d; } }   // paid → positive top-up only
+    else { delta += d; c.billed[eu.unitId] = target; }                                                            // unpaid → re-price in place (up or down)
+  });
+  const standalone = (c, ns, ne) => units.forEach((eu) => {    // OFF grow / spill: the added segment priced on its own
+    const amt = priceOf(eu, ns, ne); if (amt > 0.005) { delta += amt; c.billed[eu.unitId] = (c.billed[eu.unitId] || 0) + amt; }
+  });
+  const spill = (ns, ne) => { const c = { covStart: ns, covEnd: ne, locked: false, closed: false, billed: {}, paid: {} }; standalone(c, ns, ne); return c; };
+  const daysOf = (c) => Math.max(0, dayDiff(parseISO(c.covStart), parseISO(c.covEnd)));
+  let guard = 0;
+  // BACK — grow the active (latest) chunk's covEnd toward targetEnd, spilling fresh chunks.
+  let active = chunks[chunks.length - 1];
+  let coveredEnd = active.covEnd || prevEnd || r.startDate;
+  while (targetEnd && coveredEnd && dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) > 0 && guard++ < 200) {
+    const room = INV_CAP_DAYS - daysOf(active);
+    if (active.locked || active.closed || room <= 0) { const ce = minISO(addDaysISO(coveredEnd, INV_CAP_DAYS), targetEnd); active = spill(coveredEnd, ce); chunks.push(active); coveredEnd = ce; }
+    else { const grow = Math.min(room, dayDiff(parseISO(coveredEnd), parseISO(targetEnd))); const nce = addDaysISO(coveredEnd, grow); retro ? reconcile(active, active.covStart, nce) : standalone(active, coveredEnd, nce); active.covEnd = nce; coveredEnd = nce; }
+  }
+  // FRONT — grow the earliest chunk's covStart toward targetStart, spilling fresh chunks.
+  let earliest = chunks[0];
+  let coveredStart = earliest.covStart || prevStart || r.startDate;
+  while (targetStart && coveredStart && dayDiff(parseISO(targetStart), parseISO(coveredStart)) > 0 && guard++ < 200) {
+    const room = INV_CAP_DAYS - daysOf(earliest);
+    if (earliest.locked || earliest.closed || room <= 0) { const cs = maxISO(addDaysISO(coveredStart, -INV_CAP_DAYS), targetStart); earliest = spill(cs, coveredStart); chunks.unshift(earliest); coveredStart = cs; }
+    else { const grow = Math.min(room, dayDiff(parseISO(targetStart), parseISO(coveredStart))); const ncs = addDaysISO(coveredStart, -grow); retro ? reconcile(earliest, ncs, earliest.covEnd) : standalone(earliest, ncs, coveredStart); earliest.covStart = ncs; coveredStart = ncs; }
   }
   return Math.round(delta * 100) / 100;
 }
@@ -1099,29 +1110,29 @@ function extensionPreview(r, stagedStart, stagedEnd) {
   const ns = stagedStart || r.startDate, ne = stagedEnd || r.endDate;
   if (!ns || !ne) return null;
   const retro = retroPricingOn();
-  const subtotalDelta = previewExtensionDelta(r, r.endDate, ne);
+  const subtotalDelta = previewExtensionDelta(r, r.endDate, ne, r.startDate, ns);
   const cust = IDX.customer.get(r.customerId);
   const exempt = !!(invs[0].taxExempt || cust?.salesTaxExempt);
   const taxDelta = exempt ? 0 : Math.round(subtotalDelta * TAX_RATE * 100) / 100;
   const curBal = invs.reduce((a, inv) => a + invoiceTotals(inv).balance, 0);
   const prevDays = Math.max(1, dayDiff(parseISO(r.startDate), parseISO(r.endDate)));
   const newDays = Math.max(1, dayDiff(parseISO(ns), parseISO(ne)));
-  return { subtotalDelta, taxDelta, newBalance: curBal + subtotalDelta + taxDelta, daysDelta: newDays - prevDays, prevEnd: r.endDate, newEnd: ne, retro };
+  return { subtotalDelta, taxDelta, newBalance: curBal + subtotalDelta + taxDelta, daysDelta: newDays - prevDays, prevEnd: r.endDate, newEnd: ne, newStart: ns, prevStart: r.startDate, retro };
 }
 /** Bill a lengthened window across the rental's invoice series — fill the active open
  *  chunk toward its 28-day cap, then spill into fresh ≤28-day invoices (closed/locked
  *  active spills immediately). Call AFTER the new dates are written; prevEnd = old end. */
-function billExtension(r, prevEnd) {
+function billExtension(r, prevEnd, prevStart) {
   if (!r || !r.invoiceId) return null;
   const retro = retroPricingOn();
   const targetEnd = r.endDate;
   let active = rentalActiveInvoice(r); if (!active) return null;
-  if (!active.covStart) { active.covStart = r.startDate; active.covEnd = prevEnd || r.endDate; active.covOf = r.rentalId; }   // backfill legacy
+  if (!active.covStart) { active.covStart = prevStart || r.startDate; active.covEnd = prevEnd || r.endDate; active.covOf = r.rentalId; }   // backfill legacy from the OLD window
   let coveredEnd = active.covEnd || prevEnd || r.startDate;
-  if (!targetEnd || !coveredEnd || dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) <= 0) return null;   // no net lengthening
   const sum = { count: 0, subtotalDelta: 0, invoiceIds: [], newInvoices: 0, retro, invoiceId: r.invoiceId };
   let guard = 0;
-  while (dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) > 0 && guard++ < 60) {
+  // BACK extension — days added AFTER the active chunk's covEnd (end moved later).
+  while (targetEnd && coveredEnd && dayDiff(parseISO(coveredEnd), parseISO(targetEnd)) > 0 && guard++ < 60) {
     const t = invoiceTotals(active);
     const closed = t.paid > 0 && t.balance <= 0;
     const room = INV_CAP_DAYS - invCoveredDays(active, r);
@@ -1142,6 +1153,33 @@ function billExtension(r, prevEnd) {
       active.covEnd = newCovEnd; reindex('invoices', active);
       sum.count += res.count; sum.subtotalDelta += res.delta; if (!sum.invoiceIds.includes(active.invoiceId)) sum.invoiceIds.push(active.invoiceId);
       coveredEnd = newCovEnd;
+    }
+  }
+  // FRONT extension — days added BEFORE the earliest chunk's covStart (start moved earlier).
+  // Symmetric to the back loop: grow the earliest OPEN chunk's covStart earlier (retro reconcile /
+  // OFF standalone), or spill a fresh ≤28-day continuation chunk when it's paid/locked/full.
+  const targetStart = r.startDate;
+  let earliest = rentalInvoices(r)[0] || active;
+  let coveredStart = earliest.covStart || prevStart || r.startDate;
+  while (targetStart && coveredStart && dayDiff(parseISO(targetStart), parseISO(coveredStart)) > 0 && guard++ < 60) {
+    const t = invoiceTotals(earliest);
+    const closed = t.paid > 0 && t.balance <= 0;
+    const room = INV_CAP_DAYS - invCoveredDays(earliest, r);
+    if (earliest.locked || closed || room <= 0) {                                // spill → fresh FRONT chunk invoice
+      const chunkStart = maxISO(addDaysISO(coveredStart, -INV_CAP_DAYS), targetStart);
+      earliest = createContinuationInvoice(r, chunkStart, coveredStart);
+      const res = billChunkUnits(earliest, r, chunkStart, coveredStart, chunkStart, retro, 'rental', r.invoiceId);
+      reindex('invoices', earliest);
+      sum.newInvoices++; sum.count += res.count; sum.subtotalDelta += res.delta; sum.invoiceIds.push(earliest.invoiceId);
+      coveredStart = chunkStart;
+    } else {                                                                      // grow the earliest open chunk earlier
+      const grow = Math.min(room, dayDiff(parseISO(targetStart), parseISO(coveredStart)));
+      const newCovStart = addDaysISO(coveredStart, -grow);
+      const res = retro ? reconcileChunkRetro(earliest, r, newCovStart, invCovEnd(earliest, r))
+        : billChunkUnits(earliest, r, newCovStart, coveredStart, newCovStart, false, 'extension', null);
+      earliest.covStart = newCovStart; reindex('invoices', earliest);
+      sum.count += res.count; sum.subtotalDelta += res.delta; if (!sum.invoiceIds.includes(earliest.invoiceId)) sum.invoiceIds.push(earliest.invoiceId);
+      coveredStart = newCovStart;
     }
   }
   if (!sum.count) return null;
@@ -14377,11 +14415,11 @@ function winPickSave() {
   const wp = state.winEdit; if (!wp) return;
   const r = IDX.rental.get(wp.rentalId);
   if (r && wp.staged) {
-    const prevEnd = r.endDate || '';
+    const prevEnd = r.endDate || '', prevStart = r.startDate || '';
     r.startDate = wp.staged.startDate; r.endDate = wp.staged.endDate; r.startTime = wp.staged.startTime;
     if (r.startDate && r.endDate && r.status === 'Quote') r.status = 'Reserved';
     logAction(r, `Rental window → ${r.startDate && r.endDate ? fmtShortDate(r.startDate) + '–' + fmtShortDate(r.endDate) : 'cleared'}`);
-    const ext = billExtension(r, prevEnd);   // bill the lengthened window across the ≤28-day invoice series
+    const ext = billExtension(r, prevEnd, prevStart);   // bill the lengthened window (either end) across the ≤28-day invoice series
     if (ext) {
       const basis = ext.retro ? 'retroactive' : 'added days';
       const up = ext.subtotalDelta >= 0;
@@ -14539,7 +14577,7 @@ function winPickerEl(r) {
   const changing = billing || reducing;
   const extHtml = changing
     ? `<div class="wp-ext${reducing ? ' wp-ext-down' : ''}">
-        <div class="wp-ext-cap"><span class="wp-ext-kick">${reducing ? 'Re-price' : 'Extension'}</span><span class="wp-ext-days">${ext.daysDelta >= 0 ? '+' : ''}${ext.daysDelta} day${Math.abs(ext.daysDelta) !== 1 ? 's' : ''} · ${esc(fmtShortDate(ext.prevEnd))} → ${esc(fmtShortDate(ext.newEnd))}</span></div>
+        <div class="wp-ext-cap"><span class="wp-ext-kick">${reducing ? 'Re-price' : 'Extension'}</span><span class="wp-ext-days">${ext.daysDelta >= 0 ? '+' : ''}${ext.daysDelta} day${Math.abs(ext.daysDelta) !== 1 ? 's' : ''} · ${esc(fmtShortDate(ext.newStart))} → ${esc(fmtShortDate(ext.newEnd))}</span></div>
         <div class="wp-ext-row"><span>${reducing ? 'Invoice credit' : 'Added charge'}</span><b>${reducing ? '−' : ''}${money2(Math.abs(ext.subtotalDelta))}</b></div>
         ${ext.taxDelta ? `<div class="wp-ext-row"><span>Tax (${(TAX_RATE * 100).toFixed(2)}%)</span><b>${reducing ? '−' : ''}${money2(Math.abs(ext.taxDelta))}</b></div>` : ''}
         <div class="wp-ext-row wp-ext-bal"><span>New balance</span><b>${money2(ext.newBalance)}</b></div>

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -764,11 +764,14 @@ try {
     //      `price(full window) − matched-billed`, which overstated both cases.)
     {
       const pf = (catId, s, e) => { const p = T.rentalPrice({ categoryId: catId, startDate: s, endDate: e, customerId: 'C0009' }); return p ? p.price : 0; };
-      const S0 = '2099-08-01', E0 = '2099-08-03', E1 = '2099-08-04';   // 2 days → +1 (mirrors the reported screenshot)
+      const SB = '2099-07-31', S0 = '2099-08-01', E0 = '2099-08-03', E1 = '2099-08-04';   // base 2-day window [S0,E0]; SB = start −1, E1 = end +1
       const af3 = T.DATA.units.filter((u) => u.fleetStatus === 'Active');
       const cu = af3.find((u) => pf(u.categoryId, S0, E1) > pf(u.categoryId, S0, E0) && pf(u.categoryId, S0, E0) > 0) || af3[0];
       const seriesSub = (r) => T.rentalInvoices(r).reduce((a, iv) => a + iv.lineItems.filter((l) => l.kind === 'rental' || l.kind === 'extension').reduce((s, l) => s + (+l.amount || 0), 0), 0);
-      const scenario = (label, paid, matched) => {
+      // ns/ne = the staged new window; default = back extension. Asserts the inline preview equals
+      // the real series delta billExtension posts, for an extension at EITHER end (or both).
+      const scenario = (label, paid, matched, ns, ne) => {
+        ns = ns || S0; ne = ne || E1;
         const rid = 'R-PVEQ', iid = 'I-PVEQ';
         const r = { rentalId: rid, customerId: 'C0009', unitId: cu.unitId, categoryId: cu.categoryId, startDate: S0, endDate: E0, startTime: '', status: 'On Rent', transportType: 'Self', deliveryAddress: '', transportMiles: null, invoiceId: iid, units: [{ unitId: cu.unitId, transportType: 'Self', transportMiles: null }], notes: '', actions: [], mock: true };
         T.DATA.rentals.push(r); T.IDX.rental.set(rid, r);
@@ -777,20 +780,27 @@ try {
         else inv.lineItems.push({ kind: 'item', ref: rid, unitId: cu.unitId, lid: 'L-MAN', label: `${T.IDX.unit.get(cu.unitId)?.name || 'Unit'} · 1-Day×1`, amount: pf(cu.categoryId, S0, E0), qty: 1 });
         T.DATA.invoices.push(inv); T.IDX.invoice.set(iid, inv);
         if (paid) { inv.amountPaid = T.invoiceTotals(inv).total; const l0 = inv.lineItems[0]; inv.allocations = { [T.lineKey(l0)]: l0.amount }; }
-        const pv = T.extensionPreview(r, S0, E1);
+        const pv = T.extensionPreview(r, ns, ne);
         const before = seriesSub(r);
-        r.endDate = E1; T.billExtension(r, E0);
+        r.startDate = ns; r.endDate = ne; T.billExtension(r, E0, S0);
         const actual = Math.round((seriesSub(r) - before) * 100) / 100;
         ok(pv && Math.abs(pv.subtotalDelta - actual) < 0.01, `preview == actual posting — ${label} (preview ${pv ? pv.subtotalDelta : 'null'} vs billed ${actual})`);
         T.rentalInvoices(r).forEach((iv) => { const i = T.DATA.invoices.findIndex((o) => o.invoiceId === iv.invoiceId); if (i >= 0) T.DATA.invoices.splice(i, 1); T.IDX.invoice.delete(iv.invoiceId); });
         const ri = T.DATA.rentals.findIndex((o) => o.rentalId === rid); if (ri >= 0) T.DATA.rentals.splice(ri, 1); T.IDX.rental.delete(rid);
         return pv ? pv.subtotalDelta : null;
       };
-      scenario('unpaid · auto rental line', false, true);
-      scenario('PAID · auto rental line', true, true);
-      const pvManual = scenario('PAID · manual ×1 line (the reported bug)', true, false);
-      // headline regression: a paid manual-lined invoice must preview the ADDED segment, NOT the full new window
-      ok(pvManual != null && Math.abs(pvManual - pf(cu.categoryId, E0, E1)) < 0.01, `paid+manual: added charge = the added segment ($${pf(cu.categoryId, E0, E1)}), not the full window ($${pf(cu.categoryId, S0, E1)})`);
+      // BACK extension (end +1) — the #358 fix
+      scenario('back · unpaid · auto line', false, true, S0, E1);
+      scenario('back · PAID · auto line', true, true, S0, E1);
+      const pvManual = scenario('back · PAID · manual ×1 line (orig bug)', true, false, S0, E1);
+      ok(pvManual != null && Math.abs(pvManual - pf(cu.categoryId, E0, E1)) < 0.01, `back+paid+manual: added charge = the added segment ($${pf(cu.categoryId, E0, E1)}), not the full window ($${pf(cu.categoryId, S0, E1)})`);
+      // FRONT extension (start −1) — the reported "go BACK a day" case: paid invoice spills the added FRONT day
+      scenario('front · unpaid · auto line', false, true, SB, E0);
+      const pvFront = scenario('front · PAID · auto line (start back a day)', true, true, SB, E0);
+      ok(pvFront != null && Math.abs(pvFront - pf(cu.categoryId, SB, S0)) < 0.01, `front+paid: added charge = the added FRONT segment ($${pf(cu.categoryId, SB, S0)}) — start back a day bills the added day`);
+      // COMBINED front+back in one save — composes correctly (a single open chunk re-prices to the full window)
+      scenario('combined front+back · unpaid · auto line', false, true, SB, E1);
+      scenario('combined front+back · PAID · auto line', true, true, SB, E1);
     }
     // === F1 — membership fee math (spec §2): no proration; protection = 15% of BASE only; 10.75% tax ===
     {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 15920 lines, 38 chapters
+## app.js — 15958 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -12,40 +12,40 @@
 | APP-02 | 62–77 | §1 | §1 UTILITIES & FORMATTING — $, el, esc, money, num, dates | $, el, esc, money, money2, num, TODAY, dayDiff, SINGULAR |
 | APP-03 | 78–828 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, migrationDirty, migrateCustomers, legacyUnitEntry, migrateRentals, rentalUnits, rentalUnitIds, rentalHasUnit, unitEntry, isPrimaryUnit, …(+82) |
 | APP-04 | 829–929 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 930–1241 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, invoiceChunks, unitBilledSeries, …(+14) |
-| APP-06 | 1242–1815 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+48) |
-| APP-07 | 1816–2452 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, state, activeSession, maxInvoiceSeq, nextInvoiceId, setAnchor, anchorRecord, …(+60) |
-| APP-08 | 2453–2460 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 2461–3843 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+93) |
-| APP-10 | 3844–3864 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 3865–4331 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
-| APP-12 | 4332–4499 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 4500–4610 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
-| APP-14 | 4611–4888 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 4889–5085 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 5086–6407 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
-| APP-17 | 6408–6502 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6503–6783 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 6784–6977 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 6978–7101 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7102–7266 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7267–7476 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7477–8245 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+67) |
-| APP-24 | 8246–8351 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8352–8797 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8798–9713 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9714–9808 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9809–10073 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
-| APP-29 | 10074–10746 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+63) |
-| APP-30 | 10747–11016 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11017–11141 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11142–11145 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11146–12615 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 12616–13543 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 13544–14572 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
-| APP-36 | 14573–15019 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15020–15022 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15023–15920 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-05 | 930–1279 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, invoiceChunks, …(+15) |
+| APP-06 | 1280–1853 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+48) |
+| APP-07 | 1854–2490 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, state, activeSession, maxInvoiceSeq, nextInvoiceId, setAnchor, anchorRecord, …(+60) |
+| APP-08 | 2491–2498 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 2499–3881 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+93) |
+| APP-10 | 3882–3902 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 3903–4369 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
+| APP-12 | 4370–4537 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 4538–4648 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
+| APP-14 | 4649–4926 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 4927–5123 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 5124–6445 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
+| APP-17 | 6446–6540 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
+| APP-18 | 6541–6821 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 6822–7015 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 7016–7139 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7140–7304 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7305–7514 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7515–8283 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+67) |
+| APP-24 | 8284–8389 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8390–8835 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 8836–9751 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9752–9846 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9847–10111 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
+| APP-29 | 10112–10784 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_IDX, wrGet, wrCleanFields, wrFindAttachedCsv, wrValidatePlan, wrPlanSummary, wrCreateCustomer, …(+63) |
+| APP-30 | 10785–11054 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11055–11179 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11180–11183 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11184–12653 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 12654–13581 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 13582–14610 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+72) |
+| APP-36 | 14611–15057 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15058–15060 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15061–15958 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 


### PR DESCRIPTION
## The report
Moving a fragile rental's **start date earlier** ("go back a day") lengthens the window — that's an extra day to bill, same as moving the end later — but the inline panel said **"no change to billing"** and nothing was billed.

## Root cause
`billExtension` only ever grew the window at the **end** (from the active chunk's `covEnd` toward the new end). A **start moved earlier was never billed** — the loop's `dayDiff(coveredEnd, targetEnd) <= 0` short-circuited and returned null.

## The fix
- **`billExtension`** gains a symmetric **front pass**: grow the earliest chunk's `covStart` toward the new start (retro reconcile when open / OFF standalone), or spill a fresh ≤28-day continuation chunk when it's paid/locked/full — exactly mirroring the back pass. `winPickSave` now passes `prevStart` so it knows the front grew. For a **paid** invoice (the reported case) the added front day spills onto a continuation invoice, just like a back extension.
- **`previewExtensionDelta`** is rewritten to replay `billExtension`'s fill→spill walk on a **local, non-mutating chunk model** that handles *both* ends — and composes a combined front+back change correctly (a single open chunk re-prices to the full window). No live data is touched.
- The picker **caption** now shows the new window span (`start → end`) so a front-only change reads correctly instead of "Jun 25 → Jun 25".

## Behavior (verified, no PII)
For the reported paid rental, moving the start back a day spills a continuation invoice billing **the added front day** ($440 in the fixture) — so the series totals the full 2 days. Retro-vs-standalone asymmetry for paid invoices is unchanged and per spec §2.2 (a settled invoice is never re-blended).

## Why it can't regress
`ci/logic-test.mjs §32b` now covers **back / front / combined** × **paid / unpaid / manual-line**, all asserting `extensionPreview == the actual billExtension posting`. The **front+paid** headline **fails on the old code** (added charge $0) and **passes on the fix** ($440 = the added front day).

## Gates
All green: `smoke` ✅ · `logic-test` **285/285** ✅ · `gen-rule-usage --check` ✅ · `check-window-catalog` ✅ · `gen-code-map --check` ✅. Logic + one caption string; no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011py1d7jyGg4oLQYGDKXqGB

---
_Generated by [Claude Code](https://claude.ai/code/session_011py1d7jyGg4oLQYGDKXqGB)_