### PR TITLE
Mr. Wrangler: timestamp every chat message so you can tell what's current

### DIFF
--- a/app.js
+++ b/app.js
@@ -4009,7 +4009,7 @@ function openWranglerForKpi(roleId, idx) {
   if (o) closeOverlay();
   state.wrangler.kpiTarget = kt;
   openWranglerDock({
-    messages: [{ role: 'assistant', content: `🤠 Let's wrangle the ${role.label} role's Ring ${idx + 1} (now “${ring.label || '—'}”). Tell me in plain English what this ring should measure — I'll ask anything I need, prove it against your live yard data, and lock it in.` }],
+    messages: [{ role: 'assistant', content: `🤠 Let's wrangle the ${role.label} role's Ring ${idx + 1} (now “${ring.label || '—'}”). Tell me in plain English what this ring should measure — I'll ask anything I need, prove it against your live yard data, and lock it in.`, at: Date.now() }],
     draft: '',
   });
 }
@@ -7839,6 +7839,19 @@ function wrChatFormat(raw) {
   s = s.replace(/`([^`]+)`/g, '<code>$1</code>');           // `inline code`
   return s.replace(/\n/g, '<br>');
 }
+// §18g — stamp a Mr. Wrangler message with its send time so a glance tells you how current the
+// conversation is. Time-only within a day; the day is prepended when it rolls over (and on the
+// first message). Chats saved before we recorded per-message times simply show none.
+function wrMsgStamp(at, prevAt) {
+  if (!at) return '';
+  const d = new Date(at);
+  const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  if (prevAt && new Date(prevAt).toDateString() === d.toDateString()) return time;
+  const day = d.toDateString() === new Date().toDateString()
+    ? 'Today'
+    : d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return day + ' · ' + time;
+}
 // §18 Mr. Wrangler dock — renders the floating dock HTML (mirrors wrangler overlay but as a dock).
 function wranglerDockEl() {
   const o = state.wrangler;
@@ -7884,7 +7897,9 @@ function wranglerDockEl() {
         const txt = m.content ? wrChatFormat(m.content) : '';
         // ask_user option chips (Stage 2b) — tappable only while THIS question is the live pending one.
         const ask = (m.askOptions && m.askOptions.length && o.ask) ? `<div class="wr-ask">${m.askOptions.map((opt) => `<button class="wr-askbtn js-wr-ask" data-ans="${esc(opt)}">${esc(opt)}</button>`).join('')}</div>` : '';
-        return `<div class="wr-msg ${m.role}">${m.role === 'assistant' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub">${imgs}${files}${txt}${act}${ask}</div></div>`;
+        const stamp = wrMsgStamp(m.at, i > 0 ? o.messages[i - 1].at : null);   // §18g when this turn happened — currency at a glance
+        const time = stamp ? `<span class="wr-time">${esc(stamp)}</span>` : '';
+        return `<div class="wr-msg ${m.role}">${m.role === 'assistant' ? '<span class="wr-av">🤠</span>' : ''}<div class="wr-bub-wrap"><div class="wr-bub">${imgs}${files}${txt}${act}${ask}</div>${time}</div></div>`;
       }).join('')
     : (o.reqNumber
         ? '<div class="wr-empty">That’s the request up top. Reply here to talk it over with Mr. Wrangler, or use the buttons above to Approve or Dismiss it.</div>'
@@ -10458,7 +10473,7 @@ async function wranglerSend() {
   // rather than starting a fresh turn. Tapping an option chip resolves it the same way.
   if (o.ask && o.ask.resolve) { if (!text) { if (inp) inp.focus(); return; } o.draft = ''; if (inp) inp.value = ''; o.ask.resolve(text); return; }
   if ((!text && !imgs && !files) || o.busy) { if (inp) inp.focus(); return; }
-  o.messages.push({ role: 'user', content: text, images: imgs, files });
+  o.messages.push({ role: 'user', content: text, images: imgs, files, at: Date.now() });
   syncWranglerComment(o, 'user', text, imgs);   // §18e mirror the turn onto the issue thread
   wranglerClearNeedsAnswer(o.reqNumber);        // §18e answering a "Needs your answer" request clears it from the inbox
   o.draft = ''; o.attach = []; o.files = []; o.busy = true; o.error = ''; render();
@@ -10497,8 +10512,8 @@ async function wranglerSend() {
       // options and wait for a tap/typed reply, which resumes the loop. Tied to the live dock only.
       const askFn = (input) => new Promise((resolve) => {
         const options = Array.isArray(input.options) ? input.options.slice(0, 6).map(String) : [];
-        o.messages.push({ role: 'assistant', content: String((input && input.question) || 'Which one?'), askOptions: options });
-        o.ask = { resolve: (answer) => { o.ask = null; o.busy = true; if (answer != null && answer !== '') o.messages.push({ role: 'user', content: String(answer) }); render(); resolve(answer == null ? null : String(answer)); } };
+        o.messages.push({ role: 'assistant', content: String((input && input.question) || 'Which one?'), askOptions: options, at: Date.now() });
+        o.ask = { resolve: (answer) => { o.ask = null; o.busy = true; if (answer != null && answer !== '') o.messages.push({ role: 'user', content: String(answer), at: Date.now() }); render(); resolve(answer == null ? null : String(answer)); } };
         o.busy = false; render();
         setTimeout(() => { const f = document.querySelector('.wrangler-dock .wr-feed'); if (f) f.scrollTop = f.scrollHeight; }, 0);
       });
@@ -10527,7 +10542,7 @@ async function wranglerSend() {
       else if (!shown) shown = act ? (act.action === 'data' ? (autoPlan ? 'Done — ' + wrPlanSummary(autoPlan) + '.' : 'Here’s what I’ll change — preview it and hit apply when it looks right.') : act.action === 'kpi' ? 'Here’s the KPI — lock it in when the live number looks right.' : act.action === 'request' ? 'Got it — I’ll send this to the developer to OK.' : act.action === 'plan' ? 'Here’s the plan — tap Build when it’s right.' : 'On it — I’ll fix this right now and let you know when I’m done.') : (r.applied ? 'Done — applied your changes. 🤠' : '(no answer)');
       const _target = _onChat ? o : state.wranglerRail.find((c) => c.id === replyChatId);
       if (_target) {
-        const msg = { role: 'assistant', content: shown, action: act || null, filed: false };
+        const msg = { role: 'assistant', content: shown, action: act || null, filed: false, at: Date.now() };
         _target.messages.push(msg);
         if (autoPlan) { msg.filed = true; Promise.resolve(applyWranglerData(autoPlan)).then((res) => { if (res && res.failed) { msg.filed = false; } else if (res && res.focus) { msg.focus = res.focus; } render(); }); }   // simple safe edit / booking → write it now; stash the focus target for the "Open" link
         else if (r.applied && r.focus) msg.focus = r.focus;   // apply_changes already wrote it in the loop → keep the "Open" link to the new record
@@ -10535,7 +10550,7 @@ async function wranglerSend() {
         if (!_onChat) wranglerRailPersist(_target);   // backgrounded chat → fold the reply into its snapshot
       }
     } else {
-      o.messages.push({ role: 'assistant', content: "🤠 Demo mode — sign in to ask the real Mr. Wrangler (the live AI runs through the backend). Here's the snapshot I'd reason over:\n\n" + wranglerDigest() });
+      o.messages.push({ role: 'assistant', content: "🤠 Demo mode — sign in to ask the real Mr. Wrangler (the live AI runs through the backend). Here's the snapshot I'd reason over:\n\n" + wranglerDigest(), at: Date.now() });
     }
     if (state.wrangler.id === replyChatId) { o.busy = false; render(); setTimeout(() => { const f = document.querySelector('.wrangler-dock .wr-feed'); if (f) f.scrollTop = f.scrollHeight; }, 0); } else render();   // only clear/scroll the dock if it's still THIS chat
   } catch (e) { if (state.wrangler.id === replyChatId) { o.busy = false; o.error = wranglerErrMsg(e && e.message); render(); } }

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 16961 lines, 38 chapters
+## app.js — 16976 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -30,22 +30,22 @@
 | APP-20 | 7263–7387 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
 | APP-21 | 7388–7552 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
 | APP-22 | 7553–7762 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7763–8584 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+71) |
-| APP-24 | 8585–8690 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8691–9136 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
-| APP-26 | 9137–10073 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10074–10169 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 10170–10585 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
-| APP-29 | 10586–11636 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 11637–11906 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 11907–12037 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 12038–12041 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 12042–13641 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 13642–14570 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14571–15611 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15612–16058 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16059–16061 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16062–16961 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-23 | 7763–8599 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+72) |
+| APP-24 | 8600–8705 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
+| APP-25 | 8706–9151 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+8) |
+| APP-26 | 9152–10088 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 10089–10184 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 10185–10600 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wranglerContext, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, wrCustOpenBalance, WR_TOOL_IMPL, …(+9) |
+| APP-29 | 10601–11651 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 11652–11921 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 11922–12052 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 12053–12056 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 12057–13656 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 13657–14585 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14586–15626 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15627–16073 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 16074–16076 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 16077–16976 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 559 lines, 0 chapters
 

