### PR TITLE
Fix flaky WR-janitor test — await boot rail-load (race)

### DIFF
--- a/app.js
+++ b/app.js
@@ -16816,7 +16816,7 @@ function boot() {
 
 // #local — render straight from data.js with NO backend (offline/demo + dev smoke test).
 // saveSoon() already no-ops without a password, so edits stay in-memory only.
-function offlineBoot() { buildIndexes(); state.cascade = createCascade(DATA); seedDemoRequests(); booting = false; render(); exposeTestApi(); wranglerRailLoad(); }
+function offlineBoot() { buildIndexes(); state.cascade = createCascade(DATA); seedDemoRequests(); booting = false; render(); exposeTestApi(); window.__rwBootRail = wranglerRailLoad(); }
 /* #local demo only: a sample Requests-inbox entry so the review/continue flow is
    visible without a backend. Real installs fetch live requests via the backend. */
 function seedDemoRequests() {

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -33,6 +33,8 @@ let failed = false;
 try {
   await page.goto('http://localhost:8000/#local', { waitUntil: 'domcontentloaded', timeout: 20000 });
   await page.waitForFunction(() => !!window.__rw, { timeout: 20000 });
+  await page.evaluate(() => window.__rwBootRail);   // let offlineBoot's async wranglerRailLoad() finish before any test
+                                                      // touches wranglerRail — else it can land mid-test and wipe fixtures (race)
 
   const results = await page.evaluate(async () => {
     const T = window.__rw; const out = []; const ok = (c, m) => out.push({ ok: !!c, m });


### PR DESCRIPTION
## The bug

`WR-janitor: prunes old plain chats; keeps recent, request-linked, and undated` (`ci/logic-test.mjs`, ~line 498) is flaky due to a race condition:

- `offlineBoot()` (`app.js`) calls `wranglerRailLoad()` without `await`, and `exposeTestApi()` publishes the test hook `window.__rw` before that async load finishes.
- `ci/logic-test.mjs` only waits for `window.__rw` (`page.waitForFunction(() => !!window.__rw)`, ~line 35) before running the suite, so it can start while `wranglerRailLoad()` is still in flight.
- `wranglerRailLoad()` wholesale-overwrites `state.wranglerRail` and then re-runs `wrPruneOldChats()`. If this lands during the WR-janitor test's own prune of its seeded fixture, it wipes the fixture out from under the test — intermittently failing the check with no code change.

## The fix — test-side only, no production behavior change

- `app.js`: `offlineBoot()` already created (and discarded) the `wranglerRailLoad()` promise without awaiting it. This change just stashes that same promise on `window.__rwBootRail` instead of throwing it away — production control flow is identical (still fire-and-forget from `offlineBoot()`'s perspective).
- `ci/logic-test.mjs`: right after `window.__rw` appears, the suite now does `await page.evaluate(() => window.__rwBootRail)` once, before any test touches `wranglerRail`. This closes the race by ensuring the boot-time rail load (and its internal prune) has fully settled before the WR-janitor test seeds and prunes its own fixture.

No app-side logic (`wrPruneOldChats()` etc.) was touched — that TOCTOU hardening is out of scope for this PR.

## Test plan

- [x] `node --check app.js` — exits 0
- [x] `node --check ci/logic-test.mjs` — exits 0
- [x] `node ci/gen-rule-usage.mjs --check` — stays green (no rule-usage drift, no UI touched)
- [ ] CI browser gate (`node ci/logic-test.mjs` under Playwright) — not runnable locally (Playwright not installed), left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYt7cUN3aufPfeEMtn9SdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYt7cUN3aufPfeEMtn9SdE)_