### PR TITLE
Wrangler Ops — developer chat bridge

### DIFF
--- a/app.js
+++ b/app.js
@@ -9085,6 +9085,16 @@ function buildPopupEl(o, overlay, opts = {}) {
     const pop = el('div', 'popup'); pop.style.width = '430px';
     pop.innerHTML = popupShell({ icon: I.horseshoe || CARD_ICON.customers || '', title: 'Saddle Up — Membership', tag: `Customer · enroll`, body, foot });
     overlay.appendChild(pop);
+  } else if (o.kind === 'wranglerOps') {
+    // §18i Wrangler Ops — the DEV_PASSWORD-gated developer inbox (the dev side of the live
+    // chat bridge). Gate body until unlocked, then a two-pane list + transcript/composer.
+    const foot = o.authed
+      ? `<button class="pill ghost js-close" data-r="R18">Close</button>`
+      : `<button class="pill ghost js-close" data-r="R18">Close</button><button class="pill ignition js-wrops-unlock" data-r="R17"${o.busy ? ' disabled' : ''}>${o.busy ? 'Checking…' : 'Unlock'}</button>`;
+    const pop = el('div', 'popup wrops-popup'); pop.style.width = o.authed ? '760px' : '380px';
+    pop.innerHTML = popupShell({ icon: I.horseshoe || '🤠', title: 'Wrangler Ops', tag: 'Developer · live chats', body: wranglerOpsBody(o), foot, bodyClass: 'wrops-body' });
+    overlay.appendChild(pop);
+    if (!opts.preview && !o._focused) { o._focused = true; setTimeout(() => { const f = pop.querySelector('.js-wrops-key') || pop.querySelector('.js-wrops-in'); if (f) f.focus(); }, 0); }   // focus ONCE on open — not on every poll re-render (that would steal the caret)
   } else if (o.kind === 'comment') {
     // Phase 6 (Jac redesign) — a SIMPLE comment card that floods with the picked color.
     // Traffic-light dots top-left pick the color; the card body becomes that solid color.
@@ -9885,6 +9895,7 @@ const WINDOW_CATALOG = [
   { kind: 'verifyAch',     label: 'Verify ACH',              tag: 'Customer · verify ACH',     sample: () => { const c = (DATA.customers || []).find((x) => (x.achAccounts || []).length); return c ? { customerId: c.customerId, bankId: c.achAccounts[0].id } : {}; } },
   { kind: 'payment',       label: 'Take Payment',            tag: 'Invoice · payment',         sample: () => ({ invoiceId: ((DATA.invoices || [])[0] || {}).invoiceId }) },
   { kind: 'membershipEnroll', label: 'Membership Enrollment', tag: 'Customer · enroll',         sample: () => ({ custId: ((DATA.customers || [])[0] || {}).customerId, plan: 'Monthly', addOns: { transport: false, protection: false }, autoRenew: false, startDate: TODAY_ISO, busy: false, error: '' }) },
+  { kind: 'wranglerOps',   label: 'Wrangler Ops',            tag: 'Developer · live chats',   sample: () => ({ authed: false, devKey: '', err: '', chats: [], openId: null, msgs: [], driver: 'ai', draft: '', busy: false }) },
 ];
 /* Build an INERT preview popup for a catalog kind (or null if a record guard trips
    or it throws). Reuses buildPopupEl with {preview:true} — the REAL popup — into a
@@ -11903,6 +11914,16 @@ function initDrag() {
   document.addEventListener('pointermove', dragMove);
   document.addEventListener('pointerup', dragUp);
   document.addEventListener('pointercancel', () => cancelDrag());                       // touch scroll stole the gesture = clean cancel, never a drop
+  // §18i Wrangler Ops — a ~600ms long-press on the 🤠 launcher opens the developer inbox
+  // (invisible to normal users; the inbox itself is DEV_PASSWORD-gated). A tap is unchanged
+  // (the click handler swallows the trailing click when the long-press fired).
+  document.addEventListener('pointerdown', (e) => {
+    const btn = e.target.closest && e.target.closest('.js-wrangler'); if (!btn) return;
+    _wrLaunchFired = false; clearTimeout(_wrLaunchTimer);
+    _wrLaunchTimer = setTimeout(() => { _wrLaunchFired = true; try { if (navigator.vibrate) navigator.vibrate(15); } catch (e2) {} openWranglerOps(); }, 600);
+  });
+  const _wrLaunchEnd = () => clearTimeout(_wrLaunchTimer);
+  document.addEventListener('pointerup', _wrLaunchEnd); document.addEventListener('pointercancel', _wrLaunchEnd); document.addEventListener('pointermove', (e) => { if (_wrLaunchTimer && (Math.abs(e.movementX) > 4 || Math.abs(e.movementY) > 4)) _wrLaunchEnd(); });
   window.addEventListener('blur', () => cancelDrag());                                  // tab/window switch can eat pointerup — never leave a stuck drag
   document.addEventListener('visibilitychange', () => { if (document.hidden) cancelDrag(); });
   // Esc cancels a live drag AHEAD of the winpicker/overlay/pick chain — capture
@@ -12632,7 +12653,12 @@ function onClick(e) {
   if (closest('.js-wr-kpi-lock')) { e.stopPropagation(); lockKpiFromWrangler(Number(closest('.js-wr-kpi-lock').dataset.mi)); return; }   // Mr. Wrangler locks in an authored KPI ring
   if (closest('.js-wr-unattach')) { e.stopPropagation(); const o = state.wrangler; if (o.open && o.attach) { o.attach.splice(Number(closest('.js-wr-unattach').dataset.i), 1); render(); } return; }   // §18d drop a pending image attachment
   if (closest('.js-wr-unfile')) { e.stopPropagation(); const o = state.wrangler; if (o.open && o.files) { o.files.splice(Number(closest('.js-wr-unfile').dataset.i), 1); render(); } return; }   // §18d drop a pending file attachment
-  if (closest('.js-wrangler')) { e.stopPropagation(); if (state.wrangler.open) { wranglerRailSnapshot(); state.wrangler.open = false; return render(); } return wranglerNewChat(); }   // §18 toggle Mr. Wrangler dock — opening always starts a fresh chat (the last one waits on the §18g rail)
+  if (closest('.js-wrangler')) { e.stopPropagation(); if (_wrLaunchFired) { _wrLaunchFired = false; return; }   // §18i a long-press already opened Wrangler Ops — swallow the trailing click (don't toggle the dock)
+    if (state.wrangler.open) { wranglerRailSnapshot(); state.wrangler.open = false; return render(); } return wranglerNewChat(); }   // §18 toggle Mr. Wrangler dock — opening always starts a fresh chat (the last one waits on the §18g rail)
+  if (closest('.js-wrops-unlock')) { e.stopPropagation(); const k = document.querySelector('.overlay .js-wrops-key'); return wranglerOpsUnlock(k ? k.value : ''); }   // §18i Wrangler Ops: unlock with the dev key
+  if (closest('.js-wrops-open')) { e.stopPropagation(); return wranglerOpsOpenChat(closest('.js-wrops-open').dataset.id); }   // §18i open a chat in the inbox
+  if (closest('.js-wrops-send')) { e.stopPropagation(); const i = document.querySelector('.overlay .js-wrops-in'); return wranglerOpsSend(i ? i.value : ''); }   // §18i send a turn / take the wheel
+  if (closest('.js-wrops-release')) { e.stopPropagation(); return wranglerOpsRelease(); }   // §18i hand the wheel back to the AI
   if (closest('.js-wrc-remove')) { e.stopPropagation(); return wrRailRemove(closest('.js-wrc-remove').dataset.wrcRm); }   // §18g rail: the × on a chat tab → REMOVE that conversation (not just close it)
   if (closest('[data-wrc-needs]')) { e.stopPropagation(); return openWranglerFromRequest(Number(closest('[data-wrc-needs]').dataset.wrcNeeds)); }   // §18g rail: a flashing "needs you" chat → reopen it seeded from the request
   if (closest('[data-wrc-open]')) { e.stopPropagation(); return wranglerRailOpen(closest('[data-wrc-open]').dataset.wrcOpen); }   // §18g rail: reopen a stored conversation
@@ -13729,6 +13755,8 @@ function onInput(e) {
   if (e.target.classList.contains('js-fb-text')) { if (state.overlay?.kind === 'feedback') state.overlay.text = e.target.value; return; }
   if (e.target.classList.contains('js-cmt-text')) { if (state.overlay?.kind === 'comment') state.overlay.text = e.target.value; return; }
   if (e.target.classList.contains('js-wr-in')) { if (state.wrangler.open) state.wrangler.draft = e.target.value; return; }
+  if (e.target.classList.contains('js-wrops-in')) { if (state.overlay && state.overlay.kind === 'wranglerOps') state.overlay.draft = e.target.value; return; }   // §18i keep the composer draft through poll re-renders
+  if (e.target.classList.contains('js-wrops-key')) { if (state.overlay && state.overlay.kind === 'wranglerOps') state.overlay.devKey = e.target.value; return; }   // §18i keep the gate key through re-renders
   if (e.target.classList.contains('chat-input')) { state.chat.draft = e.target.value; return; }
   // Company Files live search → re-render the board popup and restore the caret.
   if (e.target.classList.contains('js-files-query')) {
@@ -15950,6 +15978,126 @@ function wranglerDockPollStart() {
   const loop = () => { Promise.resolve(wranglerDockPollTick()).catch(() => {}).then(() => { _wrPollTimer = setTimeout(loop, WR_DOCK_POLL_MS); }); };
   _wrPollTimer = setTimeout(loop, WR_DOCK_POLL_MS);
 }
+// ── §18i Wrangler Ops — the developer inbox (the dev side of the live bridge) ──
+// A DEV_PASSWORD-gated popup (kind 'wranglerOps') that lists EVERY role's Mr. Wrangler
+// chat (getWranglerChatsAll) and lets the developer open one and jump in: a turn sent
+// here takes the wheel (appendWranglerMessage → driver='human'; the customer dock pauses
+// via R26), and "Release to AI" hands it back (setWranglerDriver). Invisible to normal
+// users — opened only by a long-press on the 🤠 launcher. The key is cached in-session.
+let _wrOpsKey = '';
+const WR_OPS_POLL_MS = 7000;
+let _wrOpsPollTimer = null;
+let _wrLaunchTimer = null, _wrLaunchFired = false;   // §18i 🤠 launcher long-press → Wrangler Ops
+function openWranglerOps() {
+  openOverlay({ kind: 'wranglerOps', authed: !!_wrOpsKey, devKey: '', err: '', chats: [], openId: null, msgs: [], driver: 'ai', draft: '', busy: false });
+  wranglerOpsPollStart();
+  if (_wrOpsKey) wranglerOpsLoad();
+}
+async function wranglerOpsLoad() {
+  const o = state.overlay; if (!o || o.kind !== 'wranglerOps' || !_wrOpsKey) return;
+  let r; try { r = await backendCall('getWranglerChatsAll', { devKey: _wrOpsKey }); } catch (e) { return; }
+  if (!state.overlay || state.overlay.kind !== 'wranglerOps') return;
+  if (r && r.ok) { o.authed = true; o.err = ''; o.chats = r.chats || []; }
+  else if (r && r.error === 'auth') { _wrOpsKey = ''; o.authed = false; o.err = 'That dev key didn’t match.'; }
+  renderOverlay();
+}
+async function wranglerOpsUnlock(key) {
+  _wrOpsKey = (key || '').trim();
+  const o = state.overlay; if (!o) return;
+  if (!_wrOpsKey) { flashOr('.overlay .js-wrops-key', 'Enter the dev key.'); return; }
+  o.busy = true; renderOverlay();
+  await wranglerOpsLoad();
+  if (state.overlay === o) { o.busy = false; if (!o.authed) flashOr('.overlay .js-wrops-key', o.err || 'Wrong key.'); renderOverlay(); }
+}
+async function wranglerOpsOpenChat(id) {
+  const o = state.overlay; if (!o || o.kind !== 'wranglerOps') return;
+  o.openId = id; o.msgs = []; o.driver = 'ai'; renderOverlay();
+  let r; try { r = await backendCall('getWranglerChat', { devKey: _wrOpsKey, id, sinceCount: 0 }); } catch (e) { return; }
+  if (!state.overlay || state.overlay.openId !== id) return;     // switched chats during the await
+  if (r && r.ok) { o.msgs = r.messages || []; o.driver = r.driver === 'human' ? 'human' : 'ai'; renderOverlay(); }
+}
+async function wranglerOpsSend(text) {
+  const o = state.overlay; if (!o || o.kind !== 'wranglerOps' || !o.openId) return;
+  text = (text || '').trim(); if (!text || o.busy) return;
+  o.busy = true; renderOverlay();
+  let r; try { r = await backendCall('appendWranglerMessage', { devKey: _wrOpsKey, chatId: o.openId, message: { content: text, author: 'Jac' } }); } catch (e) { o.busy = false; renderOverlay(); return; }
+  if (state.overlay === o) {
+    if (r && r.ok) { o.draft = ''; o.msgs.push({ role: 'assistant', content: text, dev: true, author: 'Jac' }); o.driver = 'human'; }
+    else if (r && r.reason === 'gone') { o.err = 'That chat was pruned.'; o.openId = null; }
+    o.busy = false; renderOverlay();
+  }
+}
+async function wranglerOpsRelease() {
+  const o = state.overlay; if (!o || o.kind !== 'wranglerOps' || !o.openId) return;
+  let r; try { r = await backendCall('setWranglerDriver', { devKey: _wrOpsKey, chatId: o.openId, driver: 'ai' }); } catch (e) { return; }
+  if (state.overlay === o && r && r.ok) { o.driver = 'ai'; renderOverlay(); }
+}
+// Poll while the inbox is open: refresh the list, and the open chat's new turns + driver.
+async function wranglerOpsPollTick() {
+  const o = state.overlay; if (!o || o.kind !== 'wranglerOps' || !o.authed || !_wrOpsKey || o.busy) return;
+  try {
+    const lr = await backendCall('getWranglerChatsAll', { devKey: _wrOpsKey });
+    if (state.overlay !== o) return;
+    if (lr && lr.ok) o.chats = lr.chats || [];
+    if (o.openId) {
+      const id = o.openId, cr = await backendCall('getWranglerChat', { devKey: _wrOpsKey, id, sinceCount: o.msgs.length });
+      if (state.overlay === o && o.openId === id && cr && cr.ok) {
+        if (Array.isArray(cr.messages) && cr.messages.length) cr.messages.forEach((m) => o.msgs.push(m));
+        o.driver = cr.driver === 'human' ? 'human' : 'ai';
+      }
+    }
+    // Don't yank the caret while the developer is typing in the composer/gate — update
+    // state silently this tick; the next idle tick (or any click) repaints.
+    const typing = document.activeElement && (document.activeElement.classList.contains('js-wrops-in') || document.activeElement.classList.contains('js-wrops-key'));
+    if (state.overlay === o && !typing) renderOverlay();
+  } catch (e) { /* silent — keep last-known */ }
+}
+function wranglerOpsPollStart() {
+  if (_wrOpsPollTimer) return;
+  const loop = () => { Promise.resolve(wranglerOpsPollTick()).catch(() => {}).then(() => {
+    if (state.overlay && state.overlay.kind === 'wranglerOps') _wrOpsPollTimer = setTimeout(loop, WR_OPS_POLL_MS);
+    else _wrOpsPollTimer = null;   // inbox closed → stop the loop (restarts on next open)
+  }); };
+  _wrOpsPollTimer = setTimeout(loop, WR_OPS_POLL_MS);
+}
+function wrOpsAgo(ts) {
+  if (!ts) return '';
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60); if (m < 60) return m + 'm';
+  const h = Math.floor(m / 60); if (h < 24) return h + 'h';
+  return Math.floor(h / 24) + 'd';
+}
+function wranglerOpsRow(c, openId) {
+  const live = (Date.now() - (c.lastTs || 0)) < 120000;
+  const drv = c.driver === 'human' ? badge('You · live', 'yellow') : badge('AI', 'gray');
+  return `<button class="wrops-row${c.id === openId ? ' on' : ''} js-wrops-open" data-id="${esc(c.id)}">
+    <span class="wrops-row-top"><span class="ag-dot${live ? ' mid' : ''}"></span><span class="wrops-row-ttl">${esc(c.title || 'New chat')}</span><span class="wrops-row-role">${esc(c.role || '')}</span></span>
+    <span class="wrops-row-prev">${esc(c.preview || '—')}</span>
+    <span class="wrops-row-meta">${drv}<span class="wrops-age">${esc(wrOpsAgo(c.lastTs))}</span></span>
+  </button>`;
+}
+function wranglerOpsDetail(o) {
+  const paused = o.driver === 'human';
+  const turns = o.msgs.length
+    ? o.msgs.map((m) => { const txt = typeof m.content === 'string' ? wrChatFormat(m.content) : '<span class="muted">[attachment]</span>'; return `<div class="wr-msg ${m.role === 'user' ? 'user' : 'assistant'}">${m.role !== 'user' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub">${txt}</div></div>`; }).join('')
+    : '<div class="wrops-empty">No messages in this chat.</div>';
+  const driverBar = `<div class="wrops-driver">${paused ? badge('You have the wheel', 'yellow') : badge('AI is driving', 'gray')}${paused ? '<button class="pill ghost js-wrops-release" data-r="R18">Release to AI</button>' : ''}</div>`;
+  const composer = `<div class="wrops-compose"><input class="wrops-in js-wrops-in" placeholder="${paused ? 'Type as Mr. Wrangler…' : 'Type to take the wheel…'}" value="${esc(o.draft || '')}" ${o.busy ? 'disabled' : ''} /><button class="pill ignition js-wrops-send" data-r="R17" ${o.busy ? 'disabled' : ''}>${paused ? 'Send' : 'Take the wheel'}</button></div>`;
+  return `<div class="wrops-detail"><div class="wrops-transcript">${turns}</div>${driverBar}${composer}</div>`;
+}
+function wranglerOpsBody(o) {
+  if (!o.authed) {
+    return `<div class="wrops-gate">
+      <p class="wrops-gate-lead">Developer access — enter the Wrangler Ops key.</p>
+      <input type="password" class="wrops-key js-wrops-key" placeholder="DEV_PASSWORD" autocomplete="off" value="${esc(o.devKey || '')}" />
+      ${o.err ? `<p class="wrops-err">${esc(o.err)}</p>` : ''}
+    </div>`;
+  }
+  const list = o.chats.length ? o.chats.map((c) => wranglerOpsRow(c, o.openId)).join('') : '<div class="wrops-empty">No chats yet — they appear here as people use Mr. Wrangler.</div>';
+  const pane = o.openId ? wranglerOpsDetail(o) : '<div class="wrops-empty">Pick a chat to read it — or jump in.</div>';
+  return `<div class="wrops-wrap"><div class="wrops-list">${list}</div><div class="wrops-pane">${pane}</div></div>`;
+}
 function saveSoon(ms) { if (booting || !backendPassword) return; clearTimeout(saveTimer); saveTimer = setTimeout(flushSave, ms || 1200); }
 // #247 — sync-health. A failing backend sync used to be SILENT (savePending → flat
 // 1.2s retry, no signal), so writes vanished with no warning. Now: track consecutive
