### PR TITLE
Card header redesign — design spec (one-row header + gear options + Custom Views)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6808,13 +6808,15 @@ function columnEl(col, session) {
   // stamp the VIEW identity (list vs which record) so render() keys scroll memory by it
   const cs = card.dataset.card && session.cards ? session.cards[card.dataset.card] : null;
   card.dataset.view = (cs && cs.mode === 'standard' && cs.recId != null) ? `${cs.recType || ''}:${cs.recId}` : 'list';
-  if (!document.body.classList.contains('is-phone')) card.insertBefore(colTabsEl(col, active, session), card.firstChild);   // toggles live INSIDE the card top on desktop; on phones they move to the footer dock (§M1)
-  // Desktop: freeze the search/sort bar out of the scroll too — a full-width card
-  // header so the card-body scrollbar runs ONLY through the list below it, never in
-  // a gutter alongside the bar (the "funny" gap). On phones render() relocates the bar to the bottom dock instead.
+  // Desktop: ONE header row (Jac 2026-07-03) — merge the toggle with the list search/sort
+  // bar so a card opens at one row. List mode (there IS a .listbar) → wrap both in a .hrow;
+  // record mode (no listbar) → the toggle row rides alone above the card-head. On phones the
+  // toggle lives in the footer dock and render() relocates the .listbar there (§M1).
   if (!document.body.classList.contains('is-phone')) {
-    const lb = card.querySelector('.card-body .listbar'), body = card.querySelector('.card-body');
-    if (lb && body) card.insertBefore(lb, body);
+    const tab = colTabsEl(col, active, session);
+    const lb = card.querySelector('.card-body .listbar');
+    if (lb) { const hrow = el('div', 'hrow'); hrow.appendChild(tab); hrow.appendChild(lb); card.insertBefore(hrow, card.firstChild); }
+    else card.insertBefore(tab, card.firstChild);
   }
   wrap.appendChild(card);
   return wrap;
@@ -6932,15 +6934,12 @@ function listView(cardDef, session) {
   const cascChip = cascaded ? `<span class="casc-chip" data-tip="Cascaded from ${esc(anchorName)} — clear to browse all & add">🔗<span class="cc-name">${esc(anchorName)}</span>${closeX('js-uncascade', { data: { card } })}</span>` : '';
   bar.innerHTML = `
     ${cardJog(card, cs)}
-    <button class="bv-btn js-cardgraph${cs.graphView ? ' on' : ''}" data-card="${card}" data-tip="${cs.graphView ? 'Back to list' : 'Graph view'}">${I.graph}</button>
     <div class="mini-searchwrap${cterms.length || cascChip ? ' has-terms' : ''}${cs.search.trim() || cterms.length ? ' has-query' : ''}">
       ${cascChip}${cterms.map((ft, i) => filterTermPill(ft, i, card)).join('')}
       <input class="mini-search" placeholder="${cterms.length ? 'Add filter — Enter to pin…' : `Search ${esc(cardDef.title.toLowerCase())}…`}" value="${esc(cs.search)}" data-card="${card}" />
     </div>
-    ${(cs.graphView && gvSortHidden(card)) ? '' : `<div class="sort">
-      <button class="sortbtn js-sortmenu${av ? ' viewing' : ''}" data-card="${card}" data-tip="Views &amp; sort">${esc(av ? av.name : curField.label)} ${I.chev}</button>
-      <button class="dir js-sortdir" data-card="${card}"><span class="${cs.sort.dir === 'asc' ? 'on' : ''}">▲</span><span class="${cs.sort.dir === 'desc' ? 'on' : ''}">▼</span></button>
-    </div>`}`;
+    <button class="sortdir js-sortdir" data-card="${card}" data-tip="Sort direction" aria-label="Sort direction"><span class="${cs.sort.dir === 'asc' ? 'on' : ''}">▲</span><span class="${cs.sort.dir === 'desc' ? 'on' : ''}">▼</span></button>
+    <button class="gear js-cardgear" data-card="${card}" data-tip="Options" aria-label="Options">${I.sliders}</button>`;
   wrap.appendChild(bar);
   // §13.4 — Graph carousel: an interactive panel ABOVE the list (the list renders below,
   // filtered by the chart's g-tagged search terms). Legacy cards still full-replace the list.

--- a/app.js
+++ b/app.js
@@ -6859,6 +6859,59 @@ function colActionsHtml(active, session) {
   const dt = ec === 'shop' ? ` data-type="${esc(cs.recType)}"` : '';
   return `<div class="c-actions"><button class="hbtn js-tolist" data-tip="${anchored ? 'Browse list (pick another to anchor)' : 'Back to list'}">${I.list}</button><button class="hbtn js-anchor" data-rec="${esc(cs.recId)}"${dt} data-tip="Anchor (⊞)">${I.circle}</button><button class="hbtn js-newtab" data-rec="${esc(cs.recId)}"${dt} data-tip="New tab (+)">${I.plus}</button></div>`;
 }
+/* CARD OPTIONS (phase 3 · card-header redesign — Jac 2026-07-03).
+   Per-card default quick-filter "options" that drop from the gear (Row 2). Each is
+   { id, label, tier, combo?, test(rec) } — a one-tap filter applied OVER the already
+   role-scoped list (it only narrows, never widens — §16). `tier` gates who sees the option
+   (phase 7): 'money' → Office/Owner, 'crm' → Sales/Marketing/Office/Owner, 'ops' → anyone
+   who sees the card. Predicates REUSE the authoritative derivations — never re-derive.
+   `combo` marks a composite (a union of states), rendered with a dashed border. */
+const unitRentalNow = (u) => activeRentalForUnit(u.unitId);
+const unitIsOut = (u) => { const r = unitRentalNow(u); if (!r) return false; const eu = unitEntry(r, u.unitId); return OUT_RENTAL_STATUSES.has(eu ? unitStatus(r, eu) : r.status); };
+const unitAvailableNow = (u) => u.fleetStatus === 'Active' && u.inspectionStatus === 'Ready' && !unitRentalNow(u);   // canonical availability (§16): excludes Failed/Not Ready/For Sale/Inactive/Sold/out
+const unitWhen = (u, when) => { const r = unitRentalNow(u); return !!r && rentalRevStatus(r) === when; };
+const CARD_OPTIONS = {
+  rentals: [
+    { id: 'today',    label: 'Today',    tier: 'ops',   test: (r) => rentalRevStatus(r) === 'Today' },
+    { id: 'tomorrow', label: 'Tomorrow', tier: 'ops',   test: (r) => rentalRevStatus(r) === 'Tomorrow' },
+    { id: 'reserved', label: 'Reserved', tier: 'ops',   test: (r) => rentalDisplayStatus(r) === 'Reserved' },
+    { id: 'onrent',   label: 'On Rent',  tier: 'ops',   test: (r) => rentalDisplayStatus(r) === 'On Rent' },
+    { id: 'endrent',  label: 'End Rent', tier: 'ops',   test: (r) => rentalDisplayStatus(r) === 'End Rent' },
+    { id: 'bill',     label: 'Bill',     tier: 'money', combo: true, test: (r) => {   // ∑ overdue · unpaid · quotes · off rent · billing issues
+        const ds = rentalDisplayStatus(r);
+        if (r.status === 'Quote' || ds === 'Off Rent') return true;
+        if (OUT_RENTAL_STATUSES.has(ds) && r.endDate && r.endDate < TODAY_ISO) return true;   // still out past its end date
+        const c = IDX.customer.get(r.customerId); return !!c && (c.payStatus === 'Unpaid' || c.payStatus === 'Partial');
+      } },
+  ],
+  units: [
+    { id: 'notready',  label: 'Not Ready', tier: 'ops', test: (u) => u.inspectionStatus === 'Not Ready' },
+    { id: 'failed',    label: 'Failed',    tier: 'ops', test: (u) => u.inspectionStatus === 'Failed' },
+    { id: 'available', label: 'Available', tier: 'ops', test: (u) => unitAvailableNow(u) },
+    { id: 'today',     label: 'Today',     tier: 'ops', test: (u) => unitWhen(u, 'Today') },
+    { id: 'tomorrow',  label: 'Tomorrow',  tier: 'ops', test: (u) => unitWhen(u, 'Tomorrow') },
+    { id: 'reserved',  label: 'Reserved',  tier: 'ops', test: (u) => { const r = unitRentalNow(u); return !!r && rentalDisplayStatus(r) === 'Reserved'; } },
+    { id: 'out',       label: 'Out',       tier: 'ops', combo: true, test: (u) => unitIsOut(u) },   // ∑ On Rent · End Rent · Off Rent
+  ],
+  customers: [
+    { id: 'active',       label: 'Active',        tier: 'ops',   test: (c) => (c._digest?.activePct || 0) > 0 },
+    { id: 'lost',         label: 'Lost',          tier: 'crm',   test: (c) => (c._digest?.activePct || 0) <= 0 && (c._digest?.totalPaid || 0) > 0 },   // former customer, now inactive
+    { id: 'memberfunnel', label: 'Member Funnel', tier: 'crm',   test: (c) => !!c.membershipStage && c.membershipStage !== 'N/A' },
+    { id: 'usedfunnel',   label: 'Used Funnel',   tier: 'crm',   test: (c) => !!c.usedSalesStage && c.usedSalesStage !== 'N/A' },   // used-equipment sales pipeline
+    { id: 'members',      label: 'Members',       tier: 'ops',   test: (c) => /Member/.test(c.accountType || '') && c.accountType !== 'Member Incomplete' },
+    { id: 'business',     label: 'Business',      tier: 'ops',   test: (c) => /^Business/.test(c.accountType || '') },
+    { id: 'nonbusiness',  label: 'Non-Business',  tier: 'ops',   test: (c) => /^Non-Business/.test(c.accountType || '') },
+    { id: 'unpaid',       label: 'Unpaid',        tier: 'money', test: (c) => c.payStatus === 'Unpaid' },
+  ],
+  invoices: [
+    { id: 'notdue',      label: 'Not Due',     tier: 'money', test: (i) => invoiceTotals(i).status === 'Not Due' },
+    { id: 'unpaid',      label: 'Unpaid',      tier: 'money', test: (i) => invoiceTotals(i).status === 'Unpaid' },
+    { id: 'late',        label: 'Late',        tier: 'money', test: (i) => /^Late/.test(invoiceTotals(i).status) },   // Late · Late+30/60/90
+    { id: 'partial',     label: 'Partial',     tier: 'money', test: (i) => invoiceTotals(i).status === 'Partial' },
+    { id: 'refunded',    label: 'Refunded',    tier: 'money', test: (i) => invoiceTotals(i).status === 'Refunded' },
+    { id: 'collections', label: 'Collections', tier: 'money', test: (i) => invoiceTotals(i).status === 'Collections' },
+  ],
+};
 function memberCardEl(member, session) {
   if (member === 'calendar') return calendarCardEl(session);
   if (member === 'shop') return shopCardEl({ id: 'shop', title: 'Shop' }, session);   // the wrench "Shop" member = the COMBINED view (segment bar + 3-bar front-page graph), no forcedSeg

--- a/app.js
+++ b/app.js
@@ -6833,7 +6833,7 @@ function colTabButtonsHtml(col, active, session) {
   // "Shop" toggle that opens the shop graph; the old Service-heart toggle + Not-Ready
   // chip are absorbed into it (the graph's Services + Not Ready bars).
   const coltabBtn = (m, on, { alert = false, count = null } = {}) =>
-    `<button class="coltab js-coltab${on ? ' on' : ''}${alert ? ' alert' : ''}" data-col="${col.id}" data-member="${m}" data-tip="${esc(MEMBER_TITLE[m] || m)}${alert ? ' — needs attention' : ''}">`
+    `<button class="coltab js-coltab${on ? ' on' : ''}${alert ? ' alert' : ''}" data-col="${col.id}" data-member="${m}" aria-label="${esc(MEMBER_TITLE[m] || m)}" data-tip="${esc(MEMBER_TITLE[m] || m)}${alert ? ' — needs attention' : ''}">`
       + `<span class="ct-ico">${memberIcon(m)}</span>`
       + `<span class="ct-lbl">${esc(MEMBER_TITLE[m] || m)}</span>`
       + (count != null ? `<span class="ct-n">${count}</span>` : '')

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16914 lines, 38 chapters
+## app.js — 16913 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -25,27 +25,27 @@
 | APP-15 | 5117–5313 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
 | APP-16 | 5314–6647 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
 | APP-17 | 6648–6742 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6743–7024 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 7025–7218 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 7219–7342 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7343–7507 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7508–7717 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7718–8539 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
-| APP-24 | 8540–8645 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8646–9091 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 9092–10028 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10029–10124 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 10125–10540 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
-| APP-29 | 10541–11591 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 11592–11861 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11862–11992 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 11993–11996 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11997–13596 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 13597–14525 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14526–15566 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15567–16013 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16014–16016 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16017–16914 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-18 | 6743–7023 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 7024–7217 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 7218–7341 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7342–7506 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7507–7716 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7717–8538 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
+| APP-24 | 8539–8644 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8645–9090 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 9091–10027 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 10028–10123 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 10124–10539 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10540–11590 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 11591–11860 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11861–11991 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 11992–11995 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 11996–13595 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 13596–14524 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14525–15565 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15566–16012 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 16013–16015 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 16016–16913 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16913 lines, 38 chapters
+## app.js — 16966 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -25,27 +25,27 @@
 | APP-15 | 5117–5313 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
 | APP-16 | 5314–6647 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
 | APP-17 | 6648–6742 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6743–7023 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 7024–7217 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 7218–7341 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7342–7506 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7507–7716 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7717–8538 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
-| APP-24 | 8539–8644 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8645–9090 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 9091–10027 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10028–10123 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 10124–10539 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
-| APP-29 | 10540–11590 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 11591–11860 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11861–11991 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 11992–11995 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 11996–13595 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 13596–14524 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14525–15565 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15566–16012 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16013–16015 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16016–16913 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-18 | 6743–7076 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, unitRentalNow, unitIsOut, …(+8) |
+| APP-19 | 7077–7270 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 7271–7394 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7395–7559 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7560–7769 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7770–8591 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
+| APP-24 | 8592–8697 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8698–9143 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 9144–10080 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 10081–10176 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 10177–10592 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10593–11643 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 11644–11913 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11914–12044 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 12045–12048 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 12049–13648 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 13649–14577 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14578–15618 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15619–16065 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 16066–16068 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 16069–16966 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/superpowers/plans/2026-07-03-card-header-redesign-plan.md
+++ b/docs/superpowers/plans/2026-07-03-card-header-redesign-plan.md
@@ -1,0 +1,140 @@
+# Card header redesign — implementation plan
+
+**Spec:** `docs/superpowers/specs/2026-07-03-card-header-redesign-design.md`
+(approved, `/role`-audited). Build on `claude/wrangler-dashboard-space-h2nu0i`.
+Front-end only — `app.js`, `config.js`, `style.css`. No backend.
+
+**Real hooks already in the code (verified):**
+- Toggle: `colTabsEl` (app.js 6822), `colTabButtonsHtml` (6831), `memberIcon`
+  (6755); toggle inserted at card top on desktop (6811).
+- List surface: `listView` (6917), `listbar` (6926), graph `bv-btn`
+  `js-cardgraph` (6935); `listFor(card, session)` (6651) + `unitsVisible(...)` =
+  the **already role-scoped** row source.
+- Sort/views: `SORT_FIELDS[card]` (config.js 397), `openViewMenu` (11831),
+  `loadViews`/`saveViews` (11794).
+- Derivations (reuse, don't re-implement): `unitStatus` (231), `invoiceTotals`
+  (1609), `rentalDisplayStatus` (1641), the Today/Tomorrow display derivation
+  (config note near `rentalStatus`).
+- R20 menu: `openCtxMenu` (4334), `openCtxMenuAt` (4363), `runCtxAction` (4398).
+- Role gate: `roleTier` (13438), `tierRank`, `canMoney` (14550 =
+  `!currentRole || roleTier(currentRole) >= tierRank('money')`), `adminUnlocked`
+  (13454); `currentRole` (15295), `currentUser`.
+- Per-operator key pattern: `commentUserKey = () => currentUser || currentRole ||
+  'me'` (5556) — reuse for personal custom-view storage.
+- Icons: `I.*` (`icons.js`) + `tools/gen-icons.mjs`; status registry
+  `RAW_STATUS` (config.js 50).
+
+Each phase ends green on `node ci/smoke.mjs` + `node ci/logic-test.mjs`
+(port-swap to 9147 first) and a local `serve.mjs` drive at desktop + phone
+(390×844). R-rulebook: new stamped elements get `data-r`, regen `rule-usage.js`;
+new popups get `WINDOW_CATALOG` entries.
+
+> **Sibling change (not in this plan):** the KPI-ring compaction (~14 px) that,
+> with this header merge (~38 px/card), realizes the full ~66 px. Tracked by the
+> space mockup; land it separately.
+
+---
+
+## Phase 1 — Icon-first toggle (isolated, visual)
+1. `colTabButtonsHtml` (6831): keep icon + count on every member; render `.ct-lbl`
+   **only** on the active member. Alert ring (Shop) unchanged.
+2. `style.css`: `.coltab:not(.on) .ct-lbl { display: none }` (desktop **and**
+   phone — drop the `max-width:74px` truncation at 476, no longer needed on
+   inactive). Keep the active label full.
+**Verify:** only the selected member spells its name; counts persist; toggle stays
+short with 3 members (Units/Categories/Shop). Smoke green; local drive.
+
+## Phase 2 — Row 1: one row (toggle + search fills gap + inline ▲▼ + gear)
+1. Merge the toggle row and the top of `listbar` into one flex `.hrow`: toggle
+   (from `colTabsEl`) · search field (`mini-searchwrap`/`mini-search`, `flex:1`) ·
+   sort **direction** ▲▼ inline at the search's right edge · a new **gear** button.
+2. Move the sort ▲▼ out of the `.sort` chip; drop the `.sort .dir` border-left
+   seam. Remove the sort **field** chip and the graph button from their current
+   `listbar` spots (field → Phase 5 menu; graph → Phase 4 Row 2).
+3. `style.css`: `.hrow` layout; search `flex:1 1 auto`; `.gear` icon button
+   (`data-r`); ▲▼ inline, minimal padding, no divider.
+**Verify:** resting state is ONE row; search filters; ▲▼ flips asc/desc; gear
+present (toggles an empty Row 2 for now). Smoke green; local drive.
+
+## Phase 3 — Config: default options + composites + tier (pure data)
+1. `config.js`: `CARD_OPTIONS[card] = [{ id, label, tier, predicate }]` for
+   rentals · units · customers · invoices (per spec §6). `tier` drives Phase 4
+   role-gating.
+2. Predicates **reuse the authoritative helpers** — never re-derive:
+   - Rentals: `rentalDisplayStatus` for Today/Tomorrow/Reserved/On Rent/End Rent;
+     **Bill ∑** = predicate over `rentalStatus` + linked-invoice `invoiceTotals`
+     (overdue ∪ unpaid ∪ Quote ∪ Off Rent ∪ billing issue).
+   - Units: `unitStatus` for **Out ∑** {On Rent, End Rent, Off Rent};
+     inspection/fleet for Not Ready/Failed; **Available** = canonical availability
+     (Active AND not out AND not Failed/Not Ready/For Sale/Inactive/Sold — §16);
+     Today/Tomorrow/Reserved from the unit's linked rental derivation.
+   - Customers: account-type/pay-status/funnel for Active/Lost/Members/Business/
+     Non-Business/Unpaid; **Member Funnel** vs **Used Funnel** (used-equipment
+     sales pipeline — confirm/define the sales-stage field, §10 note).
+   - Invoices: `invoiceTotals().status` for Not Due/Unpaid/Late/Partial/Refunded/
+     Collections.
+**Verify:** logic-test seam — each predicate filters a sample set correctly, esp.
+composites (Bill/Out) and Available (a Failed unit is NOT Available).
+
+## Phase 4 — Row 2: gear → options row (multi-select, role-gated, graph, ⋯)
+1. Gear toggles `session.cards[card].optionsOpen`. Render Row 2: the entitled
+   `CARD_OPTIONS[card]` as **text** buttons + the graph `bv-btn` (moved here) + a
+   **⋯** button. All `data-r` stamped.
+2. **Role gate at render (§16):** show an option only if the role may see its
+   tier — money-state (`tier:'money'`) → `canMoney()`; funnel/CRM
+   (`tier:'crm'`) → sales-tier (`roleTier(currentRole) >= tierRank('sales')` —
+   confirm rank); maintenance/availability → shop/fleet/owner. Built entitled from
+   the start, never role-blind.
+3. **Multi-select filter:** `session.cards[card].activeOptions` (a Set); tapping
+   toggles membership + `render()`. In `listView`, AND every active option's
+   predicate over the **already role-scoped** rows (`listFor`/`unitsVisible`
+   output) — never a raw list. Composites contribute their union as one term.
+4. `style.css`: Row 2 desktop **truncates** to card width (no scrollbar in the
+   3-col grid); mobile `overflow-x:auto` scroll. Active option = orange + dark ink.
+**Verify:** gear toggles Row 2; options AND-filter; graph still toggles graph
+view; low-tier `currentRole` hides money/funnel options; desktop truncation vs
+mobile scroll. Smoke + logic green; regen `rule-usage.js`.
+
+## Phase 5 — Sort field: right-click ▲▼ → sort-only menu
+1. Right-click / long-press the ▲▼ → a dropdown listing **all** `SORT_FIELDS[card]`
+   and nothing else (via `openCtxMenuAt` or a dedicated `openDropdown`). Pick →
+   set `cs.sort.field` + `render()`.
+2. Retire the **Sort** section of `openViewMenu` (Views + per-card filter sections
+   handled in Phase 6 / as options). `WINDOW_CATALOG` entry for the sort menu.
+**Verify:** right-click ▲▼ shows only sort fields; picking re-sorts; no other menu
+content. Smoke green; `check-window-catalog` green.
+
+## Phase 6 — Row 3: personal Custom Views + create/remove + icon picker
+1. ⋯ toggles `customOpen` → Row 3 renders the operator's custom views (icon +
+   label, `data-r`). A `+ New` affordance at the end.
+2. **Personal storage:** extend `loadViews`/`saveViews` to key by operator (reuse
+   the `commentUserKey()` pattern), add an `icon` field; per-view
+   `{ name, search, terms, sort, icon }`. Clear/namespace on logout so a shared
+   terminal doesn't leak (§16).
+3. **Create:** right-click the search bar → `openCtxMenu` item **"+ View"**
+   (captures current search + `filterTerms` + `sort`) → **icon-picker popup**
+   (grid of `I.*` library icons — never hand-drawn) → name → save → Row 3.
+   `WINDOW_CATALOG` entry for the picker.
+4. **Remove:** right-click a custom-view button → **"Remove View."** Long-press on
+   mobile for both.
+5. Applying a custom view sets search + terms + sort together; its predicate runs
+   over the role-scoped list (§16).
+**Verify:** +View → picker → view appears → applies its saved query; Remove View;
+switch operator (`currentUser`) → different set (isolation). Smoke + logic +
+`gen-rule-usage --check` + `check-window-catalog` green; local drive desktop +
+phone (long-press).
+
+## Phase 7 — Cleanup, gates, self-critique
+1. Fully retire `openViewMenu` (11831): Views → Row 3, Sort → Phase 5, per-card
+   filters (e.g. invoices `payMethod`) → an option or the ⋯ overflow. Remove dead
+   `.sort`/`listbar` CSS the merge orphaned.
+2. **Role-projection + isolation verification:** simulate `currentRole` at each
+   tier → assert money/funnel options absent for operational roles; assert filters
+   never widen (run over `listFor`/`unitsVisible`); confirm views are per-operator.
+3. Run ALL gates: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
+   `node ci/gen-rule-usage.mjs --check`, `node ci/check-window-catalog.mjs`,
+   `node tools/gen-code-map.mjs --check`. Zero R0 flash-lint.
+4. jactec-ui self-critique screenshot pass (dark + light + yard); anti-slop
+   checklist; confirm one-row-at-rest reclaim.
+**Verify:** all gates green; screenshots attached; ready for the area-level local
+test → continue-or-archive fork.

--- a/docs/superpowers/plans/2026-07-03-card-header-redesign-plan.md
+++ b/docs/superpowers/plans/2026-07-03-card-header-redesign-plan.md
@@ -35,6 +35,34 @@ new popups get `WINDOW_CATALOG` entries.
 
 ---
 
+## Progress — 2026-07-03 (paused after phase 3, awaiting Jac's local drive)
+
+Shipped on `claude/wrangler-dashboard-space-h2nu0i` (PR #447), **all no-browser gates
+green**; NOT yet driven in a browser (built in a cloud session — Jac verifies locally
+before phase 4):
+- **Phase 1 ✅** icon-first toggle — `colTabButtonsHtml` + `aria-label`, `style.css`
+  `.coltab:not(.on) .ct-lbl { display:none }`.
+- **Phase 2 ✅** one-row header — `columnEl` wraps toggle + listbar in `.hrow`; listbar =
+  search (fills) + inline ▲▼ + gear (`I.sliders`). Graph + sort-field chip **removed from
+  the row** (graph → phase 4, sort field → phase 5). Gear is an **inert placeholder**
+  (`js-cardgear`, no handler yet).
+- **Phase 3 ✅** `CARD_OPTIONS` map in **app.js** (not config.js — predicates need app
+  helpers). Per-card `{ id, label, tier, combo, test }`; composites Bill/Out; Available =
+  canonical availability. Pure data, unused until phase 4.
+
+**Next → Phase 4:** gear toggles `session.cards[card].optionsOpen`; render Row 2 from the
+**entitled** `CARD_OPTIONS[card]` (role-gate by `tier`: `money`→`canMoney()`, `crm`→sales
+tier, `ops`→all) as text buttons + the graph `bv-btn` moved here + a `⋯`; `activeOptions`
+Set → AND-filter over the already role-scoped list (`listFor`/`unitsVisible`) in `listView`;
+desktop truncates, mobile scrolls; wire the `js-cardgear` click.
+
+**Notes for next session:** gear icon is Lucide `sliders` (Jac may want a literal cog via
+`gen-icons.mjs`). `lost`/`unitWhen` predicates are best-effort — verify when driven. **Run
+ALL no-browser gates before each push** (smoke/logic run in CI): `node --check app.js` ·
+`gen-rule-usage --check` · `check-window-catalog` · `gen-code-map` (regen + commit the map;
+don't use a `════` banner in a non-chapter comment or it miscounts APP-NN). Sibling: janitor
+race fix on `wrangler-fix/janitor-boot-race` (PR #449, draft, CI green) — awaiting merge.
+
 ## Phase 1 — Icon-first toggle (isolated, visual)
 1. `colTabButtonsHtml` (6831): keep icon + count on every member; render `.ct-lbl`
    **only** on the active member. Alert ring (Shop) unchanged.

--- a/docs/superpowers/specs/2026-07-03-card-header-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-03-card-header-redesign-design.md
@@ -1,7 +1,7 @@
 # Card header redesign — one-row header, gear options & Custom Views — design
 
 **Date:** 2026-07-03
-**Status:** Design **approved** (Jac, 2026-07-03) → `/role` audit → implementation plan
+**Status:** Design **approved** (Jac, 2026-07-03) · **/role audit passed** — fixes folded (§16) → implementation plan
 **Branch:** `claude/wrangler-dashboard-space-h2nu0i`
 **Mockups (hosted):**
 - One-row + space reclaim — `claude.ai/code/artifact/0a9e2a2e-e7d3-4694-a06a-07203471bb25`
@@ -128,7 +128,7 @@ status/derivation helpers; exact predicates finalize during planning.
 | --- | --- |
 | Not Ready | `unitInspectionStatus = Not Ready` |
 | Failed | `unitInspectionStatus = Failed` |
-| Available | fleet `Active` AND not currently out |
+| Available | **canonical availability** — rentable now: `Active` AND not out AND not Failed / Not Ready / For Sale / Inactive / Sold (§16) |
 | Today | units on a rental going out **today** |
 | Tomorrow | units on a rental going out **tomorrow** |
 | Reserved | units on a `Reserved` rental |
@@ -208,7 +208,9 @@ options) and a tooltip listing the bundled states.
 - **Custom Views (personal):** extend `loadViews`/`saveViews` (`app.js:11794`) to
   key storage by **operator** (`currentUser`) instead of one shared set, add an
   **`icon`** field (Lucide name), and drop the admin-only add gate. Per-view shape
-  `{ name, search, terms, sort, icon }`.
+  `{ name, search, terms, sort, icon }`. **Isolation (§16):** key server-side, or
+  at minimum namespace per operator **and clear on logout**, so a shared terminal
+  never serves one operator's views to the next.
 - **Sort fields:** unchanged (`SORT_FIELDS[card]`).
 - **Active options / open state:** per-card UI state on `session.cards[card]` —
   `activeOptions` (a **set/array**, since options multi-select AND) plus
@@ -275,3 +277,36 @@ options) and a tooltip listing the bundled states.
 - Manual (local `serve.mjs`, `localhost:9147`): icon-first toggle label follows
   selection; ▲▼ direction + right-click sort-field menu; `+View` → icon picker →
   Row 3; `Remove View`; desktop truncation vs mobile horizontal scroll.
+- Mobile: the sort ▲▼ long-press target and the icon-picker cells meet the ≥44 px
+  touch floor; `+View` / `Remove View` are reachable by long-press.
+- Role projection (§16): each role sees only the options its tier allows — money
+  and funnel filters absent for operational roles; no option widens a list.
+
+## 16. Access & role projection (from /role audit, 2026-07-03)
+
+The audit cleared the fundamentals — no margin-floor exposure, no authority
+escalation, no new gates — but flagged that the options surface must be
+**role-projected**, not built role-blind. Enforcement is **server-side**; hiding an
+option in the UI is presentation, not access control.
+
+- **Options & Custom Views are gated to the data tier each filter reads** — render
+  only what a role may see, mirroring the field-level gating the cards already do:
+  - **Money-state** filters — Rentals `Bill`, Invoices `Unpaid / Late / Partial /
+    Refunded / Collections` — **Office / Owner only**. Not shown to Dispatcher /
+    Driver / Mechanic / M.Tech (they know a rental exists and where it goes, never
+    its balance). The Invoices card is already Office/Owner, which covers its set;
+    the Rentals `Bill` option needs explicit suppression for the operational roles.
+  - **CRM / funnel** filters — Customers `Member Funnel`, `Used Funnel`, `Lost` —
+    **Sales / Marketing / Office / Owner only**. Operational roles get only the thin
+    customer slice (name / account-type), never funnel-stage segmentation.
+  - **Maintenance / availability** filters — Units `Not Ready`, `Failed`,
+    `Available`, `Out` — shop / fleet / asset / owner (availability is broadly OK).
+- **Filters only ever narrow the already-authorized list.** Every option and
+  custom-view predicate runs over the role-scoped set the card already produces
+  (`listFor(card, session)` / `unitsVisible(...)`), never a raw query. A filter can
+  subtract rows; it can never add a row the role couldn't otherwise reach. (Custom
+  views are user-authored predicates, so this guarantee is stated explicitly.)
+- **Personal Custom Views isolate per operator** (§5, §10) — server-side or
+  namespaced-per-`currentUser` + cleared on logout.
+- **Internal-only surface** — these cards and options must never project into the
+  customer self-service portal (a separate, row-isolated build).

--- a/docs/superpowers/specs/2026-07-03-card-header-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-03-card-header-redesign-design.md
@@ -1,0 +1,269 @@
+# Card header redesign — one-row header, gear options & Custom Views — design
+
+**Date:** 2026-07-03
+**Status:** Design (awaiting review) → `/role` audit → implementation plan
+**Branch:** `claude/wrangler-dashboard-space-h2nu0i`
+**Mockups (hosted):**
+- One-row + space reclaim — `claude.ai/code/artifact/0a9e2a2e-e7d3-4694-a06a-07203471bb25`
+- Assembled (one gear, three levels) — `claude.ai/code/artifact/9fca1502-aa9a-4d0b-b3bf-55b5e9a4ecda`
+
+## 1. Problem & goal
+
+The dashboard cards spend **two rows** of chrome before the first data row: the
+toggle row (`colTabsEl`, `app.js:6822`) **and** the list search/sort bar
+(`listbar`, `app.js:6926`). Measured from `style.css`, ~200 px stacks up before
+a unit/rental/customer appears — ~25–33 % of a laptop viewport. Separately, the
+sort control is a cramped "Views & sort" dropdown (`openViewMenu`,
+`app.js:11831`) Jac has flagged as **not good enough** and wants completely
+rethought.
+
+**Goal:** collapse the header to **one row at rest**, and replace the sort
+dropdown with a cleaner model — a single **gear** that drops a row of per-card
+**quick-filter options** (built from the card's gates), the graph toggle, and a
+third row of user-made **Custom Views**. Resting state stays one row, so the
+vertical-space win holds.
+
+**Success:** on load, a card is a single ~46 px row (toggle + search + gear).
+Filtering, sorting, graphing, and saved views are all reachable without a
+permanent second row. Combined with the compact KPI rings (separate change),
+the first data row rises from ~200 px to ~134 px (~66 px / ~33 % reclaimed).
+
+## 2. Scope (settled with Jac)
+
+- **Dashboard list cards** (`cardEl` list view: units, categories, rentals,
+  customers, invoices; shop deferred — may be removed). Standard/record view and
+  the calendar card are out of scope.
+- **KPI-ring compaction** (the other ~14 px) is a **sibling change**, specced by
+  the space mockup; this doc covers the **card header** only. Rings stay (all
+  five + "Coming 2026"), just rendered at the compact size.
+- **Backend:** none. Pure front-end (`app.js`, `style.css`, `config.js`).
+- **`/role` audit runs before build** — Custom Views may filter to money/PII
+  states (Unpaid, Collections, Bill), so the data-sensitivity lens applies.
+
+## 3. Row 1 — the header (always visible)
+
+Left → right, one flex row (replaces both `colTabsEl` and the current `listbar`
+top strip in list view):
+
+1. **Toggle — icon-first** (`colTabButtonsHtml`). The card's members as a
+   segmented control. **Every** member shows its `memberIcon` glyph + count
+   chip; **only the active** member also shows its text label (`.ct-lbl`).
+   Today the label shows on all members and merely truncates
+   (`style.css:476`, and phone just grows the tabs taller — `style.css:368`);
+   this change **hides `.ct-lbl` on non-active tabs** on both desktop and phone,
+   so the toggle stays short regardless of member count. Alert state (red ring on
+   Shop) is unchanged.
+2. **Search field — fills the remaining width** between the toggle and the gear
+   ("fills the difference"). Reuses the current `mini-searchwrap` / `mini-search`
+   input + pinned filter-term chips (`filterTermPill`). Placeholder
+   `Search {card}…`.
+3. **Sort direction ▲▼** — inline at the **right end of the search field**. No
+   dashed divider, no cutoff sub-box, minimal padding (drop the current
+   `.sort .dir` border-left seam). Tap = flip asc/desc (`js-sortdir`, unchanged
+   behavior; new placement).
+4. **Gear** — one icon button at the far right. The single "options" control
+   (replaces today's three-way of graph button + sort chip). Tap = toggle Row 2.
+
+Resting state is Row 1 only. Toggling the gear off collapses Rows 2/3 — this is
+what preserves the ~66 px reclaim.
+
+## 4. Row 2 — Options (drops when the gear is tapped)
+
+A horizontal strip of the card's **default quick-filter buttons** plus the graph
+toggle plus an overflow control:
+
+- **Default option buttons — TEXT ONLY, no icons** (§6 for the per-card sets).
+  Each is a one-tap filter to a gate stage, a derived state, or a **composite**
+  (a union of states — §7). Icons are reserved for Custom Views (Row 3).
+- **Graph** — the existing `bv-btn` (`app.js:6935`) moves here as one option. It
+  keeps its bar-chart glyph because it is an **action/toggle**, not a filter (the
+  no-icon rule applies to filters). Lit orange when graph view is active.
+- **⋯ three-dot** — at the end of the row. Opens Row 3 (Custom Views).
+
+**Selection model:** **single active option at a time** — tapping an option
+applies its filter and lights it orange; tapping it again (or another) clears/
+replaces it. Options AND with the free-text search + pinned chips. (Multi-select
+is a possible later enhancement — see §12.)
+
+**Overflow:**
+- **Desktop:** the row **truncates** to the card width (a horizontal scrollbar
+  reads as broken inside the 3-column grid). Options that don't fit fold into the
+  **⋯** menu (above the Custom Views).
+- **Mobile:** the row **scrolls horizontally** (`overflow-x:auto`), so every
+  default is swipeable.
+
+**Default removal / reset:** defaults are removable like any option; the full
+default set is restorable from the gear/settings menu.
+
+## 5. Row 3 — Custom Views (opens from the ⋯)
+
+User-made saved views — each a one-tap button **with an icon** (the only filter
+buttons that carry icons). A Custom View captures the current **search text +
+pinned filters + sort** (the existing `viewSig` model, promoted from the
+`openViewMenu` list to a button row). A **+ New** affordance sits at the end.
+
+**Scope (proposed — confirm §12):** Custom Views are **shared team-wide** (like
+today's `loadViews`/`saveViews`), and creation is **un-gated** (anyone can add,
+dropping the current admin-only `Add view` gate).
+
+## 6. Default options — per card
+
+Text buttons, in order. `∑` marks a **composite** (§7). Filters reuse existing
+status/derivation helpers; exact predicates finalize during planning.
+
+### Rentals — gate: Rental Status
+| Button | Filters to |
+| --- | --- |
+| Today | derived display status `Today` (`deriveDisplayStatus`) |
+| Tomorrow | derived display status `Tomorrow` |
+| Reserved | `rentalStatus = Reserved` |
+| On Rent | `rentalStatus = On Rent` |
+| End Rent | `rentalStatus = End Rent` |
+| **Bill ∑** | overdue rentals · unpaid rentals · quotes · off rent · any other billing issue (§7) |
+
+### Units — gates: Inspection · Fleet (+ schedule)
+| Button | Filters to |
+| --- | --- |
+| Not Ready | `unitInspectionStatus = Not Ready` |
+| Failed | `unitInspectionStatus = Failed` |
+| Available | fleet `Active` AND not currently out |
+| Today | units on a rental going out **today** |
+| Tomorrow | units on a rental going out **tomorrow** |
+| Reserved | units on a `Reserved` rental |
+| **Out ∑** | unit status ∈ { On Rent, End Rent, Off Rent } (§7) |
+
+### Customers — gates: Account Type · Customer Pay · Funnel
+| Button | Filters to |
+| --- | --- |
+| Active | active customers (has live rental / not lost) |
+| Lost | lost customers |
+| Member Funnel | in the membership funnel |
+| Used Funnel | in the used-equipment **Sales** funnel *(confirm §12)* |
+| Members | `accountType` ∈ member types |
+| Business | `accountType = Business` |
+| Non-Business | `accountType = Non-Business` |
+| Unpaid | `customerPayStatus = Unpaid` |
+
+### Invoices — gate: Invoice (derived)
+| Button | Filters to |
+| --- | --- |
+| Not Due | `invoiceStatus = Not Due` |
+| Unpaid | `invoiceStatus = Unpaid` |
+| Late | `invoiceStatus = Late` (+ Late+30/60/90) |
+| Partial | `invoiceStatus = Partial` |
+| Refunded | `invoiceStatus = Refunded` |
+| Collections | `invoiceStatus = Collections` |
+
+### Deferred / none
+- **Shop** — skipped; the card may be removed soon.
+- **Categories** (aggregates, no gate) and **Calendar** (date grid) — no default
+  options unless Jac requests a set.
+
+## 7. Composite options
+
+A composite is a single button whose predicate is a **union** of states, so one
+tap covers a workflow bucket:
+
+- **Rentals · Bill ∑** = overdue rentals ∪ unpaid rentals ∪ quotes (`Quote`) ∪
+  off rent (`Off Rent`) ∪ any other billing issue. Implemented as a predicate
+  over `rentalStatus` + linked-invoice status; the exact "other billing issue"
+  set is enumerated during planning against `invoiceTotals`/`rentalDisplayStatus`.
+- **Units · Out ∑** = unit rental status ∈ { On Rent, End Rent, Off Rent }
+  (`unitStatus`).
+
+Composites render with a dashed border (visually distinct from single-state
+options) and a tooltip listing the bundled states.
+
+## 8. Sort — direction & field
+
+- **Direction:** the ▲▼ inline in the search bar (Row 1). Tap = flip
+  (`js-sortdir`).
+- **Field:** **right-click the ▲▼** → a **sort-only context menu** listing **all
+  `SORT_FIELDS[card]` and nothing else** (`config.js:397`). No views, no filters
+  — a dedicated sort picker. Long-press on mobile. This replaces the "Sort"
+  section of the retired `openViewMenu`.
+
+## 9. Creating & removing Custom Views (R20 context menus)
+
+- **Create:** right-click the **search bar** → R20 context menu item **"+ View"**
+  (captures current search + pinned filters + sort). This opens an
+  **icon-library popup** — a grid of the vendored **Lucide** icons (per the icons
+  rule; sourced from `icons.js` / `tools/gen-icons.mjs`, never hand-drawn) — to
+  pick the button's glyph; then name and save. The view appears in Row 3.
+  Long-press on mobile.
+- **Remove:** right-click a **Custom View button** → **"Remove View."**
+  Long-press on mobile.
+- Both hang off the existing R20 `openCtxMenu` system (same as menu-driven
+  linking), so no new always-on chrome.
+
+## 10. Data model & config
+
+- **Default options:** a new per-card map in `config.js`, e.g.
+  `CARD_OPTIONS[card] = [{ id, label, kind: 'gate'|'derived'|'composite',
+  predicate }]`. Composites (`Bill`, `Out`) carry a predicate function; single
+  gate/derived options carry the status set + value. Reuses existing helpers
+  (`deriveDisplayStatus`, `unitStatus`, `invoiceTotals`, `rentalDisplayStatus`).
+- **Custom Views:** reuse `loadViews`/`saveViews` (`app.js:11794`), extended with
+  an **`icon`** field (Lucide name) and dropping the admin-only add gate. Storage
+  shape stays `{ name, search, terms, sort, icon }`.
+- **Sort fields:** unchanged (`SORT_FIELDS[card]`).
+- **Active option / gear-open state:** per-card UI state on
+  `session.cards[card]` (e.g. `activeOption`, `optionsOpen`, `customOpen`),
+  alongside the existing `search`/`filterTerms`/`sort`/`graphView`.
+
+## 11. Components touched
+
+- `app.js`
+  - `colTabButtonsHtml` / `colTabsEl` (`6822`, `6831`) — icon-first toggle; label
+    on active member only.
+  - `listView` / `listbar` (`6917`, `6926`) — restructure into Row 1
+    (search + ▲▼ + gear) and the droppable Row 2 (options + graph + ⋯) / Row 3
+    (custom views). Move the `bv-btn` graph (`6935`) into Row 2.
+  - New builders: options row, custom-views row, gear toggle handler, sort-field
+    context menu, icon-picker popup, `+View`/`Remove View` R20 menu items.
+  - Retire `openViewMenu` (`11831`) — split into the sort-field menu (§8) + gear
+    options (§4) + custom views (§5).
+- `config.js` — `CARD_OPTIONS` (§10); `SORT_FIELDS` reused.
+- `style.css` — Row 1 layout, `.opt` / `.opt.combo` / `.opt.graph` / `.opt.more`,
+  Row 3 `.cv`, sort ▲▼ inline (drop `.sort .dir` seam), gear button, desktop
+  truncation vs mobile `overflow-x:auto`.
+
+## 12. Decisions to confirm (at review)
+
+1. **Custom View scope** — shared team-wide (proposed) vs personal per user.
+2. **Option selection** — single-active (proposed) vs multi-select AND.
+3. **"Used Funnel"** — is this the used-equipment **Sales** funnel, distinct from
+   the membership funnel? (Names the predicate.)
+4. **Desktop truncation** — overflow defaults fold into the **⋯** menu
+   (proposed); confirm that's where they should go vs simply hidden.
+5. **Default removal** — confirm defaults are user-removable with a
+   restore-defaults action in the gear menu.
+
+## 13. R-Rulebook · icons · CI
+
+- New UI elements get `data-r` stamps; regenerate `rule-usage.js`
+  (`node ci/gen-rule-usage.mjs`).
+- New popups — the **icon-picker** and the **sort-field context menu** — get
+  `WINDOW_CATALOG` entries (`ci/check-window-catalog.mjs`).
+- All glyphs come from the library (Lucide via `tools/gen-icons.mjs`); the
+  icon-picker enumerates that vendored set. No hand-authored `<path>`.
+- Gates before push: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
+  `node ci/gen-rule-usage.mjs --check`, `node ci/check-window-catalog.mjs`,
+  `node tools/gen-code-map.mjs --check`.
+
+## 14. Vertical-space payoff
+
+- Today: toggle row (~40 px) + `listbar` (~44 px) = ~84 px of card chrome.
+- Proposed: one row (~46 px) at rest; Rows 2/3 are on-demand.
+- ≈ **−38 px per card** from the merge; with compact rings, the first data row
+  moves from ~200 px → ~134 px (**~66 px / ~33 %**).
+
+## 15. Testing
+
+- `ci/smoke.mjs` — boots, cards render one row at rest, gear toggles Row 2.
+- `ci/logic-test.mjs` — option predicates filter correctly (esp. composites
+  `Bill`/`Out`) and compose with search + sort; money/derived states
+  (Unpaid, Collections) filter to the right records.
+- Manual (local `serve.mjs`, `localhost:9147`): icon-first toggle label follows
+  selection; ▲▼ direction + right-click sort-field menu; `+View` → icon picker →
+  Row 3; `Remove View`; desktop truncation vs mobile horizontal scroll.

--- a/docs/superpowers/specs/2026-07-03-card-header-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-03-card-header-redesign-design.md
@@ -1,7 +1,7 @@
 # Card header redesign — one-row header, gear options & Custom Views — design
 
 **Date:** 2026-07-03
-**Status:** Design (awaiting review) → `/role` audit → implementation plan
+**Status:** Design **approved** (Jac, 2026-07-03) → `/role` audit → implementation plan
 **Branch:** `claude/wrangler-dashboard-space-h2nu0i`
 **Mockups (hosted):**
 - One-row + space reclaim — `claude.ai/code/artifact/0a9e2a2e-e7d3-4694-a06a-07203471bb25`
@@ -80,10 +80,10 @@ toggle plus an overflow control:
   no-icon rule applies to filters). Lit orange when graph view is active.
 - **⋯ three-dot** — at the end of the row. Opens Row 3 (Custom Views).
 
-**Selection model:** **single active option at a time** — tapping an option
-applies its filter and lights it orange; tapping it again (or another) clears/
-replaces it. Options AND with the free-text search + pinned chips. (Multi-select
-is a possible later enhancement — see §12.)
+**Selection model:** **multi-select (AND)** — options toggle independently and
+stack; several can be active at once (e.g. On Rent + Not Ready), each lit orange.
+Active options AND together and AND with the free-text search + pinned chips. A
+composite (Bill/Out) contributes its internal union as one AND-term.
 
 **Overflow:**
 - **Desktop:** the row **truncates** to the card width (a horizontal scrollbar
@@ -92,8 +92,9 @@ is a possible later enhancement — see §12.)
 - **Mobile:** the row **scrolls horizontally** (`overflow-x:auto`), so every
   default is swipeable.
 
-**Default removal / reset:** defaults are removable like any option; the full
-default set is restorable from the gear/settings menu.
+**Defaults are fixed:** the per-card default options are permanent (not
+removable); only Custom Views (Row 3) are user-added/removed. No removed-default
+state to persist.
 
 ## 5. Row 3 — Custom Views (opens from the ⋯)
 
@@ -102,9 +103,10 @@ buttons that carry icons). A Custom View captures the current **search text +
 pinned filters + sort** (the existing `viewSig` model, promoted from the
 `openViewMenu` list to a button row). A **+ New** affordance sits at the end.
 
-**Scope (proposed — confirm §12):** Custom Views are **shared team-wide** (like
-today's `loadViews`/`saveViews`), and creation is **un-gated** (anyone can add,
-dropping the current admin-only `Add view` gate).
+**Scope:** Custom Views are **personal per operator** — each logged-in user keeps
+their own set; the team shares only the defaults. Creation is un-gated (anyone
+adds their own), dropping the current admin-only `Add view` gate. Storage keys to
+`currentUser` (§10).
 
 ## 6. Default options — per card
 
@@ -138,7 +140,7 @@ status/derivation helpers; exact predicates finalize during planning.
 | Active | active customers (has live rental / not lost) |
 | Lost | lost customers |
 | Member Funnel | in the membership funnel |
-| Used Funnel | in the used-equipment **Sales** funnel *(confirm §12)* |
+| Used Funnel | in the used-equipment **Sales** funnel (distinct pipeline from membership — §10 note) |
 | Members | `accountType` ∈ member types |
 | Business | `accountType = Business` |
 | Non-Business | `accountType = Non-Business` |
@@ -203,13 +205,19 @@ options) and a tooltip listing the bundled states.
   predicate }]`. Composites (`Bill`, `Out`) carry a predicate function; single
   gate/derived options carry the status set + value. Reuses existing helpers
   (`deriveDisplayStatus`, `unitStatus`, `invoiceTotals`, `rentalDisplayStatus`).
-- **Custom Views:** reuse `loadViews`/`saveViews` (`app.js:11794`), extended with
-  an **`icon`** field (Lucide name) and dropping the admin-only add gate. Storage
-  shape stays `{ name, search, terms, sort, icon }`.
+- **Custom Views (personal):** extend `loadViews`/`saveViews` (`app.js:11794`) to
+  key storage by **operator** (`currentUser`) instead of one shared set, add an
+  **`icon`** field (Lucide name), and drop the admin-only add gate. Per-view shape
+  `{ name, search, terms, sort, icon }`.
 - **Sort fields:** unchanged (`SORT_FIELDS[card]`).
-- **Active option / gear-open state:** per-card UI state on
-  `session.cards[card]` (e.g. `activeOption`, `optionsOpen`, `customOpen`),
-  alongside the existing `search`/`filterTerms`/`sort`/`graphView`.
+- **Active options / open state:** per-card UI state on `session.cards[card]` —
+  `activeOptions` (a **set/array**, since options multi-select AND) plus
+  `optionsOpen` / `customOpen` for the gear and ⋯ rows — alongside the existing
+  `search`/`filterTerms`/`sort`/`graphView`.
+- **Used-equipment Sales funnel:** a pipeline **distinct** from the membership
+  funnel. If the data doesn't already carry a sales-funnel stage separate from
+  `membershipStage`/`funnelStage`, that field is defined during planning — flag it
+  before the Customers `Used Funnel` predicate can be built.
 
 ## 11. Components touched
 
@@ -228,16 +236,16 @@ options) and a tooltip listing the bundled states.
   Row 3 `.cv`, sort ▲▼ inline (drop `.sort .dir` seam), gear button, desktop
   truncation vs mobile `overflow-x:auto`.
 
-## 12. Decisions to confirm (at review)
+## 12. Decisions (resolved with Jac, 2026-07-03)
 
-1. **Custom View scope** — shared team-wide (proposed) vs personal per user.
-2. **Option selection** — single-active (proposed) vs multi-select AND.
-3. **"Used Funnel"** — is this the used-equipment **Sales** funnel, distinct from
-   the membership funnel? (Names the predicate.)
-4. **Desktop truncation** — overflow defaults fold into the **⋯** menu
-   (proposed); confirm that's where they should go vs simply hidden.
-5. **Default removal** — confirm defaults are user-removable with a
-   restore-defaults action in the gear menu.
+1. **Custom View scope — personal per operator** (keyed to `currentUser`, not a
+   shared set). §5, §10.
+2. **Option selection — multi-select (AND)** — options stack. §4.
+3. **"Used Funnel" — the used-equipment Sales funnel,** a pipeline distinct from
+   membership. §6, §10 note.
+4. **Desktop overflow — truncate;** excess defaults fold into the **⋯** menu.
+   Mobile scrolls horizontally. §4.
+5. **Defaults are fixed** (not removable); only Custom Views add/remove. §4.
 
 ## 13. R-Rulebook · icons · CI
 

--- a/style.css
+++ b/style.css
@@ -824,6 +824,23 @@ select.lf-in { appearance: none; cursor: pointer; }
 .sort .dir span.on { color: var(--accent); }
 .sort > button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
+/* ── Card-header ONE ROW (Jac 2026-07-03): toggle + search(fills the gap) + inline ▲▼ + gear.
+   Merges the old toggle row (.tabrow) and the list search/sort bar (.listbar) onto a single
+   line so a card opens at ~one row. Built in columnEl (desktop, list mode). ── */
+.hrow { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; padding: 13px 10px 8px; }   /* pad-top clears the 6px hazard stripe + rivets (was the .tabrow margin) */
+.hrow > .tabrow { display: flex; flex: 0 0 auto; margin: 0; min-width: 0; }   /* toggle sits LEFT — override the centering grid */
+.hrow > .tabrow .col-tabs { margin: 0; }
+.hrow > .listbar { flex: 1 1 auto; min-width: 0; padding: 0; background: none; position: static; box-shadow: none; }   /* search fills the remaining width */
+.listbar .sortdir { flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; justify-content: center; width: 26px; height: 32px; padding: 0; border: 0; background: transparent; cursor: pointer; }   /* sort direction, inline at the search's right — no divider (Jac) */
+.listbar .sortdir span { font-size: 9px; line-height: 1.05; color: var(--txt-3); }
+.listbar .sortdir span.on { color: var(--accent); }
+.listbar .sortdir:hover span { color: var(--txt-2); }
+.listbar .sortdir:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
+.listbar .gear { flex: 0 0 auto; width: 32px; height: 32px; display: grid; place-items: center; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); box-shadow: var(--chip-shadow); cursor: pointer; }   /* the ONE options button — Row 2 wired in phase 4 */
+.listbar .gear:hover { color: var(--accent); border-color: var(--accent-line); }
+.listbar .gear.on { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
+.listbar .gear svg { width: 16px; height: 16px; }
+
 /* reusable floating dropdown menu (sort fields, status options) — Tier 3 SELECTOR-LIST:
    steel panel + a left hazard rail (the signature), no orange halo (dialogs keep that). */
 .dropdown-menu { position: fixed; z-index: 9100; width: max-content; min-width: 150px; max-width: min(92vw, 340px); padding: 6px; background: var(--panel); border: 1px solid var(--line); border-radius: var(--chip-radius); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); }   /* width:max-content hugs the widest item label; min/max keep it from getting awkwardly narrow or stretching wide */

