### PR TITLE
Linking: +New auto-links the source on create

### DIFF
--- a/app.js
+++ b/app.js
@@ -12016,6 +12016,18 @@ function doLinkConfirm() {
   if (!srcRec || !tgtRec) return;
   dispatchDrop({ entity: o.srcCard, id: o.srcId, rec: srcRec }, { entity: o.targetCard, rec: tgtRec });   // reuses every hard gate + History; toasts its own failures
 }
+/* §17b — +New AUTO-LINK: tapping +New on the target card while linking creates the
+   record AND links the source straight to it — no confirm tap (creating it IS the
+   intent; "auto-linked as the details open", Jac). Called at the end of each immediate
+   create path (rental/invoice/unit); a no-op unless we're linking to that target. The
+   create fn already anchored/opened the new record, so dispatchDrop just adds the link. */
+function maybeAutoLink(targetCard, newId) {
+  const L = state.linking; if (!L || L.targetCard !== targetCard) return;
+  const srcRec = recOf(L.srcCard, L.srcId), tgtRec = recOf(targetCard, newId);
+  state.linking = null;
+  if (!srcRec || !tgtRec) return;
+  dispatchDrop({ entity: L.srcCard, id: L.srcId, rec: srcRec }, { entity: targetCard, rec: tgtRec });   // reuses every hard gate + History
+}
 
 /** §M-touch — haptic reinforcement for a COMMITTED gesture (one pulse, never on
  *  scroll/hover). Best-effort: Android/Chrome only — iOS Safari has no Vibration
@@ -14229,6 +14241,7 @@ function quickAddUnitFromSearch(value) {
   const cs = activeSession().cards.units; cs.search = ''; cs.filterTerms = [];
   openStandard('units', id);
   toast(`${name} added — set its category, hours, and inspection.`);
+  maybeAutoLink('units', id);   // §17b — if a "+ Unit" link was in progress, link the source to this new unit
   return true;
 }
 function nextCategoryId() {
@@ -15064,6 +15077,7 @@ function startNewInvoice(customerId) {
   if (!cust) { const s = activeSession(); if (s.cols) s.cols.right = 'customers'; }
   toast(cust ? `New invoice for ${cust.name} — drag rentals onto it.` : 'New invoice — drag a customer and rentals onto it.');
   render();
+  maybeAutoLink('invoices', id);   // §17b — if a "+ Invoice" link was in progress, bill the source onto this new invoice
 }
 
 function startNewRental(customerId) {
@@ -15080,6 +15094,7 @@ function startNewRental(customerId) {
   const s = activeSession(); if (s.cols) { s.cols.left = 'units'; s.cols.right = 'customers'; }
   toast(cust ? `New Quote for ${cust.name} — drag a unit onto it, then pick the window.` : 'New Quote — drag a unit and a customer onto it, then pick the window.');
   render();
+  maybeAutoLink('rentals', id);   // §17b — if a "+ Rental" link was in progress, link the source to this new Quote
 }
 
 /* ── Wave 2 (Jac 2026-06-12): pick mode is DEAD. Linking happens by DRAG (§15c

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16774 lines, 38 chapters
+## app.js — 16789 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 11475–11744 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
 | APP-31 | 11745–11869 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, initTooltip, hideTip, toast |
 | APP-32 | 11870–11873 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11874–13459 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+50) |
-| APP-34 | 13460–14387 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14388–15426 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15427–15873 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 15874–15876 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 15877–16774 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 11874–13471 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 13472–14400 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14401–15441 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15442–15888 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 15889–15891 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 15892–16789 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260630c" />
+  <link rel="stylesheet" href="style.css?v=20260630d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260630c"></script>
-  <script type="module" src="app.js?v=20260630c"></script>
+  <script src="rule-usage.js?v=20260630d"></script>
+  <script type="module" src="app.js?v=20260630d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What & why

The fast-follow you approved. While in linking mode, tapping **+New** on the target card now creates the record **and links the source straight to it** — *"auto-linked as the details open"* — instead of "create it, then tap it."

Example: long-press a unit → **+ Rental** → on the rentals card tap **+ New Rental** → the new Quote opens with that unit already on it.

## How

A small `maybeAutoLink(targetCard, newId)` runs at the end of each **immediate** create path (`startNewRental` / `startNewInvoice` / `quickAddUnitFromSearch`). If we're in linking mode for that target, it calls the existing **`dispatchDrop`** (source → new record) — reusing every §7.5/§7.6 gate + History. **No confirm popup** for the +New path (creating it *is* the confirmation). It's a no-op unless linking to that target, so normal +New is unaffected. Tapping an *existing* target still opens the confirm.

(Customer +New opens a deferred overlay, so it stays "create then tap" for now — the immediate creates cover the common cases.)

## Verification

- Unit → + Rental → **+ New Rental**: new Quote created, **unit auto-linked**, no confirm popup, linking mode cleared — **5/5**.
- Existing-target confirm flow unchanged — **8/8**.
- Gates: `smoke` · `logic-test` **400/400** · `gen-rule-usage --check` · `check-window-catalog` · `gen-code-map --check`. Cache token → `20260630d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01961vQPLR3KBNfaC5qNu45P)_