### PR TITLE
Wrangler agentic Stage 2b: ask_user follow-up popup

### DIFF
--- a/app.js
+++ b/app.js
@@ -7660,7 +7660,9 @@ function wranglerDockEl() {
         const imgs = (m.images && m.images.length) ? `<div class="wr-bub-imgs">${m.images.map((img) => { const s = wrImgSrc(img); return s ? `<img src="${esc(s)}" alt="attached image">` : ''; }).join('')}</div>` : '';
         const files = (m.files && m.files.length) ? `<div class="wr-bub-files">${m.files.map((f) => `<span class="wr-file-chip" data-tip="${esc(f.name)}">${I.paperclip || '📎'}<span class="wr-file-n">${esc(f.name)}</span></span>`).join('')}</div>` : '';
         const txt = m.content ? wrChatFormat(m.content) : '';
-        return `<div class="wr-msg ${m.role}">${m.role === 'assistant' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub">${imgs}${files}${txt}${act}</div></div>`;
+        // ask_user option chips (Stage 2b) — tappable only while THIS question is the live pending one.
+        const ask = (m.askOptions && m.askOptions.length && o.ask) ? `<div class="wr-ask">${m.askOptions.map((opt) => `<button class="wr-askbtn js-wr-ask" data-ans="${esc(opt)}">${esc(opt)}</button>`).join('')}</div>` : '';
+        return `<div class="wr-msg ${m.role}">${m.role === 'assistant' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub">${imgs}${files}${txt}${act}${ask}</div></div>`;
       }).join('')
     : '<div class="wr-empty">Ask about this record or the whole yard — service due, balances, what needs attention… or just tell me what’s broken (paste or attach a screenshot) and I’ll get it fixed.</div>';
   const attachRow = ((o.attach && o.attach.length) || (o.files && o.files.length))
@@ -10126,9 +10128,10 @@ const WR_TOOLS = [
   { name: 'find_work_orders', description: 'List work orders, filtered by unit and/or customer. Returns id, unit, report, phase, type.', input_schema: { type: 'object', properties: { unit: { type: 'string' }, customer: { type: 'string' } }, required: [] } },
   { name: 'check_unit_availability', description: 'Check whether a unit is free for a date window. Returns available + any conflicting rentals. Dates are YYYY-MM-DD.', input_schema: { type: 'object', properties: { unit: { type: 'string' }, startDate: { type: 'string' }, endDate: { type: 'string' } }, required: ['unit', 'startDate', 'endDate'] } },
   { name: 'price_rental', description: 'Quote the price for renting one or more units over a window (uses the live pricing engine; member rates apply if the customer is given). Dates are YYYY-MM-DD. Read-only — does not create anything.', input_schema: { type: 'object', properties: { units: { type: 'array', items: { type: 'string' } }, startDate: { type: 'string' }, endDate: { type: 'string' }, customer: { type: 'string' } }, required: ['units', 'startDate', 'endDate'] } },
+  { name: 'ask_user', description: "Ask the user ONE short follow-up question when you genuinely can't proceed — a real ambiguity (two customers match, which unit, missing a required detail). Pass a clear `question` and, when the choice is between known options, an `options` array (e.g. the matching customers) so they can just tap one. Use this SPARINGLY — never to confirm an obvious reading or something a find_* tool can answer. The user's answer comes back so you continue.", input_schema: { type: 'object', properties: { question: { type: 'string' }, options: { type: 'array', items: { type: 'string' } } }, required: ['question'] } },
   { name: 'apply_changes', description: "WRITE changes: create/update/import records or run an operation. Pass `ops` — the SAME op shapes documented above ({op:'create'|'update'|'import'|'csv-import', entity, fields|rows|id} and {op:'operate', name:'startRental'|'billRental'|'recordPayment', params}). It validates against the allowlist and the safety fences and RETURNS what resolved or got dropped, so if a link drops (e.g. a category that doesn't exist yet) you can create it first and call again. Safe single edits apply immediately; consequential ones (bulk, pricing, billing, payments, several records) are staged for the user to tap Apply — word those as a preview, never as saved. This is the ONLY write path — never charge a card/ACH, refund, touch a balance, change roles/passwords, hard-delete, or complete a WO.", input_schema: { type: 'object', properties: { title: { type: 'string', description: 'short label for the change' }, ops: { type: 'array', items: { type: 'object' }, description: 'the operations to apply' } }, required: ['ops'] } },
 ];