@@ -16365,6 +16513,8 @@ function boot() {
     }
     if (e.target.classList.contains('nc-in') && e.key === 'Enter' && e.target.tagName !== 'SELECT') { e.preventDefault(); return saveNewCustomer(); }
     if (e.target.classList.contains('js-wr-in') && e.key === 'Enter') { e.preventDefault(); return wranglerSend(); }   // §18
+    if (e.target.classList.contains('js-wrops-in') && e.key === 'Enter') { e.preventDefault(); return wranglerOpsSend(e.target.value); }   // §18i send / take the wheel
+    if (e.target.classList.contains('js-wrops-key') && e.key === 'Enter') { e.preventDefault(); return wranglerOpsUnlock(e.target.value); }   // §18i unlock the inbox
     if (e.target.classList.contains('chat-input') && e.key === 'Enter') { e.preventDefault(); return chatSend(); }
     // §M3 — one predictable back/dismiss chain (shared with the Android back button):
     // winpicker → overlay → Mr. Wrangler dock → team chat dock.

--- a/app.js
+++ b/app.js
@@ -12659,6 +12659,7 @@ function onClick(e) {
   if (closest('.js-wrops-open')) { e.stopPropagation(); return wranglerOpsOpenChat(closest('.js-wrops-open').dataset.id); }   // §18i open a chat in the inbox
   if (closest('.js-wrops-send')) { e.stopPropagation(); const i = document.querySelector('.overlay .js-wrops-in'); return wranglerOpsSend(i ? i.value : ''); }   // §18i send a turn / take the wheel
   if (closest('.js-wrops-release')) { e.stopPropagation(); return wranglerOpsRelease(); }   // §18i hand the wheel back to the AI
+  if (closest('.js-wrops-escalate')) { e.stopPropagation(); return wranglerOpsEscalate(); }   // §18i (Phase 6) escalate the chat to Claude Code via the existing Thread Mirror
   if (closest('.js-wrc-remove')) { e.stopPropagation(); return wrRailRemove(closest('.js-wrc-remove').dataset.wrcRm); }   // §18g rail: the × on a chat tab → REMOVE that conversation (not just close it)
   if (closest('[data-wrc-needs]')) { e.stopPropagation(); return openWranglerFromRequest(Number(closest('[data-wrc-needs]').dataset.wrcNeeds)); }   // §18g rail: a flashing "needs you" chat → reopen it seeded from the request
   if (closest('[data-wrc-open]')) { e.stopPropagation(); return wranglerRailOpen(closest('[data-wrc-open]').dataset.wrcOpen); }   // §18g rail: reopen a stored conversation
@@ -16032,6 +16033,24 @@ async function wranglerOpsRelease() {
   let r; try { r = await backendCall('setWranglerDriver', { devKey: _wrOpsKey, chatId: o.openId, driver: 'ai' }); } catch (e) { return; }
   if (state.overlay === o && r && r.ok) { o.driver = 'ai'; renderOverlay(); }
 }
+// §18i (Phase 6 seam) Escalate → Claude Code: file THIS chat as a wrangler-fix issue
+// (the existing Thread Mirror / auto-fix path) a Claude agent can pick up. Falls back to
+// a pre-filled issue tab when the backend can't file (no GITHUB_TOKEN / offline).
+async function wranglerOpsEscalate() {
+  const o = state.overlay; if (!o || o.kind !== 'wranglerOps' || !o.openId || o.busy) return;
+  const chat = (o.chats || []).find((c) => c.id === o.openId) || {};
+  const transcript = (o.msgs || []).filter((m) => typeof m.content === 'string' && m.content)
+    .map((m) => `${m.role === 'user' ? '**User**' : (m.dev ? '**Jac (dev)**' : '**Mr. Wrangler**')}: ${m.content}`).join('\n\n') || '(no message)';
+  const title = ('Wrangler Ops — ' + (chat.title || ('chat ' + o.openId))).replace(/\s+/g, ' ').slice(0, 80);
+  const body = ['_Escalated from Wrangler Ops (developer inbox)._', '', '### Chat', `- **Role:** ${chat.role || '—'}`, `- **Chat id:** ${o.openId}`, '', '### Conversation', transcript, '', '_A Claude agent can pick this up; the CI gates guard it before it ships to live._'].join('\n');
+  o.busy = true; renderOverlay();
+  let filed = null;
+  try { const r = await backendCall('wranglerFile', { title, body, label: 'wrangler-fix', images: [] }); if (r && r.ok && r.number) filed = r.number; } catch (e) {}
+  if (state.overlay === o) o.busy = false;
+  if (filed) toast(`Escalated → #${filed} — a Claude agent can take it. 🤠`);
+  else { window.open(wranglerIssueUrl(title, body, 'wrangler-fix'), '_blank', 'noopener'); toast('Opening a fix ticket — tap “Submit new issue” to escalate. 🤠'); }
+  if (state.overlay === o) renderOverlay();
+}
 // Poll while the inbox is open: refresh the list, and the open chat's new turns + driver.
 async function wranglerOpsPollTick() {
   const o = state.overlay; if (!o || o.kind !== 'wranglerOps' || !o.authed || !_wrOpsKey || o.busy) return;
@@ -16082,7 +16101,7 @@ function wranglerOpsDetail(o) {
   const turns = o.msgs.length
     ? o.msgs.map((m) => { const txt = typeof m.content === 'string' ? wrChatFormat(m.content) : '<span class="muted">[attachment]</span>'; return `<div class="wr-msg ${m.role === 'user' ? 'user' : 'assistant'}">${m.role !== 'user' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub">${txt}</div></div>`; }).join('')
     : '<div class="wrops-empty">No messages in this chat.</div>';
-  const driverBar = `<div class="wrops-driver">${paused ? badge('You have the wheel', 'yellow') : badge('AI is driving', 'gray')}${paused ? '<button class="pill ghost js-wrops-release" data-r="R18">Release to AI</button>' : ''}</div>`;
+  const driverBar = `<div class="wrops-driver">${paused ? badge('You have the wheel', 'yellow') : badge('AI is driving', 'gray')}${paused ? '<button class="pill ghost js-wrops-release" data-r="R18">Release to AI</button>' : ''}<button class="pill c-commit js-wrops-escalate" data-r="R17" data-tip="File this chat as a wrangler-fix issue a Claude agent can pick up"${o.busy ? ' disabled' : ''}>Escalate → Claude Code</button></div>`;
   const composer = `<div class="wrops-compose"><input class="wrops-in js-wrops-in" placeholder="${paused ? 'Type as Mr. Wrangler…' : 'Type to take the wheel…'}" value="${esc(o.draft || '')}" ${o.busy ? 'disabled' : ''} /><button class="pill ignition js-wrops-send" data-r="R17" ${o.busy ? 'disabled' : ''}>${paused ? 'Send' : 'Take the wheel'}</button></div>`;
   return `<div class="wrops-detail"><div class="wrops-transcript">${turns}</div>${driverBar}${composer}</div>`;
 }

--- a/app.js
+++ b/app.js
@@ -1916,7 +1916,7 @@ const state = {
   filterTerms: [],            // §5.4 — AND-narrowing filter terms (type + Enter)
   unitPick: null,             // { ids, from } — Invoice +WO narrows the Units list to the invoice's linked units (Phase 4)
   chat: { open: false, activeId: null, draft: '', chats: [] },   // §17 internal team dock (Phase 7): PERSISTENT chats (never deleted). Each = { id, tags, participants, messages, seen{userKey:lastViewedAt} }. Empty participants = dormant; reopen via a tagged element.
-  wrangler: { open: false, min: false, id: null, messages: [], busy: false, error: '', draft: '', attach: [], files: [], card: null, recId: null, recType: null, reqNumber: null, reqTitle: null, reqUrl: null },   // §18 Mr. Wrangler dock — id ties the live chat to its §18g rail snapshot; min collapses it to the header bar; survives minimize, restores conversation on reopen
+  wrangler: { open: false, min: false, id: null, messages: [], busy: false, error: '', draft: '', attach: [], files: [], card: null, recId: null, recType: null, reqNumber: null, reqTitle: null, reqUrl: null, driver: 'ai' },   // §18 Mr. Wrangler dock — id ties the live chat to its §18g rail snapshot; min collapses it to the header bar; survives minimize, restores conversation on reopen. driver: 'ai'|'human' — when a developer takes the wheel (Wrangler Ops bridge) the dock pauses (§18h)
   mobileCol: 0,               // §M1 — which column the phone shows (0 Yard · 1 Rentals · 2 Customers); drives swipe position + the per-column bottom strip
   woPartForm: null,           // woId whose "+ Add Part/Labor" inline form is open
   invLineForm: null,          // invoiceId whose "+ Add Custom" inline form is open
@@ -4389,6 +4389,7 @@ const RULE_META = {
   R23: ['Tooltip', 'data-tip → the one styled tip', 'every hover hint goes through data-tip — a native title attribute is a violation'],
   R24: ['Close ✕', 'closeX', 'red circle · white ✕ — the deliberate close/remove; hover-reveal variant on tabs'],
   R25: ['Sync banner', 'renderSyncBanner / #sync-banner', 'persistent “Not saving” plate — red hazard-stripe danger cap; raised when the backend sync is failing, hides on recovery. The ONE non-toast alert; lives on <body>, outside #app'],
+  R26: ['Paused banner', '.wr-paused (wranglerDockEl)', 'red hazard-rail plate inside the Mr. Wrangler dock — raised when a developer takes the wheel (Wrangler Ops live jump-in); the dock goes read-only until released'],
 };
 /* ════════════ APP-12 · DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) ════
    The Rulebook grew from "stamped element rules" (R0–R24 above) into the WHOLE
@@ -7629,6 +7630,7 @@ function wrChatFormat(raw) {
 // §18 Mr. Wrangler dock — renders the floating dock HTML (mirrors wrangler overlay but as a dock).
 function wranglerDockEl() {
   const o = state.wrangler;
+  const paused = o.driver === 'human';   // §18h a developer (Wrangler Ops) took the wheel → dock is read-only
   const rec = (o.card && o.recId != null) ? recOf(entityCardOf(o.card, o.recType), o.recId) : null;
   const chip = rec ? `<span class="wr-chip">${CARD_ICON[entityCardOf(o.card, o.recType)] || ''}${esc(detailTitle(entityCardOf(o.card, o.recType), rec))}</span>` : '';
   const turns = o.messages.length
@@ -7707,13 +7709,15 @@ function wranglerDockEl() {
       <button class="iconbtn js-wr-close" aria-label="Close" data-tip="Close">×</button>
     </div>
     ${reqBar}
+    ${paused ? '<div class="wr-paused" data-r="R26"><span class="wr-paused-ttl">You’re Paused</span><span class="wr-paused-sub">Developers are working on this live</span></div>' : ''}
     <div class="wr-feed">${turns}${o.busy ? '<div class="wr-msg assistant"><span class="wr-av">🤠</span><div class="wr-bub wr-think">…wrangling an answer</div></div>' : ''}</div>
     ${o.error ? `<div class="wr-err">${esc(o.error)}</div>` : ''}
     ${attachRow}
-    <div class="wr-compose"><label class="wr-attach js-wr-attach" data-tip="Attach a screenshot or a CSV/text file"><input type="file" accept="image/*,.csv,.tsv,.txt,.md,.log,text/csv,text/plain" class="js-wr-file" hidden multiple>${I.paperclip || '📎'}</label><input class="wr-in js-wr-in" placeholder="Ask Mr. Wrangler, or tell him what's broken…" value="${esc(o.draft || '')}" ${o.busy ? 'disabled' : ''} /><button class="wr-send js-wr-send" ${o.busy ? 'disabled' : ''} aria-label="Ask">${I.chev}</button></div>`;
+    <div class="wr-compose"><label class="wr-attach js-wr-attach" data-tip="Attach a screenshot or a CSV/text file"><input type="file" accept="image/*,.csv,.tsv,.txt,.md,.log,text/csv,text/plain" class="js-wr-file" hidden multiple>${I.paperclip || '📎'}</label><input class="wr-in js-wr-in" placeholder="${paused ? 'Paused while developers work on this…' : "Ask Mr. Wrangler, or tell him what's broken…"}" value="${esc(o.draft || '')}" ${o.busy || paused ? 'disabled' : ''} /><button class="wr-send js-wr-send" ${o.busy || paused ? 'disabled' : ''} aria-label="Ask">${I.chev}</button></div>`;
 }
 function mountWranglerDock() {
   const d = document.querySelector('.wrangler-dock'); if (!d) return;
+  wranglerDockPollStart();                    // §18h Wrangler Ops: poll the open chat for developer jump-in turns (single-start)
   wrHydrateBlobs(state.wrangler.messages);   // resolve any image blob refs → object URLs, then repaint
   const inp = d.querySelector('.js-wr-in');
   if (inp) inp.addEventListener('paste', (ev) => {
@@ -7945,7 +7949,7 @@ function wranglerRailSnapshot() {
   const o = state.wrangler;
   if (!o.id || !(o.messages && o.messages.length)) return;
   const snap = { id: o.id, title: wranglerConvoTitle(o), ts: Date.now(), card: o.card, recId: o.recId, recType: o.recType, reqNumber: o.reqNumber, reqTitle: o.reqTitle, reqUrl: o.reqUrl,
-    messages: o.messages.map((m) => ({ role: m.role, content: m.content, images: m.images || null, files: m.files || null, action: m.action || null, filed: m.filed || false, issue: m.issue || null })) };
+    messages: o.messages.map((m) => ({ role: m.role, content: m.content, images: m.images || null, files: m.files || null, action: m.action || null, filed: m.filed || false, issue: m.issue || null, dev: m.dev || false, author: m.author || null })) };   // §18h preserve the dev/author audit markers through a sync-up
   const i = state.wranglerRail.findIndex((c) => c.id === snap.id);
   if (i >= 0) state.wranglerRail[i] = snap; else state.wranglerRail.unshift(snap);
   wranglerRailPersist(snap);   // → IndexedDB (keep all; ingest image blobs; loud on failure)
@@ -10221,6 +10225,7 @@ async function wrRunAgent(apiMessages, system, opts) {
 
 async function wranglerSend() {
   const o = state.wrangler; if (!o.open) return;
+  if (o.driver === 'human') return;   // §18h paused — a developer has the wheel; the composer is disabled, this guards the Enter-key path too (no Anthropic call fires)
   const inp = document.querySelector('.wrangler-dock .js-wr-in');
   const text = ((inp ? inp.value : o.draft) || '').trim();
   const imgs = (o.attach && o.attach.length) ? o.attach.slice() : null;
@@ -10233,6 +10238,7 @@ async function wranglerSend() {
   syncWranglerComment(o, 'user', text, imgs);   // §18e mirror the turn onto the issue thread
   wranglerClearNeedsAnswer(o.reqNumber);        // §18e answering a "Needs your answer" request clears it from the inbox
   o.draft = ''; o.attach = []; o.files = []; o.busy = true; o.error = ''; render();
+  wranglerRailSnapshot();   // §18h live-sync the open chat up so a developer can watch it in Wrangler Ops (driver is 'ai' here — guarded at the top)
   const system = WRANGLER_SYSTEM + WR_TOOLS_NOTE + (o.kpiTarget ? '\n\n' + wranglerKpiSystem() : '') + '\n\n' + wranglerContext(o);
   // Build the payload: images become a content-block array; CSV/text files fold
   // into the message text so Mr. Wrangler reads their rows.
@@ -10304,6 +10310,7 @@ async function wranglerSend() {
         else if (r.applied && r.focus) msg.focus = r.focus;   // apply_changes already wrote it in the loop → keep the "Open" link to the new record
         syncWranglerComment({ reqNumber: replyReqNum }, 'assistant', shown);   // §18e mirror onto the RIGHT issue thread
         if (!_onChat) wranglerRailPersist(_target);   // backgrounded chat → fold the reply into its snapshot
+        else if (state.wrangler.driver !== 'human') wranglerRailSnapshot();   // §18h live chat → sync up so a developer can watch the reply in Wrangler Ops
       }
     } else {
       o.messages.push({ role: 'assistant', content: "🤠 Demo mode — sign in to ask the real Mr. Wrangler (the live AI runs through the backend). Here's the snapshot I'd reason over:\n\n" + wranglerDigest() });
@@ -15913,6 +15920,35 @@ async function loadWranglerRail() {
     }
     if (localAhead) pushWranglerRailSoon(); else lastRailJson = JSON.stringify(state.wranglerRail);
   } catch (e) { /* offline → the refresh poll retries */ }
+}
+// §18h Wrangler Ops live bridge — while the dock is OPEN, poll its OWN chat for turns a
+// developer injected (the Wrangler Ops jump-in) and the driver flag. New dev turns append
+// seamlessly (rendered like any assistant bubble); driver==='human' flips the dock to the
+// read-only PAUSED state (R26). A self-rescheduling loop, started once; a cheap no-op tick
+// when the dock is closed/offline. The cursor is the local MESSAGE COUNT (Wrangler messages
+// carry no per-message timestamp), so a tick only ever pulls turns the client doesn't have.
+const WR_DOCK_POLL_MS = 7000;
+let _wrPollTimer = null;
+async function wranglerDockPollTick() {
+  const o = state.wrangler;
+  if (!(o.open && o.id) || typeof backendPassword === 'undefined' || !backendPassword || o.busy) return;
+  const id = o.id, sinceCount = o.messages.length;
+  let r; try { r = await backendCall('getWranglerChat', { id, sinceCount }); } catch (e) { return; }   // silent: keep last-known state
+  if (!r || !r.ok) return;
+  if (!o.open || o.id !== id) return;   // the dock hopped chats or closed during the await — drop this result
+  let changed = false;
+  if (Array.isArray(r.messages) && r.messages.length) {
+    r.messages.forEach((m) => o.messages.push({ role: m.role === 'user' ? 'user' : 'assistant', content: m.content || '', images: m.images || null, dev: !!m.dev, author: m.author || null }));
+    changed = true;
+  }
+  const drv = r.driver === 'human' ? 'human' : 'ai';
+  if (o.driver !== drv) { o.driver = drv; changed = true; }
+  if (changed) { render(); setTimeout(() => { const f = document.querySelector('.wrangler-dock .wr-feed'); if (f) f.scrollTop = f.scrollHeight; }, 0); }
+}
+function wranglerDockPollStart() {
+  if (_wrPollTimer) return;
+  const loop = () => { Promise.resolve(wranglerDockPollTick()).catch(() => {}).then(() => { _wrPollTimer = setTimeout(loop, WR_DOCK_POLL_MS); }); };
+  _wrPollTimer = setTimeout(loop, WR_DOCK_POLL_MS);
 }
 function saveSoon(ms) { if (booting || !backendPassword) return; clearTimeout(saveTimer); saveTimer = setTimeout(flushSave, ms || 1200); }
 // #247 — sync-health. A failing backend sync used to be SILENT (savePending → flat

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16630 lines, 38 chapters
+## app.js — 16780 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -33,19 +33,19 @@
 | APP-23 | 7551–8375 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
 | APP-24 | 8376–8481 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
 | APP-25 | 8482–8927 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8928–9849 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9850–9944 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9945–10363 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
-| APP-29 | 10364–11414 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 11415–11684 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11685–11809 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11810–11813 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11814–13286 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13287–14214 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14215–15253 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15254–15700 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15701–15703 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15704–16630 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+47) |
+| APP-26 | 8928–9859 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9860–9955 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9956–10374 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10375–11425 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 11426–11695 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11696–11820 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11821–11824 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11825–13312 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13313–14242 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14243–15281 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15282–15728 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15729–15731 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15732–16780 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+63) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16594 lines, 38 chapters
+## app.js — 16630 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -18,34 +18,34 @@
 | APP-08 | 2510–2517 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
 | APP-09 | 2518–3904 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+94) |
 | APP-10 | 3905–3925 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 3926–4392 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