--- a/docs/superpowers/plans/2026-07-03-wrangler-dedup-before-filing-plan.md
+++ b/docs/superpowers/plans/2026-07-03-wrangler-dedup-before-filing-plan.md
@@ -1,0 +1,107 @@
+# Implementation plan — Mr. Wrangler duplicate-check before filing
+
+- **Date:** 2026-07-03
+- **Spec:** `docs/superpowers/specs/2026-07-03-wrangler-dedup-before-filing-design.md`
+- **Area:** wrangler-ai
+- **Branch:** TBD with Jac before coding (separate from the timestamp work on
+  `claude/mr-wrangler-troubleshooting-8ssi55`).
+
+## Shape of the work
+
+Most of this is **prompt + a read-only index** — no new backend, popup, or stamped
+element. Only the "Add to #NNN" branch needs a small new agentic tool. Build in
+phases so each lands independently and is verifiable on its own.
+
+Key grounding from the code:
+- `wranglerContext(o)` — `app.js:10213` (where the index gets injected).
+- `WRANGLER_SYSTEM` / `WR_TOOLS_NOTE` — the system prompt + tool note.
+- `ask_user` Stage 2b — `app.js:10498` (askFn); chips render as `.wr-askbtn` at
+  `app.js:7886`; the tap resolves the answer string back into `wrRunAgent`.
+- `wranglerFileAction` — `app.js:11168` (the existing file path; unchanged).
+- `wranglerComment` backend action takes `{ number, role, text, images }` —
+  `syncWranglerComment` (`app.js:11309`) proves any issue number can be targeted.
+- Index sources: `wranglerRequests` (`app.js:11194`, open) + `wranglerNotifs`
+  (`app.js:11203`, recently closed/resolved).
+
+## Phase 1 — the issue index (read-only; no behavior change)
+
+**Step 1 — `wrIssueIndex()` pure helper.**
+- Add near `wranglerContext`. Merge `wranglerRequests` + `wranglerNotifs`, dedupe by
+  `number`, map each to `#<n> · "<title>" · <state>` where state ∈
+  {open, needs your OK, building, fixed, closed}. Cap length (e.g. most-recent 40)
+  so the block stays small. Return `''` when both lists are empty.
+- **Verify:** unit assertion — sample requests + notifs → expected compact string;
+  empty inputs → `''`.
+
+**Step 2 — inject into `wranglerContext(o)`.**
+- Append `\n\nALREADY FILED (check before filing a new fix/request):\n` + `wrIssueIndex()`
+  when non-empty.
+- **Verify:** log the built context in a dev session; confirm the block is present
+  and correctly formatted with real data.
+
+## Phase 2 — detection + chips (prompt only)
+
+**Step 3 — `WRANGLER_SYSTEM` dedup instruction.**
+- Add: *before* proposing a `fix` or `request`, scan ALREADY FILED. If the new report
+  describes the same problem as an existing entry, do NOT emit the file action —
+  instead call `ask_user` with the single best match:
+  > "Looks like this is already reported — #NNN '<title>' (<open|already fixed>).
+  > What do you want to do?"
+  options: `["Add my note to #NNN", "File a new one anyway", "It's already fixed — refresh"]`
+  (drop the third option unless the match is completed/merged).
+- **Verify (E2E, staging):** report a known duplicate (e.g. re-tier wording) → the
+  chips appear referencing the right issue number; report a novel bug → no chips,
+  normal file path.
+
+## Phase 3 — the three branches
+
+**Step 4 — "File a new one anyway".**
+- No new code: the model proceeds to emit its normal `request`/`fix` action, which
+  flows through the existing `wranglerFileAction`.
+- **Verify:** tapping it files a new issue exactly as today.
+
+**Step 5 — "It's already fixed — refresh".**
+- No new code: the model replies with text ("fixed in #NNN — hard-refresh to load it").
+- **Verify:** tapping it files nothing and shows the refresh copy.
+
+**Step 6 — "Add my note to #NNN" (the one new capability).**
+- Add a small agentic tool `note_on_issue({ number, text })` to `WR_TOOLS` that calls
+  `backendCall('wranglerComment', { number, role: 'user', text })`. On the "Add" tap,
+  the model calls it with the match number + a one-paragraph summary of the new
+  report, then replies "Added your note to #NNN."
+- **Verify:** tapping it posts a comment on the matched issue (check the issue thread);
+  no new issue created.
+
+## Phase 4 — guards, tests, gates
+
+**Step 7 — edge guards.**
+- `!backendPassword` (demo/offline) or both lists empty → `wrIssueIndex()` returns `''`,
+  the ALREADY-FILED block is omitted, and filing behaves exactly as today (never block
+  a report on the dedup step). `not_planned`-closed matches are treated as open (no
+  "already fixed" option).
+- **Verify:** demo mode still files; a dismissed-issue match doesn't offer "fixed".
+
+**Step 8 — tests, gates, cache.**
+- Unit: `wrIssueIndex()` assertion (Step 1).
+- Gates: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
+  `node ci/gen-rule-usage.mjs --check` (no stamp change expected),
+  `node ci/check-window-catalog.mjs` (no popup change expected),
+  `node tools/gen-code-map.mjs --check` (regenerate if banners shifted).
+- Bump the shared `?v=` cache token in `index.html`.
+
+**Step 9 — E2E on staging.**
+- Drive the staging app (Claude-in-Chrome): report a known-duplicate bug, confirm the
+  chips reference the right issue, and exercise all three branches (comment lands /
+  new issue files / refresh copy). Screenshot for the handoff.
+
+## Rollout / ordering
+
+Phases 1→2 are safe to land first (index + detection only changes what the model
+*sees* and *asks*, never what it files). Phase 3 Step 6 is the only new plumbing.
+Phase 1's helper can even ship alone (dormant) if we want to split PRs.
+
+## Not doing (from the spec)
+
+Similarity-scoring engine; backend/GAS change; multi-tenant isolation. If detection
+proves leaky, add a deterministic keyword prefilter (A+B hybrid) later without redoing
+this.