--- a/style.css
+++ b/style.css
@@ -473,7 +473,7 @@ body.is-phone { touch-action: manipulation; }
 .coltab.on { background: var(--accent); color: var(--on-orange); }   /* selected = solid orange + DARK ink (rule 2) */
 .coltab.compact { padding: 7px 8px; gap: 3px; }   /* icon hugs its counter (Jac) */
 .coltab .ct-lbl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.coltab:not(.on) .ct-lbl { max-width: 74px; }     /* inactive labels truncate (Jac: "Categories…") */
+.coltab:not(.on) .ct-lbl { display: none; }     /* icon-first toggle: only the active member spells its name (Jac, 2026-07-03) */
 .coltab .ct-ico { display: inline-flex; flex: 0 0 auto; } .coltab .ct-ico svg { width: 16px; height: 16px; }
 .coltab .ct-n { font-size: 11px; font-weight: 700; color: var(--txt-3); background: var(--bg-2); padding: 1px 8px; border-radius: 999px; }
 .coltab.on .ct-n { color: var(--on-orange); background: rgba(0,0,0,.16); }


### PR DESCRIPTION
**Draft — design spec only, no app code yet.** Opened so the work on this branch has a home; implementation follows after Jac signs off on the spec.

## What this is
A design doc for reshaping the dashboard card header to reclaim vertical space and replace the cramped "Views & sort" dropdown.