-| APP-12 | 4393–4560 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 4561–4671 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
-| APP-14 | 4672–4949 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 4950–5146 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 5147–6480 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
-| APP-17 | 6481–6575 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6576–6856 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 6857–7050 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 7051–7174 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7175–7339 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7340–7549 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7550–8371 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
-| APP-24 | 8372–8477 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8478–8923 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8924–9845 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9846–9940 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9941–10356 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
-| APP-29 | 10357–11407 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13279 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13280–14207 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14208–15246 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15247–15693 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15694–15696 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15697–16594 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-11 | 3926–4393 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
+| APP-12 | 4394–4561 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 4562–4672 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
+| APP-14 | 4673–4950 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 4951–5147 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 5148–6481 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
+| APP-17 | 6482–6576 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
+| APP-18 | 6577–6857 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 6858–7051 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 7052–7175 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7176–7340 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7341–7550 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7551–8375 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
+| APP-24 | 8376–8481 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8482–8927 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 8928–9849 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9850–9944 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9945–10363 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10364–11414 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 11415–11684 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11685–11809 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11810–11813 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11814–13286 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13287–14214 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14215–15253 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15254–15700 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15701–15703 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15704–16630 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+47) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16780 lines, 38 chapters
+## app.js — 16799 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11426–11695 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11696–11820 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11821–11824 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11825–13312 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13313–14242 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14243–15281 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15282–15728 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15729–15731 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15732–16780 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+63) |
+| APP-33 | 11825–13313 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13314–14243 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14244–15282 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15283–15729 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15730–15732 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15733–16799 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+64) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/handoffs/wrangler-ops-backend.gs
+++ b/docs/handoffs/wrangler-ops-backend.gs
@@ -155,6 +155,27 @@ function appendWranglerMessage_(body) {
   } finally { lock.releaseLock(); }
 }
 
