### PR TITLE
Filter closed GitHub issues and resolved-request snaps from comms rail

### DIFF
--- a/app.js
+++ b/app.js
@@ -7466,7 +7466,7 @@ function commsRailEl() {
     const active = wrOpen && (state.wrangler.reqNumber === rq.number || state.wrangler.id === 'req' + rq.number);
     return `<button class="crail-tab ${cls}${active ? ' is-active' : ''}" data-wrc-needs="${rq.number}" role="tab" aria-selected="${active}" data-tip="${tip}"><span class="crail-dot"></span><span class="crail-t">${trim(rq.title || ('Request #' + rq.number))}</span></button>`;
   }).join('');
-  const snaps = (state.wranglerRail || []).filter((c) => !(c.reqNumber && reqNums.has(c.reqNumber)));
+  const snaps = (state.wranglerRail || []).filter((c) => !c.reqNumber);
   // the live chat first if it's a brand-new one not yet snapshotted onto the rail
   let liveTab = '';
   if (wrOpen && state.wrangler.id && !state.wrangler.reqNumber && !snaps.some((c) => c.id === state.wrangler.id) && (state.wrangler.messages || []).length) {
@@ -10919,7 +10919,7 @@ const canApproveRequests = () => roleTier(currentRole) >= tierRank('manager');
 async function refreshWranglerRequests() {
   if (typeof backendPassword === 'undefined' || !backendPassword || reqLoading) return;   // demo/offline → no inbox
   reqLoading = true;
-  try { const r = await backendCall('wranglerRequests', {}); if (r && r.ok && Array.isArray(r.requests)) { wranglerRequests = r.requests; reqLoaded = true; } } catch (e) {}
+  try { const r = await backendCall('wranglerRequests', {}); if (r && r.ok && Array.isArray(r.requests)) { wranglerRequests = r.requests.filter((x) => !x.state || x.state.toLowerCase() !== 'closed'); reqLoaded = true; } } catch (e) {}
   reqLoading = false;
   render(); if (state.overlay?.kind === 'requests') renderOverlay();
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260627g" />
+  <link rel="stylesheet" href="style.css?v=20260628b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260627g"></script>
-  <script type="module" src="app.js?v=20260627g"></script>
+  <script src="rule-usage.js?v=20260628b"></script>
+  <script type="module" src="app.js?v=20260628b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Closed GitHub issues no longer appear as active rail tabs in the comms band. Request-linked chat snaps are hidden from snapTabs — open requests render as dedicated reqTabs; chats about resolved ones no longer linger.\n\nCache-bust: `v=20260628b`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfiPGpgVuyY3XPBeRtAxmf)_