### PR TITLE
Mobile drag: pickup cue — ghost chip pops in + haptic on lift

### DIFF
--- a/app.js
+++ b/app.js
@@ -11924,6 +11924,11 @@ function initDrag() {
 // instead (see the grid swipe tracker in boot). Frees the horizontal axis for navigation.
 function armReadyTimer(arm) { return setTimeout(() => { if (DRAG.armed === arm) arm.ready = true; }, 300); }
 function armMenuTimer(arm) {   // §M3 — hold-still opens the context menu: touch long-press OR mouse click-and-hold (the right-click equivalent)
+  // PHONE: a long-press is reserved for the DRAG (Jac, 2026-06-29). The menu timer used
+  // to fire at 500ms and DISARM the drag, so any hold longer than ~½s opened the context
+  // menu instead of grabbing the row. On a phone the long-press now always drags; the R20
+  // context menu stays a desktop affordance (right-click / mouse click-and-hold).
+  if (arm.touch && document.body.classList.contains('is-phone')) return null;
   return setTimeout(() => {
     if (DRAG.armed !== arm) return;
     const t = document.elementFromPoint(arm.x, arm.y);

--- a/app.js
+++ b/app.js
@@ -11937,6 +11937,26 @@ function dragDown(e) {
   if (state.overlay) return;                                             // overlays own their clicks; the winpicker is non-modal (Task E — drag to select)
   if (e.target.closest('.tedit')) return;                                // the inline transport editor owns its pointers — let Google pan the map + drag the site pin (never arm an app/chat drag here)
   if (e.target.closest('.dispm')) return;                                // §2.3 the dispatch cockpit map owns its pointers too — Google handles pan/zoom, never the app drag engine
+  // §M3 — PHONE record-grab: a list row / open standard card is wall-to-wall pills +
+  // chat-els, leaving almost no bare space to grab — a finger-press lands on a pill ~2/3
+  // of the time, which on touch would either BAIL (.pill is in the bail list below) or
+  // hijack into a CHAT-TAG drag, so the record drag was effectively ungrabbable on a
+  // phone (Jac, 2026-06-29). On touch we resolve the whole row/card to its record FIRST:
+  // dragSourceAt already ranks a units pill as itself (the unit→rental link still wins),
+  // then a row, then an open standard card — so pressing ANYWHERE non-interactive on the
+  // row drags the record. Tap is unaffected (a press only LIFTS on a held horizontal
+  // move; a tap never does); chat-tag-dragging a single pill stays a desktop affordance.
+  if (e.pointerType === 'touch' && document.body.classList.contains('is-phone')
+      && !e.target.closest('input, textarea, select, button, .x, .inline-edit, .inline-input, .dropdown-menu, .ctx-menu')) {
+    const src = dragSourceAt(e.target);
+    if (src) {
+      DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
+      const armed = { card: src.card, rec: src.rec, x: e.clientX, y: e.clientY, pointerId: e.pointerId, touch: true, lp: null, rdy: null, ready: false };
+      armed.lp = armMenuTimer(armed);                       // §M3 — hold still → context menu
+      armed.rdy = armReadyTimer(armed);                     // a hold must precede the horizontal drag
+      DRAG.armed = armed; return;
+    }
+  }
   // §17 — a granular element marked [data-chat-el] (a pill/price/line/person) arms a
   // CHAT-TAG drag (tap still does its own thing; drag/long-press tags it into a chat).
   const chatEl = e.target.closest('[data-chat-el]');

--- a/app.js
+++ b/app.js
@@ -12061,6 +12061,7 @@ function startDrag() {
   }
   DRAG.ghost.style.transform = `translate(${DRAG.point.x + 12}px, ${DRAG.point.y - 14}px)`;
   dragLayer.appendChild(DRAG.ghost);
+  haptic([18, 28]);                                                     // §M-touch — firm pickup tick: "you've got it." iOS has NO Vibration API, so the chip ALSO pops in (the .drag-ghost lift animation) as the visible cue.
   try { dragLayer.setPointerCapture(a.pointerId); } catch (err) {}       // the stream survives the source row re-rendering away (sig-pad precedent)
   document.body.classList.add('dragging');
   document.body.dataset.drag = a.card || 'chatel';

--- a/app.js
+++ b/app.js
@@ -12021,12 +12021,11 @@ function dragMove(e) {
     const a = DRAG.armed; if (!a || e.pointerId !== a.pointerId) return;
     DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
     const dist = Math.hypot(e.clientX - a.x, e.clientY - a.y);
-    if (a.touch) {                                                       // §M3 — direction decides: horizontal lifts a drag, vertical lets the list scroll
+    if (a.touch) {                                                       // §M3 — the long-press DECIDES: before it fires, direction is navigation (vertical=scroll, horizontal=swipe); after it fires, ANY direction lifts the drag
       const adx = Math.abs(e.clientX - a.x), ady = Math.abs(e.clientY - a.y);
       if (adx < 8 && ady < 8) return;                                    // still inside the slop — a hold here becomes the menu
-      if (ady >= adx) { disarmDrag(); return; }                         // vertical intent → native scroll
-      if (!a.ready) { disarmDrag(); return; }                            // §M3 horizontal move BEFORE the long-press = a Back/Forward swipe (handled on pointerup), not a drag
-      return startDrag();                                                // held long enough → horizontal drag-to-link
+      if (a.ready) return startDrag();                                   // §M3 held long enough → grab now, in WHATEVER direction the finger moves (a real drag is rarely pure-horizontal). The direction gate below is only for the PRE-hold phase.
+      disarmDrag(); return;                                              // §M3 a move BEFORE the long-press is navigation, not a drag: vertical → native scroll, horizontal → a Back/Forward swipe (handled on pointerup)
     }
     if (dist > 6) startDrag();
     return;

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16594 lines, 38 chapters
+## app.js — 16614 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13279 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13280–14207 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14208–15246 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15247–15693 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15694–15696 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15697–16594 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13299 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13300–14227 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14228–15266 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15267–15713 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15714–15716 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15717–16614 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16614 lines, 38 chapters
+## app.js — 16613 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13299 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13300–14227 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14228–15266 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15267–15713 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15714–15716 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15717–16614 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13298 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13299–14226 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14227–15265 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15266–15712 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15713–15715 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15716–16613 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16613 lines, 38 chapters
+## app.js — 16618 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13298 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13299–14226 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14227–15265 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15266–15712 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15713–15715 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15716–16613 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13303 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13304–14231 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14232–15270 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15271–15717 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15718–15720 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15721–16618 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16618 lines, 38 chapters
+## app.js — 16619 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13303 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13304–14231 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14232–15270 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15271–15717 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15718–15720 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15721–16618 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13304 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13305–14232 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14233–15271 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15272–15718 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15719–15721 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15722–16619 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629a" />
+  <link rel="stylesheet" href="style.css?v=20260629b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629a"></script>
-  <script type="module" src="app.js?v=20260629a"></script>
+  <script src="rule-usage.js?v=20260629b"></script>
+  <script type="module" src="app.js?v=20260629b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629b" />
+  <link rel="stylesheet" href="style.css?v=20260629c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629b"></script>
-  <script type="module" src="app.js?v=20260629b"></script>
+  <script src="rule-usage.js?v=20260629c"></script>
+  <script type="module" src="app.js?v=20260629c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260628f" />
+  <link rel="stylesheet" href="style.css?v=20260629a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260628f"></script>
-  <script type="module" src="app.js?v=20260628f"></script>
+  <script src="rule-usage.js?v=20260629a"></script>
+  <script type="module" src="app.js?v=20260629a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629d" />
+  <link rel="stylesheet" href="style.css?v=20260629e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629d"></script>
-  <script type="module" src="app.js?v=20260629d"></script>
+  <script src="rule-usage.js?v=20260629e"></script>
+  <script type="module" src="app.js?v=20260629e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629c" />
+  <link rel="stylesheet" href="style.css?v=20260629d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629c"></script>
-  <script type="module" src="app.js?v=20260629c"></script>
+  <script src="rule-usage.js?v=20260629d"></script>
+  <script type="module" src="app.js?v=20260629d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2998,6 +2998,15 @@ body { font-variant-numeric: tabular-nums; }
 .drag-ghost { position: fixed; left: 0; top: 0; z-index: 9500; display: flex; align-items: center; gap: 7px; max-width: 240px; padding: 7px 12px; border-radius: 999px; background: var(--panel); border: 1px solid var(--accent); box-shadow: 0 0 0 2px var(--accent-line), 0 14px 34px -10px rgba(0,0,0,.65); color: var(--accent); font-size: 12.5px; font-weight: 700; pointer-events: none; will-change: transform; }
 .drag-ghost svg { width: 14px; height: 14px; flex: 0 0 auto; }
 .drag-ghost .dg-t { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+/* §M-touch — PICKUP CUE: the ghost chip POPS in the instant a drag lifts, so the user
+   SEES they've "got it" (the critical signal on iOS, which has no Vibration API; the
+   haptic in startDrag covers Android). Animate `scale` + `opacity` only — the JS engine
+   owns the `transform` (translate) every frame, so animating transform would fight it;
+   `scale` is an independent property that composes with it. Reduced-motion → steady. */
+@media (prefers-reduced-motion: no-preference) {
+  .drag-ghost { animation: ghostLift .16s ease-out; }
+  @keyframes ghostLift { from { scale: .66; opacity: 0; } to { scale: 1; opacity: 1; } }
+}
 /* §M2 ZIP ZONES (phone) — edge rails of valid drop-target cards during a drag. Steel
    data-plate tabs with a per-card hazard stripe (the ONLY colour — a transient drag
    overlay, so the one-orange rule holds for persistent UI). Drag onto one to jump to

--- a/style.css
+++ b/style.css
@@ -3052,6 +3052,19 @@ body.dragging .row.drop-ok { opacity: 1; }
    (touch-action must be in place BEFORE the gesture starts; once lifted, the
    engine's passive:false touchmove guard keeps the browser pan from firing) */
 .row { touch-action: pan-y; }
+/* iOS Safari: a touch-and-hold on text starts native text-selection + the callout
+   (the highlight + magnifier), which STEALS the gesture before the §M3 long-press can
+   arm the record drag (Jac, 2026-06-29 — "iphone keeps highlighting text instead of
+   long pressing"). Suppress selection + the callout on the phone grid's draggable
+   surfaces so the hold reaches the drag engine. Inputs / inline-edit fields re-enable
+   selection just below, so typing and editing still work. */
+.is-phone .grid .row, .is-phone .grid .card {
+  -webkit-user-select: none; user-select: none; -webkit-touch-callout: none;
+}
+.is-phone .grid input, .is-phone .grid textarea, .is-phone .grid [contenteditable],
+.is-phone .grid .inline-edit, .is-phone .grid .inline-input {
+  -webkit-user-select: text; user-select: text; -webkit-touch-callout: default;
+}
 /* settings overlay — the Allow-overbooking R14 toggle rides the row's right edge */
 .set-row .seg { margin-left: auto; }
 


### PR DESCRIPTION
## What & why

Jac: the user needs a clear signal the instant they've **"got it"** and can drag. `startDrag` created the ghost chip silently — no pop, and no haptic at the lift moment (haptics only fired on drop/cancel/zip-arm). On iOS there's no Vibration API, so a **visible** cue is essential.

## The fix

- **Haptic on lift** — `startDrag` now fires `haptic([18,28])`, a firm "grabbed" tick (Android; gated on the existing `state.hapticsOff` + reduced-motion checks).
- **Visual pop** — the `.drag-ghost` chip now **pops in** via a new `ghostLift` animation (`scale .66 → 1` + fade, `.16s ease-out`). It animates `scale`/`opacity` only — the drag engine owns the inline `transform` (translate) every frame, and `scale` is an independent CSS property that composes with it, so the pop never fights positioning.
- **Reduced-motion** — gated on `prefers-reduced-motion: no-preference`; under reduce the chip just appears (steady state), and `haptic()` already respects the same.

## Verification

Phone-context harness (390×844, hasTouch): on lift the chip mounts with `animationName: ghostLift` (0.16s) and **no JS errors** (the haptic call is safe even where `vibrate` is absent). Combined with the existing dim-the-list + cancel-arc + zip-zones, the pickup is now unmistakable.

Cache token bumped `20260629d` → `20260629e`. Gates: `smoke` · `gen-rule-usage --check` · `check-window-catalog` · `gen-code-map --check` all pass (no new builders/rules).

Note: haptics can't be asserted headless and iOS has no Vibration API — the visual pop is the cross-platform cue; final feel is an on-device check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01961vQPLR3KBNfaC5qNu45P)_