+/* ── PATCH to setWranglerRail_ (lives in wrangler-rail-sync-backend.gs) ──────
+ * THE single-writer guarantee, enforced server-side. A customer's normal rail
+ * sync (setWranglerRail) does a whole-row REPLACE. While the developer has taken
+ * over a chat (stored driver==='human'), that replace must NOT overwrite the row,
+ * or a mistimed customer push could wipe an injected dev turn / the driver flag.
+ * Guarding it on the SERVER closes the race no matter what the client's poll or
+ * debounce timing is — the client guard is then just an optimization.
+ *
+ * In setWranglerRail_'s upsert loop, replace the in-place write:
+ *     if (rowOf[id]) s.getRange(rowOf[id], 1, 1, 3).setValues([[String(role), id, js]]);
+ * with the guarded version:
+ *     if (rowOf[id]) {
+ *       var storedHuman = false;
+ *       try { storedHuman = JSON.parse(s.getRange(rowOf[id], 3).getValue()).driver === 'human'; } catch (e) {}
+ *       if (!storedHuman) s.getRange(rowOf[id], 1, 1, 3).setValues([[String(role), id, js]]);
+ *       // else: developer owns this chat right now — leave the dev-augmented row intact.
+ *     }
+ * (The deletion pass is unchanged: a human-driven chat is still in the client's
+ * payload, so `keep[id]` is set and it is never selected for deletion.)
+ * ───────────────────────────────────────────────────────────────────────── */
+
 /* ── 4) hand the wheel back (or take it) explicitly ───────────────────────── */
 function setWranglerDriver_(body) {
   if (!devOK_(body)) return { ok: false, error: 'auth' };

--- a/docs/handoffs/wrangler-ops-backend.gs
+++ b/docs/handoffs/wrangler-ops-backend.gs
@@ -1,0 +1,174 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * Backend additions — Wrangler Ops (developer chat bridge)
+ * Secret-free; spliced into the gitignored backend/Code.gs and clasp-deployed.
+ * See docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
+ *     docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md
+ *
+ * Lets the developer (Jac) (1) read EVERY role's Mr. Wrangler chat and
+ * (2) jump into a live thread — posting a turn the customer's open dock picks
+ * up, while the AI pauses. Builds on the existing per-role rail store
+ * (wranglerRails [role, id, json]) from wrangler-rail-sync-backend.gs.
+ *
+ * GATE: every action below is DEV-ONLY — guarded by devOK_(), which checks a
+ * dedicated DEV_PASSWORD Script Property (NOT a role, NOT the team password).
+ * Set it once: Apps Script → Project Settings → Script Properties →
+ *   DEV_PASSWORD = <a long random string>   (never in the repo, never logged)
+ *
+ * STORAGE DELTA (additive, schema-less): two fields live INSIDE each chat's
+ * json blob — `driver` ('ai' | 'human', default 'ai') and `lastTs` (ms epoch,
+ * server-stamped on append). No new columns; the wranglerRails tab is unchanged.
+ *
+ * CURSOR NOTE: Wrangler messages carry no per-message timestamp, so message
+ * delivery uses a COUNT cursor (sinceCount = how many the client already has),
+ * not a time cursor. lastTs is chat-level only (sort + liveness).
+ *
+ * Wire into doPost's action switch (these need NO signed-in role — they carry
+ * their own devKey — so place them BEFORE the role-password resolution, or pass
+ * body through; they never read `role`):
+ *   if (action === 'getWranglerChatsAll')  return json(getWranglerChatsAll_(body));        // dev-only
+ *   if (action === 'appendWranglerMessage')return json(appendWranglerMessage_(body));      // dev-only
+ *   if (action === 'setWranglerDriver')    return json(setWranglerDriver_(body));          // dev-only
+ *   if (action === 'getWranglerChat')      return json(getWranglerChat_(body, role));      // dev OR owning role
+ * The three dev-only actions carry their own devKey and ignore `role`.
+ * getWranglerChat takes the server-resolved `role` (like getWranglerRail) so a
+ * NON-dev caller can only read a chat stored under its OWN role — preserving the
+ * rail's per-role customer isolation. Place it AFTER role resolution.
+ *
+ * Reuses ss()/LockService and WRANGLERRAIL_TAB/wranglerRailSheet_() from the
+ * rail-sync additions.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/* ── Dev gate ─────────────────────────────────────────────────────────────
+ * True only when body.devKey matches the DEV_PASSWORD Script Property.
+ * Never echoes the property; returns a plain boolean. */
+function devOK_(body) {
+  var want = PropertiesService.getScriptProperties().getProperty('DEV_PASSWORD');
+  if (!want) return false;                                  // unset ⇒ feature inert
+  var got = body && body.devKey;
+  return typeof got === 'string' && got.length > 0 && got === want;
+}
+
+/* ── small helpers over the wranglerRails tab ─────────────────────────────── */
+// Last-message preview text (content may be a string or a content-block array).
+function wrPreview_(messages) {
+  if (!messages || !messages.length) return '';
+  var c = messages[messages.length - 1].content;
+  var t = '';
+  if (typeof c === 'string') t = c;
+  else if (Array.isArray(c)) { for (var i = 0; i < c.length; i++) { if (c[i] && c[i].type === 'text' && c[i].text) { t = c[i].text; break; } } if (!t) t = '[attachment]'; }
+  t = String(t).replace(/\s+/g, ' ').trim();
+  return t.length > 90 ? t.slice(0, 90) + '…' : t;
+}
+function wrLastTs_(chat) {
+  return (chat && typeof chat.lastTs === 'number') ? chat.lastTs : ((chat && typeof chat.ts === 'number') ? chat.ts : 0);
+}
+// Scan column 2 (id) across ALL roles; return {row, role, chat} or null.
+function wrFindById_(s, id) {
+  var last = s.getLastRow();
+  if (last < 2) return null;
+  var vals = s.getRange(2, 1, last - 1, 3).getValues();      // role, id, json
+  for (var i = 0; i < vals.length; i++) {
+    if (String(vals[i][1]) === String(id)) {
+      try { return { row: i + 2, role: String(vals[i][0]), chat: JSON.parse(vals[i][2]) }; }
+      catch (e) { return null; }
+    }
+  }
+  return null;
+}
+
+/* ── 1) read EVERY role's chats (metadata only — cheap to poll) ───────────── */
+function getWranglerChatsAll_(body) {
+  if (!devOK_(body)) return { ok: false, error: 'auth' };
+  var s = ss().getSheetByName(WRANGLERRAIL_TAB), out = [];
+  if (s) {
+    var last = s.getLastRow();
+    if (last >= 2) {
+      var vals = s.getRange(2, 1, last - 1, 3).getValues();    // role, id, json
+      for (var i = 0; i < vals.length; i++) {
+        try {
+          var c = JSON.parse(vals[i][2]);
+          if (!c || !c.id) continue;
+          var msgs = c.messages || [];
+          out.push({
+            id: String(c.id),
+            role: String(vals[i][0]),
+            title: c.title || '',
+            lastTs: wrLastTs_(c),
+            driver: c.driver === 'human' ? 'human' : 'ai',
+            msgCount: msgs.length,
+            preview: wrPreview_(msgs)
+          });
+        } catch (e) {}
+      }
+    }
+  }
+  out.sort(function (a, b) { return b.lastTs - a.lastTs; });   // newest activity first
+  return { ok: true, chats: out, serverTs: Date.now() };
+}
+
+/* ── 2) read one chat's NEW messages (count cursor) + driver ───────────────
+ * Dev call (valid devKey) reads ANY chat. A non-dev caller (the customer's own
+ * dock) passes no devKey and may read a chat ONLY IF it is stored under that
+ * caller's server-resolved role — the same per-role isolation getWranglerRail
+ * enforces, so chat ids can't be enumerated across roles. */
+function getWranglerChat_(body, role) {
+  var dev = devOK_(body);
+  var id = body && body.id;
+  if (!id) return { ok: false, error: 'no-id' };
+  var s = ss().getSheetByName(WRANGLERRAIL_TAB);
+  if (!s) return { ok: false, reason: 'gone' };
+  var hit = wrFindById_(s, id);
+  if (!hit) return { ok: false, reason: 'gone' };
+  // ISOLATION: non-dev callers may only read their OWN role's chat.
+  if (!dev && String(hit.role) !== String(role)) return { ok: false, error: 'auth' };
+  var msgs = (hit.chat.messages || []);
+  var since = Math.max(0, parseInt((body && body.sinceCount) || 0, 10) || 0);
+  return {
+    ok: true,
+    messages: since < msgs.length ? msgs.slice(since) : [],
+    total: msgs.length,
+    driver: hit.chat.driver === 'human' ? 'human' : 'ai',
+    lastTs: wrLastTs_(hit.chat),
+    _dev: dev ? 1 : 0                                          // harmless; lets the inbox confirm its gate
+  };
+}
+
+/* ── 3) developer posts a turn → take the wheel (driver='human') ──────────── */
+function appendWranglerMessage_(body) {
+  if (!devOK_(body)) return { ok: false, error: 'auth' };
+  var id = body && body.chatId, msg = body && body.message;
+  if (!id || !msg) return { ok: false, error: 'bad-input' };
+  var lock = LockService.getScriptLock(); lock.waitLock(30000);
+  try {
+    var s = wranglerRailSheet_();
+    var hit = wrFindById_(s, id);
+    if (!hit) return { ok: false, reason: 'gone' };           // janitor pruned it
+    var c = hit.chat;
+    if (!c.messages) c.messages = [];
+    // Persist the human turn as a plain assistant turn (coherent if the AI later
+    // resumes); keep dev/author for the audit trail (UI hides them — seamless).
+    c.messages.push({ role: 'assistant', content: String(msg.content || ''), dev: true, author: String(msg.author || 'Jac') });
+    c.driver = 'human';
+    c.lastTs = Date.now();
+    s.getRange(hit.row, 1, 1, 3).setValues([[hit.role, String(id), JSON.stringify(c)]]);
+    return { ok: true, lastTs: c.lastTs, total: c.messages.length };
+  } finally { lock.releaseLock(); }
+}
+
+/* ── 4) hand the wheel back (or take it) explicitly ───────────────────────── */
+function setWranglerDriver_(body) {
+  if (!devOK_(body)) return { ok: false, error: 'auth' };
+  var id = body && body.chatId, driver = (body && body.driver) === 'human' ? 'human' : 'ai';
+  if (!id) return { ok: false, error: 'bad-input' };
+  var lock = LockService.getScriptLock(); lock.waitLock(30000);
+  try {
+    var s = wranglerRailSheet_();
+    var hit = wrFindById_(s, id);
+    if (!hit) return { ok: false, reason: 'gone' };
+    var c = hit.chat;
+    c.driver = driver;
+    c.lastTs = Date.now();
+    s.getRange(hit.row, 1, 1, 3).setValues([[hit.role, String(id), JSON.stringify(c)]]);
+    return { ok: true, driver: driver };
+  } finally { lock.releaseLock(); }
+}

