### PR TITLE
branch-janitor: opt-in cleanup for rewrite-stranded branches

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -4,11 +4,26 @@ name: Branch janitor
 # SAFE BY DESIGN: only deletes a branch that (a) is the head of a MERGED PR,
 # (b) has NO open PR, and (c) is NOT a structural branch (main / staging / area/*).
 # So long-lived chapters (area/*) and the trunk/integration branches are never touched.
+#
+# There is also a ONE-TIME, opt-in cleanup job (prune_stranded) for the branches the
+# 2026-06-23 history rewrite stranded off main — these have no merge base with main and
+# are not merged-PR heads, so the daily job above structurally cannot see them. They were
+# verified (2026-06-27) as already-shipped or empty stubs. That job only runs from the
+# Actions tab, defaults to a dry-run, and re-guards every branch at runtime.
 
 on:
   schedule:
     - cron: '17 7 * * *'   # daily ~07:17 UTC
   workflow_dispatch:        # and on-demand from the Actions tab
+    inputs:
+      prune_stranded:
+        description: 'Run the one-time stranded-branch cleanup (2026-06-27 verified set)'
+        type: boolean
+        default: false
+      execute:
+        description: 'Actually delete (leave UNCHECKED for a dry-run list only)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -48,3 +63,89 @@ jobs:
             fi
           done < live.txt
           echo "pruned $deleted branch(es)"