-const WR_TOOLS_NOTE = "\n\nLOOKING THINGS UP — you have live read-only tools (find_customers, find_units, find_categories, find_vendors, find_rentals, find_invoices, find_work_orders, check_unit_availability, price_rental) that query the FULL records, not just the snapshot. PREFER them: when the user names a customer/unit/rental, look it up to confirm it exists and get its id before you answer or emit an action; check availability before booking; quote with price_rental rather than guessing. Don't ask the user for something a tool can find. For WRITES, prefer the apply_changes tool: call it with the ops array (same shapes as the wrangler-action block) and it returns exactly what resolved or got dropped, so you can fix a dropped link and try again — much better than emitting a blind block. Safe single edits auto-apply; consequential ones come back staged for the user's Apply (word those as a preview). You may still emit a wrangler-action block as a fallback, but don't ALSO emit one for a write you already made with apply_changes.";
+const WR_TOOLS_NOTE = "\n\nLOOKING THINGS UP — you have live read-only tools (find_customers, find_units, find_categories, find_vendors, find_rentals, find_invoices, find_work_orders, check_unit_availability, price_rental) that query the FULL records, not just the snapshot. PREFER them: when the user names a customer/unit/rental, look it up to confirm it exists and get its id before you answer or emit an action; check availability before booking; quote with price_rental rather than guessing. Don't ask the user for something a tool can find. For WRITES, prefer the apply_changes tool: call it with the ops array (same shapes as the wrangler-action block) and it returns exactly what resolved or got dropped, so you can fix a dropped link and try again — much better than emitting a blind block. Safe single edits auto-apply; consequential ones come back staged for the user's Apply (word those as a preview). You may still emit a wrangler-action block as a fallback, but don't ALSO emit one for a write you already made with apply_changes. When you truly need to disambiguate before acting, call ask_user (with tappable options when the choice is between known records) instead of guessing or burying the question in prose — but only when a tool can't resolve it.";
 // The agent loop: send → if the model calls tools, run them locally and feed results back →
 // repeat until it answers in plain text. opts.call is injectable for offline tests; it defaults
 // to the live backend pass-through. Degrades to a single shot against a backend with no tools