--- a/docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md
+++ b/docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md
@@ -1,0 +1,116 @@
+# Wrangler Ops — developer chat bridge — implementation plan
+
+- **Spec:** [2026-06-29-wrangler-ops-developer-chat-bridge-design.md](../specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md)
+- **Branch:** `claude/mirror-wrangler-chats-l8pjfd`
+- **Date:** 2026-06-29
+
+Each phase is its own bisectable commit. **Gates before any push** (per CLAUDE.md):
+`node ci/smoke.mjs`, `node ci/logic-test.mjs`, `node ci/gen-rule-usage.mjs --check`,
+`node ci/check-window-catalog.mjs`, `node tools/gen-code-map.mjs --check`. Port 8000 is reserved —
+`sed -i 's/8000/9147/g' ci/smoke.mjs ci/logic-test.mjs`, run, then `git checkout -- ci/`.
+**Cache-bust** the shared `?v=` token on the final UI commit. **All UI phases run through `/jactec-ui`**
+(yard data-plate language, `data-r` stamps, screenshot + self-critique before showing Jac).
+
+**Backend (`Code.gs`) ships via `/clasp`, never git** — additive actions only; the `/clasp` skill STOPS for
+explicit confirmation before any prod deploy. Reference handler shapes:
+`docs/handoffs/wrangler-rail-sync-backend.gs` (`getWranglerRail_`/`setWranglerRail_`).
+
+**Order rationale:** the backend contract (Phase 1) is the foundation both clients depend on; the customer
+dock changes (Phase 2) are the auth-/agent-loop-sensitive core and stay on main; the Ops inbox (Phase 3) is
+well-scoped UI against the settled contract and can drop to a Sonnet subagent through `/jactec-ui`.
+
+---
+
+## Phase 0 — Baseline (confirm green before touching anything)
+- Run all five gates on the current branch; confirm pass. Establishes the "behavior unchanged" baseline.
+- **Verify:** all gates green. No commit.
+
+---
+
+## Phase 1 — Backend dev-gated actions + storage fields (`Code.gs`, `/clasp`)
+**Why first:** both clients bind to this contract. **Auth-sensitive — contract + gate authored on main session.**
+- Add a `DEV_PASSWORD` Script Property check helper: `devOK_(body)` → `body.devKey === PROP('DEV_PASSWORD')`;
+  every action below returns `{ok:false, error:'auth'}` when it fails. Never logged/echoed.
+- Extend the rail store record with two additive fields, defaulted on read: `driver` (default `'ai'`) and
+  `lastTs` (default = max message `ts`). Schema-less Sheet → no migration.
+- New actions (route in the existing `doPost` dispatch beside `getWranglerRail`/`setWranglerRail`):
+  - `getWranglerChatsAll` → `{ok, chats:[{id,role,title,lastTs,driver,msgCount,preview}], serverTs}` —
+    flatten every role's rail; **metadata + last-message preview only** (no full transcripts).
+  - `getWranglerChat` → `{ok, messages:[ts>sinceTs], driver, lastTs}`. Accepts a dev call (`devKey`) **or** the
+    existing team-password gate for the customer's own chat. Filters by `sinceTs`.
+  - `appendWranglerMessage` → append `message`, bump `lastTs`, **set `driver:'human'`**; `{ok,lastTs}` or
+    `{ok:false,reason:'gone'}` if the chat was pruned.
+  - `setWranglerDriver` → set `driver ∈ {'ai','human'}`; `{ok}`.
+- **Verify:** local unit-stub of the four handlers (pure-function extraction tested in `logic-test` where
+  possible — see Phase 4); deploy via **`/clasp`** (STOP-gated) and smoke each action with a throwaway chat id.
+- **Model:** main session (auth gate + contract). The mechanical handler body may draft on Sonnet, but the
+  `devOK_`/dispatch wiring is reviewed on main. **Commit:** *"Wrangler Ops backend: dev-gated chat actions + driver/lastTs"*.
+
+---
+
+## Phase 2 — Customer dock: poller + silent AI pause + seamless rendering (`app.js`)
+**Stays on main — touches the agent-loop gate (`wrRunAgent`) and must never let the AI talk over Jac.**
+- **Poller** `wranglerDockPoll` near the dock mount (`mountWranglerDock`, ~`app.js:7715`): on a ~6–8s interval
+  while a dock is open + online, call `getWranglerChat(id, sinceTs=lastSeenTs)`; append new messages to
+  `state.wrangler.messages[]`, advance `lastSeenTs`, re-render. Start on open, clear on close, exponential
+  backoff on error (keep last-known state, silent).
+- **Seamless render:** a `dev:true` message renders **identically to a normal assistant bubble** — no label, no
+  "human joined" notice. `dev`/`author` retained in the message object for audit only; never surfaced.
+- **Silent AI pause:** in `wranglerSend`/`wrRunAgent` (~`app.js:10192`–`10222`), when the chat's `driver==='human'`,
+  store + sync the user's message but **short-circuit before the Anthropic call** (no agent loop). No notice.
+  Resume normally when `driver==='ai'`. **Fail-safe:** treat a failed poll as "driver unchanged" so a known
+  `human` keeps the bot quiet until an explicit release.
+- **Offline path:** unchanged sync-up; a queued dev reply surfaces on next open via the existing notification bell.
+- **Verify:** two browser profiles (or the existing rail-sync test harness) — dev appends a message, customer
+  dock shows it seamlessly within one poll; customer reply while `driver==='human'` does **not** trigger an API
+  call; release → next reply does. Smoke green.
+- **Model:** main session. **Commit:** *"Wrangler dock: poll for injected turns + silent AI pause while a human drives"*.
+
+---
+
+## Phase 3 — Developer Wrangler Ops inbox view (`app.js` + `style.css`)
+**Well-scoped UI against the settled contract — Sonnet subagent via `/jactec-ui`.**
+- A **dev-only view** unlocked by `DEV_PASSWORD` (Owner-only entry; absent from normal-role nav). Inert without the key.
+- **List:** poll `getWranglerChatsAll` (~6–8s); rows sorted by `lastTs` — role/user · title · preview · age ·
+  a **live dot** (active <~2 min) · driver state. Yard data-plate styling, `data-r` stamps.
+- **Open:** full transcript (reuse the existing Wrangler message renderer in read mode) + a **composer**.
+  Send → `appendWranglerMessage` (takes the wheel). **"Release to AI"** → `setWranglerDriver('ai')`.
+- New popup → `WINDOW_CATALOG` entry (the `check-window-catalog` gate).
+- **Verify:** open the inbox with the dev key (and confirm it's invisible without it); see a live chat appear,
+  open it, post a turn, watch it land in the customer dock (Phase 2), release. Screenshot + self-critique.
+- **Model:** Sonnet via `/jactec-ui`; the data-sensitivity/auth call (what the inbox exposes) reviewed on main.
+- **Commit:** *"Wrangler Ops inbox: live chat list + transcript + jump-in composer"*.
+
+---
+
+## Phase 4 — Logic-test coverage (`ci/logic-test.mjs`)
+- driver transitions: `ai → human` on append, `human → ai` on release.
+- AI pause: `driver==='human'` → the agent loop is not invoked; `'ai'` → it is.
+- `getWranglerChat(id, sinceTs)` returns only `ts > sinceTs`.
+- `getWranglerChatsAll` flattens chats across multiple roles into one list.
+- **Verify:** `node ci/logic-test.mjs` green incl. the new cases.
+- **Model:** Sonnet (tests against settled behavior). **Commit:** *"Tests: Wrangler Ops driver/pause/sinceTs/flatten"*.
+
+---
+
+## Phase 5 — `/jactec-ui` finalize + cache-bust
+- Regenerate `node ci/gen-rule-usage.mjs` (drop `--check`); confirm `--check`, `check-window-catalog`, and
+  `gen-code-map --check` all pass. Bump the shared `?v=` token on `style.css`/`rule-usage.js`/`app.js` in `index.html`.
+- **Verify:** all five gates green. **Commit:** *"Wrangler Ops: rule-usage + window catalog + cache-bust"*.
+
+---
+
+## Phase 6 — (seam only) Escalate → Claude Code button
+- In the Ops transcript pane, a quiet **"Escalate → Claude Code"** button wired to the existing `wranglerFile`
+  (chat → GitHub issue) — surfaces the issue URL from which a CC web session launches. No new escalation machinery.
+- **Verify:** button files an issue with the transcript; URL opens. Smoke green.
+- **Model:** Sonnet. **Commit:** *"Wrangler Ops: escalate a chat to Claude Code via the existing Thread Mirror"*.
+
+---
+
+## After the build
+- **Local area test (§3 of `/start`):** this branch is a cloud task branch — Jac pulls and serves on
+  `localhost:9147`, logs in with `$RW_PW`, exercises the inbox + a two-browser jump-in.
+- Then the **continue-or-archive fork**. Backend (`Code.gs`) lands separately via `/clasp` (not git) — track that
+  it's deployed before declaring the feature live.
+- **Not** pushed to `main` from this session — promotion is Jac's selective call (areas → `staging` → one PR).

--- a/docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md
+++ b/docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md
@@ -49,23 +49,25 @@ well-scoped UI against the settled contract and can drop to a Sonnet subagent th
 
 ---
 
-## Phase 2 — Customer dock: poller + silent AI pause + seamless rendering (`app.js`)
-**Stays on main — touches the agent-loop gate (`wrRunAgent`) and must never let the AI talk over Jac.**
-- **Poller** `wranglerDockPoll` near the dock mount (`mountWranglerDock`, ~`app.js:7715`): on a ~6–8s interval
-  while a dock is open + online, call `getWranglerChat(id, sinceTs=lastSeenTs)`; append new messages to
-  `state.wrangler.messages[]`, advance `lastSeenTs`, re-render. Start on open, clear on close, exponential
-  backoff on error (keep last-known state, silent).
-- **Seamless render:** a `dev:true` message renders **identically to a normal assistant bubble** — no label, no
-  "human joined" notice. `dev`/`author` retained in the message object for audit only; never surfaced.
-- **Silent AI pause:** in `wranglerSend`/`wrRunAgent` (~`app.js:10192`–`10222`), when the chat's `driver==='human'`,
-  store + sync the user's message but **short-circuit before the Anthropic call** (no agent loop). No notice.
-  Resume normally when `driver==='ai'`. **Fail-safe:** treat a failed poll as "driver unchanged" so a known
-  `human` keeps the bot quiet until an explicit release.
-- **Offline path:** unchanged sync-up; a queued dev reply surfaces on next open via the existing notification bell.
-- **Verify:** two browser profiles (or the existing rail-sync test harness) — dev appends a message, customer
-  dock shows it seamlessly within one poll; customer reply while `driver==='human'` does **not** trigger an API
-  call; release → next reply does. Smoke green.
-- **Model:** main session. **Commit:** *"Wrangler dock: poll for injected turns + silent AI pause while a human drives"*.
+## Phase 2 — Customer dock: poller + paused banner + AI pause (`app.js` + `style.css`)
+**Stays on main — touches the agent-loop gate (`wrRunAgent`). New UI (the banner) runs through `/jactec-ui`.**
+- **Live sync-up before the jump-in:** snapshot the open dock up on each turn so a developer can see an
+  in-progress chat (`wranglerRailSnapshot` → debounced push; pre-pause, still single-writer).
+- **Poller** `wranglerDockPoll` near the dock mount (`mountWranglerDock`, ~`app.js:7715`): ~6–8s while a dock is
+  open + online, call `getWranglerChat(id, sinceCount=o.messages.length)`; append returned dev turns to
+  `state.wrangler.messages[]`, set `o.driver`/banner, re-render. Start on open, clear on close, backoff on error.
+- **Paused banner + read-only composer:** when `o.driver==='human'`, render a **hazard-stripe banner**
+  *"You're Paused — Developers Are Working On This Live"* and **disable** the input. Clears when `driver==='ai'`.
+  New UI → `data-r="Rxx"` stamp via `/jactec-ui`.
+- **Seamless in-thread:** a `dev:true` message renders like a normal assistant bubble (no per-message label); the
+  banner is the status signal. `dev`/`author` retained for audit only.
+- **AI pause guard:** in `wranglerSend`/`wrRunAgent` (~`app.js:10192`–`10222`), if `o.driver==='human'`,
+  short-circuit before the Anthropic call (belt-and-suspenders; the composer is disabled anyway). **Fail-safe:** a
+  failed poll leaves `driver` unchanged so a known `human` stays paused until an explicit release.
+- **Single-writer:** paused customer writes nothing → developer is sole writer → no whole-chat clobber.
+- **Verify:** two browser profiles — dev appends, customer dock shows the banner + the turn within one poll, the
+  composer is disabled; release → banner clears, composer re-enables, customer can chat and the AI answers. Smoke green.
+- **Model:** main session; the banner styling/stamp via `/jactec-ui`. **Commit:** *"Wrangler dock: poll for dev turns + paused banner while a human drives"*.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md
+++ b/docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md
@@ -36,8 +36,9 @@ well-scoped UI against the settled contract and can drop to a Sonnet subagent th
 - New actions (route in the existing `doPost` dispatch beside `getWranglerRail`/`setWranglerRail`):
   - `getWranglerChatsAll` → `{ok, chats:[{id,role,title,lastTs,driver,msgCount,preview}], serverTs}` —
     flatten every role's rail; **metadata + last-message preview only** (no full transcripts).
-  - `getWranglerChat` → `{ok, messages:[ts>sinceTs], driver, lastTs}`. Accepts a dev call (`devKey`) **or** the
-    existing team-password gate for the customer's own chat. Filters by `sinceTs`.
+  - `getWranglerChat` → `{ok, messages:[past index sinceCount], total, driver, lastTs}`. Dev call (`devKey`) reads
+    any chat; a non-dev caller reads only a chat under its **own server-resolved role** (per-role isolation).
+    **Count cursor** (`sinceCount`) — Wrangler messages have no per-message timestamp.
   - `appendWranglerMessage` → append `message`, bump `lastTs`, **set `driver:'human'`**; `{ok,lastTs}` or
     `{ok:false,reason:'gone'}` if the chat was pruned.
   - `setWranglerDriver` → set `driver ∈ {'ai','human'}`; `{ok}`.
@@ -86,7 +87,7 @@ well-scoped UI against the settled contract and can drop to a Sonnet subagent th
 ## Phase 4 — Logic-test coverage (`ci/logic-test.mjs`)
 - driver transitions: `ai → human` on append, `human → ai` on release.
 - AI pause: `driver==='human'` → the agent loop is not invoked; `'ai'` → it is.
-- `getWranglerChat(id, sinceTs)` returns only `ts > sinceTs`.
+- `getWranglerChat(id, sinceCount)` returns only messages past index `sinceCount`; non-dev caller refused a foreign-role chat.
 - `getWranglerChatsAll` flattens chats across multiple roles into one list.
 - **Verify:** `node ci/logic-test.mjs` green incl. the new cases.
 - **Model:** Sonnet (tests against settled behavior). **Commit:** *"Tests: Wrangler Ops driver/pause/sinceTs/flatten"*.

--- a/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
+++ b/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
@@ -81,7 +81,7 @@ otherwise. The key is never in the repo, never echoed, never logged.
 | Action | Input | Returns | Notes |
 |--------|-------|---------|-------|
 | `getWranglerChatsAll` | `{devKey}` | `{ok, chats:[{id, role, title, lastTs, driver, msgCount, preview}], serverTs}` | **Metadata only** (last-message preview, no full transcripts) so polling stays cheap. Flattens every role's rail into one list. |
-| `getWranglerChat` | `{devKey?, id, sinceTs}` | `{ok, messages:[…newer than sinceTs], driver, lastTs}` | Used by **both** sides. Customer dock omits `devKey` (its own chat, gated by team password as today); dev inbox passes `devKey`. Returns only messages with `ts > sinceTs`. |
+| `getWranglerChat` | `{devKey?, id, sinceCount}` | `{ok, messages:[…past index sinceCount], total, driver, lastTs}` | Used by **both** sides. Dev call (valid `devKey`) reads any chat; a non-dev caller reads a chat **only if it is stored under that caller's server-resolved role** (same per-role isolation as `getWranglerRail` — ids can't be enumerated across roles). **Count cursor** (`sinceCount` = messages the client already holds), because Wrangler messages carry no per-message timestamp. |
 | `appendWranglerMessage` | `{devKey, chatId, message}` | `{ok, lastTs}` or `{ok:false, reason:'gone'}` | Appends `message`, bumps `lastTs`, **sets `driver:'human'`** (takes the wheel). `gone` if the janitor pruned the chat. |
 | `setWranglerDriver` | `{devKey, chatId, driver}` | `{ok}` | `driver ∈ {'ai','human'}`. Explicit hand-back ("release the wheel"). |
 