Spec: `docs/superpowers/specs/2026-07-03-card-header-redesign-design.md`

## The design (settled with Jac via mockups)
- **One-row header at rest:** icon-first toggle (only the selected card shows its label) + a search field that fills the remaining width, with the sort **direction ▲▼** inline on its right (no divider).
- **One gear** drops a **scrollable options row** — per-card **gate-stage quick filters** (text only) plus the **Graph** toggle and a **⋯**.
- **⋯ opens a Custom Views row** — user-saved search+filter+sort views, the only filter buttons with **icons**.
- **Create/remove views** via the R20 right-click menu (`+ View` on the search bar → icon-library popup; `Remove View` on a view). Long-press on mobile.
- **Sort field** picked from a **sort-only right-click menu** on the ▲▼.
- **Composite filters:** Rentals `Bill` (overdue + unpaid + quotes + off-rent + billing issues), Units `Out` (On/End/Off Rent).
- Per-card default option sets for Rentals · Units · Customers · Invoices (Shop deferred, Categories/Calendar none).

## Payoff
Resting state one row (~46 px) vs two rows today (~84 px): ≈ −38 px/card; with the compact KPI rings, first data row moves ~200 px → ~134 px (~66 px / ~33 %).

## Status
- [x] Design spec written & committed
- [ ] Jac reviews the spec (open decisions in §12: view scope, single vs multi-select, "Used Funnel", truncation overflow, default removal)
- [ ] `/role` audit (filters touch money/PII states)
- [ ] Implementation plan
- [ ] Build (front-end only: `app.js`, `config.js`, `style.css`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYt7cUN3aufPfeEMtn9SdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYt7cUN3aufPfeEMtn9SdE)_