### PR TITLE
Enable partial refunds (#125/#379) — backend now honors the partial amount

### DIFF
--- a/app.js
+++ b/app.js
@@ -5545,7 +5545,7 @@ function allocLines(inv) {
    sending a partial now would over-refund real money. With this false the Refund button keeps
    today's safe full-invoice behavior untouched. Flip to true ONLY after deploying the
    partial-refund backend (docs/handoffs/partial-refunds-backend.md). */
-const PARTIAL_REFUNDS_ENABLED = false;
+const PARTIAL_REFUNDS_ENABLED = true;
 function itemRefunded(inv, li) {
   if (!inv || !inv.refundAllocations) return 0;
   return Math.min(Number(inv.refundAllocations[lineKey(li)]) || 0, itemPaid(inv, li));

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260628b" />
+  <link rel="stylesheet" href="style.css?v=20260628c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260628b"></script>
-  <script type="module" src="app.js?v=20260628b"></script>
+  <script src="rule-usage.js?v=20260628c"></script>
+  <script type="module" src="app.js?v=20260628c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

Turns on the built-but-gated partial / per-line refund UI (`PARTIAL_REFUNDS_ENABLED → true`), now that the backend gap that made it unsafe is closed.

## Why it's safe now (it wasn't before)

The cash/check handler `recordManualRefund_` **ignored the partial amount and always refunded the full invoice**. Flipping this flag earlier would have let a clerk try to refund $40 and actually refund the customer the whole $100, marking it fully refunded — a live over-refund bug. That's why it was gated off.

**Backend fix (deployed live `@54`):** `recordManualRefund_` now honors `amountCents`, capped at what's still paid, accumulating `refundedAmount`, flipping `refunded=true` only on a full refund — mirroring the already-correct card path (`stripeRefundInvoice_`). Full refunds (no `amountCents`) behave identically, so the deploy was back-compat.

## Verified live (throwaway invoice, per the money-path runbook)

| Step | Result |
|---|---|
| Pay $100 cash | `amountPaid 100` |
| Refund **$40** | `amountPaid 60` · `refundedAmount 40` · status **partial-refund** ✅ |
| Over-ask $1000 | capped to remaining **$60** · `amountPaid 0` · status **refunded** ✅ |
| Cleanup | throwaway deleted |

(The old handler would've refunded $100 on step 2 — that's the bug this closes.)

## Testing

- smoke ✓ · logic **399/399** · rule-usage ✓ · window-catalog ✓ · code-map ✓
- Cache-bust `?v=20260628c`

Closes #379 · Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAvGcFt5G68nNRZRZv33H3)_