### PR TITLE
Local UI-candidate showcase (sandbox, not live)

### DIFF
--- a/card-borders.html
+++ b/card-borders.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Card Border Bake-off — Yard Sandbox</title>
+<!--
+  LOCAL SANDBOX ONLY — not wired into the app. Recreates the real units data-plate
+  card (steel gradient, hazard stripe, corner rivets, title chip) and shows THREE
+  border treatments on it: hazard-tape frame, rivet-bolted bezel, saddle-stitch.
+  Tokens + structure mirrored from style.css (.card, [data-theme=yard]).
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&family=Saira+Condensed:wght@600;700;800&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    /* mirrored from style.css */
+    --steel-1:#1b222c; --steel-2:#0d1116;
+    --rivet:#4a525e; --rivet-pit:#0b0f14;
+    --card:#14161b; --line:#262a31; --line-soft:#1f232a;
+    --bg:#0b0c0f; --bg-2:#101216; --panel:#15171c; --panel-2:#1b1e24;
+    --txt:#e9edf4; --txt-2:#a7afbc; --txt-3:#6b7480;
+    --accent:#ff7a1a; --accent-line:rgba(255,122,26,.5);
+    --yellow:#ffe000; --green:#147a47; --red:#ff1040;
+    --tan:#c2925a; --tan-deep:#8a5a2b;
+    --radius:16px; --chip-radius:12px;
+    --shadow:0 18px 50px -24px rgba(0,0,0,.75);
+    --chip-shadow:0 6px 16px -10px rgba(0,0,0,.7);
+    --hazard: repeating-linear-gradient(135deg, var(--stripe,#ffe000) 0 13px, #14181d 13px 26px);
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin:0; font-family:"Geist",system-ui,sans-serif;
+    background: radial-gradient(1200px 600px at 50% -10%, #16191f 0%, transparent 60%), var(--bg);
+    color: var(--txt); min-height:100vh; padding:0 0 70px; -webkit-font-smoothing:antialiased;
+  }
+  header { border-bottom:1px solid var(--line); background:linear-gradient(180deg,#1b2129,#0c0e11); }
+  .hazard-bar { height:8px; background: repeating-linear-gradient(135deg, var(--yellow) 0 13px, #14181d 13px 26px); }
+  .head-inner { max-width:1080px; margin:0 auto; padding:26px 24px 22px; display:flex; align-items:baseline; gap:16px; flex-wrap:wrap; }
+  .wordmark { font-family:"Saira Condensed",sans-serif; font-weight:800; text-transform:uppercase; letter-spacing:3px; font-size:26px; }
+  .wordmark b { color:var(--accent); }
+  .subtitle { color:var(--txt-3); font-size:13px; }
+  .pill-local { margin-left:auto; font-family:"Saira Condensed",sans-serif; text-transform:uppercase; letter-spacing:1.5px; font-weight:700; font-size:11px; color:var(--yellow); border:1px solid rgba(245,224,0,.4); background:rgba(245,224,0,.1); padding:5px 11px; border-radius:4px; align-self:center; }
+
+  main { max-width:1080px; margin:0 auto; padding:36px 24px 0; }
+  .row3 { display:grid; grid-template-columns:repeat(auto-fit,minmax(290px,1fr)); gap:34px; align-items:start; }
+  .slot { display:flex; flex-direction:column; gap:14px; }
+  .slot-label { font-family:"Saira Condensed",sans-serif; text-transform:uppercase; letter-spacing:2px; font-weight:700; font-size:14px; display:flex; align-items:center; gap:9px; }
+  .slot-label .idx { color:#1a1205; background:var(--accent); border-radius:3px; font-size:12px; padding:1px 8px; letter-spacing:1px; }
+  .slot-note { font-size:12px; color:var(--txt-3); line-height:1.5; }
+  .slot-note b { color:var(--tan); font-weight:600; }
+
+  /* ── THE REAL CARD (units data-plate) ─────────────────────────────────── */
+  .card {
+    position:relative; display:flex; flex-direction:column; min-width:0;
+    background: linear-gradient(180deg, var(--steel-1), var(--steel-2));
+    border:1px solid var(--line); border-radius:var(--radius);
+    box-shadow: var(--shadow); overflow:hidden;
+    --stripe: var(--yellow);
+  }
+  .card .stripe {
+    position:absolute; top:0; left:0; right:0; height:6px; z-index:5;
+    background: var(--hazard); border-bottom:1px solid rgba(0,0,0,.6); pointer-events:none;
+  }
+  .card .rivets {
+    position:absolute; inset:0; z-index:12; pointer-events:none; border-radius:inherit;
+    background:
+      radial-gradient(circle at 12px 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+      radial-gradient(circle at calc(100% - 12px) 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+      radial-gradient(circle at 12px calc(100% - 12px), var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+      radial-gradient(circle at calc(100% - 12px) calc(100% - 12px), var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px);
+  }
+  .card-head { flex:0 0 auto; display:flex; align-items:center; gap:8px; padding:13px 10px 6px; }
+  .c-titlecard {
+    display:inline-flex; align-items:center; gap:7px; padding:5px 12px;
+    border-radius:var(--chip-radius); background:var(--bg-2);
+    border:1px solid var(--line); box-shadow:var(--chip-shadow);
+  }
+  .c-titlecard .c-icon { display:inline-flex; color:var(--accent); width:14px; height:14px; }
+  .c-titlecard .c-title { font-size:13.5px; font-weight:800; letter-spacing:.2px; color:var(--txt); }
+  .c-titlecard .c-count { font-size:11px; font-weight:700; color:var(--txt-3); }
+  .c-actions { margin-left:auto; display:inline-flex; gap:2px; padding:3px; border-radius:var(--chip-radius); background:var(--panel); border:1px solid var(--line); box-shadow:var(--chip-shadow); }
+  .hbtn { width:24px; height:24px; border-radius:8px; display:inline-flex; align-items:center; justify-content:center; color:var(--txt-3); }
+  .hbtn svg { width:15px; height:15px; }
+
+  .card-body { padding:6px 10px 14px; display:flex; flex-direction:column; gap:7px; }
+  .urow {
+    display:flex; align-items:center; gap:10px; padding:9px 11px;
+    background:var(--card); border:1px solid var(--line-soft); border-radius:10px;
+  }
+  .u-id { font-family:"Saira Condensed",sans-serif; font-weight:700; letter-spacing:.6px; font-size:14px; color:var(--txt); }
+  .u-name { font-size:12px; color:var(--txt-2); }
+  .u-pill {
+    margin-left:auto; font-family:"Saira Condensed",sans-serif; text-transform:uppercase;
+    letter-spacing:1px; font-weight:700; font-size:10px; padding:3px 8px; border-radius:999px;
+    border:1px solid; white-space:nowrap;
+  }
+  .u-pill.yard { color:#4fd6a0; border-color:rgba(79,214,160,.45); background:rgba(20,122,71,.18); }
+  .u-pill.rent { color:#ffb066; border-color:rgba(255,122,26,.45); background:rgba(255,122,26,.14); }
+  .u-pill.svc  { color:#ffe000; border-color:rgba(245,224,0,.4); background:rgba(245,224,0,.12); }
+
+  /* ════════════════════════════════════════════════════════════════════ */
+  /* A — HAZARD-TAPE FRAME : the signature stripe wraps the whole perimeter */
+  .fr-hazard {
+    --stripe: var(--yellow);
+    padding:7px; border-radius:20px; background: var(--hazard);
+    box-shadow: var(--shadow);
+  }
+  .fr-hazard .card { border-radius:12px; box-shadow:none; border-color:#0a0c10; }
+  .fr-hazard .card .stripe { display:none; }   /* the frame IS the hazard */
+
+  /* ════════════════════════════════════════════════════════════════════ */
+  /* B — RIVET-BOLTED BEZEL : raised steel frame, rivets marching all edges */
+  .fr-rivet {
+    position:relative; padding:11px; border-radius:19px;
+    background: linear-gradient(180deg, #2b333e, #161b22);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.13), inset 0 -2px 7px rgba(0,0,0,.6), var(--shadow);
+  }
+  .fr-rivet::before {       /* rivets marching around all four edges */
+    content:''; position:absolute; inset:4px; border-radius:16px; pointer-events:none;
+    background:
+      radial-gradient(circle at 13px 5px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) 6px top   / 30px 10px repeat-x,
+      radial-gradient(circle at 13px 5px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) 6px bottom/ 30px 10px repeat-x,
+      radial-gradient(circle at 5px 13px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) left   6px / 10px 30px repeat-y,
+      radial-gradient(circle at 5px 13px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) right  6px / 10px 30px repeat-y;
+  }
+  .fr-rivet .card { box-shadow:none; }
+  .fr-rivet .card .rivets { display:none; }   /* bezel supplies the rivets */
+
+  /* ════════════════════════════════════════════════════════════════════ */
+  /* C — SADDLE-STITCH : ranch-twist tan dashed border, paired with rivets  */
+  .fr-stitch { position:relative; }
+  .fr-stitch .card { border-color:#33291d; }
+  .fr-stitch .stitch {
+    position:absolute; inset:7px; z-index:13; pointer-events:none;
+    border:1.5px dashed var(--tan); border-radius:11px;
+    opacity:.85;
+  }
+  .fr-stitch .stitch.inner {
+    inset:10px; border-width:1px; border-color:rgba(194,146,90,.45); border-radius:9px;
+  }
+
+  footer { max-width:1080px; margin:42px auto 0; padding:22px 24px 0; border-top:1px dashed rgba(194,146,90,.4); color:var(--txt-3); font-size:12px; line-height:1.6; }
+  footer b { color:var(--tan); font-weight:600; }
+</style>
+</head>
+<body>
+  <header>
+    <div class="hazard-bar"></div>
+    <div class="head-inner">
+      <div>
+        <div class="wordmark">Card <b>Borders</b> · Bake-off</div>
+        <div class="subtitle">Same real units data-plate, three border treatments. Sandbox — pick a direction.</div>
+      </div>
+      <span class="pill-local">Local Sandbox · Not Live</span>
+    </div>
+  </header>
+
+  <main>
+    <div class="row3">
+
+      <!-- A — HAZARD-TAPE FRAME -->
+      <div class="slot">
+        <div class="slot-label"><span class="idx">A</span> Hazard-Tape Frame</div>
+        <div class="fr-hazard">
+          <div class="card" data-card="units">
+            <div class="stripe"></div>
+            <div class="card-head">
+              <span class="c-titlecard">
+                <span class="c-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 8-9 4-9-4 9-4 9 4Z"/><path d="m3 8 9 4v10l-9-4Z"/><path d="m21 8-9 4v10l9-4Z"/></svg></span>
+                <span class="c-title">Units</span><span class="c-count">24</span>
+              </span>
+              <span class="c-actions"><span class="hbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></span>
+            </div>
+            <div class="card-body">
+              <div class="urow"><span class="u-id">CAT&nbsp;305</span><span class="u-name">Mini Excavator</span><span class="u-pill yard">On Yard</span></div>
+              <div class="urow"><span class="u-id">JD&nbsp;332G</span><span class="u-name">Skid Steer</span><span class="u-pill rent">On Rent</span></div>
+              <div class="urow"><span class="u-id">GENIE&nbsp;S-60</span><span class="u-name">Boom Lift</span><span class="u-pill svc">Service</span></div>
+            </div>
+            <div class="rivets"></div>
+          </div>
+        </div>
+        <div class="slot-note">The signature <b>hazard stripe</b> wraps the full perimeter instead of just the top band. Loudest, most unmistakably "yard." Eats ~7px on every edge.</div>
+      </div>
+
+      <!-- B — RIVET-BOLTED BEZEL -->
+      <div class="slot">
+        <div class="slot-label"><span class="idx">B</span> Rivet-Bolted Bezel</div>
+        <div class="fr-rivet">
+          <div class="card" data-card="units">
+            <div class="stripe"></div>
+            <div class="card-head">
+              <span class="c-titlecard">
+                <span class="c-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 8-9 4-9-4 9-4 9 4Z"/><path d="m3 8 9 4v10l-9-4Z"/><path d="m21 8-9 4v10l9-4Z"/></svg></span>
+                <span class="c-title">Units</span><span class="c-count">24</span>
+              </span>
+              <span class="c-actions"><span class="hbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></span>
+            </div>
+            <div class="card-body">
+              <div class="urow"><span class="u-id">CAT&nbsp;305</span><span class="u-name">Mini Excavator</span><span class="u-pill yard">On Yard</span></div>
+              <div class="urow"><span class="u-id">JD&nbsp;332G</span><span class="u-name">Skid Steer</span><span class="u-pill rent">On Rent</span></div>
+              <div class="urow"><span class="u-id">GENIE&nbsp;S-60</span><span class="u-name">Boom Lift</span><span class="u-pill svc">Service</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="slot-note">A raised <b>steel bezel</b> with rivets bolted along every edge — the card reads as a panel torqued onto the rig. Heaviest, most industrial; promotes the corner-rivet motif to the whole frame.</div>
+      </div>
+
+      <!-- C — SADDLE-STITCH -->
+      <div class="slot">
+        <div class="slot-label"><span class="idx">C</span> Saddle-Stitch</div>
+        <div class="fr-stitch">
+          <div class="card" data-card="units">
+            <div class="stripe"></div>
+            <div class="card-head">
+              <span class="c-titlecard">
+                <span class="c-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 8-9 4-9-4 9-4 9 4Z"/><path d="m3 8 9 4v10l-9-4Z"/><path d="m21 8-9 4v10l9-4Z"/></svg></span>
+                <span class="c-title">Units</span><span class="c-count">24</span>
+              </span>
+              <span class="c-actions"><span class="hbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></span>
+            </div>
+            <div class="card-body">
+              <div class="urow"><span class="u-id">CAT&nbsp;305</span><span class="u-name">Mini Excavator</span><span class="u-pill yard">On Yard</span></div>
+              <div class="urow"><span class="u-id">JD&nbsp;332G</span><span class="u-name">Skid Steer</span><span class="u-pill rent">On Rent</span></div>
+              <div class="urow"><span class="u-id">GENIE&nbsp;S-60</span><span class="u-name">Boom Lift</span><span class="u-pill svc">Service</span></div>
+            </div>
+            <div class="rivets"></div>
+            <div class="stitch"></div>
+            <div class="stitch inner"></div>
+          </div>
+        </div>
+        <div class="slot-note">The <b>ranch twist</b> — a leather-tan double saddle-stitch inset, paired with the corner rivets. Subtlest; keeps the steel core dominant and seasons it warm. The only one that leans wrangler.</div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer>
+    <b>Sandbox only.</b> <code>card-borders.html</code> isn't wired into the app — the live cards are untouched. Card surface, hazard stripe, rivets, and tokens are mirrored from <code>style.css</code> (<code>.card</code>, <code>[data-theme="yard"]</code>) so this previews the real thing. Icons here are placeholder Lucide-style "box" glyphs; the real card sources its mark from <code>icons.js</code>.
+  </footer>
+</body>
+</html>

--- a/card-textures.html
+++ b/card-textures.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Card Textures — Yard Sandbox</title>
+<!--
+  LOCAL SANDBOX ONLY — not wired into the app. Procedurally-textured takes on the
+  real units data-plate: diamond-plate steel, brushed steel, worn leather. All
+  textures are generated in CSS + inline SVG (feTurbulence) — NO image files — so
+  it stays lightweight. Swap in real photo textures later by replacing the
+  .surface background / overlay.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&family=Saira+Condensed:wght@600;700;800&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --steel-1:#1b222c; --steel-2:#0d1116;
+    --rivet:#4a525e; --rivet-pit:#0b0f14;
+    --card:#14161b; --line:#262a31; --line-soft:#1f232a;
+    --bg:#0b0c0f; --bg-2:#101216; --panel:#15171c;
+    --txt:#e9edf4; --txt-2:#a7afbc; --txt-3:#6b7480;
+    --accent:#ff7a1a; --yellow:#ffe000; --tan:#c2925a; --tan-deep:#8a5a2b;
+    --radius:16px; --chip-radius:12px;
+    --shadow:0 18px 50px -24px rgba(0,0,0,.75);
+    --chip-shadow:0 6px 16px -10px rgba(0,0,0,.7);
+    --hazard: repeating-linear-gradient(135deg, var(--stripe,#ffe000) 0 13px, #14181d 13px 26px);
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin:0; font-family:"Geist",system-ui,sans-serif;
+    background: radial-gradient(1200px 600px at 50% -10%, #16191f 0%, transparent 60%), var(--bg);
+    color: var(--txt); min-height:100vh; padding:0 0 70px; -webkit-font-smoothing:antialiased;
+  }
+  header { border-bottom:1px solid var(--line); background:linear-gradient(180deg,#1b2129,#0c0e11); position:relative; }
+  /* weathered hazard bar — hazard tape + a grunge noise overlay */
+  .hazard-bar { position:relative; height:10px; background: repeating-linear-gradient(135deg, var(--yellow) 0 13px, #14181d 13px 26px); overflow:hidden; }
+  .hazard-bar svg { position:absolute; inset:0; width:100%; height:100%; mix-blend-mode:multiply; opacity:.5; }
+  .head-inner { max-width:1080px; margin:0 auto; padding:26px 24px 22px; display:flex; align-items:baseline; gap:16px; flex-wrap:wrap; }
+  .wordmark { font-family:"Saira Condensed",sans-serif; font-weight:800; text-transform:uppercase; letter-spacing:3px; font-size:26px; }
+  .wordmark b { color:var(--accent); }
+  .subtitle { color:var(--txt-3); font-size:13px; }
+  .pill-local { margin-left:auto; font-family:"Saira Condensed",sans-serif; text-transform:uppercase; letter-spacing:1.5px; font-weight:700; font-size:11px; color:var(--yellow); border:1px solid rgba(245,224,0,.4); background:rgba(245,224,0,.1); padding:5px 11px; border-radius:4px; align-self:center; }
+
+  main { max-width:1080px; margin:0 auto; padding:36px 24px 0; }
+  .row3 { display:grid; grid-template-columns:repeat(auto-fit,minmax(290px,1fr)); gap:34px; align-items:start; }
+  .slot { display:flex; flex-direction:column; gap:14px; }
+  .slot-label { font-family:"Saira Condensed",sans-serif; text-transform:uppercase; letter-spacing:2px; font-weight:700; font-size:14px; display:flex; align-items:center; gap:9px; }
+  .slot-label .idx { color:#1a1205; background:var(--accent); border-radius:3px; font-size:12px; padding:1px 8px; letter-spacing:1px; }
+  .slot-note { font-size:12px; color:var(--txt-3); line-height:1.5; }
+  .slot-note b { color:var(--tan); font-weight:600; }
+
+  /* ── card scaffold ─────────────────────────────────────────────────── */
+  .card {
+    position:relative; display:flex; flex-direction:column; min-width:0;
+    border:1px solid var(--line); border-radius:var(--radius);
+    box-shadow: var(--shadow); overflow:hidden; --stripe:var(--yellow);
+    background: linear-gradient(180deg, var(--steel-1), var(--steel-2));
+  }
+  .surface { position:absolute; inset:0; z-index:0; }           /* texture lives here */
+  .tex { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; }
+  .card .stripe { position:absolute; top:0; left:0; right:0; height:6px; z-index:6; background: var(--hazard); border-bottom:1px solid rgba(0,0,0,.6); pointer-events:none; }
+  .card .rivets {
+    position:absolute; inset:0; z-index:12; pointer-events:none; border-radius:inherit;
+    background:
+      radial-gradient(circle at 12px 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+      radial-gradient(circle at calc(100% - 12px) 15px, var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+      radial-gradient(circle at 12px calc(100% - 12px), var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px),
+      radial-gradient(circle at calc(100% - 12px) calc(100% - 12px), var(--rivet) 0 1.4px, var(--rivet-pit) 1.7px 3px, transparent 3.4px);
+  }
+  .card-head { position:relative; z-index:3; flex:0 0 auto; display:flex; align-items:center; gap:8px; padding:13px 10px 6px; }
+  .c-titlecard { display:inline-flex; align-items:center; gap:7px; padding:5px 12px; border-radius:var(--chip-radius); background:var(--bg-2); border:1px solid var(--line); box-shadow:var(--chip-shadow); }
+  .c-titlecard .c-icon { display:inline-flex; color:var(--accent); width:14px; height:14px; }
+  .c-titlecard .c-title { font-size:13.5px; font-weight:800; color:var(--txt); }
+  .c-titlecard .c-count { font-size:11px; font-weight:700; color:var(--txt-3); }
+  .c-actions { margin-left:auto; display:inline-flex; gap:2px; padding:3px; border-radius:var(--chip-radius); background:var(--panel); border:1px solid var(--line); box-shadow:var(--chip-shadow); }
+  .hbtn { width:24px; height:24px; border-radius:8px; display:inline-flex; align-items:center; justify-content:center; color:var(--txt-3); }
+  .hbtn svg { width:15px; height:15px; }
+  .card-body { position:relative; z-index:3; padding:6px 10px 14px; display:flex; flex-direction:column; gap:7px; }
+  .urow { display:flex; align-items:center; gap:10px; padding:9px 11px; background:rgba(14,16,21,.78); border:1px solid var(--line-soft); border-radius:10px; backdrop-filter:blur(1px); }
+  .u-id { font-family:"Saira Condensed",sans-serif; font-weight:700; letter-spacing:.6px; font-size:14px; color:var(--txt); }
+  .u-name { font-size:12px; color:var(--txt-2); }
+  .u-pill { margin-left:auto; font-family:"Saira Condensed",sans-serif; text-transform:uppercase; letter-spacing:1px; font-weight:700; font-size:10px; padding:3px 8px; border-radius:999px; border:1px solid; white-space:nowrap; }
+  .u-pill.yard { color:#4fd6a0; border-color:rgba(79,214,160,.45); background:rgba(20,122,71,.18); }
+  .u-pill.rent { color:#ffb066; border-color:rgba(255,122,26,.45); background:rgba(255,122,26,.14); }
+  .u-pill.svc  { color:#ffe000; border-color:rgba(245,224,0,.4); background:rgba(245,224,0,.12); }
+
+  /* ════ A — DIAMOND-PLATE STEEL ════ */
+  .surface-diamond {
+    background-color:#252c35;
+    background-image:
+      linear-gradient(135deg, rgba(255,255,255,.10) 25%, transparent 25%),
+      linear-gradient(225deg, rgba(255,255,255,.10) 25%, transparent 25%),
+      linear-gradient(315deg, rgba(0,0,0,.30) 25%, transparent 25%),
+      linear-gradient(45deg,  rgba(0,0,0,.30) 25%, transparent 25%);
+    background-size:18px 18px;
+    background-position:0 0, 9px 0, 9px -9px, 0 9px;
+  }
+  .fr-bezel { position:relative; padding:11px; border-radius:19px; background:linear-gradient(180deg,#2b333e,#161b22); box-shadow: inset 0 1px 0 rgba(255,255,255,.13), inset 0 -2px 7px rgba(0,0,0,.6), var(--shadow); }
+  .fr-bezel::before { content:''; position:absolute; inset:4px; border-radius:16px; pointer-events:none;
+    background:
+      radial-gradient(circle at 13px 5px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) 6px top  / 30px 10px repeat-x,
+      radial-gradient(circle at 13px 5px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) 6px bottom/ 30px 10px repeat-x,
+      radial-gradient(circle at 5px 13px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) left  6px / 10px 30px repeat-y,
+      radial-gradient(circle at 5px 13px, var(--rivet) 0 1.5px, var(--rivet-pit) 1.8px 3.1px, transparent 3.5px) right 6px / 10px 30px repeat-y; }
+  .fr-bezel .card { box-shadow:none; }
+  .fr-bezel .card .rivets { display:none; }
+
+  /* ════ B — BRUSHED STEEL ════ */
+  .surface-brushed { background:linear-gradient(180deg,#3a424d,#20262e); }
+  .surface-brushed .tex { mix-blend-mode:overlay; opacity:.55; }
+  .gloss { position:absolute; inset:0; z-index:1; pointer-events:none; background:linear-gradient(105deg, transparent 0 38%, rgba(255,255,255,.10) 47%, transparent 56%); }
+
+  /* ════ C — WORN LEATHER ════ */
+  .surface-leather { background:linear-gradient(180deg,#6e4c2d,#3f2c1a); }
+  .surface-leather .tex { mix-blend-mode:overlay; opacity:.65; }
+  .fr-stitch .card { border-color:#2a2014; }
+  .stitch { position:absolute; inset:7px; z-index:13; pointer-events:none; border:1.5px dashed var(--tan); border-radius:11px; opacity:.9; }
+  .stitch.inner { inset:10px; border-width:1px; border-color:rgba(220,180,120,.5); border-radius:9px; }
+  .surface-leather ~ .card-head .c-titlecard,
+  .leather .c-titlecard { background:rgba(20,14,8,.7); border-color:#5a4226; }
+
+  footer { max-width:1080px; margin:42px auto 0; padding:22px 24px 0; border-top:1px dashed rgba(194,146,90,.4); color:var(--txt-3); font-size:12px; line-height:1.6; }
+  footer b { color:var(--tan); font-weight:600; }
+</style>
+</head>
+<body>
+  <!-- procedural texture filters (no image files) -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <defs>
+      <filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch"/><feColorMatrix type="saturate" values="0"/></filter>
+      <filter id="leathergrain"><feTurbulence type="fractalNoise" baseFrequency="0.16 0.16" numOctaves="4" seed="7" stitchTiles="stitch"/><feColorMatrix type="saturate" values="0"/><feComponentTransfer><feFuncA type="linear" slope="1.1"/></feComponentTransfer></filter>
+      <filter id="brushed"><feTurbulence type="fractalNoise" baseFrequency="0.012 0.9" numOctaves="2" stitchTiles="stitch"/><feColorMatrix type="saturate" values="0"/></filter>
+      <filter id="grunge"><feTurbulence type="fractalNoise" baseFrequency="0.5" numOctaves="3" stitchTiles="stitch"/><feColorMatrix type="saturate" values="0"/></filter>
+    </defs>
+  </svg>
+
+  <header>
+    <div class="hazard-bar"><svg preserveAspectRatio="none"><rect width="100%" height="100%" filter="url(#grunge)"/></svg></div>
+    <div class="head-inner">
+      <div>
+        <div class="wordmark">Card <b>Textures</b> · Yard</div>
+        <div class="subtitle">Procedural steel &amp; leather on the real data-plate — all CSS + SVG, no image files.</div>
+      </div>
+      <span class="pill-local">Local Sandbox · Not Live</span>
+    </div>
+  </header>
+
+  <main>
+    <div class="row3">
+
+      <!-- A — DIAMOND-PLATE STEEL -->
+      <div class="slot">
+        <div class="slot-label"><span class="idx">A</span> Diamond-Plate Steel</div>
+        <div class="fr-bezel">
+          <div class="card">
+            <div class="surface surface-diamond"></div>
+            <div class="stripe"></div>
+            <div class="card-head">
+              <span class="c-titlecard"><span class="c-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 8-9 4-9-4 9-4 9 4Z"/><path d="m3 8 9 4v10l-9-4Z"/><path d="m21 8-9 4v10l9-4Z"/></svg></span><span class="c-title">Units</span><span class="c-count">24</span></span>
+              <span class="c-actions"><span class="hbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></span>
+            </div>
+            <div class="card-body">
+              <div class="urow"><span class="u-id">CAT&nbsp;305</span><span class="u-name">Mini Excavator</span><span class="u-pill yard">On Yard</span></div>
+              <div class="urow"><span class="u-id">JD&nbsp;332G</span><span class="u-name">Skid Steer</span><span class="u-pill rent">On Rent</span></div>
+              <div class="urow"><span class="u-id">GENIE&nbsp;S-60</span><span class="u-name">Boom Lift</span><span class="u-pill svc">Service</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="slot-note"><b>Tread-plate</b> surface inside the bolted bezel — the toughest, most "shop-floor" read. The diamond pattern is pure CSS gradients.</div>
+      </div>
+
+      <!-- B — BRUSHED STEEL -->
+      <div class="slot">
+        <div class="slot-label"><span class="idx">B</span> Brushed Steel</div>
+        <div class="card">
+          <div class="surface surface-brushed"><svg class="tex" preserveAspectRatio="none"><rect width="100%" height="100%" filter="url(#brushed)"/></svg></div>
+          <div class="gloss"></div>
+          <div class="stripe"></div>
+          <div class="card-head">
+            <span class="c-titlecard"><span class="c-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 8-9 4-9-4 9-4 9 4Z"/><path d="m3 8 9 4v10l-9-4Z"/><path d="m21 8-9 4v10l9-4Z"/></svg></span><span class="c-title">Units</span><span class="c-count">24</span></span>
+            <span class="c-actions"><span class="hbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></span>
+          </div>
+          <div class="card-body">
+            <div class="urow"><span class="u-id">CAT&nbsp;305</span><span class="u-name">Mini Excavator</span><span class="u-pill yard">On Yard</span></div>
+            <div class="urow"><span class="u-id">JD&nbsp;332G</span><span class="u-name">Skid Steer</span><span class="u-pill rent">On Rent</span></div>
+            <div class="urow"><span class="u-id">GENIE&nbsp;S-60</span><span class="u-name">Boom Lift</span><span class="u-pill svc">Service</span></div>
+          </div>
+          <div class="rivets"></div>
+        </div>
+        <div class="slot-note"><b>Brushed-metal</b> grain (anisotropic SVG noise) with a raking gloss sweep. Machined and sleek — keeps the standard card shape, just richer.</div>
+      </div>
+
+      <!-- C — WORN LEATHER -->
+      <div class="slot leather">
+        <div class="slot-label"><span class="idx">C</span> Worn Leather</div>
+        <div class="fr-stitch">
+          <div class="card">
+            <div class="surface surface-leather"><svg class="tex" preserveAspectRatio="none"><rect width="100%" height="100%" filter="url(#leathergrain)"/></svg></div>
+            <div class="stripe"></div>
+            <div class="card-head">
+              <span class="c-titlecard"><span class="c-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 8-9 4-9-4 9-4 9 4Z"/><path d="m3 8 9 4v10l-9-4Z"/><path d="m21 8-9 4v10l9-4Z"/></svg></span><span class="c-title">Units</span><span class="c-count">24</span></span>
+              <span class="c-actions"><span class="hbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg></span></span>
+            </div>
+            <div class="card-body">
+              <div class="urow"><span class="u-id">CAT&nbsp;305</span><span class="u-name">Mini Excavator</span><span class="u-pill yard">On Yard</span></div>
+              <div class="urow"><span class="u-id">JD&nbsp;332G</span><span class="u-name">Skid Steer</span><span class="u-pill rent">On Rent</span></div>
+              <div class="urow"><span class="u-id">GENIE&nbsp;S-60</span><span class="u-name">Boom Lift</span><span class="u-pill svc">Service</span></div>
+            </div>
+            <div class="rivets"></div>
+            <div class="stitch"></div>
+            <div class="stitch inner"></div>
+          </div>
+        </div>
+        <div class="slot-note"><b>Tooled leather</b> grain (fractal SVG noise on a tan base) with the saddle-stitch + rivets. The full ranch hero — steel fittings on a leather panel.</div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer>
+    <b>Sandbox only.</b> <code>card-textures.html</code> isn't wired into the app. Every texture here is generated in CSS + inline SVG <code>feTurbulence</code> — <b>no image files</b>, so nothing to download and no repo bloat. To use your own photo textures from the <code>Textures</code> folder, attach them here or push them to an <code>assets/</code> folder and I'll swap them into <code>.surface</code>.
+  </footer>
+</body>
+</html>

--- a/showcase-solid.html
+++ b/showcase-solid.html
@@ -1,0 +1,439 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>UI Candidates + Live-Wire Status-Motion — Yard Sandbox</title>
+<!--
+  LOCAL SANDBOX ONLY — not wired into the live app (index.html / app.js / style.css untouched).
+  Part 1: three Uiverse components re-skinned into the yard data-plate language.
+  Part 2: "Live-Wire" — a prototype of the status-motion system (jolt / wash / creep,
+          tempo-as-clock, hover personalities). Feel it before we spec it.
+  Open directly via file:// — no server required.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Saira+Condensed:wght@600;700;800&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #0b0c0f;
+    --bg-2: #101216;
+    --panel: #15171c;
+    --panel-2: #1b1e24;
+    --accent: #ff7a1a;
+    --accent-soft: rgba(255,122,26,.14);
+    --accent-line: rgba(255,122,26,.5);
+    --yellow: #f5c542;
+    --yellow-bg: rgba(245,197,66,.15);
+    --red: #ff4242;
+    --red-bg: rgba(255,66,66,.16);
+    --green: #27c08a;
+    --green-bg: rgba(39,192,138,.16);
+    --tan: #c2925a;
+    --tan-deep: #8a5a2b;
+    --ink: #1a1205;
+    --txt: #e7eaef;
+    --txt-dim: #8b929e;
+    --border: rgba(255,255,255,.08);
+    --hazard: repeating-linear-gradient(135deg, var(--yellow) 0 13px, #14181d 13px 26px);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    font-family: "Geist", system-ui, sans-serif;
+    background:
+      radial-gradient(1200px 600px at 50% -10%, #16191f 0%, transparent 60%),
+      var(--bg);
+    color: var(--txt);
+    min-height: 100vh;
+    padding: 0 0 64px;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ---- Header ------------------------------------------------------------ */
+  header { border-bottom: 1px solid var(--border); background: linear-gradient(180deg, #1b2129, #0c0e11); }
+  .hazard-bar { height: 8px; background: var(--hazard); }
+  .head-inner { max-width: 1080px; margin: 0 auto; padding: 26px 24px 22px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+  .wordmark { font-family: "Saira Condensed", sans-serif; font-weight: 800; text-transform: uppercase; letter-spacing: 3px; font-size: 26px; }
+  .wordmark b { color: var(--accent); }
+  .subtitle { color: var(--txt-dim); font-size: 13px; }
+  .pill-local { margin-left: auto; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 11px; color: var(--yellow); border: 1px solid rgba(245,197,66,.4); background: rgba(245,197,66,.1); padding: 5px 11px; border-radius: 4px; align-self: center; }
+
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .section-title { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2.5px; font-weight: 800; font-size: 20px; margin: 36px 0 4px; }
+  .section-sub { color: var(--txt-dim); font-size: 13px; margin: 0 0 4px; }
+
+  /* ---- Part 1: source-device cards --------------------------------------- */
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 24px; margin-top: 20px; }
+  .plate { position: relative; background: linear-gradient(180deg, var(--panel-2), var(--panel)); border: 1px solid var(--border); border-radius: 10px; padding: 22px 22px 26px; display: flex; flex-direction: column; gap: 18px; box-shadow: 0 1px 0 rgba(255,255,255,.03) inset, 0 14px 30px rgba(0,0,0,.35); }
+  .plate::before, .plate::after, .plate > .rivet-b, .plate > .rivet-c { content: ""; position: absolute; width: 6px; height: 6px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, #4a525e, #1a1d22 70%); box-shadow: 0 1px 1px rgba(0,0,0,.6); }
+  .plate::before { top: 9px; left: 9px; } .plate::after { top: 9px; right: 9px; }
+  .plate > .rivet-b { bottom: 9px; left: 9px; } .plate > .rivet-c { bottom: 9px; right: 9px; }
+  .plate-label { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; display: flex; align-items: center; gap: 9px; }
+  .plate-label .idx { color: var(--ink); background: var(--accent); border-radius: 3px; font-size: 11px; padding: 1px 6px; letter-spacing: 1px; }
+  .plate-credit { font-size: 11px; color: var(--txt-dim); }
+  .stage { background: linear-gradient(180deg, #0e1015, #0a0b0e); border: 1px solid var(--border); border-radius: 8px; min-height: 150px; display: flex; align-items: center; justify-content: center; gap: 22px; padding: 28px 18px; }
+  .note { font-size: 12px; color: var(--txt-dim); line-height: 1.5; }
+  .note b { color: var(--tan); font-weight: 600; }
+
+  /* 1 — draw checkbox */
+  .container { cursor: pointer; display: inline-flex; align-items: center; gap: 12px; }
+  .container input { display: none; }
+  .container .draw-box { overflow: visible; }
+  .container .draw-box .path { fill: none; stroke: var(--txt-dim); stroke-width: 6; stroke-linecap: round; stroke-linejoin: round; transition: stroke .25s ease, fill .35s ease .15s; stroke-dasharray: 1; stroke-dashoffset: 0; }
+  .container input:checked + .draw-box .path { stroke: var(--accent); fill: var(--accent-soft); animation: draw 0.6s cubic-bezier(.5,0,.3,1) forwards; }
+  @keyframes draw { 0% { stroke-dashoffset: 1; } 100% { stroke-dashoffset: 0; } }
+  .container:hover .draw-box .path { stroke: var(--accent-line); }
+  .container input:focus-visible + .draw-box { outline: 2px solid var(--accent); outline-offset: 4px; border-radius: 6px; }
+  .cb-caption { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 15px; color: var(--txt-dim); transition: color .25s ease; }
+  .container input:checked ~ .cb-caption { color: var(--accent); }
+
+  /* 2 — keyed fancy button */
+  .fancy { position: relative; display: inline-block; text-decoration: none; cursor: pointer; padding: 14px 30px; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2.5px; font-weight: 700; font-size: 15px; color: var(--accent); background: linear-gradient(180deg, #1c222a, #0f1217); border: 2px solid var(--accent-line); border-radius: 3px; transition: color .35s ease, background .35s ease, border-color .35s ease; -webkit-tap-highlight-color: transparent; }
+  .fancy .text { position: relative; z-index: 2; }
+  .fancy .top-key, .fancy .bottom-key-1, .fancy .bottom-key-2 { position: absolute; transition: width .4s ease, left .4s ease, right .4s ease; z-index: 1; background: var(--accent); height: 2px; }
+  .fancy .top-key { width: 28px; top: -2px; left: 16px; }
+  .fancy .bottom-key-1 { width: 18px; right: 26px; bottom: -2px; }
+  .fancy .bottom-key-2 { width: 8px; right: 16px; bottom: -2px; }
+  .fancy:hover, .fancy:focus-visible { color: var(--ink); background: linear-gradient(180deg, #ff8a2e, #ff7a1a); border-color: var(--accent); outline: none; }
+  .fancy:focus-visible { box-shadow: 0 0 0 3px var(--accent-soft), 0 0 0 5px var(--accent); }
+  .fancy:hover .top-key { left: -2px; width: 0; }
+  .fancy:hover .bottom-key-1, .fancy:hover .bottom-key-2 { right: 0; width: 0; }
+  .fancy:active { transform: translateY(1px); }
+
+  /* 3 — diagonal sweep button */
+  .sweep { border: none; display: inline-block; position: relative; padding: 0.8em 2.6em; font-size: 16px; background: transparent; cursor: pointer; user-select: none; overflow: hidden; color: var(--accent); z-index: 1; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2.5px; font-weight: 700; transition: color .3s; -webkit-tap-highlight-color: transparent; }
+  .sweep span { position: absolute; left: 0; top: 0; width: 100%; height: 100%; z-index: -1; border: 3px solid var(--accent); border-radius: 2px; }
+  .sweep span::before { content: ""; display: block; position: absolute; width: 8%; height: 500%; background: rgba(255,255,255,.08); top: 50%; left: 50%; transform: translate(-50%, -50%) rotate(-60deg); transition: all 0.3s; }
+  .sweep:hover span::before { transform: translate(-50%, -50%) rotate(-90deg); width: 100%; background: var(--accent); }
+  .sweep:hover { color: var(--ink); }
+  .sweep:active span::before { background: #e0680f; }
+  .sweep:focus-visible { outline: 2px solid var(--yellow); outline-offset: 3px; }
+
+  /* ====================================================================== */
+  /* PART 2 — "LIVE-WIRE" STATUS-MOTION PROTOTYPE                            */
+  /* ====================================================================== */
+  .northstar { margin: 14px 0 0; padding: 14px 18px; border-left: 3px solid var(--accent); background: var(--accent-soft); border-radius: 0 6px 6px 0; font-size: 14px; line-height: 1.5; }
+  .northstar b { color: var(--accent); }
+
+  .proto-block { position: relative; border: 1px solid var(--border); border-radius: 10px; background: linear-gradient(180deg, var(--panel-2), var(--panel)); padding: 18px 20px 24px; margin-top: 22px; }
+  .proto-label { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; color: var(--txt); margin-bottom: 14px; }
+  .proto-label .idx { color: var(--ink); background: var(--accent); border-radius: 3px; font-size: 11px; padding: 1px 6px; margin-right: 6px; }
+  .proto-stage { background: linear-gradient(180deg, #0e1015, #0a0b0e); border: 1px solid var(--border); border-radius: 8px; padding: 26px 22px; display: flex; align-items: center; gap: 28px; flex-wrap: wrap; }
+
+  /* --- the demo unit tile --- */
+  .unit-tile { position: relative; width: 210px; height: 124px; border-radius: 8px; background: linear-gradient(180deg, #12151a, #0c0e12); border: 1px solid var(--border); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 7px; overflow: hidden; flex: 0 0 auto; }
+  .unit-tile .tile-name { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 22px; }
+  .unit-tile .tile-status { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 600; font-size: 12px; color: var(--txt-dim); transition: color .3s ease; }
+  .unit-tile.s-red .tile-status { color: var(--red); }
+  .unit-tile.s-yellow .tile-status { color: var(--yellow); }
+  .unit-tile.s-green .tile-status { color: var(--green); }
+
+  /* perimeter zip overlay (SVG rect, normalized pathLength=100) */
+  .zip-svg { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+  .zip-svg rect { fill: none; stroke: transparent; stroke-width: 3; opacity: 0; transition: opacity .3s ease; }
+  /* RED ambient — a short segment races the border, fast, forever (urgent loop) */
+  .unit-tile.s-red .zip-svg rect { stroke: var(--red); stroke-dasharray: 16 84; opacity: 1; animation: race var(--zip-period, 2.2s) linear infinite; }
+  /* JOLT — one hard fast lap + a shudder, then JS settles into s-red */
+  .unit-tile.s-jolt { animation: shudder .18s linear 1; }
+  .unit-tile.s-jolt .zip-svg rect { stroke: var(--red); stroke-dasharray: 16 84; opacity: 1; animation: race .34s linear 1; }
+  /* YELLOW — solid border that creeps in then breathes (patient) */
+  .unit-tile.s-yellow .zip-svg rect { stroke: var(--yellow); stroke-dasharray: none; opacity: 1; animation: creepIn .9s ease-out both, breathe var(--pulse, 2.2s) ease-in-out .9s infinite; }
+  /* GREEN — silent. no ambient. only the wash transition animates it. */
+  .unit-tile.s-green .zip-svg rect { stroke: var(--green); stroke-dasharray: none; opacity: .8; }
+
+  @keyframes race { to { stroke-dashoffset: -100; } }
+  @keyframes shudder { 0%,100% { transform: translateX(0); } 20% { transform: translateX(-2px); } 60% { transform: translateX(2px); } 85% { transform: translateX(-1px); } }
+  @keyframes creepIn { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes breathe { 0%,100% { opacity: .38; } 50% { opacity: 1; } }
+
+  /* wash overlay — green floods L→R, one-shot (resolution) */
+  .wash-overlay { position: absolute; inset: 0; background: linear-gradient(90deg, var(--green-bg), rgba(39,192,138,.30)); transform: translateX(-101%); pointer-events: none; }
+  .unit-tile.s-wash .wash-overlay { animation: wash .5s cubic-bezier(.2,.7,.2,1) forwards; }
+  @keyframes wash { to { transform: translateX(0); } }
+
+  /* brand stamp — pressed in only on genuine completion (milestone green) */
+  .brand-stamp { position: absolute; font-size: 30px; color: var(--green); opacity: 0; transform: scale(1.6) rotate(-14deg); pointer-events: none; filter: drop-shadow(0 0 6px rgba(39,192,138,.5)); }
+  .unit-tile.s-brand .brand-stamp { animation: stamp .32s cubic-bezier(.2,.8,.2,1) forwards; }
+  @keyframes stamp { 0% { opacity: 0; transform: scale(1.6) rotate(-14deg); } 55% { opacity: 1; } 100% { opacity: 1; transform: scale(1) rotate(0); } }
+
+  /* --- control buttons --- */
+  .proto-controls { display: flex; flex-direction: column; gap: 9px; }
+  .ctl { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 13px; cursor: pointer; padding: 9px 16px; border-radius: 4px; border: 1px solid var(--border); background: linear-gradient(180deg, #1c222a, #0f1217); color: var(--txt); transition: border-color .2s ease, color .2s ease, background .2s ease; text-align: left; min-width: 200px; }
+  .ctl:hover { border-color: var(--accent-line); }
+  .ctl .verb { color: var(--txt-dim); font-weight: 600; }
+  .ctl[data-fire="jolt"]:hover { color: var(--red); border-color: var(--red); }
+  .ctl[data-fire="creep"]:hover { color: var(--yellow); border-color: var(--yellow); }
+  .ctl[data-fire="wash"]:hover, .ctl[data-fire="brand"]:hover { color: var(--green); border-color: var(--green); }
+  .ctl:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* --- tempo clock --- */
+  .tempo-row { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; }
+  .sm-pill { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 12px; padding: 6px 12px; border-radius: 999px; border: 1.5px solid var(--yellow); color: var(--yellow); background: var(--yellow-bg); position: relative; }
+  .sm-pill.tempo::after { content: ""; position: absolute; inset: -3px; border-radius: 999px; border: 1.5px solid var(--yellow); animation: breathe var(--pulse, 2.2s) ease-in-out infinite; pointer-events: none; }
+  input[type=range] { accent-color: var(--accent); width: 220px; }
+  .tempo-readout { font-family: "Saira Condensed", sans-serif; letter-spacing: 1px; font-weight: 700; color: var(--txt); min-width: 92px; }
+  .tempo-cap { font-size: 11px; color: var(--txt-dim); }
+
+  /* --- hover personalities row --- */
+  .hover-row { display: flex; gap: 22px; flex-wrap: wrap; align-items: center; }
+  .smb { position: relative; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 14px; padding: 12px 26px; border-radius: 4px; background: transparent; cursor: pointer; overflow: hidden; border: 2px solid; -webkit-tap-highlight-color: transparent; }
+  .smb .lbl { position: relative; z-index: 2; }
+  .smb .hb { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: 1; }
+  .smb .hb rect { fill: none; stroke-width: 3; opacity: 0; }
+  /* red: zip on hover */
+  .smb.red { border-color: var(--red); color: var(--red); }
+  .smb.red:hover .hb rect, .smb.red:focus-visible .hb rect { stroke: var(--red); stroke-dasharray: 16 84; opacity: 1; animation: race .9s linear infinite; }
+  /* yellow: breathe on hover */
+  .smb.yellow { border-color: var(--yellow); color: var(--yellow); }
+  .smb.yellow:hover .hb rect, .smb.yellow:focus-visible .hb rect { stroke: var(--yellow); opacity: 1; animation: breathe 1.6s ease-in-out infinite; }
+  /* green: sweep-fill + settle on hover */
+  .smb.green { border-color: var(--green); color: var(--green); transition: color .35s ease; }
+  .smb.green .fill { position: absolute; inset: 0; background: var(--green); transform: translateX(-101%); transition: transform .4s cubic-bezier(.2,.7,.2,1); z-index: 1; }
+  .smb.green:hover .fill, .smb.green:focus-visible .fill { transform: translateX(0); }
+  .smb.green:hover, .smb.green:focus-visible { color: var(--ink); }
+  .smb:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+  footer { max-width: 1080px; margin: 40px auto 0; padding: 22px 24px 0; border-top: 1px dashed rgba(194,146,90,.4); color: var(--txt-dim); font-size: 12px; line-height: 1.6; }
+  footer b { color: var(--tan); font-weight: 600; }
+
+  /* ---- Reduced motion: kill loops/transitions, KEEP the information ------ */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
+    .zip-svg rect, .smb .hb rect { animation: none !important; opacity: 1 !important; stroke-dasharray: none !important; }
+    .wash-overlay, .unit-tile.s-wash .wash-overlay { animation: none !important; transform: translateX(0) !important; }
+    .brand-stamp, .unit-tile.s-brand .brand-stamp { animation: none !important; opacity: 1 !important; transform: none !important; }
+    .sm-pill.tempo::after { animation: none !important; }
+    .smb.green .fill { transition: none !important; }
+    /* the COLOR still carries the status — motion was only ever the delight layer */
+  }
+</style>
+<style>
+  /* ===== SOLID-FILL + WHITE-TEXT VARIANT (override layer) ===== */
+  --amber-deep: #b8860b;
+  /* source-device buttons */
+  .fancy { background: var(--accent) !important; color:#fff !important; border-color: var(--accent) !important; }
+  .fancy .top-key, .fancy .bottom-key-1, .fancy .bottom-key-2 { background:#fff !important; }
+  .fancy:hover, .fancy:focus-visible { background:#ff8a2e !important; color:#fff !important; }
+  .sweep { color:#fff !important; }
+  .sweep span { background: var(--accent) !important; border-color: var(--accent) !important; }
+  .sweep span::before { background: rgba(255,255,255,.28) !important; }
+  .sweep:hover, .sweep:hover span::before { color:#fff !important; }
+  .container input:checked + .draw-box .path { fill: var(--accent) !important; stroke: var(--accent) !important; }
+  .container input:checked ~ .cb-caption { color:#fff !important; }
+  /* status buttons -> solid fills, white text */
+  .smb { color:#fff !important; }
+  .smb.red    { background: var(--red) !important;    border-color: var(--red) !important; }
+  .smb.yellow { background: #b8860b !important;        border-color: var(--yellow) !important; }
+  .smb.green  { background: var(--green) !important;  border-color: var(--green) !important; }
+  .smb .hb rect { stroke:#fff !important; }
+  .smb.green .fill { display:none !important; }
+  .smb.green:hover, .smb.green:focus-visible { color:#fff !important; filter: brightness(1.12); }
+  /* control buttons -> solid, semantic colors */
+  .ctl { color:#fff !important; border:none !important; }
+  .ctl[data-fire="jolt"]  { background: var(--red) !important; }
+  .ctl[data-fire="creep"] { background: #b8860b !important; }
+  .ctl[data-fire="wash"], .ctl[data-fire="brand"] { background: var(--green) !important; }
+  .ctl[data-fire="reset"] { background: #3a424e !important; }
+  .ctl .verb { color: rgba(255,255,255,.72) !important; }
+  /* unit tile -> solid status fill + white text */
+  .unit-tile.s-red    { background: var(--red) !important; }
+  .unit-tile.s-yellow { background: #b8860b !important; }
+  .unit-tile.s-green  { background: var(--green) !important; }
+  .unit-tile.s-red .tile-name, .unit-tile.s-yellow .tile-name, .unit-tile.s-green .tile-name,
+  .unit-tile.s-red .tile-status, .unit-tile.s-yellow .tile-status, .unit-tile.s-green .tile-status { color:#fff !important; }
+  .unit-tile .zip-svg rect { stroke:#fff !important; }
+  .brand-stamp { color:#fff !important; filter: drop-shadow(0 0 6px rgba(0,0,0,.35)); }
+  .wash-overlay { background: linear-gradient(90deg, rgba(255,255,255,.15), rgba(255,255,255,.38)) !important; }
+  /* tempo pill solid */
+  .sm-pill { background: #b8860b !important; color:#fff !important; border-color: var(--yellow) !important; }
+  .sm-pill.tempo::after { border-color:#fff !important; }
+</style>
+
+</head>
+<body>
+  <header>
+    <div class="hazard-bar"></div>
+    <div class="head-inner">
+      <div>
+        <div class="wordmark">Rental <b>Wrangler</b> · Yard Sandbox</div>
+        <div class="subtitle">SOLID-FILL + WHITE-TEXT variant — compare against the outline version.</div>
+      </div>
+      <span class="pill-local">Local Sandbox · Not Live</span>
+    </div>
+  </header>
+
+  <div class="wrap">
+    <!-- ============ PART 1 ============ -->
+    <h2 class="section-title">Part 1 · Source devices</h2>
+    <p class="section-sub">The three found components, re-skinned. These are the motion vocabulary Part 2 is built from.</p>
+    <div class="grid">
+      <section class="plate">
+        <span class="rivet-b"></span><span class="rivet-c"></span>
+        <div><div class="plate-label"><span class="idx">01</span> Brand-It Checkbox</div><div class="plate-credit">orig. Uiverse · SelfMadeSystem — re-skinned</div></div>
+        <div class="stage">
+          <label class="container"><input type="checkbox" />
+            <svg class="draw-box" viewBox="0 0 64 64" height="2.4em" width="2.4em"><path d="M 0 16 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 16 L 32 48 L 64 16 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 16" pathLength="1" class="path"></path></svg>
+            <span class="cb-caption">Brand It</span>
+          </label>
+        </div>
+        <div class="note">The <b>DRAW</b> primitive — outline strokes on, fills accent. Powers green-check confirms + the brand stamp.</div>
+      </section>
+      <section class="plate">
+        <span class="rivet-b"></span><span class="rivet-c"></span>
+        <div><div class="plate-label"><span class="idx">02</span> Keyed Action Button</div><div class="plate-credit">orig. Uiverse · cssbuttons-io — re-skinned</div></div>
+        <div class="stage"><a class="fancy" href="#" role="button"><span class="top-key"></span><span class="text">Saddle Up</span><span class="bottom-key-1"></span><span class="bottom-key-2"></span></a></div>
+        <div class="note">Ignition-style primary. <b>Orange = action</b>, and it stays OUT of the status tree so the accent never dilutes.</div>
+      </section>
+      <section class="plate">
+        <span class="rivet-b"></span><span class="rivet-c"></span>
+        <div><div class="plate-label"><span class="idx">03</span> Diagonal Sweep Button</div><div class="plate-credit">orig. Uiverse · adamgiebl — re-skinned</div></div>
+        <div class="stage"><button class="sweep"><span></span>Round Up</button></div>
+        <div class="note">The <b>SWEEP</b> primitive — a bar floods across a face. Powers the green "wash" resolution motion.</div>
+      </section>
+    </div>
+
+    <!-- ============ PART 2 ============ -->
+    <h2 class="section-title">Part 2 · "Live-Wire" status-motion</h2>
+    <p class="section-sub">red / yellow / green expressed through the primitives above. Sandbox prototype — timings are first-draft.</p>
+    <div class="northstar">
+      <b>North-star rule:</b> Getting worse is sudden &amp; loud. Getting better is smooth &amp; quiet. Staying bad is a patient loop. Being fine is silent.
+    </div>
+
+    <!-- Block 1: transition grammar -->
+    <div class="proto-block">
+      <div class="proto-label"><span class="idx">①</span> Transition grammar — fire an event, feel the verb</div>
+      <div class="proto-stage">
+        <div class="unit-tile" id="tile">
+          <svg class="zip-svg" viewBox="0 0 100 100" preserveAspectRatio="none"><rect x="1.5" y="1.5" width="97" height="97" rx="6" pathLength="100" vector-effect="non-scaling-stroke"></rect></svg>
+          <div class="wash-overlay"></div>
+          <div class="tile-name">CAT 305</div>
+          <div class="tile-status" id="tileStatus">Idle</div>
+          <div class="brand-stamp">★</div>
+        </div>
+        <div class="proto-controls">
+          <button class="ctl" data-fire="jolt">Escalate <span class="verb">· jolt (→ red)</span></button>
+          <button class="ctl" data-fire="creep">Warn <span class="verb">· creep (→ yellow)</span></button>
+          <button class="ctl" data-fire="wash">Resolve <span class="verb">· wash (→ green)</span></button>
+          <button class="ctl" data-fire="brand">Complete <span class="verb">· wash + brand</span></button>
+          <button class="ctl" data-fire="reset">Reset <span class="verb">· idle</span></button>
+        </div>
+      </div>
+      <div class="note" style="margin-top:12px">Red <b>jolts</b> then settles into a patient loop. Green <b>washes</b> once and goes silent forever. Yellow <b>creeps</b> in. Milestone completions get the <b>brand</b> stamp. (On a phone each also fires a haptic twin — no-op on desktop.)</div>
+    </div>
+
+    <!-- Block 2: tempo clock -->
+    <div class="proto-block">
+      <div class="proto-label"><span class="idx">②</span> Tempo as a clock — same yellow, the pulse counts down</div>
+      <div class="proto-stage">
+        <div class="tempo-row">
+          <span class="sm-pill tempo" id="tempoPill">Due soon</span>
+          <input type="range" id="tempoRange" min="0" max="7" step="0.5" value="7" aria-label="days until due" />
+          <span class="tempo-readout" id="tempoReadout">7 days out</span>
+        </div>
+      </div>
+      <div class="note" style="margin-top:12px"><b>Drag toward 0</b> — the breathe quickens as the deadline nears. Clamped to a floor so it never strobes. Under reduced-motion this collapses to the number, which is why the readout always shows.</div>
+    </div>
+
+    <!-- Block 3: hover personalities -->
+    <div class="proto-block">
+      <div class="proto-label"><span class="idx">③</span> Interaction layer — hover each (status owns the border)</div>
+      <div class="proto-stage">
+        <div class="hover-row">
+          <button class="smb red"><svg class="hb" viewBox="0 0 100 100" preserveAspectRatio="none"><rect x="1.5" y="1.5" width="97" height="97" rx="4" pathLength="100" vector-effect="non-scaling-stroke"></rect></svg><span class="lbl">Abort</span></button>
+          <button class="smb yellow"><svg class="hb" viewBox="0 0 100 100" preserveAspectRatio="none"><rect x="1.5" y="1.5" width="97" height="97" rx="4" pathLength="100" vector-effect="non-scaling-stroke"></rect></svg><span class="lbl">Hold</span></button>
+          <button class="smb green"><span class="fill"></span><span class="lbl">Ready</span></button>
+        </div>
+      </div>
+      <div class="note" style="margin-top:12px">Red <b>zips</b> the border (urgent), yellow <b>breathes</b> (patient), green <b>sweep-fills</b> and settles (go). Same three personalities as the transitions — one language.</div>
+    </div>
+  </div>
+
+  <footer>
+    <b>Sandbox only.</b> Not imported anywhere — <code>index.html</code>, <code>app.js</code>, <code>style.css</code> untouched. Open straight off disk. If the feel lands, we lock timings + resolve the open tensions (red-split, budget eviction, reduced-motion equivalents) in a spec, then stamp it into the rulebook via <code>/jactec-ui</code>.
+  </footer>
+
+<script>
+  (function () {
+    var tile = document.getElementById('tile');
+    var statusEl = document.getElementById('tileStatus');
+    var STATES = ['s-jolt', 's-red', 's-creep', 's-yellow', 's-wash', 's-green', 's-brand'];
+    var settleTimer = null;
+
+    function buzz(pattern) {
+      if (navigator.vibrate) { try { navigator.vibrate(pattern); } catch (e) {} }
+    }
+    function clearStates() {
+      if (settleTimer) { clearTimeout(settleTimer); settleTimer = null; }
+      STATES.forEach(function (c) { tile.classList.remove(c); });
+      void tile.offsetWidth; // force reflow so re-fired animations restart
+    }
+
+    var actions = {
+      jolt: function () {
+        clearStates();
+        tile.classList.add('s-jolt');
+        statusEl.textContent = 'Fault · blocked';
+        buzz([45, 35, 45]); // sharp double-buzz = alarm
+        settleTimer = setTimeout(function () {
+          tile.classList.remove('s-jolt');
+          tile.classList.add('s-red'); // settle into the patient loop
+          statusEl.textContent = 'On rent · overdue';
+        }, 340);
+      },
+      creep: function () {
+        clearStates();
+        tile.classList.add('s-yellow');
+        statusEl.textContent = 'Due soon';
+        // no buzz — it crept in, you didn't feel it
+      },
+      wash: function () {
+        clearStates();
+        tile.classList.add('s-wash');
+        statusEl.textContent = 'Returned';
+        buzz(22); // one gentle confirm tap
+        settleTimer = setTimeout(function () {
+          tile.classList.remove('s-wash');
+          tile.classList.add('s-green');
+        }, 500);
+      },
+      brand: function () {
+        clearStates();
+        tile.classList.add('s-wash', 's-brand');
+        statusEl.textContent = 'Complete';
+        buzz(22);
+        settleTimer = setTimeout(function () {
+          tile.classList.remove('s-wash');
+          tile.classList.add('s-green');
+        }, 500);
+      },
+      reset: function () {
+        clearStates();
+        statusEl.textContent = 'Idle';
+      }
+    };
+
+    document.querySelectorAll('.ctl').forEach(function (b) {
+      b.addEventListener('click', function () { actions[b.dataset.fire](); });
+    });
+
+    // --- tempo clock ---
+    var range = document.getElementById('tempoRange');
+    var pill = document.getElementById('tempoPill');
+    var readout = document.getElementById('tempoReadout');
+    var FLOOR = 0.55, CEIL = 2.4; // seconds
+    function updateTempo() {
+      var days = parseFloat(range.value);
+      var period = FLOOR + (days / 7) * (CEIL - FLOOR);
+      pill.style.setProperty('--pulse', period.toFixed(2) + 's');
+      if (days <= 0) { readout.textContent = 'Due now'; pill.textContent = 'Due now'; }
+      else { readout.textContent = days + (days === 1 ? ' day out' : ' days out'); pill.textContent = 'Due soon'; }
+    }
+    range.addEventListener('input', updateTempo);
+    updateTempo();
+  })();
+</script>
+</body>
+</html>

--- a/showcase.html
+++ b/showcase.html
@@ -1,0 +1,425 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>UI Candidates — Yard Data-Plate Showcase</title>
+<!--
+  LOCAL SANDBOX ONLY — not wired into the live app (index.html / app.js / style.css untouched).
+  Three Uiverse components, re-skinned into the JacRentals "yard data-plate" language for evaluation.
+  Open directly via file:// — no server required.
+-->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Saira+Condensed:wght@600;700;800&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #0b0c0f;
+    --bg-2: #101216;
+    --panel: #15171c;
+    --panel-2: #1b1e24;
+    --accent: #ff7a1a;          /* safety-orange */
+    --accent-soft: rgba(255,122,26,.14);
+    --accent-line: rgba(255,122,26,.5);
+    --yellow: #f5c542;          /* caution */
+    --red: #ff4242;
+    --tan: #c2925a;             /* worn leather (ranch seasoning) */
+    --tan-deep: #8a5a2b;
+    --ink: #1a1205;             /* dark ink on orange */
+    --txt: #e7eaef;
+    --txt-dim: #8b929e;
+    --border: rgba(255,255,255,.08);
+    --hazard: repeating-linear-gradient(135deg, var(--yellow) 0 13px, #14181d 13px 26px);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    font-family: "Geist", system-ui, sans-serif;
+    background:
+      radial-gradient(1200px 600px at 50% -10%, #16191f 0%, transparent 60%),
+      var(--bg);
+    color: var(--txt);
+    min-height: 100vh;
+    padding: 0 0 64px;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .stamp {
+    font-family: "Saira Condensed", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+  }
+
+  /* ---- Header: hazard stripe + wordmark ---------------------------------- */
+  header {
+    border-bottom: 1px solid var(--border);
+    background: linear-gradient(180deg, #1b2129, #0c0e11);
+    position: relative;
+  }
+  .hazard-bar { height: 8px; background: var(--hazard); }
+  .head-inner {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 26px 24px 22px;
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .wordmark {
+    font-family: "Saira Condensed", sans-serif;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    font-size: 26px;
+    color: var(--txt);
+  }
+  .wordmark b { color: var(--accent); }
+  .subtitle {
+    color: var(--txt-dim);
+    font-size: 13px;
+    letter-spacing: .3px;
+  }
+  .pill-local {
+    margin-left: auto;
+    font-family: "Saira Condensed", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    font-weight: 700;
+    font-size: 11px;
+    color: var(--yellow);
+    border: 1px solid rgba(245,197,66,.4);
+    background: rgba(245,197,66,.1);
+    padding: 5px 11px;
+    border-radius: 4px;
+    align-self: center;
+  }
+
+  /* ---- Grid of data-plate cards ------------------------------------------ */
+  main {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 36px 24px 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 24px;
+  }
+
+  .plate {
+    position: relative;
+    background: linear-gradient(180deg, var(--panel-2), var(--panel));
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 22px 22px 26px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    box-shadow: 0 1px 0 rgba(255,255,255,.03) inset, 0 14px 30px rgba(0,0,0,.35);
+  }
+  /* corner rivets */
+  .plate::before, .plate::after,
+  .plate > .rivet-b, .plate > .rivet-c {
+    content: "";
+    position: absolute;
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #4a525e, #1a1d22 70%);
+    box-shadow: 0 1px 1px rgba(0,0,0,.6);
+  }
+  .plate::before { top: 9px; left: 9px; }
+  .plate::after { top: 9px; right: 9px; }
+  .plate > .rivet-b { bottom: 9px; left: 9px; }
+  .plate > .rivet-c { bottom: 9px; right: 9px; }
+
+  .plate-label {
+    font-family: "Saira Condensed", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--txt);
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .plate-label .idx {
+    color: var(--ink);
+    background: var(--accent);
+    border-radius: 3px;
+    font-size: 11px;
+    padding: 1px 6px;
+    letter-spacing: 1px;
+  }
+  .plate-credit { font-size: 11px; color: var(--txt-dim); letter-spacing: .3px; }
+
+  .stage {
+    background:
+      linear-gradient(180deg, #0e1015, #0a0b0e);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    min-height: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 22px;
+    padding: 28px 18px;
+  }
+  .note { font-size: 12px; color: var(--txt-dim); line-height: 1.5; }
+  .note b { color: var(--tan); font-weight: 600; }
+
+  /* ====================================================================== */
+  /* 1 — DRAW-CHECKBOX (SelfMadeSystem original, re-skinned)                 */
+  /*    box outline draws on, fills safety-orange when branded               */
+  /* ====================================================================== */
+  .container {
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .container input { display: none; }
+  .container .draw-box {
+    overflow: visible;
+  }
+  .container .draw-box .path {
+    fill: none;
+    stroke: var(--txt-dim);
+    stroke-width: 6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    transition: stroke .25s ease, stroke-dashoffset .5s cubic-bezier(.4,0,.2,1), fill .35s ease .15s;
+  }
+  .container input:checked + .draw-box .path {
+    stroke: var(--accent);
+    fill: var(--accent-soft);
+    stroke-dasharray: 1;
+    stroke-dashoffset: 0;
+    animation: draw 0.6s cubic-bezier(.5,0,.3,1) forwards;
+  }
+  .container input:not(:checked) + .draw-box .path {
+    stroke-dasharray: 1;
+    stroke-dashoffset: 0;
+  }
+  @keyframes draw {
+    0%   { stroke-dashoffset: 1; }
+    100% { stroke-dashoffset: 0; }
+  }
+  .container:hover .draw-box .path { stroke: var(--accent-line); }
+  .container input:focus-visible + .draw-box {
+    outline: 2px solid var(--accent);
+    outline-offset: 4px;
+    border-radius: 6px;
+  }
+  .cb-caption {
+    font-family: "Saira Condensed", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--txt-dim);
+    transition: color .25s ease;
+  }
+  .container input:checked ~ .cb-caption { color: var(--accent); }
+
+  /* ====================================================================== */
+  /* 2 — KEYED "FANCY" BUTTON (cssbuttons-io original, re-skinned)           */
+  /*    offset hi-vis "keys" snap into the frame on hover/press             */
+  /* ====================================================================== */
+  .fancy {
+    position: relative;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    padding: 14px 30px;
+    font-family: "Saira Condensed", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 2.5px;
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--accent);
+    background: linear-gradient(180deg, #1c222a, #0f1217);
+    border: 2px solid var(--accent-line);
+    border-radius: 3px;
+    transition: color .35s ease, background .35s ease, border-color .35s ease;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .fancy .text { position: relative; z-index: 2; }
+  .fancy .top-key,
+  .fancy .bottom-key-1,
+  .fancy .bottom-key-2 {
+    position: absolute;
+    background: var(--bg);
+    transition: width .4s ease, left .4s ease, right .4s ease;
+    z-index: 1;
+  }
+  .fancy .top-key {
+    height: 2px; width: 28px;
+    top: -2px; left: 16px;
+    background: var(--accent);
+  }
+  .fancy .bottom-key-1 {
+    height: 2px; width: 18px;
+    right: 26px; bottom: -2px;
+    background: var(--accent);
+  }
+  .fancy .bottom-key-2 {
+    height: 2px; width: 8px;
+    right: 16px; bottom: -2px;
+    background: var(--accent);
+  }
+  .fancy:hover, .fancy:focus-visible {
+    color: var(--ink);
+    background: linear-gradient(180deg, #ff8a2e, #ff7a1a);
+    border-color: var(--accent);
+    outline: none;
+  }
+  .fancy:focus-visible { box-shadow: 0 0 0 3px var(--accent-soft), 0 0 0 5px var(--accent); }
+  .fancy:hover .top-key { left: -2px; width: 0; }
+  .fancy:hover .bottom-key-1 { right: 0; width: 0; }
+  .fancy:hover .bottom-key-2 { right: 0; width: 0; }
+  .fancy:active { transform: translateY(1px); }
+
+  /* ====================================================================== */
+  /* 3 — DIAGONAL SWEEP BUTTON (adamgiebl original, re-skinned)              */
+  /*    a hi-vis bar sweeps across and fills on hover                       */
+  /* ====================================================================== */
+  .sweep {
+    border: none;
+    display: inline-block;
+    position: relative;
+    padding: 0.8em 2.6em;
+    font-size: 16px;
+    background: transparent;
+    cursor: pointer;
+    user-select: none;
+    overflow: hidden;
+    color: var(--accent);
+    z-index: 1;
+    font-family: "Saira Condensed", sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 2.5px;
+    font-weight: 700;
+    transition: color .3s;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .sweep span {
+    position: absolute;
+    left: 0; top: 0;
+    width: 100%; height: 100%;
+    background: transparent;
+    z-index: -1;
+    border: 3px solid var(--accent);
+    border-radius: 2px;
+  }
+  .sweep span::before {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 8%; height: 500%;
+    background: rgba(255,255,255,.08);
+    top: 50%; left: 50%;
+    transform: translate(-50%, -50%) rotate(-60deg);
+    transition: all 0.3s;
+  }
+  .sweep:hover span::before {
+    transform: translate(-50%, -50%) rotate(-90deg);
+    width: 100%;
+    background: var(--accent);
+  }
+  .sweep:hover { color: var(--ink); }
+  .sweep:active span::before { background: #e0680f; }
+  .sweep:focus-visible { outline: 2px solid var(--yellow); outline-offset: 3px; }
+
+  footer {
+    max-width: 1080px;
+    margin: 40px auto 0;
+    padding: 22px 24px 0;
+    border-top: 1px dashed rgba(194,146,90,.4); /* saddle-stitch divider */
+    color: var(--txt-dim);
+    font-size: 12px;
+    line-height: 1.6;
+  }
+  footer b { color: var(--tan); font-weight: 600; }
+
+  /* ---- Accessibility: respect reduced motion ----------------------------- */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: .001ms !important;
+      transition-duration: .001ms !important;
+    }
+    .container input:checked + .draw-box .path { animation: none; }
+  }
+</style>
+</head>
+<body>
+  <header>
+    <div class="hazard-bar"></div>
+    <div class="head-inner">
+      <div>
+        <div class="wordmark">Rental <b>Wrangler</b> · UI Candidates</div>
+        <div class="subtitle">Three found components, re-skinned to the yard data-plate language for a look-see.</div>
+      </div>
+      <span class="pill-local">Local Sandbox · Not Live</span>
+    </div>
+  </header>
+
+  <main>
+    <!-- 1 — Draw checkbox -->
+    <section class="plate">
+      <span class="rivet-b"></span><span class="rivet-c"></span>
+      <div>
+        <div class="plate-label"><span class="idx">01</span> Brand-It Checkbox</div>
+        <div class="plate-credit">orig. Uiverse · SelfMadeSystem — re-skinned</div>
+      </div>
+      <div class="stage">
+        <label class="container">
+          <input type="checkbox" />
+          <svg class="draw-box" viewBox="0 0 64 64" height="2.4em" width="2.4em">
+            <path d="M 0 16 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 16 L 32 48 L 64 16 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 16" pathLength="1" class="path"></path>
+          </svg>
+          <span class="cb-caption">Brand It</span>
+        </label>
+      </div>
+      <div class="note">Outline draws on and fills <b>safety-orange</b> when checked. Good fit for a "confirm / mark complete" toggle. Tab to it — focus ring + keyboard toggle work.</div>
+    </section>
+
+    <!-- 2 — Keyed fancy button -->
+    <section class="plate">
+      <span class="rivet-b"></span><span class="rivet-c"></span>
+      <div>
+        <div class="plate-label"><span class="idx">02</span> Keyed Action Button</div>
+        <div class="plate-credit">orig. Uiverse · cssbuttons-io — re-skinned</div>
+      </div>
+      <div class="stage">
+        <a class="fancy" href="#" role="button">
+          <span class="top-key"></span>
+          <span class="text">Saddle Up</span>
+          <span class="bottom-key-1"></span>
+          <span class="bottom-key-2"></span>
+        </a>
+      </div>
+      <div class="note">Offset hi-vis "keys" retract and the face ignites <b>orange</b> on hover/focus. Reads as an ignition-style primary action.</div>
+    </section>
+
+    <!-- 3 — Diagonal sweep button -->
+    <section class="plate">
+      <span class="rivet-b"></span><span class="rivet-c"></span>
+      <div>
+        <div class="plate-label"><span class="idx">03</span> Diagonal Sweep Button</div>
+        <div class="plate-credit">orig. Uiverse · adamgiebl — re-skinned</div>
+      </div>
+      <div class="stage">
+        <button class="sweep"><span></span>Round Up</button>
+      </div>
+      <div class="note">A bar sweeps diagonally and floods the frame <b>orange</b> on hover. A lighter-weight secondary action.</div>
+    </section>
+  </main>
+
+  <footer>
+    <b>Sandbox only.</b> This file is not imported anywhere in the app — <code>index.html</code>, <code>app.js</code>, and <code>style.css</code> are untouched. Open it straight off disk. If you like any of these, we'd give it a <code>data-r</code> rulebook stamp and wire it in properly through <code>/jactec-ui</code>.
+  </footer>
+</body>
+</html>

--- a/showcase.html
+++ b/showcase.html
@@ -3,10 +3,12 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>UI Candidates — Yard Data-Plate Showcase</title>
+<title>UI Candidates + Live-Wire Status-Motion — Yard Sandbox</title>
 <!--
   LOCAL SANDBOX ONLY — not wired into the live app (index.html / app.js / style.css untouched).
-  Three Uiverse components, re-skinned into the JacRentals "yard data-plate" language for evaluation.
+  Part 1: three Uiverse components re-skinned into the yard data-plate language.
+  Part 2: "Live-Wire" — a prototype of the status-motion system (jolt / wash / creep,
+          tempo-as-clock, hover personalities). Feel it before we spec it.
   Open directly via file:// — no server required.
 -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -18,14 +20,18 @@
     --bg-2: #101216;
     --panel: #15171c;
     --panel-2: #1b1e24;
-    --accent: #ff7a1a;          /* safety-orange */
+    --accent: #ff7a1a;
     --accent-soft: rgba(255,122,26,.14);
     --accent-line: rgba(255,122,26,.5);
-    --yellow: #f5c542;          /* caution */
+    --yellow: #f5c542;
+    --yellow-bg: rgba(245,197,66,.15);
     --red: #ff4242;
-    --tan: #c2925a;             /* worn leather (ranch seasoning) */
+    --red-bg: rgba(255,66,66,.16);
+    --green: #27c08a;
+    --green-bg: rgba(39,192,138,.16);
+    --tan: #c2925a;
     --tan-deep: #8a5a2b;
-    --ink: #1a1205;             /* dark ink on orange */
+    --ink: #1a1205;
     --txt: #e7eaef;
     --txt-dim: #8b929e;
     --border: rgba(255,255,255,.08);
@@ -46,311 +52,162 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  .stamp {
-    font-family: "Saira Condensed", sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    font-weight: 700;
-  }
-
-  /* ---- Header: hazard stripe + wordmark ---------------------------------- */
-  header {
-    border-bottom: 1px solid var(--border);
-    background: linear-gradient(180deg, #1b2129, #0c0e11);
-    position: relative;
-  }
+  /* ---- Header ------------------------------------------------------------ */
+  header { border-bottom: 1px solid var(--border); background: linear-gradient(180deg, #1b2129, #0c0e11); }
   .hazard-bar { height: 8px; background: var(--hazard); }
-  .head-inner {
-    max-width: 1080px;
-    margin: 0 auto;
-    padding: 26px 24px 22px;
-    display: flex;
-    align-items: baseline;
-    gap: 16px;
-    flex-wrap: wrap;
-  }
-  .wordmark {
-    font-family: "Saira Condensed", sans-serif;
-    font-weight: 800;
-    text-transform: uppercase;
-    letter-spacing: 3px;
-    font-size: 26px;
-    color: var(--txt);
-  }
+  .head-inner { max-width: 1080px; margin: 0 auto; padding: 26px 24px 22px; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }
+  .wordmark { font-family: "Saira Condensed", sans-serif; font-weight: 800; text-transform: uppercase; letter-spacing: 3px; font-size: 26px; }
   .wordmark b { color: var(--accent); }
-  .subtitle {
-    color: var(--txt-dim);
-    font-size: 13px;
-    letter-spacing: .3px;
-  }
-  .pill-local {
-    margin-left: auto;
-    font-family: "Saira Condensed", sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    font-weight: 700;
-    font-size: 11px;
-    color: var(--yellow);
-    border: 1px solid rgba(245,197,66,.4);
-    background: rgba(245,197,66,.1);
-    padding: 5px 11px;
-    border-radius: 4px;
-    align-self: center;
-  }
+  .subtitle { color: var(--txt-dim); font-size: 13px; }
+  .pill-local { margin-left: auto; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 11px; color: var(--yellow); border: 1px solid rgba(245,197,66,.4); background: rgba(245,197,66,.1); padding: 5px 11px; border-radius: 4px; align-self: center; }
 
-  /* ---- Grid of data-plate cards ------------------------------------------ */
-  main {
-    max-width: 1080px;
-    margin: 0 auto;
-    padding: 36px 24px 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 24px;
-  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .section-title { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2.5px; font-weight: 800; font-size: 20px; margin: 36px 0 4px; }
+  .section-sub { color: var(--txt-dim); font-size: 13px; margin: 0 0 4px; }
 
-  .plate {
-    position: relative;
-    background: linear-gradient(180deg, var(--panel-2), var(--panel));
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 22px 22px 26px;
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    box-shadow: 0 1px 0 rgba(255,255,255,.03) inset, 0 14px 30px rgba(0,0,0,.35);
-  }
-  /* corner rivets */
-  .plate::before, .plate::after,
-  .plate > .rivet-b, .plate > .rivet-c {
-    content: "";
-    position: absolute;
-    width: 6px; height: 6px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 35% 30%, #4a525e, #1a1d22 70%);
-    box-shadow: 0 1px 1px rgba(0,0,0,.6);
-  }
-  .plate::before { top: 9px; left: 9px; }
-  .plate::after { top: 9px; right: 9px; }
-  .plate > .rivet-b { bottom: 9px; left: 9px; }
-  .plate > .rivet-c { bottom: 9px; right: 9px; }
-
-  .plate-label {
-    font-family: "Saira Condensed", sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    font-weight: 700;
-    font-size: 13px;
-    color: var(--txt);
-    display: flex;
-    align-items: center;
-    gap: 9px;
-  }
-  .plate-label .idx {
-    color: var(--ink);
-    background: var(--accent);
-    border-radius: 3px;
-    font-size: 11px;
-    padding: 1px 6px;
-    letter-spacing: 1px;
-  }
-  .plate-credit { font-size: 11px; color: var(--txt-dim); letter-spacing: .3px; }
-
-  .stage {
-    background:
-      linear-gradient(180deg, #0e1015, #0a0b0e);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    min-height: 150px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 22px;
-    padding: 28px 18px;
-  }
+  /* ---- Part 1: source-device cards --------------------------------------- */
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 24px; margin-top: 20px; }
+  .plate { position: relative; background: linear-gradient(180deg, var(--panel-2), var(--panel)); border: 1px solid var(--border); border-radius: 10px; padding: 22px 22px 26px; display: flex; flex-direction: column; gap: 18px; box-shadow: 0 1px 0 rgba(255,255,255,.03) inset, 0 14px 30px rgba(0,0,0,.35); }
+  .plate::before, .plate::after, .plate > .rivet-b, .plate > .rivet-c { content: ""; position: absolute; width: 6px; height: 6px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, #4a525e, #1a1d22 70%); box-shadow: 0 1px 1px rgba(0,0,0,.6); }
+  .plate::before { top: 9px; left: 9px; } .plate::after { top: 9px; right: 9px; }
+  .plate > .rivet-b { bottom: 9px; left: 9px; } .plate > .rivet-c { bottom: 9px; right: 9px; }
+  .plate-label { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; display: flex; align-items: center; gap: 9px; }
+  .plate-label .idx { color: var(--ink); background: var(--accent); border-radius: 3px; font-size: 11px; padding: 1px 6px; letter-spacing: 1px; }
+  .plate-credit { font-size: 11px; color: var(--txt-dim); }
+  .stage { background: linear-gradient(180deg, #0e1015, #0a0b0e); border: 1px solid var(--border); border-radius: 8px; min-height: 150px; display: flex; align-items: center; justify-content: center; gap: 22px; padding: 28px 18px; }
   .note { font-size: 12px; color: var(--txt-dim); line-height: 1.5; }
   .note b { color: var(--tan); font-weight: 600; }
 
-  /* ====================================================================== */
-  /* 1 — DRAW-CHECKBOX (SelfMadeSystem original, re-skinned)                 */
-  /*    box outline draws on, fills safety-orange when branded               */
-  /* ====================================================================== */
-  .container {
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-  }
+  /* 1 — draw checkbox */
+  .container { cursor: pointer; display: inline-flex; align-items: center; gap: 12px; }
   .container input { display: none; }
-  .container .draw-box {
-    overflow: visible;
-  }
-  .container .draw-box .path {
-    fill: none;
-    stroke: var(--txt-dim);
-    stroke-width: 6;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    transition: stroke .25s ease, stroke-dashoffset .5s cubic-bezier(.4,0,.2,1), fill .35s ease .15s;
-  }
-  .container input:checked + .draw-box .path {
-    stroke: var(--accent);
-    fill: var(--accent-soft);
-    stroke-dasharray: 1;
-    stroke-dashoffset: 0;
-    animation: draw 0.6s cubic-bezier(.5,0,.3,1) forwards;
-  }
-  .container input:not(:checked) + .draw-box .path {
-    stroke-dasharray: 1;
-    stroke-dashoffset: 0;
-  }
-  @keyframes draw {
-    0%   { stroke-dashoffset: 1; }
-    100% { stroke-dashoffset: 0; }
-  }
+  .container .draw-box { overflow: visible; }
+  .container .draw-box .path { fill: none; stroke: var(--txt-dim); stroke-width: 6; stroke-linecap: round; stroke-linejoin: round; transition: stroke .25s ease, fill .35s ease .15s; stroke-dasharray: 1; stroke-dashoffset: 0; }
+  .container input:checked + .draw-box .path { stroke: var(--accent); fill: var(--accent-soft); animation: draw 0.6s cubic-bezier(.5,0,.3,1) forwards; }
+  @keyframes draw { 0% { stroke-dashoffset: 1; } 100% { stroke-dashoffset: 0; } }
   .container:hover .draw-box .path { stroke: var(--accent-line); }
-  .container input:focus-visible + .draw-box {
-    outline: 2px solid var(--accent);
-    outline-offset: 4px;
-    border-radius: 6px;
-  }
-  .cb-caption {
-    font-family: "Saira Condensed", sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    font-weight: 700;
-    font-size: 15px;
-    color: var(--txt-dim);
-    transition: color .25s ease;
-  }
+  .container input:focus-visible + .draw-box { outline: 2px solid var(--accent); outline-offset: 4px; border-radius: 6px; }
+  .cb-caption { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 15px; color: var(--txt-dim); transition: color .25s ease; }
   .container input:checked ~ .cb-caption { color: var(--accent); }
 
-  /* ====================================================================== */
-  /* 2 — KEYED "FANCY" BUTTON (cssbuttons-io original, re-skinned)           */
-  /*    offset hi-vis "keys" snap into the frame on hover/press             */
-  /* ====================================================================== */
-  .fancy {
-    position: relative;
-    display: inline-block;
-    text-decoration: none;
-    cursor: pointer;
-    padding: 14px 30px;
-    font-family: "Saira Condensed", sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 2.5px;
-    font-weight: 700;
-    font-size: 15px;
-    color: var(--accent);
-    background: linear-gradient(180deg, #1c222a, #0f1217);
-    border: 2px solid var(--accent-line);
-    border-radius: 3px;
-    transition: color .35s ease, background .35s ease, border-color .35s ease;
-    -webkit-tap-highlight-color: transparent;
-  }
+  /* 2 — keyed fancy button */
+  .fancy { position: relative; display: inline-block; text-decoration: none; cursor: pointer; padding: 14px 30px; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2.5px; font-weight: 700; font-size: 15px; color: var(--accent); background: linear-gradient(180deg, #1c222a, #0f1217); border: 2px solid var(--accent-line); border-radius: 3px; transition: color .35s ease, background .35s ease, border-color .35s ease; -webkit-tap-highlight-color: transparent; }
   .fancy .text { position: relative; z-index: 2; }
-  .fancy .top-key,
-  .fancy .bottom-key-1,
-  .fancy .bottom-key-2 {
-    position: absolute;
-    background: var(--bg);
-    transition: width .4s ease, left .4s ease, right .4s ease;
-    z-index: 1;
-  }
-  .fancy .top-key {
-    height: 2px; width: 28px;
-    top: -2px; left: 16px;
-    background: var(--accent);
-  }
-  .fancy .bottom-key-1 {
-    height: 2px; width: 18px;
-    right: 26px; bottom: -2px;
-    background: var(--accent);
-  }
-  .fancy .bottom-key-2 {
-    height: 2px; width: 8px;
-    right: 16px; bottom: -2px;
-    background: var(--accent);
-  }
-  .fancy:hover, .fancy:focus-visible {
-    color: var(--ink);
-    background: linear-gradient(180deg, #ff8a2e, #ff7a1a);
-    border-color: var(--accent);
-    outline: none;
-  }
+  .fancy .top-key, .fancy .bottom-key-1, .fancy .bottom-key-2 { position: absolute; transition: width .4s ease, left .4s ease, right .4s ease; z-index: 1; background: var(--accent); height: 2px; }
+  .fancy .top-key { width: 28px; top: -2px; left: 16px; }
+  .fancy .bottom-key-1 { width: 18px; right: 26px; bottom: -2px; }
+  .fancy .bottom-key-2 { width: 8px; right: 16px; bottom: -2px; }
+  .fancy:hover, .fancy:focus-visible { color: var(--ink); background: linear-gradient(180deg, #ff8a2e, #ff7a1a); border-color: var(--accent); outline: none; }
   .fancy:focus-visible { box-shadow: 0 0 0 3px var(--accent-soft), 0 0 0 5px var(--accent); }
   .fancy:hover .top-key { left: -2px; width: 0; }
-  .fancy:hover .bottom-key-1 { right: 0; width: 0; }
-  .fancy:hover .bottom-key-2 { right: 0; width: 0; }
+  .fancy:hover .bottom-key-1, .fancy:hover .bottom-key-2 { right: 0; width: 0; }
   .fancy:active { transform: translateY(1px); }
 
-  /* ====================================================================== */
-  /* 3 — DIAGONAL SWEEP BUTTON (adamgiebl original, re-skinned)              */
-  /*    a hi-vis bar sweeps across and fills on hover                       */
-  /* ====================================================================== */
-  .sweep {
-    border: none;
-    display: inline-block;
-    position: relative;
-    padding: 0.8em 2.6em;
-    font-size: 16px;
-    background: transparent;
-    cursor: pointer;
-    user-select: none;
-    overflow: hidden;
-    color: var(--accent);
-    z-index: 1;
-    font-family: "Saira Condensed", sans-serif;
-    text-transform: uppercase;
-    letter-spacing: 2.5px;
-    font-weight: 700;
-    transition: color .3s;
-    -webkit-tap-highlight-color: transparent;
-  }
-  .sweep span {
-    position: absolute;
-    left: 0; top: 0;
-    width: 100%; height: 100%;
-    background: transparent;
-    z-index: -1;
-    border: 3px solid var(--accent);
-    border-radius: 2px;
-  }
-  .sweep span::before {
-    content: "";
-    display: block;
-    position: absolute;
-    width: 8%; height: 500%;
-    background: rgba(255,255,255,.08);
-    top: 50%; left: 50%;
-    transform: translate(-50%, -50%) rotate(-60deg);
-    transition: all 0.3s;
-  }
-  .sweep:hover span::before {
-    transform: translate(-50%, -50%) rotate(-90deg);
-    width: 100%;
-    background: var(--accent);
-  }
+  /* 3 — diagonal sweep button */
+  .sweep { border: none; display: inline-block; position: relative; padding: 0.8em 2.6em; font-size: 16px; background: transparent; cursor: pointer; user-select: none; overflow: hidden; color: var(--accent); z-index: 1; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2.5px; font-weight: 700; transition: color .3s; -webkit-tap-highlight-color: transparent; }
+  .sweep span { position: absolute; left: 0; top: 0; width: 100%; height: 100%; z-index: -1; border: 3px solid var(--accent); border-radius: 2px; }
+  .sweep span::before { content: ""; display: block; position: absolute; width: 8%; height: 500%; background: rgba(255,255,255,.08); top: 50%; left: 50%; transform: translate(-50%, -50%) rotate(-60deg); transition: all 0.3s; }
+  .sweep:hover span::before { transform: translate(-50%, -50%) rotate(-90deg); width: 100%; background: var(--accent); }
   .sweep:hover { color: var(--ink); }
   .sweep:active span::before { background: #e0680f; }
   .sweep:focus-visible { outline: 2px solid var(--yellow); outline-offset: 3px; }
 
-  footer {
-    max-width: 1080px;
-    margin: 40px auto 0;
-    padding: 22px 24px 0;
-    border-top: 1px dashed rgba(194,146,90,.4); /* saddle-stitch divider */
-    color: var(--txt-dim);
-    font-size: 12px;
-    line-height: 1.6;
-  }
+  /* ====================================================================== */
+  /* PART 2 — "LIVE-WIRE" STATUS-MOTION PROTOTYPE                            */
+  /* ====================================================================== */
+  .northstar { margin: 14px 0 0; padding: 14px 18px; border-left: 3px solid var(--accent); background: var(--accent-soft); border-radius: 0 6px 6px 0; font-size: 14px; line-height: 1.5; }
+  .northstar b { color: var(--accent); }
+
+  .proto-block { position: relative; border: 1px solid var(--border); border-radius: 10px; background: linear-gradient(180deg, var(--panel-2), var(--panel)); padding: 18px 20px 24px; margin-top: 22px; }
+  .proto-label { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; color: var(--txt); margin-bottom: 14px; }
+  .proto-label .idx { color: var(--ink); background: var(--accent); border-radius: 3px; font-size: 11px; padding: 1px 6px; margin-right: 6px; }
+  .proto-stage { background: linear-gradient(180deg, #0e1015, #0a0b0e); border: 1px solid var(--border); border-radius: 8px; padding: 26px 22px; display: flex; align-items: center; gap: 28px; flex-wrap: wrap; }
+
+  /* --- the demo unit tile --- */
+  .unit-tile { position: relative; width: 210px; height: 124px; border-radius: 8px; background: linear-gradient(180deg, #12151a, #0c0e12); border: 1px solid var(--border); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 7px; overflow: hidden; flex: 0 0 auto; }
+  .unit-tile .tile-name { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 22px; }
+  .unit-tile .tile-status { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 600; font-size: 12px; color: var(--txt-dim); transition: color .3s ease; }
+  .unit-tile.s-red .tile-status { color: var(--red); }
+  .unit-tile.s-yellow .tile-status { color: var(--yellow); }
+  .unit-tile.s-green .tile-status { color: var(--green); }
+
+  /* perimeter zip overlay (SVG rect, normalized pathLength=100) */
+  .zip-svg { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+  .zip-svg rect { fill: none; stroke: transparent; stroke-width: 3; opacity: 0; transition: opacity .3s ease; }
+  /* RED ambient — a short segment races the border, fast, forever (urgent loop) */
+  .unit-tile.s-red .zip-svg rect { stroke: var(--red); stroke-dasharray: 16 84; opacity: 1; animation: race var(--zip-period, 2.2s) linear infinite; }
+  /* JOLT — one hard fast lap + a shudder, then JS settles into s-red */
+  .unit-tile.s-jolt { animation: shudder .18s linear 1; }
+  .unit-tile.s-jolt .zip-svg rect { stroke: var(--red); stroke-dasharray: 16 84; opacity: 1; animation: race .34s linear 1; }
+  /* YELLOW — solid border that creeps in then breathes (patient) */
+  .unit-tile.s-yellow .zip-svg rect { stroke: var(--yellow); stroke-dasharray: none; opacity: 1; animation: creepIn .9s ease-out both, breathe var(--pulse, 2.2s) ease-in-out .9s infinite; }
+  /* GREEN — silent. no ambient. only the wash transition animates it. */
+  .unit-tile.s-green .zip-svg rect { stroke: var(--green); stroke-dasharray: none; opacity: .8; }
+
+  @keyframes race { to { stroke-dashoffset: -100; } }
+  @keyframes shudder { 0%,100% { transform: translateX(0); } 20% { transform: translateX(-2px); } 60% { transform: translateX(2px); } 85% { transform: translateX(-1px); } }
+  @keyframes creepIn { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes breathe { 0%,100% { opacity: .38; } 50% { opacity: 1; } }
+
+  /* wash overlay — green floods L→R, one-shot (resolution) */
+  .wash-overlay { position: absolute; inset: 0; background: linear-gradient(90deg, var(--green-bg), rgba(39,192,138,.30)); transform: translateX(-101%); pointer-events: none; }
+  .unit-tile.s-wash .wash-overlay { animation: wash .5s cubic-bezier(.2,.7,.2,1) forwards; }
+  @keyframes wash { to { transform: translateX(0); } }
+
+  /* brand stamp — pressed in only on genuine completion (milestone green) */
+  .brand-stamp { position: absolute; font-size: 30px; color: var(--green); opacity: 0; transform: scale(1.6) rotate(-14deg); pointer-events: none; filter: drop-shadow(0 0 6px rgba(39,192,138,.5)); }
+  .unit-tile.s-brand .brand-stamp { animation: stamp .32s cubic-bezier(.2,.8,.2,1) forwards; }
+  @keyframes stamp { 0% { opacity: 0; transform: scale(1.6) rotate(-14deg); } 55% { opacity: 1; } 100% { opacity: 1; transform: scale(1) rotate(0); } }
+
+  /* --- control buttons --- */
+  .proto-controls { display: flex; flex-direction: column; gap: 9px; }
+  .ctl { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 13px; cursor: pointer; padding: 9px 16px; border-radius: 4px; border: 1px solid var(--border); background: linear-gradient(180deg, #1c222a, #0f1217); color: var(--txt); transition: border-color .2s ease, color .2s ease, background .2s ease; text-align: left; min-width: 200px; }
+  .ctl:hover { border-color: var(--accent-line); }
+  .ctl .verb { color: var(--txt-dim); font-weight: 600; }
+  .ctl[data-fire="jolt"]:hover { color: var(--red); border-color: var(--red); }
+  .ctl[data-fire="creep"]:hover { color: var(--yellow); border-color: var(--yellow); }
+  .ctl[data-fire="wash"]:hover, .ctl[data-fire="brand"]:hover { color: var(--green); border-color: var(--green); }
+  .ctl:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* --- tempo clock --- */
+  .tempo-row { display: flex; align-items: center; gap: 22px; flex-wrap: wrap; }
+  .sm-pill { font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 12px; padding: 6px 12px; border-radius: 999px; border: 1.5px solid var(--yellow); color: var(--yellow); background: var(--yellow-bg); position: relative; }
+  .sm-pill.tempo::after { content: ""; position: absolute; inset: -3px; border-radius: 999px; border: 1.5px solid var(--yellow); animation: breathe var(--pulse, 2.2s) ease-in-out infinite; pointer-events: none; }
+  input[type=range] { accent-color: var(--accent); width: 220px; }
+  .tempo-readout { font-family: "Saira Condensed", sans-serif; letter-spacing: 1px; font-weight: 700; color: var(--txt); min-width: 92px; }
+  .tempo-cap { font-size: 11px; color: var(--txt-dim); }
+
+  /* --- hover personalities row --- */
+  .hover-row { display: flex; gap: 22px; flex-wrap: wrap; align-items: center; }
+  .smb { position: relative; font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 14px; padding: 12px 26px; border-radius: 4px; background: transparent; cursor: pointer; overflow: hidden; border: 2px solid; -webkit-tap-highlight-color: transparent; }
+  .smb .lbl { position: relative; z-index: 2; }
+  .smb .hb { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: 1; }
+  .smb .hb rect { fill: none; stroke-width: 3; opacity: 0; }
+  /* red: zip on hover */
+  .smb.red { border-color: var(--red); color: var(--red); }
+  .smb.red:hover .hb rect, .smb.red:focus-visible .hb rect { stroke: var(--red); stroke-dasharray: 16 84; opacity: 1; animation: race .9s linear infinite; }
+  /* yellow: breathe on hover */
+  .smb.yellow { border-color: var(--yellow); color: var(--yellow); }
+  .smb.yellow:hover .hb rect, .smb.yellow:focus-visible .hb rect { stroke: var(--yellow); opacity: 1; animation: breathe 1.6s ease-in-out infinite; }
+  /* green: sweep-fill + settle on hover */
+  .smb.green { border-color: var(--green); color: var(--green); transition: color .35s ease; }
+  .smb.green .fill { position: absolute; inset: 0; background: var(--green); transform: translateX(-101%); transition: transform .4s cubic-bezier(.2,.7,.2,1); z-index: 1; }
+  .smb.green:hover .fill, .smb.green:focus-visible .fill { transform: translateX(0); }
+  .smb.green:hover, .smb.green:focus-visible { color: var(--ink); }
+  .smb:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+  footer { max-width: 1080px; margin: 40px auto 0; padding: 22px 24px 0; border-top: 1px dashed rgba(194,146,90,.4); color: var(--txt-dim); font-size: 12px; line-height: 1.6; }
   footer b { color: var(--tan); font-weight: 600; }
 
-  /* ---- Accessibility: respect reduced motion ----------------------------- */
+  /* ---- Reduced motion: kill loops/transitions, KEEP the information ------ */
   @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
-      animation-duration: .001ms !important;
-      transition-duration: .001ms !important;
-    }
-    .container input:checked + .draw-box .path { animation: none; }
+    *, *::before, *::after { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
+    .zip-svg rect, .smb .hb rect { animation: none !important; opacity: 1 !important; stroke-dasharray: none !important; }
+    .wash-overlay, .unit-tile.s-wash .wash-overlay { animation: none !important; transform: translateX(0) !important; }
+    .brand-stamp, .unit-tile.s-brand .brand-stamp { animation: none !important; opacity: 1 !important; transform: none !important; }
+    .sm-pill.tempo::after { animation: none !important; }
+    .smb.green .fill { transition: none !important; }
+    /* the COLOR still carries the status — motion was only ever the delight layer */
   }
 </style>
 </head>
@@ -359,67 +216,182 @@
     <div class="hazard-bar"></div>
     <div class="head-inner">
       <div>
-        <div class="wordmark">Rental <b>Wrangler</b> · UI Candidates</div>
-        <div class="subtitle">Three found components, re-skinned to the yard data-plate language for a look-see.</div>
+        <div class="wordmark">Rental <b>Wrangler</b> · Yard Sandbox</div>
+        <div class="subtitle">Found components, re-skinned — plus a live prototype of the status-motion system.</div>
       </div>
       <span class="pill-local">Local Sandbox · Not Live</span>
     </div>
   </header>
 
-  <main>
-    <!-- 1 — Draw checkbox -->
-    <section class="plate">
-      <span class="rivet-b"></span><span class="rivet-c"></span>
-      <div>
-        <div class="plate-label"><span class="idx">01</span> Brand-It Checkbox</div>
-        <div class="plate-credit">orig. Uiverse · SelfMadeSystem — re-skinned</div>
-      </div>
-      <div class="stage">
-        <label class="container">
-          <input type="checkbox" />
-          <svg class="draw-box" viewBox="0 0 64 64" height="2.4em" width="2.4em">
-            <path d="M 0 16 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 16 L 32 48 L 64 16 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 16" pathLength="1" class="path"></path>
-          </svg>
-          <span class="cb-caption">Brand It</span>
-        </label>
-      </div>
-      <div class="note">Outline draws on and fills <b>safety-orange</b> when checked. Good fit for a "confirm / mark complete" toggle. Tab to it — focus ring + keyboard toggle work.</div>
-    </section>
+  <div class="wrap">
+    <!-- ============ PART 1 ============ -->
+    <h2 class="section-title">Part 1 · Source devices</h2>
+    <p class="section-sub">The three found components, re-skinned. These are the motion vocabulary Part 2 is built from.</p>
+    <div class="grid">
+      <section class="plate">
+        <span class="rivet-b"></span><span class="rivet-c"></span>
+        <div><div class="plate-label"><span class="idx">01</span> Brand-It Checkbox</div><div class="plate-credit">orig. Uiverse · SelfMadeSystem — re-skinned</div></div>
+        <div class="stage">
+          <label class="container"><input type="checkbox" />
+            <svg class="draw-box" viewBox="0 0 64 64" height="2.4em" width="2.4em"><path d="M 0 16 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 16 L 32 48 L 64 16 V 8 A 8 8 90 0 0 56 0 H 8 A 8 8 90 0 0 0 8 V 56 A 8 8 90 0 0 8 64 H 56 A 8 8 90 0 0 64 56 V 16" pathLength="1" class="path"></path></svg>
+            <span class="cb-caption">Brand It</span>
+          </label>
+        </div>
+        <div class="note">The <b>DRAW</b> primitive — outline strokes on, fills accent. Powers green-check confirms + the brand stamp.</div>
+      </section>
+      <section class="plate">
+        <span class="rivet-b"></span><span class="rivet-c"></span>
+        <div><div class="plate-label"><span class="idx">02</span> Keyed Action Button</div><div class="plate-credit">orig. Uiverse · cssbuttons-io — re-skinned</div></div>
+        <div class="stage"><a class="fancy" href="#" role="button"><span class="top-key"></span><span class="text">Saddle Up</span><span class="bottom-key-1"></span><span class="bottom-key-2"></span></a></div>
+        <div class="note">Ignition-style primary. <b>Orange = action</b>, and it stays OUT of the status tree so the accent never dilutes.</div>
+      </section>
+      <section class="plate">
+        <span class="rivet-b"></span><span class="rivet-c"></span>
+        <div><div class="plate-label"><span class="idx">03</span> Diagonal Sweep Button</div><div class="plate-credit">orig. Uiverse · adamgiebl — re-skinned</div></div>
+        <div class="stage"><button class="sweep"><span></span>Round Up</button></div>
+        <div class="note">The <b>SWEEP</b> primitive — a bar floods across a face. Powers the green "wash" resolution motion.</div>
+      </section>
+    </div>
 
-    <!-- 2 — Keyed fancy button -->
-    <section class="plate">
-      <span class="rivet-b"></span><span class="rivet-c"></span>
-      <div>
-        <div class="plate-label"><span class="idx">02</span> Keyed Action Button</div>
-        <div class="plate-credit">orig. Uiverse · cssbuttons-io — re-skinned</div>
-      </div>
-      <div class="stage">
-        <a class="fancy" href="#" role="button">
-          <span class="top-key"></span>
-          <span class="text">Saddle Up</span>
-          <span class="bottom-key-1"></span>
-          <span class="bottom-key-2"></span>
-        </a>
-      </div>
-      <div class="note">Offset hi-vis "keys" retract and the face ignites <b>orange</b> on hover/focus. Reads as an ignition-style primary action.</div>
-    </section>
+    <!-- ============ PART 2 ============ -->
+    <h2 class="section-title">Part 2 · "Live-Wire" status-motion</h2>
+    <p class="section-sub">red / yellow / green expressed through the primitives above. Sandbox prototype — timings are first-draft.</p>
+    <div class="northstar">
+      <b>North-star rule:</b> Getting worse is sudden &amp; loud. Getting better is smooth &amp; quiet. Staying bad is a patient loop. Being fine is silent.
+    </div>
 
-    <!-- 3 — Diagonal sweep button -->
-    <section class="plate">
-      <span class="rivet-b"></span><span class="rivet-c"></span>
-      <div>
-        <div class="plate-label"><span class="idx">03</span> Diagonal Sweep Button</div>
-        <div class="plate-credit">orig. Uiverse · adamgiebl — re-skinned</div>
+    <!-- Block 1: transition grammar -->
+    <div class="proto-block">
+      <div class="proto-label"><span class="idx">①</span> Transition grammar — fire an event, feel the verb</div>
+      <div class="proto-stage">
+        <div class="unit-tile" id="tile">
+          <svg class="zip-svg" viewBox="0 0 100 100" preserveAspectRatio="none"><rect x="1.5" y="1.5" width="97" height="97" rx="6" pathLength="100" vector-effect="non-scaling-stroke"></rect></svg>
+          <div class="wash-overlay"></div>
+          <div class="tile-name">CAT 305</div>
+          <div class="tile-status" id="tileStatus">Idle</div>
+          <div class="brand-stamp">★</div>
+        </div>
+        <div class="proto-controls">
+          <button class="ctl" data-fire="jolt">Escalate <span class="verb">· jolt (→ red)</span></button>
+          <button class="ctl" data-fire="creep">Warn <span class="verb">· creep (→ yellow)</span></button>
+          <button class="ctl" data-fire="wash">Resolve <span class="verb">· wash (→ green)</span></button>
+          <button class="ctl" data-fire="brand">Complete <span class="verb">· wash + brand</span></button>
+          <button class="ctl" data-fire="reset">Reset <span class="verb">· idle</span></button>
+        </div>
       </div>
-      <div class="stage">
-        <button class="sweep"><span></span>Round Up</button>
+      <div class="note" style="margin-top:12px">Red <b>jolts</b> then settles into a patient loop. Green <b>washes</b> once and goes silent forever. Yellow <b>creeps</b> in. Milestone completions get the <b>brand</b> stamp. (On a phone each also fires a haptic twin — no-op on desktop.)</div>
+    </div>
+
+    <!-- Block 2: tempo clock -->
+    <div class="proto-block">
+      <div class="proto-label"><span class="idx">②</span> Tempo as a clock — same yellow, the pulse counts down</div>
+      <div class="proto-stage">
+        <div class="tempo-row">
+          <span class="sm-pill tempo" id="tempoPill">Due soon</span>
+          <input type="range" id="tempoRange" min="0" max="7" step="0.5" value="7" aria-label="days until due" />
+          <span class="tempo-readout" id="tempoReadout">7 days out</span>
+        </div>
       </div>
-      <div class="note">A bar sweeps diagonally and floods the frame <b>orange</b> on hover. A lighter-weight secondary action.</div>
-    </section>
-  </main>
+      <div class="note" style="margin-top:12px"><b>Drag toward 0</b> — the breathe quickens as the deadline nears. Clamped to a floor so it never strobes. Under reduced-motion this collapses to the number, which is why the readout always shows.</div>
+    </div>
+
+    <!-- Block 3: hover personalities -->
+    <div class="proto-block">
+      <div class="proto-label"><span class="idx">③</span> Interaction layer — hover each (status owns the border)</div>
+      <div class="proto-stage">
+        <div class="hover-row">
+          <button class="smb red"><svg class="hb" viewBox="0 0 100 100" preserveAspectRatio="none"><rect x="1.5" y="1.5" width="97" height="97" rx="4" pathLength="100" vector-effect="non-scaling-stroke"></rect></svg><span class="lbl">Abort</span></button>
+          <button class="smb yellow"><svg class="hb" viewBox="0 0 100 100" preserveAspectRatio="none"><rect x="1.5" y="1.5" width="97" height="97" rx="4" pathLength="100" vector-effect="non-scaling-stroke"></rect></svg><span class="lbl">Hold</span></button>
+          <button class="smb green"><span class="fill"></span><span class="lbl">Ready</span></button>
+        </div>
+      </div>
+      <div class="note" style="margin-top:12px">Red <b>zips</b> the border (urgent), yellow <b>breathes</b> (patient), green <b>sweep-fills</b> and settles (go). Same three personalities as the transitions — one language.</div>
+    </div>
+  </div>
 
   <footer>
-    <b>Sandbox only.</b> This file is not imported anywhere in the app — <code>index.html</code>, <code>app.js</code>, and <code>style.css</code> are untouched. Open it straight off disk. If you like any of these, we'd give it a <code>data-r</code> rulebook stamp and wire it in properly through <code>/jactec-ui</code>.
+    <b>Sandbox only.</b> Not imported anywhere — <code>index.html</code>, <code>app.js</code>, <code>style.css</code> untouched. Open straight off disk. If the feel lands, we lock timings + resolve the open tensions (red-split, budget eviction, reduced-motion equivalents) in a spec, then stamp it into the rulebook via <code>/jactec-ui</code>.
   </footer>
+
+<script>
+  (function () {
+    var tile = document.getElementById('tile');
+    var statusEl = document.getElementById('tileStatus');
+    var STATES = ['s-jolt', 's-red', 's-creep', 's-yellow', 's-wash', 's-green', 's-brand'];
+    var settleTimer = null;
+
+    function buzz(pattern) {
+      if (navigator.vibrate) { try { navigator.vibrate(pattern); } catch (e) {} }
+    }
+    function clearStates() {
+      if (settleTimer) { clearTimeout(settleTimer); settleTimer = null; }
+      STATES.forEach(function (c) { tile.classList.remove(c); });
+      void tile.offsetWidth; // force reflow so re-fired animations restart
+    }
+
+    var actions = {
+      jolt: function () {
+        clearStates();
+        tile.classList.add('s-jolt');
+        statusEl.textContent = 'Fault · blocked';
+        buzz([45, 35, 45]); // sharp double-buzz = alarm
+        settleTimer = setTimeout(function () {
+          tile.classList.remove('s-jolt');
+          tile.classList.add('s-red'); // settle into the patient loop
+          statusEl.textContent = 'On rent · overdue';
+        }, 340);
+      },
+      creep: function () {
+        clearStates();
+        tile.classList.add('s-yellow');
+        statusEl.textContent = 'Due soon';
+        // no buzz — it crept in, you didn't feel it
+      },
+      wash: function () {
+        clearStates();
+        tile.classList.add('s-wash');
+        statusEl.textContent = 'Returned';
+        buzz(22); // one gentle confirm tap
+        settleTimer = setTimeout(function () {
+          tile.classList.remove('s-wash');
+          tile.classList.add('s-green');
+        }, 500);
+      },
+      brand: function () {
+        clearStates();
+        tile.classList.add('s-wash', 's-brand');
+        statusEl.textContent = 'Complete';
+        buzz(22);
+        settleTimer = setTimeout(function () {
+          tile.classList.remove('s-wash');
+          tile.classList.add('s-green');
+        }, 500);
+      },
+      reset: function () {
+        clearStates();
+        statusEl.textContent = 'Idle';
+      }
+    };
+
+    document.querySelectorAll('.ctl').forEach(function (b) {
+      b.addEventListener('click', function () { actions[b.dataset.fire](); });
+    });
+
+    // --- tempo clock ---
+    var range = document.getElementById('tempoRange');
+    var pill = document.getElementById('tempoPill');
+    var readout = document.getElementById('tempoReadout');
+    var FLOOR = 0.55, CEIL = 2.4; // seconds
+    function updateTempo() {
+      var days = parseFloat(range.value);
+      var period = FLOOR + (days / 7) * (CEIL - FLOOR);
+      pill.style.setProperty('--pulse', period.toFixed(2) + 's');
+      if (days <= 0) { readout.textContent = 'Due now'; pill.textContent = 'Due now'; }
+      else { readout.textContent = days + (days === 1 ? ' day out' : ' days out'); pill.textContent = 'Due soon'; }
+    }
+    range.addEventListener('input', updateTempo);
+    updateTempo();
+  })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## What

Adds a single standalone `showcase.html` to preview three found Uiverse components, **re-skinned into the yard data-plate design language** for evaluation:

1. **Brand-It Checkbox** (orig. SelfMadeSystem) — outline draws on + fills safety-orange when checked.
2. **Keyed Action Button** (orig. cssbuttons-io) — offset hi-vis "keys" retract and the face ignites orange on hover/focus.
3. **Diagonal Sweep Button** (orig. adamgiebl) — a bar sweeps across and floods the frame orange.

All three use our tokens (safety-orange accent, hazard-stripe, Saira Condensed, rivets, saddle-stitch divider), with visible focus states and `prefers-reduced-motion` respected.

## Scope / safety

- **Sandbox only.** `showcase.html` is not imported anywhere — `index.html`, `app.js`, and `style.css` are untouched, so nothing ships to the live site.
- Open it directly via `file://` (no server needed). This is a cloud session, so a `localhost` URL wouldn't reach the browser.
- No `data-r` rulebook stamps yet (intentionally — it's not wired into the app). If any candidate is approved, it gets stamped and integrated properly via `/jactec-ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EduFfXkZ5w5FrUdB62prca

---
_Generated by [Claude Code](https://claude.ai/code/session_01EduFfXkZ5w5FrUdB62prca)_