### PR TITLE
Mobile: long-press anywhere on a row/standard card drags the record

### DIFF
--- a/app.js
+++ b/app.js
@@ -11937,6 +11937,26 @@ function dragDown(e) {
   if (state.overlay) return;                                             // overlays own their clicks; the winpicker is non-modal (Task E — drag to select)
   if (e.target.closest('.tedit')) return;                                // the inline transport editor owns its pointers — let Google pan the map + drag the site pin (never arm an app/chat drag here)
   if (e.target.closest('.dispm')) return;                                // §2.3 the dispatch cockpit map owns its pointers too — Google handles pan/zoom, never the app drag engine
+  // §M3 — PHONE record-grab: a list row / open standard card is wall-to-wall pills +
+  // chat-els, leaving almost no bare space to grab — a finger-press lands on a pill ~2/3
+  // of the time, which on touch would either BAIL (.pill is in the bail list below) or
+  // hijack into a CHAT-TAG drag, so the record drag was effectively ungrabbable on a
+  // phone (Jac, 2026-06-29). On touch we resolve the whole row/card to its record FIRST:
+  // dragSourceAt already ranks a units pill as itself (the unit→rental link still wins),
+  // then a row, then an open standard card — so pressing ANYWHERE non-interactive on the
+  // row drags the record. Tap is unaffected (a press only LIFTS on a held horizontal
+  // move; a tap never does); chat-tag-dragging a single pill stays a desktop affordance.
+  if (e.pointerType === 'touch' && document.body.classList.contains('is-phone')
+      && !e.target.closest('input, textarea, select, button, .x, .inline-edit, .inline-input, .dropdown-menu, .ctx-menu')) {
+    const src = dragSourceAt(e.target);
+    if (src) {
+      DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
+      const armed = { card: src.card, rec: src.rec, x: e.clientX, y: e.clientY, pointerId: e.pointerId, touch: true, lp: null, rdy: null, ready: false };
+      armed.lp = armMenuTimer(armed);                       // §M3 — hold still → context menu
+      armed.rdy = armReadyTimer(armed);                     // a hold must precede the horizontal drag
+      DRAG.armed = armed; return;
+    }
+  }
   // §17 — a granular element marked [data-chat-el] (a pill/price/line/person) arms a
   // CHAT-TAG drag (tap still does its own thing; drag/long-press tags it into a chat).
   const chatEl = e.target.closest('[data-chat-el]');

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16594 lines, 38 chapters
+## app.js — 16614 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13279 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13280–14207 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14208–15246 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15247–15693 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15694–15696 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15697–16594 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13299 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13300–14227 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14228–15266 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15267–15713 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15714–15716 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15717–16614 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260628f" />
+  <link rel="stylesheet" href="style.css?v=20260629a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260628f"></script>
-  <script type="module" src="app.js?v=20260628f"></script>
+  <script src="rule-usage.js?v=20260629a"></script>
+  <script type="module" src="app.js?v=20260629a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What & why

You reported: **can't drag rows or standard-mode items on mobile** — "nothing moves," even with the correct long-press.

**Root cause (proven, not guessed).** On a phone, a list row (and an open standard-mode card) is wall-to-wall pills + chat-els — a units row samples at **~68% covered** (28 bare / 37 pill / 23 chat-el across its width). The touch path in `dragDown()` resolved a press in this order:

1. on a `[data-chat-el]` pill → arms a **chat-tag drag** (not a record drag)
2. on any other `.pill` → **bails entirely** (`.pill` is in the bail list) → *nothing happens*
3. only on **bare** row space → the actual record/row drag

So a finger almost never landed on grabbable space. The drag engine itself was fine — driving a drag from a rare bare pixel lifted the record correctly.

## The fix

On **touch + `is-phone`**, resolve the press through `dragSourceAt()` **first** (it already ranks a units pill as itself → unit→rental linking still wins, then a row, then an open standard card), skipping only genuinely interactive controls (`input`/`textarea`/`select`/`button`/`.x`/inline-edit/menus). Pressing **anywhere non-interactive on a row now drags the record**.

Preserved:
- **Tap** = the element's own action (a press only *lifts* on a held horizontal move; a tap never does)
- **Vertical** slide still scrolls
- A **pre-hold horizontal flick** still swipe-navigates Back/Forward
- **Desktop** behavior unchanged
- Chat-tag-dragging a single pill stays a desktop affordance

Per your call, applied to both list rows and open standard-mode cards.

No visual/markup change → no new builders, `data-r` stamps, `RULE_META`, `rule-usage.js`, or `WINDOW_CATALOG` changes. Single-spot change in `dragDown()` (`app.js`).

## Verification

Phone-context (390×844, `hasTouch`) Playwright harness driving real CDP touch events — **8/8**:
- record drag lifts from a **pill**, a **chat-el**, and **bare** points
- quick **tap** does not lift a drag and still fires the tap action
- **vertical** slide → no drag (scroll preserved)
- pre-hold **horizontal flick** → no drag (swipe-nav intact)
- **desktop** mouse-drag of a row still lifts; phone branch skipped on desktop

Gates: `smoke` (boots clean) · `logic-test` **400/400** · `gen-rule-usage --check` · `check-window-catalog` · `gen-code-map --check` all pass. (`docs/code-map.generated.md` regenerated — line-number shifts only, no chapter changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01961vQPLR3KBNfaC5qNu45P)_