### PR TITLE
Cache-bust ?v=h — force a fresh GitHub Pages deployment (new SHA)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703g" />
+  <link rel="stylesheet" href="style.css?v=20260703h" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703g"></script>
-  <script type="module" src="app.js?v=20260703g"></script>
+  <script src="rule-usage.js?v=20260703h"></script>
+  <script type="module" src="app.js?v=20260703h"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Why

The Pages deploy for the graph-redesign merge (`89f91f8`) failed on GitHub's side (`##[error]Deployment failed, try again later.`), and re-running that same run kept failing identically — GitHub Pages itself reports **operational** (no incident), so a same-SHA deployment appears stuck. A brand-new commit produces a **new deployment id**, which can succeed where re-running the stuck one won't.

## Change

Bumps the shared cache-bust token `?v=20260703g → 20260703h` in `index.html`. **No functional change** — the graph redesign already landed in #450; this only triggers a fresh deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr

---
_Generated by [Claude Code](https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr)_