+
+  # ── One-time cleanup of the 2026-06-23-rewrite-stranded branches. Opt-in + dry-run by default. ──
+  # Every branch below was verified 2026-06-27 (verify-stranded-superseded.sh): 26 added no app.js
+  # code (TODO/doc/CI stubs); 17 are superseded (their work is already on main). None hold unshipped
+  # work. The daily 'prune' job can't reach them (not merged-PR heads, no merge base with main).
+  # After this has been run once and the branches are gone, delete this job.
+  prune_stranded:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prune_stranded == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      EXECUTE: ${{ github.event.inputs.execute }}
+    steps:
+      - name: Prune stranded branches (re-guarded; dry-run unless 'execute' is checked)
+        run: |
+          set -euo pipefail
+          STRANDED="
+            backend-data/card-error-surfacing
+            backend-data/custom-fields-defaults
+            backend-data/sync-outage-p0
+            ci/bump-actions-node24
+            claude/vibrant-roentgen-1ce051
+            claude/wonderful-chatelet-b05184
+            claude/wrangler-fix-34
+            comms-notifications/customer-text-email
+            comms-notifications/notifications
+            customers-crm/dedup-name-graduation
+            design-overhaul
+            design-system/regen-rule-usage
+            design-system/row-density-pass
+            design-system/rulebook-full-catalog
+            financials-kpi/roi-zero-cost-guard
+            frontend-performance/boot-render-coalesce
+            handoff/ach-payments
+            handoff/col-polish
+            handoff/dispatch-cockpit
+            handoff/graph-carousel
+            handoff/popup-tiers
+            handoff/pr138-docs-merge
+            invoicing-payments/card-save-gate
+            invoicing-payments/invoice-card
+            invoicing-payments/invoice-link-label
+            invoicing-payments/payment-card-picker
+            maintenance-shop/default-services
+            memberships/membership-todo
+            mobile-remote/customer-portal
+            rentals-dispatch/new-rental-date-default
+            rentals-dispatch/onrent-cardfile-gate
+            rentals-dispatch/retire-window-picker
+            rentals-dispatch/status-button
+            search-views/global-search-customer-sync
+            units-fleet/category-rows-scroll-group
+            units-fleet/typed-inspection-fields
+            wrangler-ai/notif-rail-collapse
+            wrangler-fix-116-cash-refund
+            wrangler-fix-117-cash-refund
+            wrangler-fix-66-new-customer
+            wrangler-fix/38-transport-equal-width
+            wrangler-fix/transport-button-width
+            wrangler/card-error-surfacing
+          "
+          # runtime safety nets, independent of the embedded list
+          gh pr list -R "$REPO" --state open --limit 1000 --json headRefName -q '.[].headRefName' | sort -u > open.txt
+          gh api "repos/$REPO/branches?per_page=100" --paginate -q '.[].name' | sort -u > live.txt
+          mode="DRY-RUN"; [ "${EXECUTE:-false}" = "true" ] && mode="DELETE"
+          echo "mode=$mode  (open-PRs=$(wc -l < open.txt), live branches=$(wc -l < live.txt))"
+          deleted=0; skipped=0
+          for b in $STRANDED; do
+            [ -z "$b" ] && continue
+            case "$b" in
+              main|staging|area/*|backup/*) echo "  GUARD skip (structural): $b"; skipped=$((skipped+1)); continue ;;
+            esac
+            grep -qxF "$b" live.txt || { echo "  already gone: $b"; continue; }
+            if grep -qxF "$b" open.txt; then echo "  GUARD skip (has open PR): $b"; skipped=$((skipped+1)); continue; fi
+            if [ "$mode" = "DRY-RUN" ]; then
+              echo "  [dry-run] would delete: $b"; continue
+            fi
+            echo "  deleting: $b"
+            if gh api -X DELETE "repos/$REPO/git/refs/heads/$b" >/dev/null 2>&1; then
+              deleted=$((deleted+1))
+            else
+              echo "    (skipped — protected or already gone)"; skipped=$((skipped+1))
+            fi
+          done
+          echo "stranded cleanup: mode=$mode deleted=$deleted guarded/skipped=$skipped"


### PR DESCRIPTION
## Why

Triage of the ~100 remote branches found that the **2026-06-23 history rewrite** re-rooted `main`/`staging` but left ~43 older task branches **stranded** — they share *no merge base* with `main`, and (because of the `area → staging → main` workflow) they were never the head of a merged PR. So the existing daily janitor job — which only deletes **merged-PR heads** — structurally cannot reach them, and they accumulate forever. They also can't be evaluated by `git diff` against `main` (no common ancestor).

## What

Adds a **one-time, opt-in** `prune_stranded` job to `branch-janitor.yml`:
- Runs **only** from the Actions tab (`workflow_dispatch`), never on the daily schedule.
- **Dry-run by default** — lists what it would delete; deletes only when the `execute` input is checked.
- Deletes the **2026-06-27-verified** stranded set: **26 empty stubs** (TODO/doc/CI branches with no `app.js` code) + **17 superseded** (their work is already on `main`, confirmed by signature check). None hold unshipped work.
- **Runtime guards** independent of the embedded list: re-skips any `main`/`staging`/`area/*`/`backup/*` branch or any branch with an **open PR**, and no-ops branches already gone.
- The existing daily `prune` job is unchanged.

This has to run server-side in Actions because branch *deletion* via `git push --delete` is blocked by the egress proxy (org policy) in cloud sessions — the daily job already deletes via `gh api` with the workflow token, and this reuses that path.

## Notes
- After it's run once and the branches are gone, the `prune_stranded` job can be deleted.
- It does **not** touch `area/*`. The areas are themselves stranded off the rewritten `main`; re-baselining them (delete + re-cut fresh off `main`) is a separate, deliberate step.
- The 9 recently-merged `wrangler/*-nr130b` / `wrangler-fix/378` / `settings-flash` / `termite` branches are genuine merged-PR heads and will be cleared by the **daily** job on its next run.

## Test
- `python3 -c "import yaml; yaml.safe_load(...)"` — valid; jobs: `prune`, `prune_stranded`.
- Simulated the `prune_stranded` loop against the live branch + open-PR sets: would delete exactly **43**, **0** guarded — matches the verified set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRpQNwVkni29vr5xCEBKXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRpQNwVkni29vr5xCEBKXt)_