--- a/docs/superpowers/specs/2026-07-03-wrangler-dedup-before-filing-design.md
+++ b/docs/superpowers/specs/2026-07-03-wrangler-dedup-before-filing-design.md
@@ -1,0 +1,139 @@
+# Mr. Wrangler — duplicate-check before filing an issue
+
+- **Date:** 2026-07-03
+- **Status:** Design approved (brainstorming) — pending implementation plan
+- **Area:** wrangler-ai
+- **Author:** Mr. Wrangler troubleshooting session
+
+## Problem
+
+Mr. Wrangler files a brand-new GitHub issue every time a bug/request is reported,
+with **no awareness of what already exists**. `wranglerFileAction` (`app.js:11168`)
+calls `backendCall('wranglerFile', { title, body, label })`, which creates a fresh
+issue unconditionally. `wranglerContext(o)` (`app.js:10213`) feeds the model the
+yard data and the focused record but **nothing about existing issues**, so it files
+blind.
+
+The result is heavy duplication of one real problem:
+
+- **Weekly re-tier on extend** → 4 issues: #416, #420, #425, #444.
+- **Invoice option missing on calendar-extend** → 2 issues: #426, #443.
+
+The rail then copies each conversation across 5–6 roles, so one bug becomes ~20
+rail rows. Worse, **already-fixed** bugs get re-filed as if new, making the queue
+look like an unresolved flood and burying the signal that fixes shipped.
+
+## Goal
+
+Before Mr. Wrangler files a `fix`/`request`, it checks what already exists and lets
+the **reporter choose** what to do — never filing a duplicate silently, and catching
+the case where the bug is already fixed (just needs a refresh).
+
+## Decisions (from brainstorming)
+
+1. **On a match, the reporter chooses** — Add to the existing issue / File a new one
+   anyway / (if the match is already fixed) refresh. Not auto-fold, not auto-block.
+2. **Detection is AI-judged** — Mr. Wrangler judges matches *semantically* from an
+   index of existing issues. Chosen over deterministic text matching because the real
+   duplicates are worded three different ways ("Weekly rate not applied" vs "doesn't
+   re-tier to weekly" vs "1-day×n instead of 7-day") and text matching would miss them.
+3. **Scope = open + recently-closed/fixed** — required so the "already fixed — refresh"
+   branch can fire.
+
+## Architecture / data flow
+
+### 1. The issue index (no new backend)
+
+The client already holds both halves of the index:
+
+- **Open issues** — `wranglerRequests` (`app.js:11194`), loaded by `refreshWranglerRequests`.
+- **Recently closed/resolved** — `wranglerNotifs` (`app.js:11203`), loaded by
+  `refreshWranglerNotifications` (the notifications feed already curates resolved/
+  closed/merged items with `{ number, title, kind, merged, closedAt, url }`).
+
+A tiny pure helper `wrIssueIndex()` formats these into a compact block:
+
+```
+ALREADY FILED (check before filing a new fix/request):
+#444 · "Rental extension doesn't re-tier to weekly rate" · fixed
+#426 · "Invoice option missing when extending rental via calendar" · open (needs your OK)
+#414 · "Cannot bill rental when customer has a negative-balance invoice" · fixed
+...
+```
+
+Kept to `#number · title · state` per line so it stays small.
+
+### 2. The check (in the agentic loop, prompt-driven)
+
+- `wranglerContext(o)` (`app.js:10213`) appends the `wrIssueIndex()` block.
+- `WRANGLER_SYSTEM` gains one instruction: **before** proposing a `fix` or `request`
+  action, scan ALREADY FILED; if the new report describes the same problem as an
+  existing entry, do **not** file — call `ask_user` with the match instead.
+
+### 3. The reporter chooses (existing `ask_user` chips — Stage 2b)
+
+Mr. Wrangler surfaces the match through the existing `ask_user` flow
+(`app.js:10498`, rendered as `.wr-askbtn` chips at `app.js:7886`):
+
+> "Looks like this is already reported — **#NNN '\<title\>'** (\<open / already fixed\>).
+> What do you want to do?"
+
+Chips and their wiring:
+
+| Chip | Action |
+|---|---|
+| **Add my note to #NNN** | Post a comment on #NNN via the existing `wranglerComment` / `syncWranglerComment` path (`app.js:11292`+). No new issue. |
+| **File a new one anyway** | Proceed with the normal `wranglerFileAction` — nothing is lost; the reporter overrides. |
+| **It's already fixed — refresh** *(only when the match is closed/fixed)* | No file. Reply: "That's fixed in #NNN — hard-refresh (Ctrl/Cmd+Shift+R) to load it." |
+
+## Components / changes (small, additive)
+
+1. **`wrIssueIndex()`** — new pure helper; formats `wranglerRequests` + `wranglerNotifs`
+   into the compact ALREADY-FILED block. Unit-testable.
+2. **`wranglerContext(o)`** (`app.js:10213`) — append the index block.
+3. **`WRANGLER_SYSTEM`** — add the dedup instruction + the 3-chip protocol.
+4. **"Add to #NNN" wiring** — route that chip answer to post a comment on the matched
+   issue (reuse `wranglerComment` backend action; mirror via `syncWranglerComment`).
+
+No new popup window → **no `WINDOW_CATALOG` change**. No new stamped element
+(`.wr-askbtn` already exists) → **no `rule-usage` change**.
+
+## Edge cases
+
+- **No match** → files normally (behavior unchanged).
+- **Index empty / offline / demo** (`!backendPassword`, or lists not yet loaded) →
+  skip the check and file normally. Never block a report on the dedup step.
+- **Model misjudges a match** → the "File a new one anyway" chip is the escape hatch;
+  no report is ever lost.
+- **Multiple candidate matches** → the model surfaces the single best match (top 1);
+  keep the prompt from listing many.
+- **Match is closed-but-not-actually-fixed** (`not_planned`) → treat as open for the
+  "already fixed" copy — only show "already fixed — refresh" when the match was
+  completed/merged, not when it was dismissed.
+
+## Testing & gates
+
+- `wrIssueIndex()` is a pure function → add a unit check (given sample requests +
+  notifs → expected compact string). Fits the existing `ci/logic-test.mjs` style for
+  pure helpers, or a small standalone assertion.
+- The AI judgment itself is prompt behavior (like the rest of Mr. Wrangler, which is
+  not covered by `ci/logic-test`) → verified by an **E2E drive on staging**: report a
+  known-duplicate bug and confirm the chips appear and each branch behaves.
+- Standard gates: `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
+  `node ci/gen-rule-usage.mjs --check`, `node ci/check-window-catalog.mjs`,
+  `node tools/gen-code-map.mjs --check`. Cache token bump on deploy.
+
+## Out of scope (YAGNI)
+
+- No similarity-scoring engine (that was the rejected deterministic approach B).
+- No backend/GAS change (reuse `wranglerComment` + the already-loaded issue data).
+- No multi-tenant issue isolation (single-tenant today; revisit with the Wrangler
+  Ops multi-tenant work in #407).
+
+## Known limitation & future
+
+Detection is prompt-driven, so a stray file could slip through if the model ignores
+the instruction. Mitigations: a strong instruction and a prominent index, and the
+reporter confirms every match. If it proves leaky in practice, add a **deterministic
+prefilter** (the A+B hybrid) — narrow candidates by keyword, then let the model judge
+the finalists — without redoing this design.

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703a" />
+  <link rel="stylesheet" href="style.css?v=20260703b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703a"></script>
-  <script type="module" src="app.js?v=20260703a"></script>
+  <script src="rule-usage.js?v=20260703b"></script>
+  <script type="module" src="app.js?v=20260703b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703b" />
+  <link rel="stylesheet" href="style.css?v=20260703d" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703b"></script>
-  <script type="module" src="app.js?v=20260703b"></script>
+  <script src="rule-usage.js?v=20260703d"></script>
+  <script type="module" src="app.js?v=20260703d"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1160,10 +1160,10 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-pop .popup-head .wr-chip.muted { color: var(--txt-3); }
 .wr-feed { flex: 1 1 auto; overflow-y: auto; padding: 14px 16px; display: flex; flex-direction: column; gap: 12px; min-height: 150px; }
 .wr-empty { color: var(--txt-3); font-size: 13px; text-align: center; padding: 30px 14px; line-height: 1.55; }
-.wr-msg { display: flex; gap: 8px; align-items: flex-end; max-width: 92%; }
+.wr-msg { display: flex; gap: 8px; align-items: flex-start; max-width: 92%; }
 .wr-msg.user { align-self: flex-end; }
 .wr-msg.assistant { align-self: flex-start; }
-.wr-av { flex: 0 0 auto; font-size: 19px; line-height: 1; }
+.wr-av { flex: 0 0 auto; font-size: 19px; line-height: 1; margin-top: 3px; }
 .wr-bub { padding: 9px 13px; border-radius: 13px; font-size: 13.5px; line-height: 1.5; word-wrap: break-word; }
 .wr-msg.assistant .wr-bub { background: #232c37; color: var(--txt); border-bottom-left-radius: 4px; }
 .wr-msg.user .wr-bub { background: var(--accent); color: #1a1205; font-weight: 500; border-bottom-right-radius: 4px; }

--- a/style.css
+++ b/style.css
@@ -1168,6 +1168,9 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-msg.assistant .wr-bub { background: #232c37; color: var(--txt); border-bottom-left-radius: 4px; }
 .wr-msg.user .wr-bub { background: var(--accent); color: #1a1205; font-weight: 500; border-bottom-right-radius: 4px; }
 .wr-bub.wr-think { color: var(--txt-3); font-style: italic; }
+.wr-bub-wrap { display: flex; flex-direction: column; gap: 3px; min-width: 0; align-items: flex-start; }
+.wr-msg.user .wr-bub-wrap { align-items: flex-end; }
+.wr-time { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; font-size: 9.5px; font-weight: 700; color: var(--txt-3); padding: 0 3px; }
 .wr-err { color: var(--red); font-size: 12px; padding: 0 16px 6px; }
 .wr-compose { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--line); }
 /* §18d attach/paste images — paperclip stamp + pending thumbnails + sent-in-bubble.


### PR DESCRIPTION
## What
Every Mr. Wrangler message now shows **when it was sent**, so a conversation's recency is readable at a glance instead of being undated. Answers Jac's "I can't tell if this is current" — surfaced while triaging the Notifications panel / chat rail.

## Root cause (proven)
Team-chat messages are stamped (`at: Date.now()` + `when`, `app.js` team-chat push) but **every Mr. Wrangler message was pushed with no timestamp field** — user send (`app.js` `wranglerSend`), Wrangler's `ask_user` question + the typed/tapped answer, Wrangler's reply `msg`, the demo-mode reply, and the role-KPI seed. The dock had nothing to render. Fixed **at the cause**: stamp each message on push, then render it.

## Changes
- **`app.js`** — new `wrMsgStamp(at, prevAt)` helper (time within a day; day prepended when it rolls over and on the first message); stamp `at: Date.now()` at all six message-push sites; wrap each bubble in `.wr-bub-wrap` with a `.wr-time` micro-label.
- **`style.css`** — `.wr-bub-wrap` (column) + `.wr-time`, a muted stamped-Saira micro-label on `--txt-3`, mirroring team chat's `.cbub-name`. Tokens → themes for free (dark/light/ranch).
- **`index.html`** — cache token `20260703a → b`.
- **`docs/code-map.generated.md`** — regenerated for shifted `APP-NN` banners.

## Design (jactec-ui)
The timestamp is a **meta micro-label**, not a lint-family element (pill/flag/add/button/field), so — like `.cbub-name`/`.cflag-m` — it carries **no `data-r` stamp and no `RULE_META` change**. Reuses existing tokens only; no new color/font literals.

## Notes
- Chats saved **before** this change have no per-message time recorded, so they show none until new turns happen (we can't fabricate history).

## Gates
`node --check app.js` · `node ci/gen-rule-usage.mjs --check` · `node ci/check-window-catalog.mjs` · `node tools/gen-code-map.mjs --check` — all green. `smoke` + `logic-test` run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNm5w83mrE5f9JtSXaMVGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNm5w83mrE5f9JtSXaMVGs)_