### PR TITLE
Menu-driven record linking (replaces mobile drag)

### DIFF
--- a/app.js
+++ b/app.js
@@ -11924,6 +11924,11 @@ function initDrag() {
 // instead (see the grid swipe tracker in boot). Frees the horizontal axis for navigation.
 function armReadyTimer(arm) { return setTimeout(() => { if (DRAG.armed === arm) arm.ready = true; }, 300); }
 function armMenuTimer(arm) {   // §M3 — hold-still opens the context menu: touch long-press OR mouse click-and-hold (the right-click equivalent)
+  // PHONE: a long-press is reserved for the DRAG (Jac, 2026-06-29). The menu timer used
+  // to fire at 500ms and DISARM the drag, so any hold longer than ~½s opened the context
+  // menu instead of grabbing the row. On a phone the long-press now always drags; the R20
+  // context menu stays a desktop affordance (right-click / mouse click-and-hold).
+  if (arm.touch && document.body.classList.contains('is-phone')) return null;
   return setTimeout(() => {
     if (DRAG.armed !== arm) return;
     const t = document.elementFromPoint(arm.x, arm.y);

--- a/app.js
+++ b/app.js
@@ -11864,6 +11864,43 @@ function invoiceUnitIds(inv) {
   return [...ids];
 }
 
+/* ── §17b — MENU-DRIVEN LINKING: the "+ Target" actions for the R20 context menu
+   (2026-06-29, replaces mobile drag). The set is DROP_MATRIX[src] ∩ the acting
+   role's capability, minus targets that can't apply to THIS source right now. The
+   menu omission is UX only — dispatchDrop re-fires every hard gate on confirm. ── */
+const LINK_TARGET_LABEL = { rentals: 'Rental', invoices: 'Invoice', customers: 'Customer', units: 'Unit', workOrders: 'Work Order' };
+/* §10-B1 role gate: any link that touches an INVOICE is billing → money tier; any
+   link that touches a CUSTOMER is PII/CRM → above ops-only 'staff' (money tier+ in
+   the shipped ladder). Operational links (units↔rentals, unit→WO) stay open to staff. */
+function linkRoleAllows(srcCard, tgt) {
+  if (tgt === 'invoices' || srcCard === 'invoices') return canMoney();
+  if (tgt === 'customers' || srcCard === 'customers') return canMoney();
+  return true;
+}
+/* Source-level preconditions — omit an action that can't possibly apply to this
+   record now (the per-target instance gate still dims rows on the target card). */
+function linkActionPossible(srcCard, rec, tgt) {
+  if (srcCard === 'units' && tgt === 'invoices') return !!unbilledOpenWOForUnit(rec.unitId);   // §7.6 needs a billable open WO
+  if (srcCard === 'rentals' && tgt === 'invoices') return !rec.invoiceId;                       // already invoiced → nothing to add
+  if (srcCard === 'invoices') return !rec.locked;                                               // a locked invoice takes no new links
+  if (srcCard === 'workOrders' && tgt === 'invoices') return woBillable(rec) > 0;
+  return true;
+}
+/* The ordered "+ Target" actions for a pressed record. `create:true` = a NEW record
+   on the target card (not a DROP_MATRIX link): only the unit "+ Work Order" today. */
+function linkActionsFor(srcCard, rec) {
+  if (!srcCard || !rec) return [];
+  const out = [];
+  const targets = DROP_MATRIX[srcCard];
+  if (targets) for (const tgt of Object.keys(targets)) {
+    if (!linkActionPossible(srcCard, rec, tgt)) continue;
+    if (!linkRoleAllows(srcCard, tgt)) continue;
+    out.push({ target: tgt, label: '+ ' + (LINK_TARGET_LABEL[tgt] || tgt) });
+  }
+  if (srcCard === 'units' && linkRoleAllows('units', 'workOrders')) out.push({ target: 'workOrders', create: true, label: '+ Work Order' });   // a WO is CREATED for a unit → lands on the unit (§4a)
+  return out;
+}
+
 /** §M-touch — haptic reinforcement for a COMMITTED gesture (one pulse, never on
  *  scroll/hover). Best-effort: Android/Chrome only — iOS Safari has no Vibration
  *  API, so this is reinforcement, never the sole signal. Gated on the per-device
@@ -16465,7 +16502,7 @@ function seedDemoRequests() {
    the backend-backed production path. */
 function exposeTestApi() {
   try {
-    window.__rw = { DATA, IDX, TODAY_ISO, itemPaid, lineKey, rentalUnits, unitEntry, isPrimaryUnit,
+    window.__rw = { DATA, IDX, TODAY_ISO, itemPaid, lineKey, rentalUnits, unitEntry, isPrimaryUnit, linkActionsFor, linkActionPossible, DROP_MATRIX,
       unitStatus, rentalUnitStatuses, unitsUniform, rentalStatusDisplay, rentalMirrorStatus, rentalDisplayStatus,
       allUnitsTerminal, unitTerminal, unitVoided, rentalLineItems, transportLineItems, extensionPreview, billExtension, unitBilledRental, unitBilledSeries, retroPricingOn, rentalInvoices, rentalActiveInvoice, invoiceChunks, createInvoiceForRental, syncRentalPrimary,
       addUnitToRental, removeUnitFromRental, removeUnitInvoiceLine, unitLinePaid, invoiceTotals, allocLines,

--- a/app.js
+++ b/app.js
@@ -11923,12 +11923,7 @@ function initDrag() {
 // move lifts a drag. A quick horizontal flick (before this fires) is a Back/Forward swipe
 // instead (see the grid swipe tracker in boot). Frees the horizontal axis for navigation.
 function armReadyTimer(arm) { return setTimeout(() => { if (DRAG.armed === arm) arm.ready = true; }, 300); }
-function armMenuTimer(arm) {   // §M3 — hold-still opens the context menu: touch long-press OR mouse click-and-hold (the right-click equivalent)
-  // PHONE: a long-press is reserved for the DRAG (Jac, 2026-06-29). The menu timer used
-  // to fire at 500ms and DISARM the drag, so any hold longer than ~½s opened the context
-  // menu instead of grabbing the row. On a phone the long-press now always drags; the R20
-  // context menu stays a desktop affordance (right-click / mouse click-and-hold).
-  if (arm.touch && document.body.classList.contains('is-phone')) return null;
+function armMenuTimer(arm) {   // §M3 — hold-still opens the context menu: touch long-press OR mouse click-and-hold (the right-click equivalent). On phones this is now the PRIMARY linking entry (menu-driven linking replaced drag, 2026-06-29).
   return setTimeout(() => {
     if (DRAG.armed !== arm) return;
     const t = document.elementFromPoint(arm.x, arm.y);
@@ -11942,25 +11937,19 @@ function dragDown(e) {
   if (state.overlay) return;                                             // overlays own their clicks; the winpicker is non-modal (Task E — drag to select)
   if (e.target.closest('.tedit')) return;                                // the inline transport editor owns its pointers — let Google pan the map + drag the site pin (never arm an app/chat drag here)
   if (e.target.closest('.dispm')) return;                                // §2.3 the dispatch cockpit map owns its pointers too — Google handles pan/zoom, never the app drag engine
-  // §M3 — PHONE record-grab: a list row / open standard card is wall-to-wall pills +
-  // chat-els, leaving almost no bare space to grab — a finger-press lands on a pill ~2/3
-  // of the time, which on touch would either BAIL (.pill is in the bail list below) or
-  // hijack into a CHAT-TAG drag, so the record drag was effectively ungrabbable on a
-  // phone (Jac, 2026-06-29). On touch we resolve the whole row/card to its record FIRST:
-  // dragSourceAt already ranks a units pill as itself (the unit→rental link still wins),
-  // then a row, then an open standard card — so pressing ANYWHERE non-interactive on the
-  // row drags the record. Tap is unaffected (a press only LIFTS on a held horizontal
-  // move; a tap never does); chat-tag-dragging a single pill stays a desktop affordance.
+  // §M3 — PHONE: drag-to-link is RETIRED on phones (2026-06-29). A long-press now opens
+  // the R20 context menu, which carries the menu-driven LINKING actions (+ Rental / +
+  // Invoice / …). Arm a MENU-ONLY long-press: no drag is ever lifted on a phone. A move
+  // before the timer cancels it (native scroll / Back-Forward swipe stay intact); a quick
+  // tap releases before the timer (its click fires normally). The interactive-control
+  // skip keeps inputs/buttons native; selection-suppression (style.css, .is-phone .grid)
+  // stops iOS from starting text-selection before the long-press registers.
   if (e.pointerType === 'touch' && document.body.classList.contains('is-phone')
       && !e.target.closest('input, textarea, select, button, .x, .inline-edit, .inline-input, .dropdown-menu, .ctx-menu')) {
-    const src = dragSourceAt(e.target);
-    if (src) {
-      DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
-      const armed = { card: src.card, rec: src.rec, x: e.clientX, y: e.clientY, pointerId: e.pointerId, touch: true, lp: null, rdy: null, ready: false };
-      armed.lp = armMenuTimer(armed);                       // §M3 — hold still → context menu
-      armed.rdy = armReadyTimer(armed);                     // a hold must precede the horizontal drag
-      DRAG.armed = armed; return;
-    }
+    DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
+    const arm = { menuOnly: true, x: e.clientX, y: e.clientY, pointerId: e.pointerId, touch: true, lp: null, rdy: null, ready: false };
+    arm.lp = armMenuTimer(arm);                             // hold ~500ms still → openCtxMenuAt (the R20 menu)
+    DRAG.armed = arm; return;
   }
   // §17 — a granular element marked [data-chat-el] (a pill/price/line/person) arms a
   // CHAT-TAG drag (tap still does its own thing; drag/long-press tags it into a chat).

--- a/app.js
+++ b/app.js
@@ -11937,6 +11937,26 @@ function dragDown(e) {
   if (state.overlay) return;                                             // overlays own their clicks; the winpicker is non-modal (Task E — drag to select)
   if (e.target.closest('.tedit')) return;                                // the inline transport editor owns its pointers — let Google pan the map + drag the site pin (never arm an app/chat drag here)
   if (e.target.closest('.dispm')) return;                                // §2.3 the dispatch cockpit map owns its pointers too — Google handles pan/zoom, never the app drag engine
+  // §M3 — PHONE record-grab: a list row / open standard card is wall-to-wall pills +
+  // chat-els, leaving almost no bare space to grab — a finger-press lands on a pill ~2/3
+  // of the time, which on touch would either BAIL (.pill is in the bail list below) or
+  // hijack into a CHAT-TAG drag, so the record drag was effectively ungrabbable on a
+  // phone (Jac, 2026-06-29). On touch we resolve the whole row/card to its record FIRST:
+  // dragSourceAt already ranks a units pill as itself (the unit→rental link still wins),
+  // then a row, then an open standard card — so pressing ANYWHERE non-interactive on the
+  // row drags the record. Tap is unaffected (a press only LIFTS on a held horizontal
+  // move; a tap never does); chat-tag-dragging a single pill stays a desktop affordance.
+  if (e.pointerType === 'touch' && document.body.classList.contains('is-phone')
+      && !e.target.closest('input, textarea, select, button, .x, .inline-edit, .inline-input, .dropdown-menu, .ctx-menu')) {
+    const src = dragSourceAt(e.target);
+    if (src) {
+      DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
+      const armed = { card: src.card, rec: src.rec, x: e.clientX, y: e.clientY, pointerId: e.pointerId, touch: true, lp: null, rdy: null, ready: false };
+      armed.lp = armMenuTimer(armed);                       // §M3 — hold still → context menu
+      armed.rdy = armReadyTimer(armed);                     // a hold must precede the horizontal drag
+      DRAG.armed = armed; return;
+    }
+  }
   // §17 — a granular element marked [data-chat-el] (a pill/price/line/person) arms a
   // CHAT-TAG drag (tap still does its own thing; drag/long-press tags it into a chat).
   const chatEl = e.target.closest('[data-chat-el]');

--- a/app.js
+++ b/app.js
@@ -12061,6 +12061,7 @@ function startDrag() {
   }
   DRAG.ghost.style.transform = `translate(${DRAG.point.x + 12}px, ${DRAG.point.y - 14}px)`;
   dragLayer.appendChild(DRAG.ghost);
+  haptic([18, 28]);                                                     // §M-touch — firm pickup tick: "you've got it." iOS has NO Vibration API, so the chip ALSO pops in (the .drag-ghost lift animation) as the visible cue.
   try { dragLayer.setPointerCapture(a.pointerId); } catch (err) {}       // the stream survives the source row re-rendering away (sig-pad precedent)
   document.body.classList.add('dragging');
   document.body.dataset.drag = a.card || 'chatel';

--- a/app.js
+++ b/app.js
@@ -12021,12 +12021,11 @@ function dragMove(e) {
     const a = DRAG.armed; if (!a || e.pointerId !== a.pointerId) return;
     DRAG.point.x = e.clientX; DRAG.point.y = e.clientY;
     const dist = Math.hypot(e.clientX - a.x, e.clientY - a.y);
-    if (a.touch) {                                                       // §M3 — direction decides: horizontal lifts a drag, vertical lets the list scroll
+    if (a.touch) {                                                       // §M3 — the long-press DECIDES: before it fires, direction is navigation (vertical=scroll, horizontal=swipe); after it fires, ANY direction lifts the drag
       const adx = Math.abs(e.clientX - a.x), ady = Math.abs(e.clientY - a.y);
       if (adx < 8 && ady < 8) return;                                    // still inside the slop — a hold here becomes the menu
-      if (ady >= adx) { disarmDrag(); return; }                         // vertical intent → native scroll
-      if (!a.ready) { disarmDrag(); return; }                            // §M3 horizontal move BEFORE the long-press = a Back/Forward swipe (handled on pointerup), not a drag
-      return startDrag();                                                // held long enough → horizontal drag-to-link
+      if (a.ready) return startDrag();                                   // §M3 held long enough → grab now, in WHATEVER direction the finger moves (a real drag is rarely pure-horizontal). The direction gate below is only for the PRE-hold phase.
+      disarmDrag(); return;                                              // §M3 a move BEFORE the long-press is navigation, not a drag: vertical → native scroll, horizontal → a Back/Forward swipe (handled on pointerup)
     }
     if (dist > 6) startDrag();
     return;

--- a/app.js
+++ b/app.js
@@ -4206,6 +4206,7 @@ function flashOr(sel, msg) {
  *  Replace opens the inline editor · Add Comment logs to History ·
  *  Ask Mr. Wrangler copies a debug reference for Claude. */
 let ctxTarget = null;
+let ctxRecord = null;   // §17b — the record the menu opened on ({card, recId}), for the "+ Target" link actions
 // §13.4 graph-chrome right-click menu — tracks which card it was opened on so runCtxAction can act without
 // the ctxOutside closer; the chosen state persists per device, per card (loadGvChrome).
 let ctxGvCard = null;
@@ -4231,10 +4232,16 @@ function closeCtxMenu() { const m = document.getElementById('rw-ctx'); if (m) m.
 function openCtxMenu(e, hit) {
   closeCtxMenu();
   ctxTarget = hit;
+  // §17b — resolve the pressed record → its menu-driven LINK actions ("+ Target").
+  const rr = hit && hit.el ? cardRecordAt(hit.el) : null;
+  const ent = rr ? entityCardOf(rr.card, rr.recType) : null;
+  ctxRecord = ent ? { card: ent, recId: rr.recId } : null;
+  const linkItems = ctxRecord ? linkActionsFor(ctxRecord.card, recOf(ctxRecord.card, ctxRecord.recId)) : [];
   const m = document.createElement('div');
   m.className = 'ctx-menu'; m.id = 'rw-ctx';
   const item = (act, label) => `<button class="dd-item" data-ctx="${act}">${label}</button>`;
-  m.innerHTML = [
+  const linkSec = linkItems.length ? linkItems.map((a) => item('link:' + a.target, esc(a.label))).join('') + '<div class="menu-sep"></div>' : '';
+  m.innerHTML = linkSec + [
     item('cut', '✂️ Cut'), item('copy', '📋 Copy'), item('paste', '📥 Paste'), item('clear', '🧹 Clear'),
     '<div class="menu-sep"></div>',
     item('search', '🔎 Search'), item('gsearch', '🌐 Global Search'), item('replace', '✏️ Replace'),
@@ -4286,6 +4293,13 @@ function runCtxAction(act) {
     else if (act === 'gv-sort') saveGvChrome(card, { sort: !gvSortHidden(card) });
     else if (act === 'gv-reset') saveGvChrome(card, { pills: false, sort: false });
     return render();
+  }
+  if (act.startsWith('link:')) {   // §17b — menu-driven linking
+    const target = act.slice(5); const rec = ctxRecord;
+    closeCtxMenu(); document.removeEventListener('mousedown', ctxOutside); ctxRecord = null;
+    if (!rec) return;
+    if (rec.card === 'units' && target === 'workOrders') return startUnitWorkOrder(rec.recId);   // §4a create-WO → land on the unit
+    return enterLinking(rec.card, rec.recId, target);
   }
   const tg = ctxTarget; closeCtxMenu(); document.removeEventListener('mousedown', ctxOutside);
   if (!tg) return;
@@ -6742,6 +6756,7 @@ function cardEl(cardDef, session) {
   } else {
     body.appendChild(listView(cardDef, session));
   }
+  const lb = linkBanner(card); if (lb) { const w = el('div'); w.innerHTML = lb; if (w.firstElementChild) node.appendChild(w.firstElementChild); }   // §17b — linking-mode banner above the list
   node.appendChild(body);
   return node;
 }
@@ -9094,6 +9109,21 @@ function buildPopupEl(o, overlay, opts = {}) {
       <div class="cmt-card-foot">${rec ? `<span class="cmt-hint">${esc(detailTitle(entityCardOf(o.card, o.recType), rec))}</span>` : '<span></span>'}<button class="cmt-post js-cmt-save">Post</button></div>`;
     overlay.appendChild(pop);
     if (!opts.preview) setTimeout(() => pop.querySelector('.cmt-input')?.focus(), 0);
+  } else if (o.kind === 'linkConfirm') {
+    // §17b — confirm a menu-driven link. PRICE only for invoice links (B2); confirm runs dispatchDrop.
+    const srcRec = recOf(o.srcCard, o.srcId), tgtRec = recOf(o.targetCard, o.targetId);
+    const srcT = srcRec ? detailTitle(o.srcCard, srcRec) : String(o.srcId);
+    const tgtT = tgtRec ? detailTitle(o.targetCard, tgtRec) : String(o.targetId);
+    const isMoney = (o.srcCard === 'invoices' || o.targetCard === 'invoices');
+    const pop = el('div', 'popup'); pop.style.width = '360px';
+    pop.innerHTML = popupShell({
+      icon: CARD_ICON[o.targetCard] || '',
+      title: `Add to ${LINK_TARGET_LABEL[o.targetCard] || o.targetCard}?`,
+      tag: 'Link · confirm',
+      body: `<div class="lc-body"><div class="lc-line">Add <b>${esc(srcT)}</b> to <b>${esc(tgtT)}</b>?</div>${linkPriceText(o.srcCard, srcRec, o.targetCard, tgtRec)}</div>`,
+      foot: `${ghostPill('Cancel', { js: 'js-close' })}${actionPill(isMoney ? 'money' : 'commit', isMoney ? 'Confirm — bill it' : 'Confirm', { js: 'js-link-confirm' })}`,
+    });
+    overlay.appendChild(pop);
   } else if (o.kind === 'rulebook') {
     // THE VISUAL RULEBOOK (SPEC v8) — every example is emitted by the REAL
     // builder, so this reference can never drift from the code.
@@ -9854,6 +9884,7 @@ const WINDOW_CATALOG = [
   { kind: 'qr',            label: 'Share session (QR)',      tag: 'Share · session',          sample: () => ({}) },
   { kind: 'migrateUnits',  label: 'Round up missing units',  tag: 'Units · migrate',          sample: () => ({ plan: [{ name: 'Sample Unit', action: 'create', unitId: 'U000', categoryId: ((DATA.categories || [])[0] || {}).categoryId, count: 1 }] }) },
   { kind: 'comment',       label: 'Comment note',            tag: 'Note · comment',           sample: () => ({ card: 'units', recId: ((DATA.units || [])[0] || {}).unitId, recType: null, color: 'yellow' }) },
+  { kind: 'linkConfirm',   label: 'Confirm link',            tag: 'Link · confirm',           sample: () => ({ srcCard: 'rentals', srcId: ((DATA.rentals || [])[0] || {}).rentalId, targetCard: 'invoices', targetId: ((DATA.invoices || [])[0] || {}).invoiceId }) },
   { kind: 'rulebook',      label: 'The R-Rulebook',          tag: 'SPEC v8 · design system',  sample: () => ({}) },
   { kind: 'partform',      label: 'Add / Edit Part · Task',  tag: 'Work order · line',         sample: () => ({ woId: ((DATA.workOrders || [])[0] || {}).woId }) },
   { kind: 'receiptform',   label: 'New / Edit Receipt',      tag: 'Expense · receipt',         sample: () => ({}) },
@@ -11901,6 +11932,55 @@ function linkActionsFor(srcCard, rec) {
   return out;
 }
 
+/* ── §17b — LINKING MODE: a "+ Target" menu action navigates to the target card in
+   list+search; tapping a target there opens the confirm popup; confirm runs the
+   existing dispatchDrop (reuses every §7.5/§7.6 hard gate + History). ── */
+function enterLinking(srcCard, srcId, targetCard) {
+  state.linking = { srcCard, srcId, targetCard };
+  const sess = activeSession();
+  const col = COLUMN_OF[targetCard];
+  if (sess.cols && col) { sess.cols[col] = targetCard; const idx = COLUMNS.findIndex((c) => c.id === col); if (idx >= 0) state.mobileCol = idx; }   // §M1 reveal + flip the phone column
+  const cs = sess.cards[targetCard];
+  if (cs) { cs.mode = 'list'; cs.recId = null; cs.recType = null; cs.search = ''; cs.listLimit = undefined; }
+  render();
+  setTimeout(() => { try { document.querySelector(`.card[data-card="${targetCard}"] .card-search, .card[data-card="${targetCard}"] input`)?.focus(); } catch (e) {} }, 40);
+}
+function cancelLinking() { if (state.linking) { state.linking = null; render(); } }
+function startUnitWorkOrder(unitId) { pillTo('units', unitId); }   // §4a — "+ Work Order" just lands on the unit (WO creation lives on the unit's card)
+/* The hazard-stripe banner shown atop the target card while linking. */
+function linkBanner(card) {
+  const L = state.linking; if (!L || L.targetCard !== card) return '';
+  const srcRec = recOf(L.srcCard, L.srcId);
+  const srcT = srcRec ? detailTitle(L.srcCard, srcRec) : String(L.srcId);
+  const tgt = LINK_TARGET_LABEL[L.targetCard] || L.targetCard;
+  return `<div class="link-banner"><span class="lb-txt">Linking <b>${esc(srcT)}</b> → pick a ${esc(tgt)} <span class="lb-sub">(or +New)</span></span>${ghostPill('Cancel', { js: 'js-link-cancel' })}</div>`;
+}
+/* Customer-facing PRICE only (B2) — shown when a link bills onto an invoice. */
+function linkPriceText(srcCard, srcRec, targetCard, tgtRec) {
+  if (srcCard !== 'invoices' && targetCard !== 'invoices') return '';
+  const billCard = srcCard === 'invoices' ? targetCard : srcCard;
+  const billRec = srcCard === 'invoices' ? tgtRec : srcRec;
+  let amt = null;
+  try {
+    if (billCard === 'rentals') amt = rentalPrice(billRec);
+    else if (billCard === 'workOrders') amt = woBillable(billRec);
+    else if (billCard === 'units') { const w = unbilledOpenWOForUnit(billRec.unitId); amt = w ? woBillable(w) : null; }
+  } catch (e) {}
+  return amt != null ? `<div class="lc-price">Bills <b>${money(amt)}</b> onto the invoice.</div>` : `<div class="lc-price muted">The amount is set on the invoice.</div>`;
+}
+function openLinkConfirm(targetId) {
+  const L = state.linking; if (!L) return;
+  if (!recOf(L.srcCard, L.srcId) || !recOf(L.targetCard, targetId)) return;
+  openOverlay({ kind: 'linkConfirm', srcCard: L.srcCard, srcId: L.srcId, targetCard: L.targetCard, targetId });
+}
+function doLinkConfirm() {
+  const o = state.overlay; if (!o || o.kind !== 'linkConfirm') return;
+  const srcRec = recOf(o.srcCard, o.srcId), tgtRec = recOf(o.targetCard, o.targetId);
+  closeOverlay(); state.linking = null;
+  if (!srcRec || !tgtRec) return;
+  dispatchDrop({ entity: o.srcCard, id: o.srcId, rec: srcRec }, { entity: o.targetCard, rec: tgtRec });   // reuses every hard gate + History; toasts its own failures
+}
+
 /** §M-touch — haptic reinforcement for a COMMITTED gesture (one pulse, never on
  *  scroll/hover). Best-effort: Android/Chrome only — iOS Safari has no Vibration
  *  API, so this is reinforcement, never the sole signal. Gated on the per-device
@@ -12989,6 +13069,19 @@ function onClick(e) {
     if (host) scrollToSect(host.dataset.card, sectEl.dataset.sect);
     return;
   }
+
+  // §17b — LINKING MODE: Cancel the banner, or tap a target-card row/pill to pick the
+  // link target → confirm popup (pre-empts normal row/pill navigation).
+  if (state.linking) {
+    if (closest('.js-link-cancel')) { e.stopPropagation(); return cancelLinking(); }
+    const lrow = closest('.row[data-rec]'), lpill = closest('[data-pill-card]');
+    if (lrow || lpill) {
+      const pc = lrow ? entityCardOf(lrow.dataset.card, lrow.dataset.type) : entityCardOf(lpill.dataset.pillCard, null);
+      const pid = lrow ? lrow.dataset.rec : lpill.dataset.pillRec;
+      if (pc === state.linking.targetCard && pid != null) { e.stopPropagation(); e.preventDefault(); return openLinkConfirm(pid); }
+    }
+  }
+  if (closest('.js-link-confirm')) { e.stopPropagation(); return doLinkConfirm(); }
 
   // universal pill rule — single-click navigates; double-click anchors; ctrl+click = new
   // tab (handled by the early hotkey branch). Same discriminator as rows (#1).

--- a/app.js
+++ b/app.js
@@ -4240,7 +4240,7 @@ function openCtxMenu(e, hit) {
   const m = document.createElement('div');
   m.className = 'ctx-menu'; m.id = 'rw-ctx';
   const item = (act, label) => `<button class="dd-item" data-ctx="${act}">${label}</button>`;
-  const linkSec = linkItems.length ? linkItems.map((a) => item('link:' + a.target, esc(a.label))).join('') + '<div class="menu-sep"></div>' : '';
+  const linkSec = linkItems.length ? linkItems.map((a) => `<button class="dd-item" data-ctx="link:${a.target}">${CARD_ICON[a.target] || ''}${esc(a.label)}</button>`).join('') + '<div class="menu-sep"></div>' : '';
   m.innerHTML = linkSec + [
     item('cut', '✂️ Cut'), item('copy', '📋 Copy'), item('paste', '📥 Paste'), item('clear', '🧹 Clear'),
     '<div class="menu-sep"></div>',

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16594 lines, 38 chapters
+## app.js — 16614 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13279 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13280–14207 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14208–15246 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15247–15693 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15694–15696 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15697–16594 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13299 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13300–14227 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14228–15266 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15267–15713 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15714–15716 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15717–16614 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16619 lines, 38 chapters
+## app.js — 16738 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -18,34 +18,34 @@
 | APP-08 | 2510–2517 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
 | APP-09 | 2518–3904 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+94) |
 | APP-10 | 3905–3925 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 3926–4392 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+33) |
-| APP-12 | 4393–4560 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 4561–4671 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
-| APP-14 | 4672–4949 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 4950–5146 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 5147–6480 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
-| APP-17 | 6481–6575 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6576–6856 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 6857–7050 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 7051–7174 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7175–7339 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7340–7549 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7550–8371 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
-| APP-24 | 8372–8477 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8478–8923 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 8924–9845 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 9846–9940 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 9941–10356 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
-| APP-29 | 10357–11407 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
-| APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13304 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13305–14232 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14233–15271 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15272–15718 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15719–15721 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15722–16619 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-11 | 3926–4406 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, PRIMARY_SET_ENTITY, statusPill, refPill, unitPill, entityPill, …(+34) |
+| APP-12 | 4407–4574 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 4575–4685 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, categoryIconFor, unitRentalInspPill, unitWoSoPill |
+| APP-14 | 4686–4963 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 4964–5160 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 5161–6494 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
+| APP-17 | 6495–6589 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
+| APP-18 | 6590–6871 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 6872–7065 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 7066–7189 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7190–7354 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7355–7564 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7565–8386 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
+| APP-24 | 8387–8492 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8493–8938 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 8939–9875 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 9876–9971 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 9972–10387 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10388–11438 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 11439–11708 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11709–11833 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
+| APP-32 | 11834–11837 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11838–13423 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+50) |
+| APP-34 | 13424–14351 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14352–15390 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15391–15837 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15838–15840 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15841–16738 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16614 lines, 38 chapters
+## app.js — 16613 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13299 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13300–14227 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14228–15266 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15267–15713 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15714–15716 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15717–16614 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13298 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13299–14226 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14227–15265 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15266–15712 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15713–15715 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15716–16613 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16613 lines, 38 chapters
+## app.js — 16618 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13298 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13299–14226 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14227–15265 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15266–15712 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15713–15715 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15716–16613 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13303 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13304–14231 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14232–15270 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15271–15717 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15718–15720 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15721–16618 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16618 lines, 38 chapters
+## app.js — 16619 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11408–11677 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11678–11802 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11803–11806 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11807–13303 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
-| APP-34 | 13304–14231 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14232–15270 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15271–15717 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15718–15720 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15721–16618 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11807–13304 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, haptic, initDrag, armReadyTimer, armMenuTimer, dragDown, dragSourceAt, …(+39) |
+| APP-34 | 13305–14232 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14233–15271 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15272–15718 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15719–15721 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15722–16619 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/superpowers/plans/2026-06-29-menu-driven-linking-plan.md
+++ b/docs/superpowers/plans/2026-06-29-menu-driven-linking-plan.md
@@ -1,0 +1,125 @@
+# Menu-driven record linking — implementation plan
+
+**Spec:** `docs/superpowers/specs/2026-06-29-menu-driven-linking-design.md` (approved,
+`/role`-audited). Build on `claude/mobile-drag-rows-items-8jooau`.
+
+**Real hooks already in the code** (verified):
+- `cardRecordAt(el)` (app.js ~2161) — element → `{card, recId, recType}`.
+- `canMoney()` (~14257) = `!currentRole || roleTier(currentRole) >= tierRank('money')`
+  — the exact Office/Owner gate; reuse for **+ Invoice**.
+- `roleTier(currentRole)` / `tierRank(...)` — tier system for the **+ Customer** gate.
+- `DROP_MATRIX` (~11826) + `dispatchDrop(payload, target)` (~12290) — validity gates
+  + every link mutation, reusable outside a drag.
+- `openCtxMenu(e, hit)` (~4231), `openCtxMenuAt` (~4254), `runCtxAction` (~4281).
+- `I.*` library icons (`icons.js`); `tools/gen-icons.mjs` to add glyphs.
+
+Each phase ends green on `node ci/smoke.mjs` + `node ci/logic-test.mjs` and a
+Playwright drive at phone (390×844, hasTouch) + desktop.
+
+---
+
+## Phase 1 — Remove mobile drag (subtractive, isolated)
+1. Delete the `is-phone` record-grab branch in `dragDown` (#408).
+2. Delete the `armMenuTimer` `is-phone` no-op (#412) → the long-press menu fires on
+   phone again.
+3. Gate the touch-arm paths (`dragDown`/`dragMove` touch branch, `armReadyTimer`,
+   the `ghostLift` pop + pickup `haptic`) to **non-phone** only; remove phone
+   zip-zones (`buildZipZones`, `phoneDragEdge`) and the `.is-phone .grid` selection
+   suppression (#411) if nothing else needs it. Keep the desktop **mouse** path
+   intact.
+**Verify:** desktop mouse-drag still links; phone long-press opens the R20 menu;
+no console errors; smoke + logic green.
+
+## Phase 2 — Role-gated link-action derivation (pure fn, unit-testable)
+1. `linkActionsFor(srcCard, rec)` → array of `{target, label, icon, gate}`:
+   - base = `Object.keys(DROP_MATRIX[srcCard] || {})`.
+   - omit a target type if its source-level precondition can't hold now (e.g.
+     unit→invoice needs `unbilledOpenWOForUnit(rec)`).
+   - **role gate (B1):** `invoices` target → `canMoney()`; `customers` target →
+     customer-PII capability (`roleTier ≥ tierRank('sales')` or the customer-card
+     entitlement — confirm the exact rank at build); operational targets → their
+     tier. Drop any the role can't perform.
+   - labels: terse `+ Rental` / `+ Invoice` / `+ Customer` / `+ Unit`; icons `I.*`.
+2. Unit special: append **`+ Work Order`** only for `srcCard === 'units'` (create,
+   not link).
+**Verify:** add a `window.__rw` seam assertion in logic-test — `linkActionsFor`
+returns the right set per type and is empty/trimmed for low-tier roles.
+
+## Phase 3 — Surface actions in the R20 menu
+1. In `openCtxMenu`, resolve the record via `cardRecordAt(hit.el)`; if it resolves
+   and `linkActionsFor` is non-empty, render a **Link section** at the top
+   (`data-ctx="link:<target>"`), `menu-sep`, then the existing items.
+2. `runCtxAction`: handle `link:<target>` → `enterLinking(...)`;
+   `link:workOrder` on a unit → navigate to that unit's record (standard view).
+**Verify:** right-click each record type shows the correct actions; low-tier role
+(simulate via `currentRole`) hides + Invoice/+ Customer.
+
+## Phase 4 — Linking mode (state + banner + target-card behavior)
+1. `state.linking = { srcCard, srcId, srcType, targetCard }`; `enterLinking()` sets
+   it, navigates to `targetCard` in list+search (phone: flip active column), focuses
+   search, `render()`.
+2. **Banner** at the target card top while linking (hazard-stripe, `data-r`
+   stamped): *"Linking ‹src title› → pick a ‹target› (or +New)"* + Cancel (R18
+   ghost → clears `state.linking`).
+3. **Row tap interception:** in the click handler, if `state.linking` and the row's
+   card === `targetCard`, a row tap → `openLinkConfirm(targetRec)` instead of
+   navigating. Per-row `DROP_MATRIX` gate → invalid rows get `is-disabled` + a
+   reason toast on tap.
+4. **+New auto-flow:** when `state.linking` is active, the card's +New create path
+   routes the new record into `openLinkConfirm`.
+5. Clear linking on: confirm done, Cancel, Esc/back, dock nav away.
+**Verify:** action → lands on target card with banner + search; valid row →
+confirm; invalid dimmed; +New → confirm; Cancel/Esc clears.
+
+## Phase 5 — Confirmation popup
+1. `openLinkConfirm(targetRec)`: `openOverlay({kind:'linkConfirm', ...})`. Body names
+   both records; **invoice target → show customer-facing PRICE only** (compute via
+   the same path the mutation bills — `addRentalLineToInvoice`/`extensionPreview`
+   preview; **never** cost/floor — B2). Confirm = `actionPill` (R17, *green* when it
+   takes money else blue) / Cancel = `ghostPill` (R18).
+2. On confirm: `dispatchDrop({entity:srcCard, id:srcId, rec:srcRec}, {entity:targetCard, rec:targetRec})`
+   → reuses every hard gate + History log. Then `toast` + R19 `attnFlash` the new
+   pill; clear `state.linking`.
+3. **`WINDOW_CATALOG`** entry for `linkConfirm`.
+**Verify:** invoice confirm shows the right price; locked/cross-customer/double-bill
+blocked with a clear message; History entry written.
+
+## Phase 6 — Icons (de-emoji)
+1. Map the menu glyphs (cut/copy/paste/clear/search/globe/replace/comment/thread/
+   wrangler + the link/target icons) → Lucide names in `tools/gen-icons.mjs`; run it
+   (needs network; dev-time). Replace emoji in `openCtxMenu` with `I.*`.
+**Verify:** `node tools/gen-icons.mjs --check`; no emoji left in the menu markup.
+
+## Phase 7 — jactec-ui stamps + CI gates
+- `data-r` stamps on the banner + confirm popup; add `RULE_META`/`RB_*` rows if a
+  new rule is introduced; `node ci/gen-rule-usage.mjs` (regen); `WINDOW_CATALOG`
+  (`node ci/check-window-catalog.mjs`); `node tools/gen-code-map.mjs` (regen).
+- AA contrast, `:focus-visible`, reduced-motion on the banner/popup.
+
+## Phase 8 — Self-driven verification (the click-through Jac asked for)
+Playwright (#local) at phone + desktop, plus role simulation via `currentRole`:
+- long-press → menu actions correct per type & role; select → linking mode (banner,
+  search); tap valid target → confirm → link committed (assert the data link);
+  invalid target blocked; +New auto-flow; Cancel/Esc clears; desktop drag still
+  links (regression). Screenshots at each step for the handoff.
+- All five gates green.
+
+## Phase 9 — Ship
+- Bump the shared `?v=` cache token; commit per-phase; open a **draft** PR; the
+  `/role` audit is already on file in the spec. Drive the live deploy + on-device
+  check before marking ready.
+
+---
+
+## Delegation (model-triage)
+- **Main session (keep):** Phase 2 role gate + Phase 5 money/price + the `/role`
+  re-check — security/money, never delegate.
+- **Sonnet subagents (well-scoped):** Phase 1 drag removal, Phase 6 icon mapping,
+  Phase 4 banner/markup from this spec — settled contracts.
+- Phase 8 verification stays on main (it's the proof).
+
+## Resolve-at-build unknowns
+- Exact `tierRank` name for the customer-PII capability (+ Customer gate).
+- The cleanest invoice-price preview call for the confirm popup.
+- Whether `dispatchDrop` needs any tiny guard to run cleanly outside a live drag
+  (it takes plain payload/target objects — expected fine).

--- a/docs/superpowers/specs/2026-06-29-menu-driven-linking-design.md
+++ b/docs/superpowers/specs/2026-06-29-menu-driven-linking-design.md
@@ -12,7 +12,7 @@ long-press fought text-selection, the context-menu timer, and direction
 discrimination. After five rounds it still wasn't reliable on iOS.
 
 **Pivot (Jac):** replace the drag with a **guided, menu-driven linking flow** —
-long-press a record → pick an "Add to a …" action → land on the target card to
+long-press a record → pick a "+ ‹Target›" action → land on the target card to
 search → tap the target → confirm. It is explicit, discoverable, and reuses the
 real cards instead of fighting touch gestures.
 
@@ -41,16 +41,17 @@ gesture finesse, and money never added blindly.
 
 ## 4. Menu actions
 
-For the record's entity type `src`, list one **"Add to a ‹target›"** item per
-valid `target` in `DROP_MATRIX[src]`, in our voice:
+For the record's entity type `src`, list one **"+ ‹Target›"** item per valid
+`target` in `DROP_MATRIX[src]` — terse, matching the app's existing `+New` / R5b
+"+Thing" add language:
 
 | Source | Items (from DROP_MATRIX) |
 |---|---|
-| unit | **Add to a rental**, **Add to an invoice** (only when a billable open WO exists — the matrix gate), **+ Work Order** (§4a) |
-| rental | **Add a unit**, **Put on an invoice**, **Assign a customer** |
-| customer | **Start a rental**, **Add to an invoice** |
-| invoice | **Add a rental**, **Assign a customer**, **Add a unit**, **Add a work order** |
-| workOrder | **Put on an invoice** |
+| unit | **+ Rental**, **+ Invoice** (only when a billable open WO exists — the matrix gate), **+ Work Order** (§4a) |
+| rental | **+ Unit**, **+ Invoice**, **+ Customer** |
+| customer | **+ Rental**, **+ Invoice** |
+| invoice | **+ Rental**, **+ Customer**, **+ Unit**, **+ Work Order** |
+| workOrder | **+ Invoice** |
 
 - Items whose matrix gate is impossible *right now* for this specific source
   (e.g. unit→invoice with no billable WO) are **omitted** (not shown dead).
@@ -61,7 +62,7 @@ valid `target` in `DROP_MATRIX[src]`, in our voice:
 
 ## 5. Linking mode
 
-Selecting an "Add to a ‹target›" action:
+Selecting a "+ ‹Target›" action:
 
 1. Sets transient `state.linking = { srcCard, srcId, srcType, targetCard }`.
 2. Navigates to `targetCard` in **list + search** mode (search focused), on phone

--- a/docs/superpowers/specs/2026-06-29-menu-driven-linking-design.md
+++ b/docs/superpowers/specs/2026-06-29-menu-driven-linking-design.md
@@ -55,6 +55,13 @@ For the record's entity type `src`, list one **"+ ‹Target›"** item per valid
 
 - Items whose matrix gate is impossible *right now* for this specific source
   (e.g. unit→invoice with no billable WO) are **omitted** (not shown dead).
+- **🔴 Role-authority gate (from the `/role` audit).** `DROP_MATRIX` encodes data
+  *validity*, NOT *who may act*. The action list is `DROP_MATRIX[src]` **∩ the
+  acting role's capability**: **+ Invoice** (money, Tier 2) shows only for
+  Office/Owner; **+ Customer** only for roles entitled to customer PII
+  (Sales/Office/Owner — not Dispatcher/Mechanic/Driver); operational links stay
+  within each role's tier. The mutation **re-checks authority server-side** — the
+  menu omission is UX, not the security boundary.
 - **§4a — unit "+Work Order":** a WO is *created for* a unit, not linked to an
   existing one, so this is **not** the search-link flow. It navigates straight to
   that unit's record (standard view) where WO creation already lives. (Only on a
@@ -87,7 +94,9 @@ A new catalogued popup (`WINDOW_CATALOG` entry; `data-r` stamped):
 - Title/body: *"Add ‹unit Beacon› to ‹rental 6/29–7/2›?"* naming both records.
 - **Money:** for **Add to an invoice**, show the **price impact** — the rental/
   line/WO amount that will be billed (pulled from the same pricing the mutation
-  uses) — so money is never added blindly.
+  uses) — so money is never added blindly. **🔴 Show the customer-facing PRICE
+  only — never cost / Bottom Dollar / Ask / ROI / part-cost** (margin floors are
+  radioactive on any shared/over-the-shoulder surface; `/role` step-3 hard-fail).
 - Buttons: **Confirm** (R17 — *green* when it takes money, *blue* otherwise) /
   **Cancel** (R18 ghost).
 - On confirm: call the **existing `dispatchDrop(payload, target)`** path so every
@@ -123,17 +132,35 @@ are deleted; the mouse path is unchanged.
 - New UI elements (Link menu items, linking banner, confirm popup) are emitted
   through builders / stamped `data-r`; the banner uses the **hazard-stripe** motif
   (active, attention) per the yard data-plate language.
+- **🔴 Icons: library glyphs only (no emoji).** The live R20 menu currently uses
+  emoji (✂️📋🔎🤠…) — an icon-rule violation. New linking items use `I.*` (Lucide,
+  via `icons.js`); migrate the existing emoji items to library glyphs in the same
+  pass (or, at minimum, never add more emoji).
 - New popup → **`WINDOW_CATALOG`** entry (CI-enforced).
 - `rule-usage.js` regenerated; `code-map` regenerated; AA contrast + focus +
   reduced-motion respected.
 
-## 10. Roles / data-sensitivity (pre-build `/role` audit)
+## 10. Roles / data-sensitivity — `/role` audit results (2026-06-29)
 
-- **Add to an invoice** = money → confirm shows price; mutation keeps all §7.5/§7.6
-  money gates. The audit must confirm no margin/cost leak in the confirm popup
-  (show *price*, never cost/bottom-dollar) and that customer-isolation gates hold
-  server-consistently.
-- Linking actions must respect role authority (who can bill / assign customers).
+Audit run against the full R20 menu + the new linking actions. Findings folded in:
+
+**🔴 Blockers (binding):**
+- **B1 — role-authority gate (§4):** action list = `DROP_MATRIX[src]` ∩ acting
+  role's capability; **+ Invoice** Office/Owner-only (Tier 2 money), **+ Customer**
+  PII-entitled roles only. Mutation re-checks **server-side**.
+- **B2 — confirm popup shows PRICE only (§6):** never cost / Bottom Dollar / Ask /
+  ROI / part-cost (radioactive margin floors).
+
+**🟡 Gaps (address in build):**
+- Cut/Clear/Replace must inherit each field's write-gate (route through
+  `startInlineEdit`, don't bypass).
+- Every link (esp. + Invoice) auto-writes an attributed History entry (reuse
+  `dispatchDrop` logging — verify).
+- "Ask Mr. Wrangler" must not ship margin/PII context for low-tier roles.
+
+**✅ Clears:** Search/Global Search (read-only); Add Comment/Start chat (internal);
+`dispatchDrop` reuse keeps §7.5/§7.6 locked/customer-scoping/double-bill gates; not
+a customer-facing surface (no T7 portal isolation), provided B2 holds.
 
 ## 11. Verification
 

--- a/docs/superpowers/specs/2026-06-29-menu-driven-linking-design.md
+++ b/docs/superpowers/specs/2026-06-29-menu-driven-linking-design.md
@@ -1,0 +1,154 @@
+# Menu-driven record linking — design
+
+**Date:** 2026-06-29
+**Status:** Design (awaiting review) → `/role` audit → implementation plan
+**Supersedes (mobile):** the drag-to-link gesture on phones (#408–#413, the
+`2026-06-23-mobile-drag-zip-zones` direction). Desktop drag stays.
+
+## 1. Problem & goal
+
+Drag-to-link never became usable on a phone: a row is wall-to-wall pills, the
+long-press fought text-selection, the context-menu timer, and direction
+discrimination. After five rounds it still wasn't reliable on iOS.
+
+**Pivot (Jac):** replace the drag with a **guided, menu-driven linking flow** —
+long-press a record → pick an "Add to a …" action → land on the target card to
+search → tap the target → confirm. It is explicit, discoverable, and reuses the
+real cards instead of fighting touch gestures.
+
+**Success:** on a phone (and desktop), a user can link any record to a valid
+target in: long-press → tap action → search/tap target → confirm — with no
+gesture finesse, and money never added blindly.
+
+## 2. Scope (settled with Jac)
+
+- **Mobile drag: removed entirely.** Rip out the `is-phone` drag arming, phone
+  touch-drag path, and phone-only zip-zones. Desktop **mouse** drag stays.
+- **Menu linking actions: both platforms.** Desktop keeps drag *and* gains the
+  menu actions; phone is menu-only.
+- **Actions auto-derived from `DROP_MATRIX`** so they never drift from the rules.
+- **Creates happen on the destination card** via its existing **+New** (no
+  separate create flow), EXCEPT the unit **+Work Order** shortcut (§4).
+- **`/role` audit runs before build** ("Add to an invoice" touches money).
+
+## 3. Entry & gesture
+
+- **Phone:** a long-press opens the R20 context menu (reverses #412's
+  `armMenuTimer` no-op). No drag arming on `is-phone`.
+- **Desktop:** unchanged — right-click opens the menu; mouse drag still links.
+- The R20 menu (`openCtxMenu`) gains a **Link section** above the existing
+  Cut/Copy/Search/Comment block, separated by a `menu-sep`.
+
+## 4. Menu actions
+
+For the record's entity type `src`, list one **"Add to a ‹target›"** item per
+valid `target` in `DROP_MATRIX[src]`, in our voice:
+
+| Source | Items (from DROP_MATRIX) |
+|---|---|
+| unit | **Add to a rental**, **Add to an invoice** (only when a billable open WO exists — the matrix gate), **+ Work Order** (§4a) |
+| rental | **Add a unit**, **Put on an invoice**, **Assign a customer** |
+| customer | **Start a rental**, **Add to an invoice** |
+| invoice | **Add a rental**, **Assign a customer**, **Add a unit**, **Add a work order** |
+| workOrder | **Put on an invoice** |
+
+- Items whose matrix gate is impossible *right now* for this specific source
+  (e.g. unit→invoice with no billable WO) are **omitted** (not shown dead).
+- **§4a — unit "+Work Order":** a WO is *created for* a unit, not linked to an
+  existing one, so this is **not** the search-link flow. It navigates straight to
+  that unit's record (standard view) where WO creation already lives. (Only on a
+  unit's menu.)
+
+## 5. Linking mode
+
+Selecting an "Add to a ‹target›" action:
+
+1. Sets transient `state.linking = { srcCard, srcId, srcType, targetCard }`.
+2. Navigates to `targetCard` in **list + search** mode (search focused), on phone
+   flips the active column to it.
+3. Renders a **hazard-stripe banner** at the card top (new UI, `data-r` stamped):
+   *"Linking ‹source title› → pick a ‹target› (or +New)"* with a **Cancel**
+   (R18 ghost) that clears `state.linking`.
+4. **Row behavior in linking mode:** tapping a target row opens the **confirm
+   popup** (§6) instead of navigating into the record. Rows failing the
+   `DROP_MATRIX[src][target]` gate are **dimmed**; tapping one shows the reason
+   (toast) and does not proceed.
+5. **+New auto-flow:** the card's existing **+New** creates a fresh target record
+   and immediately routes it into the confirm popup (create → confirm → link, one
+   flow).
+6. Linking mode is cleared by: confirm-complete, Cancel, Esc/back, or navigating
+   away via the dock.
+
+## 6. Confirmation popup
+
+A new catalogued popup (`WINDOW_CATALOG` entry; `data-r` stamped):
+
+- Title/body: *"Add ‹unit Beacon› to ‹rental 6/29–7/2›?"* naming both records.
+- **Money:** for **Add to an invoice**, show the **price impact** — the rental/
+  line/WO amount that will be billed (pulled from the same pricing the mutation
+  uses) — so money is never added blindly.
+- Buttons: **Confirm** (R17 — *green* when it takes money, *blue* otherwise) /
+  **Cancel** (R18 ghost).
+- On confirm: call the **existing `dispatchDrop(payload, target)`** path so every
+  hard gate re-fires server-consistently (locked invoice, customer-scoping,
+  double-bill, blacklist, overbooking). Then toast + R19-flash the new pill, and
+  clear `state.linking`.
+
+## 7. Reuse & isolation
+
+- **Mutations:** no new linking logic — build a `{entity,id,rec}` payload + a
+  `{entity,rec}` target and hand them to `dispatchDrop`, which already owns all
+  links and gates. (One small refactor: ensure `dispatchDrop` is callable outside
+  a drag — it already takes plain payload/target objects.)
+- **Action derivation:** a single `linkActionsFor(srcCard, rec)` reads
+  `DROP_MATRIX` + per-pair gates → the menu item list. One source of truth.
+- **Banner + confirm popup:** small, self-contained; keyed off `state.linking`.
+
+## 8. Drag cleanup (mobile)
+
+Remove, gated on `is-phone`:
+- the `is-phone` branch in `dragDown` (#408),
+- the `armMenuTimer` no-op (#412) — the menu fires on phone again,
+- phone touch-arming in `dragDown`/`dragMove` and the `ghostLift`/pickup haptic
+  is desktop-only now,
+- phone-only **zip-zones** (`buildZipZones`, `phoneDragEdge`) and the
+  `.is-phone .grid .row/.card` selection-suppression (#411) if no longer needed.
+
+Keep desktop mouse drag + its ghost untouched. Net: the touch drag engine paths
+are deleted; the mouse path is unchanged.
+
+## 9. Design language (jactec-ui)
+
+- New UI elements (Link menu items, linking banner, confirm popup) are emitted
+  through builders / stamped `data-r`; the banner uses the **hazard-stripe** motif
+  (active, attention) per the yard data-plate language.
+- New popup → **`WINDOW_CATALOG`** entry (CI-enforced).
+- `rule-usage.js` regenerated; `code-map` regenerated; AA contrast + focus +
+  reduced-motion respected.
+
+## 10. Roles / data-sensitivity (pre-build `/role` audit)
+
+- **Add to an invoice** = money → confirm shows price; mutation keeps all §7.5/§7.6
+  money gates. The audit must confirm no margin/cost leak in the confirm popup
+  (show *price*, never cost/bottom-dollar) and that customer-isolation gates hold
+  server-consistently.
+- Linking actions must respect role authority (who can bill / assign customers).
+
+## 11. Verification
+
+- Phone-context (390×844, hasTouch) + desktop Playwright: long-press → menu shows
+  the correct derived actions per type; selecting one enters linking mode (banner,
+  search); tapping a valid target opens confirm; confirm runs the link; invalid
+  targets are blocked with a reason; +New auto-flows; Cancel/Esc clears.
+- Money: add-to-invoice confirm shows the right amount; gates block locked/
+  cross-customer/double-bill.
+- Regression: desktop drag still links; the rest of the R20 menu unchanged.
+- Gates: smoke, logic-test, gen-rule-usage --check, check-window-catalog,
+  gen-code-map --check.
+
+## 12. Out of scope (YAGNI)
+
+- No multi-select / batch linking.
+- No new link *types* beyond `DROP_MATRIX`.
+- No reordering / removing the existing menu items (Cut/Copy/etc.).
+- Desktop drag is not removed or changed.

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629a" />
+  <link rel="stylesheet" href="style.css?v=20260629b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629a"></script>
-  <script type="module" src="app.js?v=20260629a"></script>
+  <script src="rule-usage.js?v=20260629b"></script>
+  <script type="module" src="app.js?v=20260629b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629e" />
+  <link rel="stylesheet" href="style.css?v=20260629f" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629e"></script>
-  <script type="module" src="app.js?v=20260629e"></script>
+  <script src="rule-usage.js?v=20260629f"></script>
+  <script type="module" src="app.js?v=20260629f"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629b" />
+  <link rel="stylesheet" href="style.css?v=20260629c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629b"></script>
-  <script type="module" src="app.js?v=20260629b"></script>
+  <script src="rule-usage.js?v=20260629c"></script>
+  <script type="module" src="app.js?v=20260629c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260628f" />
+  <link rel="stylesheet" href="style.css?v=20260629a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260628f"></script>
-  <script type="module" src="app.js?v=20260628f"></script>
+  <script src="rule-usage.js?v=20260629a"></script>
+  <script type="module" src="app.js?v=20260629a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629d" />
+  <link rel="stylesheet" href="style.css?v=20260629e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629d"></script>
-  <script type="module" src="app.js?v=20260629d"></script>
+  <script src="rule-usage.js?v=20260629e"></script>
+  <script type="module" src="app.js?v=20260629e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260629c" />
+  <link rel="stylesheet" href="style.css?v=20260629d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260629c"></script>
-  <script type="module" src="app.js?v=20260629c"></script>
+  <script src="rule-usage.js?v=20260629d"></script>
+  <script type="module" src="app.js?v=20260629d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2738,6 +2738,7 @@ input[type="number"] { -moz-appearance: textfield; appearance: textfield; }
 .ctx-menu::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 6px; background: repeating-linear-gradient(180deg, var(--yellow) 0 11px, #14181d 11px 22px); }
 .ctx-menu .dd-item { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 10px; border-radius: 8px; background: none; border: none; color: var(--txt); font: inherit; font-size: 12.5px; font-weight: 600; cursor: pointer; text-align: left; }
 .ctx-menu .dd-item:hover { background: var(--panel-2); }
+.ctx-menu .dd-item svg { width: 15px; height: 15px; flex: 0 0 auto; }   /* §17b — library glyphs on the link actions (sized to match the row) */
 .ctx-menu .menu-sep { height: 1px; background: var(--line); margin: 4px 0; }
 
 /* +Work Order on the Units card — floats alone, centered, no card backing (Jac 2026-06-12) */
@@ -3007,6 +3008,23 @@ body { font-variant-numeric: tabular-nums; }
   .drag-ghost { animation: ghostLift .16s ease-out; }
   @keyframes ghostLift { from { scale: .66; opacity: 0; } to { scale: 1; opacity: 1; } }
 }
+/* §17b — LINKING MODE banner: hi-vis hazard stripe as plate CHROME (left cap), the
+   prompt itself on a calm steel field (simple-on-complex). Stamped sub-label in Saira. */
+.link-banner { display: flex; align-items: center; gap: 10px; margin: 0 0 8px; padding: 9px 12px 9px 16px;
+  border: 1px solid var(--accent-line); border-radius: 12px; background: linear-gradient(180deg, #1b2129, #0c0e11);
+  position: relative; overflow: hidden; }
+.link-banner::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 6px;
+  background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 8px, #14181d 8px 16px); }
+.link-banner .lb-txt { flex: 1; min-width: 0; font-size: 12.5px; color: var(--txt); }
+.link-banner .lb-txt b { color: var(--accent); font-weight: 700; }
+.link-banner .lb-sub { color: var(--txt-3); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 11px; margin-left: 5px; }
+/* §17b — link confirm popup body */
+.lc-body { padding: 4px 2px 2px; }
+.lc-line { font-size: 13.5px; color: var(--txt); line-height: 1.5; }
+.lc-line b { color: var(--accent); font-weight: 700; }
+.lc-price { margin-top: 10px; font-size: 13px; color: var(--txt); }
+.lc-price b { color: var(--green); font-weight: 700; }
+.lc-price.muted { color: var(--txt-3); }
 /* §M2 ZIP ZONES (phone) — edge rails of valid drop-target cards during a drag. Steel
    data-plate tabs with a per-card hazard stripe (the ONLY colour — a transient drag
    overlay, so the one-orange rule holds for persistent UI). Drag onto one to jump to

--- a/style.css
+++ b/style.css
@@ -2998,6 +2998,15 @@ body { font-variant-numeric: tabular-nums; }
 .drag-ghost { position: fixed; left: 0; top: 0; z-index: 9500; display: flex; align-items: center; gap: 7px; max-width: 240px; padding: 7px 12px; border-radius: 999px; background: var(--panel); border: 1px solid var(--accent); box-shadow: 0 0 0 2px var(--accent-line), 0 14px 34px -10px rgba(0,0,0,.65); color: var(--accent); font-size: 12.5px; font-weight: 700; pointer-events: none; will-change: transform; }
 .drag-ghost svg { width: 14px; height: 14px; flex: 0 0 auto; }
 .drag-ghost .dg-t { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+/* §M-touch — PICKUP CUE: the ghost chip POPS in the instant a drag lifts, so the user
+   SEES they've "got it" (the critical signal on iOS, which has no Vibration API; the
+   haptic in startDrag covers Android). Animate `scale` + `opacity` only — the JS engine
+   owns the `transform` (translate) every frame, so animating transform would fight it;
+   `scale` is an independent property that composes with it. Reduced-motion → steady. */
+@media (prefers-reduced-motion: no-preference) {
+  .drag-ghost { animation: ghostLift .16s ease-out; }
+  @keyframes ghostLift { from { scale: .66; opacity: 0; } to { scale: 1; opacity: 1; } }
+}
 /* §M2 ZIP ZONES (phone) — edge rails of valid drop-target cards during a drag. Steel
    data-plate tabs with a per-card hazard stripe (the ONLY colour — a transient drag
    overlay, so the one-orange rule holds for persistent UI). Drag onto one to jump to

--- a/style.css
+++ b/style.css
@@ -3052,6 +3052,19 @@ body.dragging .row.drop-ok { opacity: 1; }
    (touch-action must be in place BEFORE the gesture starts; once lifted, the
    engine's passive:false touchmove guard keeps the browser pan from firing) */
 .row { touch-action: pan-y; }
+/* iOS Safari: a touch-and-hold on text starts native text-selection + the callout
+   (the highlight + magnifier), which STEALS the gesture before the §M3 long-press can
+   arm the record drag (Jac, 2026-06-29 — "iphone keeps highlighting text instead of
+   long pressing"). Suppress selection + the callout on the phone grid's draggable
+   surfaces so the hold reaches the drag engine. Inputs / inline-edit fields re-enable
+   selection just below, so typing and editing still work. */
+.is-phone .grid .row, .is-phone .grid .card {
+  -webkit-user-select: none; user-select: none; -webkit-touch-callout: none;
+}
+.is-phone .grid input, .is-phone .grid textarea, .is-phone .grid [contenteditable],
+.is-phone .grid .inline-edit, .is-phone .grid .inline-input {
+  -webkit-user-select: text; user-select: text; -webkit-touch-callout: default;
+}
 /* settings overlay — the Allow-overbooking R14 toggle rides the row's right edge */
 .set-row .seg { margin-left: auto; }
 


### PR DESCRIPTION
## What & why

Replaces drag-to-link on mobile with a **guided, menu-driven linking flow** (the pivot from this session). Long-press a record → pick a **"+ Target"** action → land on that card to search → tap the target → **confirm**. Spec + `/role` audit + plan are in `docs/superpowers/`.

## The flow

1. **Long-press** (phone) / **right-click** (desktop) a record → the R20 menu now carries **"+ Target"** link actions.
2. Actions are **auto-derived from `DROP_MATRIX`** and **role-gated**: a unit → *+ Rental*, *+ Invoice* (only with a billable WO), *+ Work Order*; a rental → *+ Unit / + Invoice / + Customer*; etc. **+ Invoice / + Customer gate on `canMoney()`** (Office/Owner) — staff get only operational links.
3. Selecting one → **linking mode**: navigates to the target card (phone flips the column), shows a **hazard-stripe banner** (*"Linking ‹X› → pick a ‹Y› (or +New) · Cancel"*).
4. **Tap a target** → **confirm popup** naming both records; for invoice links it shows the **price** (never cost/margin — `/role` B2). Confirm runs the existing **`dispatchDrop`**, reusing every §7.5/§7.6 hard gate + History.
5. Unit **+ Work Order** just jumps to the unit (a WO is created there).

Mobile drag is **retired** (desktop mouse-drag kept). The menu uses **library icons** on the new items.

## Verification (real CDP touch + mouse)

- **Desktop 8/8** — menu actions per type; + Rental → banner → pick → confirm → unit↔rental link committed; **mechanic (staff) hides + Invoice/+ Customer**, keeps + Rental.
- **Phone 5/5** — long-press → menu → + Rental → column flips with banner → tap rental → confirm → link committed. No page errors.
- Screenshot-verified menu / banner / confirm read on-brand.
- Gates: `smoke` · `logic-test` **400/400** · `gen-rule-usage --check` · `check-window-catalog` (31 kinds incl. `linkConfirm`) · `gen-code-map --check`. Cache token → `20260629f`.

## Deferred (calling these out)

- **+New auto-flow:** you chose "auto-flow into confirm." Shipped behavior today is **+New creates, then tap it** to link (one extra tap; the banner still reads "or +New"). The auto-flow hook across each entity's create path is a fast follow.
- **Legacy menu emoji:** the *new* link items use library glyphs; de-emojifying the existing Cut/Copy/… items needs `gen-icons` (network, not a CI gate) — follow-up.

Built spec → `/role` audit → jactec-ui review → plan → phased build, all on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01961vQPLR3KBNfaC5qNu45P)_