@@ -96,8 +96,9 @@ no migration. (Track C — backend ships by `/clasp` paste, not git.)
 While a Wrangler dock is **open**:
 
 - **Poller** `wranglerDockPoll` (~6–8s, only when open + online): calls
-  `getWranglerChat(id, sinceTs=lastSeenTs)`. New messages are appended to
-  `state.wrangler.messages[]` and rendered.
+  `getWranglerChat(id, sinceCount=local message count)`. Returned messages are
+  appended to `state.wrangler.messages[]` and rendered. (`lastTs` is chat-level,
+  server-stamped on append — used for inbox sort/liveness, not message delivery.)
 - **Seamless rendering (per Jac, 2026-06-29):** developer messages (`dev:true`)
   render **identically to a normal Mr. Wrangler assistant bubble** — no "Support"
   label, no "a human joined" notice. To the customer it is one continuous Mr.
@@ -217,7 +218,8 @@ into this. No new escalation machinery is built in this MVP.
     `setWranglerDriver('ai')`.
   - AI pause: with `driver==='human'`, a new customer message does **not** invoke
     the agent loop; with `driver==='ai'` it does.
-  - `getWranglerChat(id, sinceTs)` returns only messages with `ts > sinceTs`.
+  - `getWranglerChat(id, sinceCount)` returns only messages past index `sinceCount`;
+    a non-dev caller is refused a chat stored under a different role.
   - `getWranglerChatsAll` flattens chats across multiple roles into one list.
 - `ci/smoke.mjs`: app still boots with the Ops view registered.
 - New UI (Ops inbox view + dev composer) runs through **`/jactec-ui`**:

--- a/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
+++ b/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
@@ -99,34 +99,40 @@ While a Wrangler dock is **open**:
   `getWranglerChat(id, sinceCount=local message count)`. Returned messages are
   appended to `state.wrangler.messages[]` and rendered. (`lastTs` is chat-level,
   server-stamped on append — used for inbox sort/liveness, not message delivery.)
-- **Seamless rendering (per Jac, 2026-06-29):** developer messages (`dev:true`)
-  render **identically to a normal Mr. Wrangler assistant bubble** — no "Support"
-  label, no "a human joined" notice. To the customer it is one continuous Mr.
-  Wrangler. (The `dev:true`/`author` fields are retained internally for the audit
-  trail and dev tooling only; they never surface in the customer UI.)
-- **AI pause (silent):** when `driver === 'human'`, the local agent loop
-  (`wrRunAgent`) is **suppressed** — the customer's next message is still stored and
-  synced up via the normal path, but does **not** trigger an Anthropic call. No
-  customer-facing notice (consistent with the seamless choice). Normal behavior
-  resumes when `driver` flips back to `'ai'`.
-- **Fail-safe:** once a human has posted, `driver:'human'` is the persisted server
-  state. Even if a poll fails, the bot stays paused until an **explicit**
-  `setWranglerDriver('ai')` — we err toward never letting the AI talk over Jac.
+- **Paused banner + read-only composer (per Jac, 2026-06-29):** when
+  `driver === 'human'`, the customer's dock shows a prominent **hazard-stripe
+  banner** — *"You're Paused — Developers Are Working On This Live"* — and the
+  composer is **disabled** (read-only). The customer watches the developer work the
+  thread; they cannot send while paused. Banner clears and the composer re-enables
+  when `driver` flips back to `'ai'`.
+- **Single-writer concurrency (why the pause matters):** because the paused
+  customer writes **nothing** while `driver === 'human'`, the developer is the
+  **sole writer** of that chat row — so the whole-chat-replace sync can never clobber
+  an injected dev turn or the `driver` flag. No per-message ids, no append-twin
+  action, no merge logic needed; Phase 1's contract stands. On release, the
+  customer's local copy already holds the dev turns (pulled by the poller), so its
+  next normal full-rail push includes them — one more pull on resume closes the tiny
+  remaining window.
+- **Seamless in-thread (no per-message label):** individual developer turns
+  (`dev:true`) render like a normal assistant bubble — no "Support" tag per message.
+  The **banner** is the single, honest status signal that humans are on it. The
+  `dev:true`/`author` fields are retained for the audit trail only.
+- **AI pause:** while `driver === 'human'` the local agent loop (`wrRunAgent`) is
+  also suppressed (belt-and-suspenders — the composer is disabled anyway, but a
+  guard prevents any queued/programmatic send from firing an Anthropic call).
+- **Fail-safe:** once a human has taken the wheel, `driver:'human'` is the persisted
+  server state. Even through a failed poll the dock stays paused until an explicit
+  `setWranglerDriver('ai')`.
 - **Poll lifecycle:** starts on dock open, stops on close, exponential backoff on
   error (keep last-known state, silent to the customer).
