### PR TITLE
Mr. Wrangler: 'bring them to it' + Open link work on mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -10598,10 +10598,7 @@ function wrFocusRecord(entity, id) {
   if (!entity || !id) return;
   try {
     if (WR_BOARD_TYPES.has(entity)) { openOverlay({ kind: 'board', board: entity, recId: id }); return; }
-    if (WR_SHOP_TYPES.has(entity)) { anchorRecord('shop', id, entity); return; }
-    const s = activeSession(); const col = COLUMN_OF[entity]; const cs = s.cards[entity];
-    if (col && cs && s.cols) { s.cols[col] = entity; cs.mode = 'standard'; cs.recId = id; cs.recType = null; cs.graphView = false; }
-    else { anchorRecord(entity, id); }
+    pillTo(entity, id);   // the app's link-pill nav: reveals the column AND flips the phone's visible column (state.mobileCol), then openStandard — so it lands where you can see it on mobile, not just desktop
   } catch (e) { /* nav is best-effort */ }
 }
 // Short clickable label for the "Open →" link Wrangler shows after it does something.
@@ -12396,7 +12393,7 @@ function onClick(e) {
   if (closest('.js-wr-close')) { e.stopPropagation(); wranglerRailSnapshot(); state.wrangler.open = false; return render(); }   // §18 close the dock back to the launcher; the chat lands on the §18g rail
   if (closest('.js-wr-act')) { e.stopPropagation(); return wranglerFileAction(Number(closest('.js-wr-act').dataset.mi)); }   // §18d file the fix/request Mr. Wrangler proposed inline
   if (closest('.js-wr-apply')) { e.stopPropagation(); const o = state.wrangler; if (!o.open) return; const m = o.messages[Number(closest('.js-wr-apply').dataset.mi)]; if (!m || !m.action || m.filed) return; const plan = m.action._plan || wrValidatePlan(m.action); if (!plan.ops.length) return; m.filed = true; render(); Promise.resolve(applyWranglerData(plan)).then((res) => { if (res && res.failed) { m.filed = false; } else if (res && res.focus) { m.focus = res.focus; } render(); }); return; }
-  if (closest('.js-wr-goto')) { e.stopPropagation(); const b = closest('.js-wr-goto'); wrFocusRecord(b.dataset.ent, b.dataset.id); return render(); }   // the clickable "Open →" link → jump to the record Wrangler made   // Mr. Wrangler applies the previewed add/update/import; a failed async op (e.g. a payment that didn't go through) un-files so the user can retry
+  if (closest('.js-wr-goto')) { e.stopPropagation(); const b = closest('.js-wr-goto'); wrFocusRecord(b.dataset.ent, b.dataset.id); state.wrangler.min = true; return render(); }   // the clickable "Open →" link → jump to the record + collapse the dock so it's revealed (esp. on mobile)   // Mr. Wrangler applies the previewed add/update/import; a failed async op (e.g. a payment that didn't go through) un-files so the user can retry
   if (closest('.js-wr-kpi-lock')) { e.stopPropagation(); lockKpiFromWrangler(Number(closest('.js-wr-kpi-lock').dataset.mi)); return; }   // Mr. Wrangler locks in an authored KPI ring
   if (closest('.js-wr-unattach')) { e.stopPropagation(); const o = state.wrangler; if (o.open && o.attach) { o.attach.splice(Number(closest('.js-wr-unattach').dataset.i), 1); render(); } return; }   // §18d drop a pending image attachment
   if (closest('.js-wr-unfile')) { e.stopPropagation(); const o = state.wrangler; if (o.open && o.files) { o.files.splice(Number(closest('.js-wr-unfile').dataset.i), 1); render(); } return; }   // §18d drop a pending file attachment

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -433,8 +433,10 @@ try {
       T.wrFocusRecord('customers', 'C0009');
       const cs = T.activeSession().cards.customers;
       ok(cs.mode === 'standard' && cs.recId === 'C0009', 'WR-focus: a grid record (customer) focuses in place');
+      // MOBILE: it flips the phone's visible column to where the record lives (the bug Jac hit)
+      ok(T.__state.mobileCol === 2, 'WR-focus (mobile): the phone column flips to the record (customers → right/2)');
       const wo = T.DATA.workOrders[0];
-      if (wo) { T.wrFocusRecord('workOrders', wo.woId); const a = T.activeSession().anchor; ok(a && a.card === 'shop' && a.recId === wo.woId, 'WR-focus: a shop record (work order) anchors a tab'); }
+      if (wo) { T.wrFocusRecord('workOrders', wo.woId); const sc = T.activeSession().cards.shop; ok(sc.mode === 'standard' && sc.recId === wo.woId && sc.recType === 'workOrders' && T.__state.mobileCol === 0, 'WR-focus: a shop record (work order) shows on the shop card + flips to the yard column'); }
     }
 
     // 12o) Bookings auto-apply + a clickable "Open" link (Jac): startRental no longer needs the Apply tap,

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16368 lines, 38 chapters
+## app.js — 16365 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -36,16 +36,16 @@
 | APP-26 | 8871–9786 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
 | APP-27 | 9787–9881 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
 | APP-28 | 9882–10156 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, wranglerSend, parseWranglerAction, wrSalvageDataAction, …(+1) |
-| APP-29 | 10157–11183 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+96) |
-| APP-30 | 11184–11453 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11454–11578 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11579–11582 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11583–13053 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13054–13981 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 13982–15020 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15021–15467 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15468–15470 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15471–16368 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-29 | 10157–11180 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+96) |
+| APP-30 | 11181–11450 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11451–11575 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11576–11579 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11580–13050 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13051–13978 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 13979–15017 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15018–15464 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15465–15467 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15468–16365 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260626o" />
+  <link rel="stylesheet" href="style.css?v=20260626p" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260626o"></script>
-  <script type="module" src="app.js?v=20260626o"></script>
+  <script src="rule-usage.js?v=20260626p"></script>
+  <script type="module" src="app.js?v=20260626p"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Reported (on mobile)

The "Open" link did nothing and Wrangler didn't take the user to the new item — **on a phone**.

## Cause

`wrFocusRecord` set the **desktop 3-column state** (`cols`/`cards`) directly. The phone uses a single-column layout driven by `state.mobileCol`, which that path never touched — so nothing surfaced, and the "Open" link (same path) failed identically.

## Fix

`wrFocusRecord` now delegates to the app's own link-pill navigation **`pillTo()`** — the exact seam every cross-column link uses — which reveals the column **and flips `state.mobileCol`** (the phone's visible column) before `openStandard`. The "Open →" link handler also collapses the dock so the record is revealed on the phone. Back-office records still open their full-screen board popup (already mobile-fine).

## Tests / gates

- Focus block updated: asserts `state.mobileCol` flips to the record's column (customers → 2, shop → 0) and shop records land on the shop card. Suite **373 → 374**.
- All gates green: smoke, logic-test (374/374), rule-usage, window-catalog, code-map. Cache-bust `?v=20260626p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAvGcFt5G68nNRZRZv33H3)_