### PR TITLE
Design system: pill/button/text rulebook (R0–R25 update)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -33,7 +33,7 @@ colors:
   text-3: "#6b7480"
   track: "#22262e"
   # — Status registry: each hue means ONE thing everywhere
-  ready: "#34d399"               # green  — ready / active
+  ready: "#358a5d"               # green  — ready / active (muted: "done" stays quiet)
   caution: "#ffe000"             # yellow — caution
   danger: "#ff1040"              # red    — danger / overdue / failed
   link: "#5b9dff"               # blue   — link / commit action

--- a/docs/superpowers/specs/2026-06-30-pill-text-rulebook-focal-designation.md
+++ b/docs/superpowers/specs/2026-06-30-pill-text-rulebook-focal-designation.md
@@ -1,0 +1,73 @@
+# Focal-Primary Designation — LOCKED (2026-06-30)
+
+Companion to `2026-06-30-pill-text-rulebook-spec.md`. One focal Primary per container (Jac-designated). Everything else Secondary; flags & quiet links Ghost. Urgency = color + motion, never tier promotion.
+
+## Global rules (emerged during designation — apply everywhere)
+- **G1 · Commit buttons ramp.** A blue commit/primary action (Complete WO, Complete Rental, Complete Service, Pay/Charge, etc.) is **Secondary (not-yet-actionable) until its preconditions are met, then promotes to Primary blue.**
+- **G2 · Bottleneck-only in multi-line.** Inside a multi-line section (e.g. WO part/task lines), **only the bottleneck line is Primary**; sibling lines are Secondary.
+
+## Scope change
+- **Remove the Rentals "Blocker" section** — colors now carry warnings; the dedicated red "X not ready" bar is retired.
+
+## Rows
+| Row | Focal Primary |
+|---|---|
+| Units | Inspection status |
+| Rentals | Rental-status gate |
+| Customers | Pay / account status |
+| Invoices | Invoice status |
+| Categories | Rentable / Total |
+| Shop · WO | Phase (bottleneck) status |
+| Shop · Service | Service-urgency status |
+| Shop · Inspection | Result status |
+
+## Units detail
+| Section | Focal Primary |
+|---|---|
+| Yard Tool | **Rental status** |
+| Inspection | **"Resume / finish inspection" action** |
+| Work Orders | **Bottleneck phase** (G2; Complete WO per G1) |
+| GPS | GPS status |
+| Investment | Fleet-status gate |
+
+## Rentals detail
+| Section | Focal Primary |
+|---|---|
+| Header | Rental-status gate |
+| Blocker | **REMOVED** (retire the section) |
+| Calendar | **Selected window** |
+| Unit rows | **Per-unit status gate** |
+| Transport rail | **Transport-type toggle** |
+| Footer | none until every unit = No Show / Cancelled / Returned → then **Complete** = Primary (G1) |
+
+## Customers detail
+| Section | Focal Primary |
+|---|---|
+| Account | Account-type status |
+| Funnels | Primary funnel gate |
+| Cards on File | +Add Card / default card |
+
+## Invoices detail
+| Section | Focal Primary |
+|---|---|
+| Header | Pay / Charge action (G1) |
+| Line Items | ⏸ **REVISIT** (deferred by Jac) |
+
+## Shop bodies
+| Body | Focal Primary |
+|---|---|
+| Work Order | Bottleneck phase (G2; Complete WO per G1) |
+| Inspection | "Resume / finish inspection" action |
+| Service | Service-urgency status (Complete Service per G1) |
+
+## Mini-cards & calendars
+| Container | Focal Primary |
+|---|---|
+| Member / mini card | Headline status (mirrors its row) |
+| Title chip (R10) | none — identity only |
+| KPI ring tile | **no change** (leave as-is) |
+| Rental window calendar | Selected window |
+| Date-search calendar | Selected date |
+
+## Deferred to attack next
+- Invoices · Line Items (#24)

--- a/docs/superpowers/specs/2026-06-30-pill-text-rulebook-spec.md
+++ b/docs/superpowers/specs/2026-06-30-pill-text-rulebook-spec.md
@@ -1,0 +1,98 @@
+# Pill / Button / Text Rulebook — App-Wide Application Spec
+
+**Goal:** apply the new tier/color/text/motion rulebook to the *real app* (→ `area/design-system` → staging). **Textures are NOT part of this.**
+
+**The cascade principle:** every visible element comes from one stamped builder (R0–R25). So we decide the treatment **once per builder**, and it lands on every instance — rows, detail sections, mini-cards, calendars, popups, boards — automatically. No per-screen decisions needed beyond the builder map below.
+
+---
+
+## Part A — The rules (decide once)
+
+**A1 · Tiers (visual weight).**
+- **Primary** — the one state/action the user advances on a surface. Solid fill, white ink. Red/yellow = hazard-striped (lighter charcoal `#14181d`). Parent-record icon. Chevron if it opens a menu.
+- **Secondary** — supporting status/action. Outline, colored text (R/Y/G). Red/yellow = striped border (matches primary stripe). Parent icon. Hover → solid border.
+- **Ghost / flag** — low-emphasis state, flag, or link. Parent icon + colored text, underline on hover; red/yellow = hazard underline.
+- **Add** — create/link a record. Solid **blue** border (secondary style), `+Thing`.
+- **Disabled** — checkerboard.
+
+**A2 · Color = meaning (unchanged registry, one muting).** green = ready/done **(muted `#358a5d`, stays quiet — "nothing to do")** · yellow = caution/attention · red = danger/overdue · blue = commit/link/reserved · purple = scheduled/member · orange = ignition/selected/linked. White ink on green & yellow primaries.
+
+**A3 · Type scale.** Title (record name) · Section (section header) · Label (field label) · Body (content) · Small (caption). Maps to the existing Saira-stamped / Geist-body split — no new fonts.
+
+**A4 · Motion by date-proximity.** Any date-bearing element: **today = stripes scroll + glow-behind · ±1 day = scroll · 3+ days = static.** Respects reduced-motion.
+
+**A5 · Icon = parent record's icon** on every status element and ghost link (unit category, customer person, invoice, WO wrench, etc.).
+
+**A6 · One focal Primary per container (THE tier rule).** Exactly one **focal element** per *section / list-row / mini-card / mini-calendar* is **Primary** — the single status the user advances **or** the one action to take there (status OR action, whichever the container exists for; designated per container). Every other interactive element is **Secondary**; flags & quiet links are **Ghost**. A detail view therefore has *multiple* Primaries (one per section) — that's correct. Read-only badges that merely report are **never** the focal slot → Secondary. **Urgency is shown by color + motion, never by promoting something to Primary** (an overdue/No-Card exception glows/scrolls in place; it does not steal the focal slot). The calendar's focal Primary = the **today cell** (or the selected date).
+
+---
+
+## Part B — Builder → treatment map (THE cascade table)
+
+This is the whole spec in one table. Change each builder once → it cascades everywhere.
+
+| R | Builder | Today | New treatment | Motion? |
+|---|---|---|---|---|
+| **R1** | `gatePill` (advance dropdown — rental/WO/fleet/invoice/funnel/bill status) | status-color pill + chevron | **PRIMARY** — solid, white ink, status color, striped red/yellow, chevron, parent icon | ✅ when date-bound (On Rent→due, Late, etc.) |
+| **R3** | `statusPill` (read-only status badge) | colored fill pill | **SECONDARY** — outline + colored text + parent icon | ✅ when date-bound |
+| **R3b** | `badge` (plain fact "480 HRS") | gray chip | *unchanged* (facts aren't status) | — |
+| **R4 / R4b** | `dPill` (derived pill riding parent) | ink+icon | *unchanged*; parent icon; R4b pulse → **glow-behind** | ✅ (R4b) |
+| **R2** | `refPill` (linked record) | orange outline | *unchanged* — keep the "orange = linked" law (NOT folded into R/Y/G) | — |
+| **R5b** | `addBtn(link/line)` | **blue dashed** | **ADD** — **solid** blue border | — |
+| **R5c** | `addBtn()` (empty field) | gray dashed | *unchanged* (it's a field, not an action) | — |
+| **R6** | `reqBtn` (required) | white loud | *unchanged* | — |
+| **R7** | `linkName` (hyperlink) | blue italic underline | **GHOST-link** — parent icon + text + underline (folds flags & links into one ghost look) | — |
+| **R8** | `kv({derived})` | italic | **Body/Small** italic (type scale) | — |
+| **R9 / R9b** | `flagEl` (title flags) | mini stacked flags | **GHOST/flag** — parent icon + colored text; red/yellow hazard underline; R9b pulse → **glow-behind** | ✅ date flags (Starts Today, Returning Today, Overdue) |
+| **R10** | `.c-titlecard` | dark chip | **Title** type; record icon | — |
+| **R11** | `.section` | status-tinted header+border | header = **Section** type; border = status color (muted green) | — |
+| **R12** | `notesSection` | boxless | **Body** type | — |
+| **R13** | `historySection` | count chips + log | chips = **Secondary**; links = **Ghost**; Label/Small type | — |
+| **R14** | `segCtl` (3-state toggle: condition/wash/transport) | segmented | selected segment = **Primary color fill**; others quiet | — |
+| **R15** | `yardToolHtml` (journey) | timeline nodes | nodes = add/ghost; status color per node; **Section/Label** text | ✅ a node due today |
+| **R16** | `winPickerEl` (rental calendar) | month grid | **today cell glows; in-window = status color; selected = orange; unavailable = red** | ✅ today cell |
+| **R17** | `actionPill` (commit/money/danger) | blue/green/red | the prominent action = **PRIMARY** (intent color, solid); danger red = striped + motion when urgent; lesser actions = Secondary | ✅ urgent danger |
+| **R18** | `ghostPill` (quiet action) | muted | **GHOST** (no parent icon — it's an action, not a record) | — |
+| **R22** | `dateField` (date picker) | calendar | today cell glows; same calendar treatment as R16 | ✅ today cell |
+| **R24** | `closeX` | red ✕ | *unchanged* | — |
+| **R25** | sync banner | red hazard cap | *unchanged* (already the signature) | — |
+
+R0 (lint), R19 (attn-flash), R20 (ctx menu), R21 (file-drop), R23 (tooltip) — **no change**.
+
+---
+
+## Part C — Applied per surface (verification the table covers everything)
+
+**List rows (every card):** headline status (R1/R3) → Primary/Secondary; flags (R9) → ghost; refs (R2) → orange; facts (R3b) → gray; date-bound overdue/late → motion. *Covered by R1/R3/R9/R3b/R2.*
+
+**Units detail:** Yard tool (R15), Condition/Wash (R14), WO sections (R1 gates→Primary, R5b adds, R17 actions), Specs/GPS/Investment (R5c/R8/R3→Secondary, R1 fleet gate→Primary), Notes (R12), History (R13). *Covered.*
+
+**Rentals detail:** Status gate (R1→Primary), Customer/Invoice pills (R2 orange), balance (R8), calendar (R16 motion), unit rows (R2/R4/R8), transport rail (R15/R14), Complete/Cancel (R17 Primary/danger), notes/history. *Covered.*
+
+**Customers detail:** account fields (R5c), account-type/agreement status (R3→Secondary), PO/protection facts (R3b), funnel gates (R1→Primary), cards-on-file (R3/R17), activity chart (no rule — left as-is), notes/history. *Covered.*
+
+**Invoices detail:** status gate (R1→Primary), customer link (R2), line links (R7→ghost), totals (R8), pay/charge/refund (R17 money/danger), notes/history. *Covered.*
+
+**Shop (WO / Service / Inspection):** phase gates (R1→Primary, striped when red/yellow + motion on ETA), flags (R9 ghost), adds (R5b), Complete/Cancel (R17), inspection result (R3→Secondary or R14 toggle), bill-customer gate (R1→Primary), service countdown (R8 + motion when due). *Covered.*
+
+**Mini / member cards (R10 + abbreviated):** title chip = Title; the one headline status = Primary; rest Secondary/ghost. *Covered by tier rules.*
+
+**Calendars (R16 window + R22 date picker):** today glow, in-window status color, selected orange, unavailable red, near-term scroll. *Covered.*
+
+**KPI ring tiles:** band color keeps registry; ≥95% halo stays; Label type. *Covered (color/type only).*
+
+**Back-office boards (Parts/Vendors/Expenses/Files):** same builders → inherit automatically. *Covered.*
+
+---
+
+## Part D — Decisions (LOCKED 2026-06-30)
+
+1. **Tier rule = one focal Primary per container** (A6). Focal = the status the user advances **or** the one action — designated per container. All other interactive = Secondary; flags & quiet links = Ghost. Multiple Primaries across a detail view (one per section) is correct.
+2. **Read-only status (R3)** = **Secondary outline** by default; it's only Primary when it IS the section's designated focal element.
+3. **Motion = full** — date-proximity motion runs in **rows AND detail** (overdue/late, service-due, payment-due, scheduled follow-ups, and date flags like Starts/Returning Today).
+4. **Hyperlinks stay separate** — R7 hyperlinks remain blue-italic-underline; **only R9 flags** adopt the ghost look. (No fold.)
+5. **Urgency = color + motion, never tier promotion.** **Calendar focal = today cell.** **Green muted** (`#358a5d`); white ink on green/yellow Primary; red/yellow striped with charcoal `#14181d`; Secondary stripe matches Primary; striped Secondary → solid border on hover.
+
+## Part E — Delivery
+
+Updated **R-Rulebook (R0–R25)** = builders re-treated per Part B + `RULE_META` / `RB_FOUNDATION` / `RB_TABS` text refreshed + `rule-usage.js` regenerated + admin Rulebook overlay updated. Branch **`area/design-system`** → CI gates green (`smoke`, `logic-test`, `gen-rule-usage --check`, `check-window-catalog`, `check-design-md`, code-map) → **`staging`** → **`main`**. Textures/skinner excluded.

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@
   --txt: #e9edf4; --txt-2: #a7afbc; --txt-3: #6b7480; --track: #22262e; --on-orange: #1a1205;
 
   /* status colors (base = text/border tone, -bg = soft fill) */
-  --green:#34d399;  --green-bg:rgba(52,211,153,.14);
+  --green:#358a5d;  --green-bg:rgba(53,138,93,.14);
   --yellow:#ffe000; --yellow-bg:rgba(255,224,0,.15);
   --red:#ff1040;    --red-bg:rgba(255,16,64,.18);
   --blue:#5b9dff;   --blue-bg:rgba(91,157,255,.14);

--- a/style.css
+++ b/style.css
@@ -992,6 +992,32 @@ select.lf-in { appearance: none; cursor: pointer; }
   height: 22px;
 }
 
+/* ══ R-Rulebook v2 TIERS (spec 2026-06-30) — ONE focal Primary per container ══
+   PRIMARY = R1 gate + any .focal status → solid fill, white ink, hazard-striped
+   red/yellow. SECONDARY = R3 status NOT .focal → outline (soft fill dropped).
+   ADD (R5b) = solid blue border. G1 commit buttons ramp via .ramp/.ramp.ready.
+   Urgency stays color + (Phase-2) motion — it never promotes tier. Scoped by
+   data-r / class so R2 refs, R3b badges, R4 derived pills are untouched. */
+.pill.gate, .pill.focal { border-color: transparent; color: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.3), inset 0 1px 0 rgba(255,255,255,.18); }
+.pill.gate.c-green,  .pill.focal.c-green  { background: var(--green); }
+.pill.gate.c-blue,   .pill.focal.c-blue   { background: var(--blue); }
+.pill.gate.c-navy,   .pill.focal.c-navy   { background: var(--navy); }
+.pill.gate.c-purple, .pill.focal.c-purple { background: var(--purple); }
+.pill.gate.c-pink,   .pill.focal.c-pink   { background: var(--pink); }
+.pill.gate.c-brown,  .pill.focal.c-brown  { background: var(--brown); }
+.pill.gate.c-gray,   .pill.focal.c-gray   { background: var(--gray); }
+.pill.gate.c-orange, .pill.focal.c-orange { background: var(--orange); color: var(--on-orange); }
+.pill.gate.c-red,    .pill.focal.c-red    { background: repeating-linear-gradient(135deg, var(--red) 0 11px, #14181d 11px 22px); text-shadow: 0 1px 2px rgba(0,0,0,.75); }
+.pill.gate.c-yellow, .pill.focal.c-yellow { background: repeating-linear-gradient(135deg, var(--yellow) 0 11px, #14181d 11px 22px); text-shadow: 0 1px 2px rgba(0,0,0,.85); }
+.pill.gate .chev, .pill.gate svg { opacity: .92; }
+/* SECONDARY — read-only status not designated the container's focal element */
+.pill[data-r="R3"]:not(.focal) { background: transparent; box-shadow: none; }
+/* ADD (R5b) — solid blue border (was dashed) */
+.add-field.anchor { border-style: solid; }
+/* G1 — commit/blue-action buttons ramp: Secondary until preconditions met (.ready) */
+.pill.ramp:not(.ready) { background: transparent; color: var(--txt-3); border-color: var(--line); box-shadow: none; }
+.pill.ramp.ready { background: var(--blue); color: #fff; border-color: transparent; }
+
 /* ── Standard mode (§0.2 / §12) ──────────────────────────────────────────── */
 .detail { padding: 12px; display: flex; flex-direction: column; gap: 12px; }
 .detail-head { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }


### PR DESCRIPTION
Implements the locked pill/button/text rulebook spec (`docs/superpowers/specs/2026-06-30-pill-text-rulebook-spec.md`) into the canonical **R-Rulebook (R0–R25)**, for `area/design-system` → `staging` → `main`. **Textures/skinner are NOT part of this** (separate branch).

## Plan (phased)
- **Phase 1 — colors + tiers + parent icons** (this PR). Review on staging.
- **Phase 2 — date-proximity motion** (follow-up).

## Spec (locked)
- One **focal Primary** per section / row / mini-card / mini-calendar (status the user advances *or* the one action); everything else **Secondary**; flags & quiet links **Ghost**.
- Read-only status (R3) = Secondary outline unless it's the focal element.
- Urgency = **color + motion, never tier promotion**.
- **Green muted** (`#358a5d`); white ink on green/yellow Primary; red/yellow hazard-striped (charcoal `#14181d`); Secondary stripe matches Primary, → solid on hover.
- Hyperlinks (R7) stay blue-italic; only flags (R9) go Ghost.

## Progress
- [x] Spec committed as the design record
- [x] **Phase 1a:** muted-green token (cascades to every status pill/row/flag/ring) + DESIGN.md synced
- [ ] Phase 1b: tier treatments (R1 Primary / R3 Secondary / R9 Ghost / R5b solid-blue add) + focal designation per container
- [ ] Phase 1c: confirm parent icons across surfaces (statusPill already emits the parent-card icon)
- [ ] `RULE_META` / `RB_FOUNDATION` / `RB_TABS` text + rule-usage regen + admin overlay

CI gates run locally and green so far (`gen-rule-usage --check`, `check-window-catalog`, `check-design-md`, code-map). Browser gates (`smoke`, `logic-test`) run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015m3Fn3n7sgeVLgS5oGcw98)_