+- **Live visibility before the jump-in:** so a developer can see an in-progress
+  conversation (which normally only syncs up on close), the open dock snapshots-up
+  on each turn (`wranglerRailSnapshot` → debounced push). That happens **before** any
+  pause, while the customer is still the only writer — so it stays single-writer too.
 
-**Honest limitation:** live reply only reaches a customer whose dock is **open**.
-If closed, the message waits for their next open and is surfaced via the existing
-**notification bell** (a normal Mr. Wrangler reply notification — still seamless).
-
-### Trade-off recorded: seamless impersonation
-
-Jac chose seamless (developer replies indistinguishable from the AI) over a
-labeled "Support" bubble. Benefit: a frictionless single-assistant experience.
-Trade-off: the customer is not told a human joined the thread. This is an
-intentional product decision for an owner-operated support tool; noted here so it
-is explicit and revisitable. The internal audit fields (`dev:true`, `author`)
-preserve a record of which turns were human even though the UI hides it.
+**Honest limitation:** the pause/jump-in only reaches a customer whose dock is
+**open**. If closed, the chat is no longer live; the developer can still read it in
+the inbox and a reply surfaces on the customer's next open via the notification bell.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
+++ b/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
@@ -1,0 +1,238 @@
+# Wrangler Ops — the developer chat bridge
+
+**Date:** 2026-06-29
+**Status:** Approved design (MVP)
+**Area:** Mr. Wrangler (in-app AI assistant)
+**Scope:** Single tenant (JacRentals) now; designed to generalize to multi-tenant later.
+
+---
+
+## 1. Problem & goal
+
+Rental Wrangler is scaling toward serving up to ~50 rental companies. As the
+developer, Jac wants to **support customers who are trying to solve problems
+through Mr. Wrangler** — by (1) seeing the Mr. Wrangler conversations happening
+in the app, and (2) **jumping into a live thread himself** to continue it when
+the AI is failing the user. Escalating a conversation into a Claude Code session
+to fix something in code is a third capability, but it is mostly already built
+(see §9) and is **not** the focus of this MVP.
+
+**MVP = developer inbox (see all chats) + live jump-in (continue a thread).**
+
+### Hard constraint that shapes everything
+
+The backend is Google Sheets behind a Google Apps Script web app. **There are no
+websockets or server-push.** "Live" therefore means **polling** (~6–8s). This is
+accepted: it matches the existing architecture and is fine for "support jumps in."
+
+### Tenancy decision
+
+The app is **single-tenant today** — one backend Sheet, one team password, and
+`getWranglerRail`/`setWranglerRail` keyed by **role**, not company. This MVP is
+built for the single JacRentals tenant. Every new backend action is designed so a
+`companyId` filter can be added later without reshaping the contract — the seam is
+left, the 50-backend fan-out is **not** built now (see §10).
+
+---
+
+## 2. Existing plumbing we build on
+
+- Live transcript: `state.wrangler.messages[]` — clean `{role, content, ...}` JSON
+  (Anthropic message shape). App `§18`, ~`app.js:9642–10313`.
+- Persistence: IndexedDB (`jactec.wrangler` → `chats` store) + backend Sheet via
+  `getWranglerRail` / `setWranglerRail` (cross-device sync, keyed by role).
+- Agent loop: `wrRunAgent(messages, system, opts)` (`app.js:10192`) →
+  `backendCall('wrangler', …)` → Anthropic via the GAS backend (server-side key).
+- Thread Mirror (reused for escalation only): `wranglerFile` (chat → GitHub issue),
+  `wranglerComment` / `wranglerThread` (mirror turns), plus the auto-fix pipeline
+  (`docs/wrangler-pipeline.md`, Track B) that hands issues to a Claude Code agent.
+
+---
+
+## 3. Architecture overview
+
+```
+  Customer's Wrangler dock                 Backend Sheet (GAS)                Developer's Wrangler Ops inbox
+  ─────────────────────────                ───────────────────                ──────────────────────────────
+  chats sync up (existing) ───setWranglerRail──▶  rail store                          │
+                                              { …chats, driver, lastTs }              │
+  dock poll (~6–8s) ◀──getWranglerChat(id,sinceTs)──┤                                 │
+   • append dev msgs (seamless)                     │                                 │
+   • driver==='human' → AI paused                   ├──getWranglerChatsAll──▶ poll (~6–8s): list all chats
+                                                     │                          • open → full transcript
+  customer reply ───setWranglerRail──▶ (stored, no AI call while human-driving)│      • composer → append (takes wheel)
+                                                     │◀──appendWranglerMessage──┤      • "Release to AI" → setWranglerDriver
+                                                     │◀──setWranglerDriver──────┤
+```
+
+Three isolated units: **backend actions** (§4), **customer dock poller + AI pause**
+(§5), **developer Ops inbox** (§6). Each communicates through the documented action
+contracts and can be tested independently.
+
+---
+
+## 4. Unit A — backend dev-gated actions (`Code.gs`, ships via `/clasp`, additive)
+
+**Gate:** a dedicated `DEV_PASSWORD` Script Property — **not** the team password,
+**not** a role. Owner/developer-only. Every action below validates
+`body.devKey === DEV_PASSWORD` server-side and returns `{ok:false, error:'auth'}`
+otherwise. The key is never in the repo, never echoed, never logged.
+
+| Action | Input | Returns | Notes |
+|--------|-------|---------|-------|
+| `getWranglerChatsAll` | `{devKey}` | `{ok, chats:[{id, role, title, lastTs, driver, msgCount, preview}], serverTs}` | **Metadata only** (last-message preview, no full transcripts) so polling stays cheap. Flattens every role's rail into one list. |
+| `getWranglerChat` | `{devKey?, id, sinceTs}` | `{ok, messages:[…newer than sinceTs], driver, lastTs}` | Used by **both** sides. Customer dock omits `devKey` (its own chat, gated by team password as today); dev inbox passes `devKey`. Returns only messages with `ts > sinceTs`. |
+| `appendWranglerMessage` | `{devKey, chatId, message}` | `{ok, lastTs}` or `{ok:false, reason:'gone'}` | Appends `message`, bumps `lastTs`, **sets `driver:'human'`** (takes the wheel). `gone` if the janitor pruned the chat. |
+| `setWranglerDriver` | `{devKey, chatId, driver}` | `{ok}` | `driver ∈ {'ai','human'}`. Explicit hand-back ("release the wheel"). |
+
+**Storage delta:** two additive fields on each stored chat — `driver` (default
+`'ai'`) and `lastTs`. The rail store is schema-less Sheets, so this is additive;
+no migration. (Track C — backend ships by `/clasp` paste, not git.)
+
+---
+
+## 5. Unit B — customer dock: polling + AI pause (`app.js`)
+
+While a Wrangler dock is **open**:
+
+- **Poller** `wranglerDockPoll` (~6–8s, only when open + online): calls
+  `getWranglerChat(id, sinceTs=lastSeenTs)`. New messages are appended to
+  `state.wrangler.messages[]` and rendered.
+- **Seamless rendering (per Jac, 2026-06-29):** developer messages (`dev:true`)
+  render **identically to a normal Mr. Wrangler assistant bubble** — no "Support"
+  label, no "a human joined" notice. To the customer it is one continuous Mr.
+  Wrangler. (The `dev:true`/`author` fields are retained internally for the audit
+  trail and dev tooling only; they never surface in the customer UI.)
+- **AI pause (silent):** when `driver === 'human'`, the local agent loop
+  (`wrRunAgent`) is **suppressed** — the customer's next message is still stored and
+  synced up via the normal path, but does **not** trigger an Anthropic call. No
+  customer-facing notice (consistent with the seamless choice). Normal behavior
+  resumes when `driver` flips back to `'ai'`.
+- **Fail-safe:** once a human has posted, `driver:'human'` is the persisted server
+  state. Even if a poll fails, the bot stays paused until an **explicit**
+  `setWranglerDriver('ai')` — we err toward never letting the AI talk over Jac.
+- **Poll lifecycle:** starts on dock open, stops on close, exponential backoff on
+  error (keep last-known state, silent to the customer).
+
+**Honest limitation:** live reply only reaches a customer whose dock is **open**.
+If closed, the message waits for their next open and is surfaced via the existing
+**notification bell** (a normal Mr. Wrangler reply notification — still seamless).
+
+### Trade-off recorded: seamless impersonation
+
+Jac chose seamless (developer replies indistinguishable from the AI) over a
+labeled "Support" bubble. Benefit: a frictionless single-assistant experience.
+Trade-off: the customer is not told a human joined the thread. This is an
+intentional product decision for an owner-operated support tool; noted here so it
+is explicit and revisitable. The internal audit fields (`dev:true`, `author`)
+preserve a record of which turns were human even though the UI hides it.
+
+---
+
+## 6. Unit C — developer Wrangler Ops inbox (`app.js`)
+
+- A **dev-only view**, invisible and inert without the `DEV_PASSWORD` (entered
+  through an Owner-only unlock; not present in any normal role's navigation).
+- **List:** polls `getWranglerChatsAll` (~6–8s), rows sorted by `lastTs`. Each row:
+  role/user, title, last preview, age, a **"live" dot** when active in the last
+  ~2 min, and the **driver** state (AI vs you).
+- **Open a chat:** full transcript pane (reuses the existing Wrangler message
+  renderer in a read view) + a **composer**. Sending calls `appendWranglerMessage`
+  (which takes the wheel). A **"Release to AI"** button calls
+  `setWranglerDriver('ai')`.
+- **Escalate → Claude Code** (secondary; reuses §9): a button that fires
+  `wranglerFile` to mint a GitHub issue seeded with the transcript and surfaces the
+  issue URL, from which a Claude Code web session launches. Present so the seam
+  exists; not the MVP focus.
+
+---
+
+## 7. Identity / author model
+
+Developer turns are stored as `{role:'assistant', dev:true, author:'Jac', ts}`:
+
+- **As Anthropic context:** plain `assistant` turns, so if the AI later resumes the
+  thread the conversation reads coherently.
+- **As customer UI:** rendered exactly like Mr. Wrangler (seamless — §5).
+- **As audit/dev signal:** `dev:true`/`author` mark which turns were human; used by
+  the Ops inbox and any future audit view, never shown to the customer.
+
+---
+
+## 8. Security & gating (kept on the main session — auth-sensitive)
+
+- `DEV_PASSWORD` is a Script Property, validated server-side on **every** dev action
+  (`getWranglerChatsAll`, `appendWranglerMessage`, `setWranglerDriver`, and dev
+  calls to `getWranglerChat`). Never the team password, never echoed, never in the
+  public repo, never logged.
+- The Ops surface is invisible/inert without the key.
+- **PII:** Jac will see real customer chats — the intended support capability,
+  owner-only. Nothing leaves the existing backend: no new external copy, no Drive
+  or repo spill. (Consistent with the standing PII guard — read live data for
+  support, never paste it into the public repo, commits, or seeds.)
+- Money/safety fences are unchanged: developer messages are plain chat turns and do
+  **not** bypass the existing hard-blocks (no card/ACH charge, no refund, no WO
+  completion, no role/password change) — those gates live below this feature.
+
+---
+
+## 9. Escalate to Claude Code (already-built path, reused not rebuilt)
+
+The Thread Mirror already does the heavy lifting: `wranglerFile` files a chat as a
+GitHub issue with the full transcript + context + images; `wranglerComment` /
+`wranglerThread` mirror turns; the Track-B pipeline (`docs/wrangler-pipeline.md`)
+hands `wrangler-fix`-labelled issues to a Claude Code agent that patches, runs CI,
+and ships. The Ops inbox simply exposes a clean **"Escalate → Claude Code"** entry
+into this. No new escalation machinery is built in this MVP.
+
+---
+
+## 10. Out of scope (YAGNI for the MVP)
+
+- **Multi-tenant `companyId` fan-out** — the action contracts leave room for a
+  tenant filter, but reading across 50 separate backends is not built now.
+- **True realtime** (Firebase/Ably or similar) — polling only.
+- **Polished escalate-to-CC flow** — the button reuses §9 as-is.
+- **Customer-facing "request a human" button** — for now Jac watches and jumps in.
+
+---
+
+## 11. Error handling
+
+- **Poll failures:** exponential backoff, keep last-known state, silent to the
+  customer.
+- **Pruned chat** (the chat janitor removed it): `appendWranglerMessage` /
+  `setWranglerDriver` return `{ok:false, reason:'gone'}`; the inbox drops the row.
+- **Offline customer:** developer messages persist server-side; delivered on the
+  customer's next dock open (notification bell).
+- **AI-pause is fail-safe:** persisted `driver:'human'` keeps the bot quiet through
+  failed polls until an explicit release.
+
+---
+
+## 12. Testing
+
+- `ci/logic-test.mjs` (pure logic, no browser):
+  - driver transitions: `ai → human` on `appendWranglerMessage`, `human → ai` on
+    `setWranglerDriver('ai')`.
+  - AI pause: with `driver==='human'`, a new customer message does **not** invoke
+    the agent loop; with `driver==='ai'` it does.
+  - `getWranglerChat(id, sinceTs)` returns only messages with `ts > sinceTs`.
+  - `getWranglerChatsAll` flattens chats across multiple roles into one list.
+- `ci/smoke.mjs`: app still boots with the Ops view registered.
+- New UI (Ops inbox view + dev composer) runs through **`/jactec-ui`**:
+  `data-r="Rxx"` stamps on every new element, a `WINDOW_CATALOG` entry for the Ops
+  popup, and `node ci/gen-rule-usage.mjs` regenerated (the `--check` gate).
+- Backend actions are additive GAS; manual smoke via the live Ops inbox after a
+  `/clasp` deploy.
+
+---
+
+## 13. Build order (for the implementation plan)
+
+1. Backend actions + storage fields (`driver`, `lastTs`) — `/clasp` deploy.
+2. Customer dock poller + silent AI pause + seamless dev-message rendering.
+3. Developer Wrangler Ops inbox (list → transcript → composer → release).
+4. `logic-test.mjs` coverage for driver/pause/sinceTs/flatten.
+5. `/jactec-ui` pass: stamps, `WINDOW_CATALOG`, rule-usage regen.
+6. (Seam only) "Escalate → Claude Code" button wired to existing `wranglerFile`.

--- a/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
+++ b/docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md
@@ -138,8 +138,11 @@ the inbox and a reply surfaces on the customer's next open via the notification 
 
 ## 6. Unit C — developer Wrangler Ops inbox (`app.js`)
 
-- A **dev-only view**, invisible and inert without the `DEV_PASSWORD` (entered
-  through an Owner-only unlock; not present in any normal role's navigation).
+- A **dev-only popup** (`kind: 'wranglerOps'`), invisible and inert without the
+  `DEV_PASSWORD`. **Entry point (per Jac, 2026-06-29):** a **~600ms long-press on the
+  🤠 Mr. Wrangler launcher** opens it (a tap is unchanged) — zero footprint for normal
+  users. The key is entered in a gate field and **cached in-session** so it isn't
+  re-typed each open; a wrong key flashes (`attnFlash`) and never unlocks.
 - **List:** polls `getWranglerChatsAll` (~6–8s), rows sorted by `lastTs`. Each row:
   role/user, title, last preview, age, a **"live" dot** when active in the last
   ~2 min, and the **driver** state (AI vs you).

--- a/style.css
+++ b/style.css
@@ -1199,6 +1199,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wrops-detail { display: flex; flex-direction: column; height: 100%; min-height: 0; }
 .wrops-transcript { flex: 1 1 auto; overflow-y: auto; padding: 14px 16px; display: flex; flex-direction: column; gap: 12px; }
 .wrops-driver { display: flex; align-items: center; gap: 8px; padding: 8px 14px; border-top: 1px solid var(--line); }
+.wrops-driver .js-wrops-escalate { margin-left: auto; }
 .wrops-compose { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--line); }
 .wrops-in { flex: 1 1 auto; height: 38px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); padding: 0 12px; font-size: 13.5px; }
 .wrops-in:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/style.css
