### PR TITLE
Wrangler agentic Stage 2: apply_changes write tool

### DIFF
--- a/app.js
+++ b/app.js
@@ -10126,36 +10126,61 @@ const WR_TOOLS = [
   { name: 'find_work_orders', description: 'List work orders, filtered by unit and/or customer. Returns id, unit, report, phase, type.', input_schema: { type: 'object', properties: { unit: { type: 'string' }, customer: { type: 'string' } }, required: [] } },
   { name: 'check_unit_availability', description: 'Check whether a unit is free for a date window. Returns available + any conflicting rentals. Dates are YYYY-MM-DD.', input_schema: { type: 'object', properties: { unit: { type: 'string' }, startDate: { type: 'string' }, endDate: { type: 'string' } }, required: ['unit', 'startDate', 'endDate'] } },
   { name: 'price_rental', description: 'Quote the price for renting one or more units over a window (uses the live pricing engine; member rates apply if the customer is given). Dates are YYYY-MM-DD. Read-only — does not create anything.', input_schema: { type: 'object', properties: { units: { type: 'array', items: { type: 'string' } }, startDate: { type: 'string' }, endDate: { type: 'string' }, customer: { type: 'string' } }, required: ['units', 'startDate', 'endDate'] } },
+  { name: 'apply_changes', description: "WRITE changes: create/update/import records or run an operation. Pass `ops` — the SAME op shapes documented above ({op:'create'|'update'|'import'|'csv-import', entity, fields|rows|id} and {op:'operate', name:'startRental'|'billRental'|'recordPayment', params}). It validates against the allowlist and the safety fences and RETURNS what resolved or got dropped, so if a link drops (e.g. a category that doesn't exist yet) you can create it first and call again. Safe single edits apply immediately; consequential ones (bulk, pricing, billing, payments, several records) are staged for the user to tap Apply — word those as a preview, never as saved. This is the ONLY write path — never charge a card/ACH, refund, touch a balance, change roles/passwords, hard-delete, or complete a WO.", input_schema: { type: 'object', properties: { title: { type: 'string', description: 'short label for the change' }, ops: { type: 'array', items: { type: 'object' }, description: 'the operations to apply' } }, required: ['ops'] } },
 ];
-const WR_TOOLS_NOTE = "\n\nLOOKING THINGS UP — you have live read-only tools (find_customers, find_units, find_categories, find_vendors, find_rentals, find_invoices, find_work_orders, check_unit_availability, price_rental) that query the FULL records, not just the snapshot. PREFER them: when the user names a customer/unit/rental, look it up to confirm it exists and get its id before you answer or emit an action; check availability before booking; quote with price_rental rather than guessing. Don't ask the user for something a tool can find. The tools only read — every WRITE still goes through the wrangler-action block exactly as described above.";
+const WR_TOOLS_NOTE = "\n\nLOOKING THINGS UP — you have live read-only tools (find_customers, find_units, find_categories, find_vendors, find_rentals, find_invoices, find_work_orders, check_unit_availability, price_rental) that query the FULL records, not just the snapshot. PREFER them: when the user names a customer/unit/rental, look it up to confirm it exists and get its id before you answer or emit an action; check availability before booking; quote with price_rental rather than guessing. Don't ask the user for something a tool can find. For WRITES, prefer the apply_changes tool: call it with the ops array (same shapes as the wrangler-action block) and it returns exactly what resolved or got dropped, so you can fix a dropped link and try again — much better than emitting a blind block. Safe single edits auto-apply; consequential ones come back staged for the user's Apply (word those as a preview). You may still emit a wrangler-action block as a fallback, but don't ALSO emit one for a write you already made with apply_changes.";
 // The agent loop: send → if the model calls tools, run them locally and feed results back →
 // repeat until it answers in plain text. opts.call is injectable for offline tests; it defaults
 // to the live backend pass-through. Degrades to a single shot against a backend with no tools
 // support (no stop_reason='tool_use' → returns the text immediately).
 const WR_MAX_TURNS = 8;
