### PR TITLE
Unmute the login intro audio on Saddle Up

### DIFF
--- a/app.js
+++ b/app.js
@@ -16459,7 +16459,9 @@ async function attemptLogin() {
   const btn = document.getElementById('login-go'); if (btn) { btn.textContent = 'Signing in…'; btn.disabled = true; }
   // Roll the Mr. Wrangler intro behind the box while the (slow) backend load runs — a little entertainment for the wait.
   const screen = document.querySelector('.login-screen'); if (screen) screen.classList.add('signing-in');
-  const vid = document.getElementById('login-video'); if (vid) { try { const p = vid.play(); if (p && p.catch) p.catch(() => {}); } catch (e) {} }
+  // The Saddle Up click is a genuine user gesture, so unmuting here lets the intro's
+  // audio play under the browser's autoplay policy (a muted-only clip would stay silent).
+  const vid = document.getElementById('login-video'); if (vid) { try { vid.muted = false; const p = vid.play(); if (p && p.catch) p.catch(() => {}); } catch (e) {} }
   try {
     // Ask the backend for the role. The role-aware backend returns it; an older
     // backend (pre-roles) replies "unknown action" → we proceed without a role

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16921 lines, 38 chapters
+## app.js — 16923 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -45,7 +45,7 @@
 | APP-35 | 14533–15573 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
 | APP-36 | 15574–16020 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
 | APP-37 | 16021–16023 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16024–16921 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-38 | 16024–16923 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260702b" />
+  <link rel="stylesheet" href="style.css?v=20260702c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260702b"></script>
-  <script type="module" src="app.js?v=20260702b"></script>
+  <script src="rule-usage.js?v=20260702c"></script>
+  <script type="module" src="app.js?v=20260702c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What changed

Follow-up to #439. The login intro video was muted; this lets it play **with sound**.

- **`app.js` (`attemptLogin`)** — set `vid.muted = false` right where `vid.play()` already fires. Clicking **Saddle Up?** is a genuine user-activation gesture, so playing audio there is permitted under the browser autoplay policy (a muted-only clip would stay silent). The new clip carries a real audio track (`soun` handler + AAC), so this produces actual sound.
- **`index.html`** — bumped the shared `?v=` cache token (`20260702b` → `20260702c`) so the change loads immediately.
- **`docs/code-map.generated.md`** — regenerated (the 2 added lines shifted downstream chapter line numbers; Code-Atlas drift guard).

### Behavior notes
- Audio plays during the sign-in *wait* (while the backend loads) and stops when login completes and the login screen tears down — so on a fast login it's a brief clip. Accepted tradeoff per Jac.
- It plays out loud on every login.

## Verification

All gates pass locally:

- `node ci/smoke.mjs` → boots clean, login renders ✅
- `node ci/logic-test.mjs` → 400/400 ✅
- `node ci/gen-rule-usage.mjs --check` → current ✅
- `node ci/check-window-catalog.mjs` → current ✅
- `node tools/gen-code-map.mjs --check` → current (regenerated) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHNJwtwpXfo2ysr4ZrMuyd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHNJwtwpXfo2ysr4ZrMuyd)_