+++ b/style.css
@@ -1169,6 +1169,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-msg.user .wr-bub { background: var(--accent); color: #1a1205; font-weight: 500; border-bottom-right-radius: 4px; }
 .wr-bub.wr-think { color: var(--txt-3); font-style: italic; }
 .wr-err { color: var(--red); font-size: 12px; padding: 0 16px 6px; }
+/* R26 — Wrangler Ops PAUSED plate: a developer took the wheel (live jump-in), so the
+   dock is read-only until released. Red hazard rail + calm steel body + stamped label. */
+.wr-paused { position: relative; display: flex; flex-direction: column; gap: 1px; padding: 8px 14px 8px 22px; background: var(--red-bg); border-bottom: 1px solid var(--red); flex: 0 0 auto; }
+.wr-paused::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 8px; background: repeating-linear-gradient(135deg, var(--red) 0 7px, #14181d 7px 14px); }
+.wr-paused-ttl { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 70%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 55%, transparent); }
+.wr-paused-sub { font-size: 11.5px; color: var(--txt-2); }
 .wr-compose { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--line); }
 /* §18d attach/paste images — paperclip stamp + pending thumbnails + sent-in-bubble.
    The chat takes a paste or a dropped file, Claude-style. */

--- a/style.css
+++ b/style.css
@@ -1175,6 +1175,35 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-paused::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 8px; background: repeating-linear-gradient(135deg, var(--red) 0 7px, #14181d 7px 14px); }
 .wr-paused-ttl { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 70%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 55%, transparent); }
 .wr-paused-sub { font-size: 11.5px; color: var(--txt-2); }
+/* §18i Wrangler Ops — the developer inbox plate: DEV_PASSWORD gate, then a two-pane
+   chat list + transcript/composer. All tokens → themes for dark/light/ranch for free. */
+.wrops-body { padding: 0; }
+.wrops-gate { display: flex; flex-direction: column; gap: 10px; padding: 18px; }
+.wrops-gate-lead { font-size: 13px; color: var(--txt-2); }
+.wrops-key { height: 38px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); padding: 0 12px; font-size: 14px; letter-spacing: 1px; }
+.wrops-key:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.wrops-err { color: var(--red); font-size: 12px; }
+.wrops-wrap { display: grid; grid-template-columns: 280px 1fr; height: 62vh; min-height: 0; }
+.wrops-list { overflow-y: auto; border-right: 1px solid var(--line); display: flex; flex-direction: column; }
+.wrops-row { display: flex; flex-direction: column; gap: 4px; padding: 10px 13px; border: 0; border-bottom: 1px solid var(--line); background: transparent; text-align: left; cursor: pointer; color: var(--txt); width: 100%; }
+.wrops-row:hover { background: var(--panel-2); }
+.wrops-row.on { background: var(--accent-soft); box-shadow: inset 3px 0 0 var(--accent); }
+.wrops-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.wrops-row-top { display: flex; align-items: center; gap: 7px; min-width: 0; }
+.wrops-row-ttl { font-weight: 600; font-size: 13px; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wrops-row-role { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 10px; color: var(--txt-3); flex: 0 0 auto; }
+.wrops-row-prev { font-size: 12px; color: var(--txt-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wrops-row-meta { display: flex; align-items: center; gap: 8px; }
+.wrops-age { font-size: 11px; color: var(--txt-3); margin-left: auto; }
+.wrops-pane { display: flex; flex-direction: column; min-width: 0; }
+.wrops-detail { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+.wrops-transcript { flex: 1 1 auto; overflow-y: auto; padding: 14px 16px; display: flex; flex-direction: column; gap: 12px; }
+.wrops-driver { display: flex; align-items: center; gap: 8px; padding: 8px 14px; border-top: 1px solid var(--line); }
+.wrops-compose { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--line); }
+.wrops-in { flex: 1 1 auto; height: 38px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); padding: 0 12px; font-size: 13.5px; }
+.wrops-in:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.wrops-empty { color: var(--txt-3); font-size: 13px; text-align: center; padding: 30px 16px; line-height: 1.5; }
+@media (max-width: 700px) { .wrops-popup { width: 94vw !important; } .wrops-wrap { grid-template-columns: 1fr; height: 70vh; } .wrops-list { max-height: 38%; border-right: 0; border-bottom: 1px solid var(--line); } }
 .wr-compose { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--line); }
 /* §18d attach/paste images — paperclip stamp + pending thumbnails + sent-in-bubble.
    The chat takes a paste or a dropped file, Claude-style. */


### PR DESCRIPTION
## What & why

Mirror Mr. Wrangler chats into a **developer-side live bridge** so Jac can support customers as Rental Wrangler scales toward ~50 rental companies. MVP capabilities:

1. **Developer inbox** — see every Mr. Wrangler conversation across roles.
2. **Live jump-in** — take the wheel of a customer's chat; the customer dock pauses while a human drives.

Built as a **polling bridge on the existing rail-sync** (the backend is Sheets behind GAS — no websockets). Single-tenant (JacRentals) now, with the contract seam left for multi-tenant later.

## Status — MVP built (Phases 1–3 + 6)

- **Phase 1 · Backend** — dev-gated actions in `docs/handoffs/wrangler-ops-backend.gs` (`getWranglerChatsAll`, `getWranglerChat`, `appendWranglerMessage`, `setWranglerDriver`) + a server-side single-writer guard for `setWranglerRail_`. **Deploy pending** (`DEV_PASSWORD` + `/clasp`).
- **Phase 2 · Customer dock** — `driver` state, a ~7s poller, the **R26 paused banner** + read-only composer while a developer drives, the AI-pause guard, live sync-up so in-progress chats are visible.
- **Phase 3 · Developer inbox** — a `DEV_PASSWORD`-gated `wranglerOps` popup opened by a **long-press on the 🤠 launcher** (invisible to normal users): chat list → transcript → jump-in composer + Release-to-AI.
- **Phase 6 · Escalate → Claude Code** — files the open chat as a `wrangler-fix` issue (reuses the existing Thread Mirror / auto-fix pipeline).

## Key decisions

- **Pause-banner model**: taking the wheel pauses the customer (banner + read-only) — which also makes the developer the **sole writer**, closing the whole-chat clobber race (no message-id change needed). Seamless dev messages in-thread; the banner is the one status signal.
- **Dedicated `DEV_PASSWORD`** gate, server-validated on every dev action; never the team password, never in the repo.
- **Count cursor** (not `sinceTs`) for message delivery — Wrangler messages carry no per-message timestamp.

## Not in this PR

- **Backend deploy** (`DEV_PASSWORD` + `/clasp`) — required before end-to-end testing.
- **Phase 4** logic-tests — the substantive logic is the GAS backend (not exercised by `ci/logic-test`); frontend bits are DOM/network-coupled.
- **Phase 5** cache-bust — happens at promotion (not shipping to `main` from this session).
- **Visual `/jactec-ui` self-critique + E2E** — needs a local serve (cloud session can't render a browser to the user).

## Gates

Non-browser gates green locally (syntax, `check-window-catalog` → 31 kinds, `gen-rule-usage --check`, `gen-code-map --check`). Smoke/logic run in CI (Playwright isn't installable in this container).

Spec: `docs/superpowers/specs/2026-06-29-wrangler-ops-developer-chat-bridge-design.md` · Plan: `docs/superpowers/plans/2026-06-29-wrangler-ops-developer-chat-bridge-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)