@@ -10172,6 +10175,7 @@ async function wrRunAgent(apiMessages, system, opts) {
       let out;
       try {
         if (tu.name === 'apply_changes') out = await wrApplyChangesTool(tu.input || {}, ctx, opts);
+        else if (tu.name === 'ask_user') { const ans = opts.ask ? await opts.ask(tu.input || {}) : null; out = { answer: (ans == null || ans === '') ? '(no answer given — use your best judgement and proceed)' : String(ans) }; }
         else { const impl = WR_TOOL_IMPL[tu.name]; out = impl ? impl(tu.input || {}) : { error: `unknown tool ${tu.name}` }; }
       } catch (e) { out = { error: String((e && e.message) || e) }; }
       if (opts.onTool) { try { opts.onTool(tu.name, tu.input, out); } catch (e) {} }
@@ -10189,6 +10193,9 @@ async function wranglerSend() {
   const text = ((inp ? inp.value : o.draft) || '').trim();
   const imgs = (o.attach && o.attach.length) ? o.attach.slice() : null;
   const files = (o.files && o.files.length) ? o.files.slice() : null;
+  // A typed reply while Mr. Wrangler has a pending ask_user question ANSWERS it (resumes the loop),
+  // rather than starting a fresh turn. Tapping an option chip resolves it the same way.
+  if (o.ask && o.ask.resolve) { if (!text) { if (inp) inp.focus(); return; } o.draft = ''; if (inp) inp.value = ''; o.ask.resolve(text); return; }
   if ((!text && !imgs && !files) || o.busy) { if (inp) inp.focus(); return; }
   o.messages.push({ role: 'user', content: text, images: imgs, files });
   syncWranglerComment(o, 'user', text, imgs);   // §18e mirror the turn onto the issue thread
@@ -10225,7 +10232,16 @@ async function wranglerSend() {
   const replyChatId = o.id, replyReqNum = o.reqNumber;
   try {
     if (typeof backendPassword !== 'undefined' && backendPassword) {
-      const r = await wrRunAgent(payloadMsgs, system);   // agentic loop: looks records up + writes via tools, then answers
+      // ask_user (Stage 2b): the loop suspends here on a follow-up question — we post it with tappable
+      // options and wait for a tap/typed reply, which resumes the loop. Tied to the live dock only.
+      const askFn = (input) => new Promise((resolve) => {
+        const options = Array.isArray(input.options) ? input.options.slice(0, 6).map(String) : [];
+        o.messages.push({ role: 'assistant', content: String((input && input.question) || 'Which one?'), askOptions: options });
+        o.ask = { resolve: (answer) => { o.ask = null; o.busy = true; if (answer != null && answer !== '') o.messages.push({ role: 'user', content: String(answer) }); render(); resolve(answer == null ? null : String(answer)); } };
+        o.busy = false; render();
+        setTimeout(() => { const f = document.querySelector('.wrangler-dock .wr-feed'); if (f) f.scrollTop = f.scrollHeight; }, 0);
+      });
+      const r = await wrRunAgent(payloadMsgs, system, { ask: askFn });   // agentic loop: looks up, writes, and asks via tools, then answers
       if (!r || r.error) throw new Error((r && r.error) || 'no response');
       const raw = (r.text || '').trim();
       // A consequential write staged by apply_changes acts exactly like a parsed data block (preview→Apply).
@@ -12559,6 +12575,7 @@ function onClick(e) {
   if (closest('[data-cmt-color]')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'comment') { const ta = document.querySelector('.overlay .js-cmt-text'); if (ta) o.text = ta.value; o.color = closest('[data-cmt-color]').dataset.cmtColor; renderOverlay(); } return; }
   if (closest('.js-cmt-save')) { e.stopPropagation(); return saveCommentOverlay(); }
   if (closest('.js-fb-send')) { e.stopPropagation(); return sendFeedback(); }
+  if (closest('.js-wr-ask')) { e.stopPropagation(); const o = state.wrangler; if (o.ask && o.ask.resolve) o.ask.resolve(closest('.js-wr-ask').dataset.ans); return; }   // §18 tap an ask_user option → resumes the loop with that answer
   if (closest('.js-wr-send')) { e.stopPropagation(); return wranglerSend(); }   // §18 Mr. Wrangler
   if (closest('.js-wr-min')) { e.stopPropagation(); state.wrangler.min = !state.wrangler.min; return render(); }   // §18 collapse/expand the wrangler dock to its header bar, in place
   if (closest('.js-wr-close')) { e.stopPropagation(); wranglerRailSnapshot(); state.wrangler.open = false; return render(); }   // §18 close the dock back to the launcher; the chat lands on the §18g rail

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -396,12 +396,13 @@ try {
 
     // 12j-agentic) Stage 1 — read-tool implementations + the agent loop (offline, no network).
     {
-      // Tool catalog is well-formed: every read tool has an impl; apply_changes is the one
-      // write tool, handled specially by the loop (wrApplyChangesTool), not via WR_TOOL_IMPL.
+      // Tool catalog is well-formed: every read tool has an impl; apply_changes + ask_user are
+      // handled specially by the loop (wrApplyChangesTool / opts.ask), not via WR_TOOL_IMPL.
+      const LOOP_TOOLS = ['apply_changes', 'ask_user'];
       const toolNames = T.WR_TOOLS.map((t) => t.name).sort();
-      const covered = toolNames.every((n) => n === 'apply_changes' || typeof T.WR_TOOL_IMPL[n] === 'function');
+      const covered = toolNames.every((n) => LOOP_TOOLS.includes(n) || typeof T.WR_TOOL_IMPL[n] === 'function');
       const noOrphanImpl = Object.keys(T.WR_TOOL_IMPL).every((n) => toolNames.includes(n));
-      ok(covered && noOrphanImpl && toolNames.includes('apply_changes'), 'WR-agent: every tool schema has an implementation (apply_changes via the loop)');
+      ok(covered && noOrphanImpl && LOOP_TOOLS.every((n) => toolNames.includes(n)), 'WR-agent: every tool schema has an implementation (apply_changes + ask_user via the loop)');
       ok(T.WR_TOOLS.every((t) => t.name && t.description && t.input_schema && t.input_schema.type === 'object'), 'WR-agent: every tool schema is well-formed (name, description, object input_schema)');
 
       // Read tools query the FULL live data and return compact rows.
@@ -467,6 +468,23 @@ try {
       const vBefore = T.DATA.vendors.length;
       const wres = await T.wrRunAgent([{ role: 'user', content: 'add vendor WR-Stage2-Vendor' }], 'sys', { call: wbackend });
       ok(wres.text === 'Added the vendor.' && wres.applied >= 1 && T.DATA.vendors.length === vBefore + 1, 'WR-write: the loop runs apply_changes and the create lands');
+    }
+
+    // 12j-ask) Stage 2b — ask_user suspends the loop for a follow-up, resumes with the answer.
+    {
+      const acalls = [];
+      const abackend = async (body) => { acalls.push(body); if (acalls.length === 1) return { stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 'a1', name: 'ask_user', input: { question: 'Which Cameron?', options: ['Cameron Miller', 'Cameron Diaz'] } }] }; return { stop_reason: 'end_turn', text: 'Booked for Cameron Miller.' }; };
+      let asked = null;
+      const ares = await T.wrRunAgent([{ role: 'user', content: 'book cameron' }], 'sys', { call: abackend, ask: (input) => { asked = input; return Promise.resolve('Cameron Miller'); } });
+      ok(asked && asked.question === 'Which Cameron?' && asked.options.length === 2, 'WR-ask: ask_user surfaces the question + options to the UI');
+      ok(ares.text === 'Booked for Cameron Miller.', 'WR-ask: the loop resumes and finishes after the answer');
+      const afed = acalls[1].messages; const ar = afed[afed.length - 1];
+      ok(ar.role === 'user' && ar.content[0].type === 'tool_result' && ar.content[0].tool_use_id === 'a1' && /Cameron Miller/.test(ar.content[0].content), 'WR-ask: the chosen answer is fed back as the tool_result');
+      // No ask handler (e.g. backgrounded) → the loop proceeds with best-judgement, never hangs.
+      const acalls2 = [];
+      const abackend2 = async (body) => { acalls2.push(body); if (acalls2.length === 1) return { stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 'a2', name: 'ask_user', input: { question: 'Which?' } }] }; return { stop_reason: 'end_turn', text: 'ok' }; };
+      const ares2 = await T.wrRunAgent([{ role: 'user', content: 'x' }], 'sys', { call: abackend2 });
+      ok(ares2.text === 'ok' && /no answer/.test(acalls2[1].messages[acalls2[1].messages.length - 1].content[0].content), 'WR-ask: with no ask handler the loop proceeds (no hang)');
     }
 
     // 12k) Chat markdown — Wrangler's replies render **bold**/`code`, but stay XSS-safe (escape before format).

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16536 lines, 38 chapters
+## app.js — 16553 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -30,22 +30,22 @@
 | APP-20 | 7042–7165 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
 | APP-21 | 7166–7330 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
 | APP-22 | 7331–7540 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7541–8318 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+68) |
-| APP-24 | 8319–8424 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8425–8870 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8871–9786 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9787–9881 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9882–10308 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
-| APP-29 | 10309–11351 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+98) |
-| APP-30 | 11352–11621 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11622–11746 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11747–11750 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11751–13221 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13222–14149 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14150–15188 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15189–15635 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15636–15638 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15639–16536 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-23 | 7541–8320 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+68) |
+| APP-24 | 8321–8426 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8427–8872 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 8873–9788 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9789–9883 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9884–10324 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10325–11367 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+98) |
+| APP-30 | 11368–11637 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11638–11762 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11763–11766 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11767–13238 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13239–14166 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14167–15205 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15206–15652 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15653–15655 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15656–16553 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260627c" />
+  <link rel="stylesheet" href="style.css?v=20260627d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260627c"></script>
-  <script type="module" src="app.js?v=20260627c"></script>
+  <script src="rule-usage.js?v=20260627d"></script>
+  <script type="module" src="app.js?v=20260627d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1214,6 +1214,17 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-actbtn:focus-visible { outline: 2px solid var(--accent-line, #ff7a1a); outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) { .wr-actbtn:active { transform: none; } }
 .wr-actbtn-build { background: linear-gradient(180deg, #43d07f, #2faa63); color: #04140c; }   /* the plan-OK "go build it" commit */
+/* ask_user follow-up options — ARMED chips (orange outline, not fill): a set of choices, none
+   selected yet, so they stay quiet against the steel bubble and don't read as ignition actions. */
+.wr-ask { margin-top: 9px; display: flex; flex-wrap: wrap; gap: 7px; }
+.wr-askbtn { cursor: pointer; min-height: 30px; padding: 5px 12px; border-radius: 8px;
+  border: 1.5px solid var(--accent-line, #ff7a1a); background: rgba(255, 122, 26, .08); color: var(--txt);
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 11.5px;
+  letter-spacing: 1.1px; text-transform: uppercase; white-space: normal; text-align: left; }
+.wr-askbtn:hover { background: linear-gradient(180deg, #ff9036, #ff7a1a); color: #1a1205; border-color: transparent; }
+.wr-askbtn:active { transform: translateY(1px); }
+.wr-askbtn:focus-visible { outline: 2px solid var(--accent-line, #ff7a1a); outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) { .wr-askbtn:active { transform: none; } }
 .wr-apply { margin-top: 9px; display: flex; flex-direction: column; gap: 6px; align-items: flex-start; }
 .wr-apply-sum { font-size: 12px; font-weight: 700; color: var(--txt); }
 .wr-apply-skip { font-size: 10.5px; color: var(--yellow); }


### PR DESCRIPTION
## What

The feature you asked about — **Mr. Wrangler can now use a popup for follow-up questions.**

- **`ask_user` tool**: when Wrangler genuinely needs to disambiguate (two customers match, which unit), it poses **one** short question with tappable option chips instead of guessing or burying it in prose.
- **Suspend/resume loop**: the agent loop suspends on `ask_user`, the dock posts the question, and a **tap (or typed reply)** resumes the loop — the answer is fed back as the tool_result and Wrangler continues. Same spirit as your own "ask via popups" rule, applied to Wrangler.
- Prompt guidance keeps it **sparing**: only when a `find_*` tool can't resolve it — never to confirm an obvious reading.

## Design

Option chips are **armed/outline** (orange outline, not fill) so a set of unselected choices stays quiet against the steel bubble and doesn't read as several ignition actions — respects "one orange, one meaning." Saira Condensed labels, hover → ignition fill, `:focus-visible`, reduced-motion respected, flex-wrap for narrow/mobile. With no ask handler (a backgrounded chat) the loop proceeds on best judgement rather than hanging.

## Testing

- `node ci/logic-test.mjs` → **396/396** (4 new: question surfaced with options, chosen answer fed back with matching `tool_use_id`, loop resumes to completion, no-handler fallback)
- `node ci/smoke.mjs` ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓ · `gen-code-map --check` ✓
- Cache-bust bumped to `?v=20260627d`

## Note

UI self-critique was done against the design tokens (armed-chip rationale above); a live on-device screenshot pass is easy to add when you test it — the chips only appear mid-conversation when Wrangler asks.

## Next

**Stage 3** — retire the 200-row snapshot from the system prompt and slim it, now that the model discovers data through tools. That's the last stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAvGcFt5G68nNRZRZv33H3)_