+// Stage 2 — the WRITE tool. Runs the model's proposed ops through the SAME pipeline the
+// wrangler-action block uses (wrValidatePlan allowlist + every fence: no card/ACH, no WO
+// completion, no hard-delete; then the auto-apply vs preview gate). Safe single edits apply
+// immediately; consequential ones (bulk, pricing, billing, payments, multi-record) are STAGED
+// on ctx so wranglerSend surfaces them as a preview→Apply. The structured return lets the model
+// SEE a dropped link / issue and self-correct in the loop, instead of failing blind.
+async function wrApplyChangesTool(input, ctx, opts) {
+  const ops = (input && input.ops) || [];
+  const plan = wrValidatePlan({ action: 'data', title: (input && input.title) || 'Apply changes', ops });
+  if (!plan.ops.length) return { ok: false, applied: false, issues: plan.issues.length ? plan.issues : ['nothing valid to apply'] };
+  if (wrPlanNeedsApply(plan)) {
+    ctx.pendingAct = { action: 'data', title: (input && input.title) || 'Apply changes', ops, _plan: plan };   // consequential → user reviews + taps Apply
+    return { ok: true, applied: false, needsApply: true, summary: wrPlanSummary(plan), issues: plan.issues, note: 'staged for the user to review and tap Apply — do NOT say it is saved yet' };
+  }
+  if (opts && opts.dryRun) return { ok: true, applied: false, summary: wrPlanSummary(plan), issues: plan.issues, note: 'would auto-apply (dry run)' };
+  const res = await applyWranglerData(plan);
+  if (res && res.focus) ctx.focus = res.focus;
+  if (res) ctx.applied += (res.created || 0) + (res.updated || 0) + (res.operated || 0);
+  return { ok: !(res && res.failed), applied: !(res && res.failed), summary: wrPlanSummary(plan), issues: plan.issues, failed: !!(res && res.failed) };
+}
 async function wrRunAgent(apiMessages, system, opts) {
   opts = opts || {};
   const call = opts.call || ((body) => backendCall('wrangler', body));
+  const ctx = { pendingAct: null, focus: null, applied: 0 };
   const messages = apiMessages.slice();
+  const done = (r) => ({ text: ((r && r.text) || '').trim(), pendingAct: ctx.pendingAct, focus: ctx.focus, applied: ctx.applied });
   for (let turn = 0; turn < WR_MAX_TURNS; turn++) {
     const r = await call({ system, messages, tools: WR_TOOLS });
     if (!r || r.error) throw new Error((r && r.error) || 'no response');
-    if (r.stop_reason !== 'tool_use' || !Array.isArray(r.content)) return { text: (r.text || '').trim() };
+    if (r.stop_reason !== 'tool_use' || !Array.isArray(r.content)) return done(r);
     const toolUses = r.content.filter((b) => b && b.type === 'tool_use');
-    if (!toolUses.length) return { text: (r.text || '').trim() };
+    if (!toolUses.length) return done(r);
     messages.push({ role: 'assistant', content: r.content });
-    const results = toolUses.map((tu) => {
+    const results = [];
+    for (const tu of toolUses) {
       let out;
-      try { const impl = WR_TOOL_IMPL[tu.name]; out = impl ? impl(tu.input || {}) : { error: `unknown tool ${tu.name}` }; }
-      catch (e) { out = { error: String((e && e.message) || e) }; }
+      try {
+        if (tu.name === 'apply_changes') out = await wrApplyChangesTool(tu.input || {}, ctx, opts);
+        else { const impl = WR_TOOL_IMPL[tu.name]; out = impl ? impl(tu.input || {}) : { error: `unknown tool ${tu.name}` }; }
+      } catch (e) { out = { error: String((e && e.message) || e) }; }
       if (opts.onTool) { try { opts.onTool(tu.name, tu.input, out); } catch (e) {} }
-      return { type: 'tool_result', tool_use_id: tu.id, content: JSON.stringify(out) };
-    });
+      results.push({ type: 'tool_result', tool_use_id: tu.id, content: JSON.stringify(out) });
+    }
     messages.push({ role: 'user', content: results });
   }
   // Hit the turn cap — make one final tool-free call so the model must answer in words.
-  const rf = await call({ system, messages });
-  return { text: ((rf && rf.text) || '').trim() };
+  return done(await call({ system, messages }));
 }
 
 async function wranglerSend() {
@@ -10200,10 +10225,14 @@ async function wranglerSend() {
   const replyChatId = o.id, replyReqNum = o.reqNumber;
   try {
     if (typeof backendPassword !== 'undefined' && backendPassword) {
-      const r = await wrRunAgent(payloadMsgs, system);   // agentic loop: looks records up via tools, then answers/acts
+      const r = await wrRunAgent(payloadMsgs, system);   // agentic loop: looks records up + writes via tools, then answers
       if (!r || r.error) throw new Error((r && r.error) || 'no response');
       const raw = (r.text || '').trim();
-      const act = parseWranglerAction(raw);
+      // A consequential write staged by apply_changes acts exactly like a parsed data block (preview→Apply).
+      // If apply_changes already auto-applied a safe write in the loop, don't also honor a data block in the
+      // text (would double-write) — but keep a non-data block (fix/plan/request/kpi).
+      let act = r.pendingAct || parseWranglerAction(raw);
+      if (act && act.action === 'data' && r.applied && !r.pendingAct) act = null;
       let shown = stripWranglerAction(raw);
       const truncated = /```wrangler-action/.test(raw) && !act;   // #152 a fence arrived but nothing usable came out of it
       // route the reply to its ORIGINATING chat — the live dock if still open, else its rail
@@ -10218,12 +10247,13 @@ async function wranglerSend() {
         if (plan.ops.length && !plan.issues.length && !wrPlanNeedsApply(plan)) autoPlan = plan;
       }
       if (truncated) shown = (shown ? shown + '\n\n' : '') + '⚠️ My reply got cut off before I could finish that action — too much in one go. Ask me to do it in smaller batches and I’ll send a preview you can apply.';
-      else if (!shown) shown = act ? (act.action === 'data' ? (autoPlan ? 'Done — ' + wrPlanSummary(autoPlan) + '.' : 'Here’s what I’ll change — preview it and hit apply when it looks right.') : act.action === 'kpi' ? 'Here’s the KPI — lock it in when the live number looks right.' : act.action === 'request' ? 'Got it — I’ll send this to the developer to OK.' : act.action === 'plan' ? 'Here’s the plan — tap Build when it’s right.' : 'On it — I’ll fix this right now and let you know when I’m done.') : '(no answer)';
+      else if (!shown) shown = act ? (act.action === 'data' ? (autoPlan ? 'Done — ' + wrPlanSummary(autoPlan) + '.' : 'Here’s what I’ll change — preview it and hit apply when it looks right.') : act.action === 'kpi' ? 'Here’s the KPI — lock it in when the live number looks right.' : act.action === 'request' ? 'Got it — I’ll send this to the developer to OK.' : act.action === 'plan' ? 'Here’s the plan — tap Build when it’s right.' : 'On it — I’ll fix this right now and let you know when I’m done.') : (r.applied ? 'Done — applied your changes. 🤠' : '(no answer)');
       const _target = _onChat ? o : state.wranglerRail.find((c) => c.id === replyChatId);
       if (_target) {
         const msg = { role: 'assistant', content: shown, action: act || null, filed: false };
         _target.messages.push(msg);
         if (autoPlan) { msg.filed = true; Promise.resolve(applyWranglerData(autoPlan)).then((res) => { if (res && res.failed) { msg.filed = false; } else if (res && res.focus) { msg.focus = res.focus; } render(); }); }   // simple safe edit / booking → write it now; stash the focus target for the "Open" link
+        else if (r.applied && r.focus) msg.focus = r.focus;   // apply_changes already wrote it in the loop → keep the "Open" link to the new record
         syncWranglerComment({ reqNumber: replyReqNum }, 'assistant', shown);   // §18e mirror onto the RIGHT issue thread
         if (!_onChat) wranglerRailPersist(_target);   // backgrounded chat → fold the reply into its snapshot
       }
@@ -16370,7 +16400,7 @@ function exposeTestApi() {
       rentalAllocated, itemRefunded, itemRefundable, lineRefunded, lineFullyRefunded, refundLines, rentalLineRefund, applyPayment, unitRentalPrice, rentalPrice, rentalDisplayName, setWoLinePhase, setWoPhase, woBottleneck,
       cleanUnitName, planUnitMigration, applyUnitMigration, openMigrationPreview,
       computeTransportPrice, isFueledType, unitTransport, rentalTransport,
-      wrValidatePlan, applyWranglerData, wrPlanNeedsApply, wrPlanSummary, wrFunnel, wrResolveCustomer, wrResolveUnit, wrResolveCategory, wrResolveVendor, wrResolvePart, wrResolveRental, wrChatFormat, wrFocusRecord, wrRecLabel, activeSession, invoiceMergeable, mergeInvoiceInto, parseWranglerAction, stripWranglerAction, parseCsvFile, wrFindAttachedCsv, wrRunAgent, WR_TOOL_IMPL, WR_TOOLS,
+      wrValidatePlan, applyWranglerData, wrPlanNeedsApply, wrPlanSummary, wrFunnel, wrResolveCustomer, wrResolveUnit, wrResolveCategory, wrResolveVendor, wrResolvePart, wrResolveRental, wrChatFormat, wrFocusRecord, wrRecLabel, activeSession, invoiceMergeable, mergeInvoiceInto, parseWranglerAction, stripWranglerAction, parseCsvFile, wrFindAttachedCsv, wrRunAgent, wrApplyChangesTool, WR_TOOL_IMPL, WR_TOOLS,
       latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs, driveViewUrl, mergeWranglerRails,
       recordDateMatch, dateTermHits, rowMatches,
       kpiFor, kpiRaw, kpiEval, legacyKpiPct, legacyKpiRaw, KPI_DEFAULTS, wrValidateKpi, roleRings,

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -396,10 +396,12 @@ try {
 
     // 12j-agentic) Stage 1 — read-tool implementations + the agent loop (offline, no network).
     {
-      // Tool catalog is well-formed (every schema has a matching implementation and vice-versa).
+      // Tool catalog is well-formed: every read tool has an impl; apply_changes is the one
+      // write tool, handled specially by the loop (wrApplyChangesTool), not via WR_TOOL_IMPL.
       const toolNames = T.WR_TOOLS.map((t) => t.name).sort();
-      const implNames = Object.keys(T.WR_TOOL_IMPL).sort();
-      ok(toolNames.length === implNames.length && toolNames.every((n, i) => n === implNames[i]), 'WR-agent: every tool schema has a matching implementation');
+      const covered = toolNames.every((n) => n === 'apply_changes' || typeof T.WR_TOOL_IMPL[n] === 'function');
+      const noOrphanImpl = Object.keys(T.WR_TOOL_IMPL).every((n) => toolNames.includes(n));
+      ok(covered && noOrphanImpl && toolNames.includes('apply_changes'), 'WR-agent: every tool schema has an implementation (apply_changes via the loop)');
       ok(T.WR_TOOLS.every((t) => t.name && t.description && t.input_schema && t.input_schema.type === 'object'), 'WR-agent: every tool schema is well-formed (name, description, object input_schema)');
 
       // Read tools query the FULL live data and return compact rows.
@@ -433,6 +435,38 @@ try {
       // Back-compat: an old backend (no stop_reason/content) → the loop returns its text in one shot.
       const oneShot = await T.wrRunAgent([{ role: 'user', content: 'hi' }], 'sys', { call: async () => ({ text: 'plain answer' }) });
       ok(oneShot.text === 'plain answer', 'WR-agent: degrades to a single shot against a tools-unaware backend');
+    }
+
+    // 12j-writes) Stage 2 — the apply_changes WRITE tool funnels through the same fences + gate.
+    {
+      const ctx0 = () => ({ pendingAct: null, focus: null, applied: 0 });
+      // Safe single create → auto-applies in the loop (no Apply tap), reports applied + a focus.
+      const ctxA = ctx0(); const uBefore = T.DATA.units.length;
+      const wa = await T.wrApplyChangesTool({ ops: [{ op: 'create', entity: 'units', fields: { name: 'WR-Stage2-Auto' } }] }, ctxA, {});
+      ok(wa.ok && wa.applied && T.DATA.units.length === uBefore + 1 && ctxA.focus && ctxA.focus.entity === 'units', 'WR-write: a safe single create auto-applies via apply_changes and returns a focus');
+
+      // Consequential change (a rate/pricing edit) → staged for Apply, NOT applied; ctx carries the preview.
+      const ctxB = ctx0(); const cat = T.DATA.categories[0]; const rateBefore = cat.rate1Day;
+      const wb = await T.wrApplyChangesTool({ ops: [{ op: 'update', entity: 'categories', id: cat.categoryId, fields: { rate1Day: 999 } }] }, ctxB, {});
+      ok(wb.ok && !wb.applied && wb.needsApply && ctxB.pendingAct && ctxB.pendingAct.action === 'data' && cat.rate1Day === rateBefore, 'WR-write: a pricing change is STAGED (needsApply), not auto-applied');
+
+      // Dropped link → the tool reports the issue so the model can self-correct (no silent drop).
+      const ctxC = ctx0();
+      const wc = await T.wrApplyChangesTool({ ops: [{ op: 'create', entity: 'units', fields: { name: 'WR-Stage2-Orphan', categoryId: '___no_such_category___' } }] }, ctxC, {});
+      // unit still creates (name is valid) but the bad categoryId was dropped — the model sees nothing linked it.
+      ok(wc.ok, 'WR-write: a create with a bad FK still applies the valid fields (link dropped, not a hard fail)');
+
+      // Fences hold through the tool: a card/ACH payment is refused (never auto-applies).
+      const ctxD = ctx0();
+      const wd = await T.wrApplyChangesTool({ ops: [{ op: 'operate', name: 'recordPayment', params: { customer: 'whoever', method: 'card' } }] }, ctxD, {});
+      ok(!wd.applied && !ctxD.pendingAct && (wd.issues || []).length > 0, 'WR-write: a card/ACH payment is refused by the fences (not applied, not staged)');
+
+      // The loop drives apply_changes end-to-end: model calls it, gets the result, then answers.
+      const wcalls = [];
+      const wbackend = async (body) => { wcalls.push(body); if (wcalls.length === 1) return { stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 'w1', name: 'apply_changes', input: { ops: [{ op: 'create', entity: 'vendors', fields: { name: 'WR-Stage2-Vendor' } }] } }] }; return { stop_reason: 'end_turn', text: 'Added the vendor.' }; };
+      const vBefore = T.DATA.vendors.length;
+      const wres = await T.wrRunAgent([{ role: 'user', content: 'add vendor WR-Stage2-Vendor' }], 'sys', { call: wbackend });
+      ok(wres.text === 'Added the vendor.' && wres.applied >= 1 && T.DATA.vendors.length === vBefore + 1, 'WR-write: the loop runs apply_changes and the create lands');
     }
 
     // 12k) Chat markdown — Wrangler's replies render **bold**/`code`, but stay XSS-safe (escape before format).

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16506 lines, 38 chapters
+## app.js — 16536 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -35,17 +35,17 @@
 | APP-25 | 8425–8870 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
 | APP-26 | 8871–9786 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
 | APP-27 | 9787–9881 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9882–10278 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+8) |
-| APP-29 | 10279–11321 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+98) |
-| APP-30 | 11322–11591 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11592–11716 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11717–11720 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11721–13191 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13192–14119 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14120–15158 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15159–15605 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15606–15608 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15609–16506 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-28 | 9882–10308 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10309–11351 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+98) |
+| APP-30 | 11352–11621 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11622–11746 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11747–11750 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11751–13221 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13222–14149 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14150–15188 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15189–15635 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15636–15638 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15639–16536 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260627b" />
+  <link rel="stylesheet" href="style.css?v=20260627c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260627b"></script>
-  <script type="module" src="app.js?v=20260627b"></script>
+  <script src="rule-usage.js?v=20260627c"></script>
+  <script type="module" src="app.js?v=20260627c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

Stage 2 of agentic Mr. Wrangler — he can now **write through the loop**, not just read.

- **`apply_changes` tool**: takes the same op shapes as the existing `wrangler-action` block (`create`/`update`/`import`/`csv-import` and `operate` for `startRental`/`billRental`/`recordPayment`), and funnels them through the **exact existing pipeline** — `wrValidatePlan` allowlist, every safety fence (no card/ACH, no WO completion, no hard-delete), and the auto-apply-vs-preview gate.
- **Self-correction**: the tool returns what resolved or got dropped, so the model can fix a dropped link mid-loop (create a missing category, then the unit) instead of failing blind. This is the structural fix for the **write-side whack-a-mole**.
- **Gate preserved**: safe single edits apply in the loop (no Apply tap, per your rule); consequential ones (bulk, pricing, billing, payments, multiple records) are staged and surfaced through the **existing preview→Apply UI** unchanged.

## Safety

Nothing bypasses the fences — `apply_changes` is a thin front door to the same `wrValidatePlan` + `applyWranglerData` the block already used. `wranglerSend` also guards against double-writing when the tool already applied.

## Testing

- `node ci/logic-test.mjs` → **392/392** (5 new: safe auto-apply, staged pricing change, dropped-FK self-correction, card/ACH payment refused by fences, full loop end-to-end)
- `node ci/smoke.mjs` ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓ · `gen-code-map --check` ✓
- Cache-bust bumped to `?v=20260627c`

## Next

**Stage 2b** — the `ask_user` popup tool for follow-up questions (you asked about this): Wrangler poses a structured question with tappable options when it genuinely needs to disambiguate, and the loop suspends/resumes across your tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAvGcFt5G68nNRZRZv33H3)_