### PR TITLE
jactec-ui re-spec — audit, taste ledger, chart language, options-first loop

### DIFF
--- a/.claude/skills/jactec-ui/SKILL.md
+++ b/.claude/skills/jactec-ui/SKILL.md
@@ -2,367 +2,116 @@
 name: jactec-ui
 description: >-
   The single design skill for JacTec / Rental Wrangler. Use whenever you build,
-  reshape, or restyle ANY UI — a screen, column, card, section, pill, flag,
-  button, field, popup, menu, date picker, KPI ring, or any visible element in
-  app.js / style.css — AND for the four folded sub-capabilities: (1) aesthetic
-  direction / typography / avoiding templated AI-default "slop"; (2) MOBILE work
-  — phone reflow of the 3-column yard grid, bottom sheets, viewport/safe-area/dvh
-  sizing, touch gestures (tap vs long-press vs drag vs swipe) and Vibration-API
-  haptics; (3) DESIGN.md — scaffolding or linting the portable YAML-tokens design
-  file (Google Labs spec); (4) the /role audit — reviewing a spec/feature/screen
-  through the 15 Jac Rentals role lenses + the authority / data-sensitivity / gate
-  checklist to catch margin/PII leaks and missing gates BEFORE building. Governs
-  the "yard data-plate" design language (dark industrial steel, ONE safety-orange
-  accent, hi-vis hazard-stripe signature, stamped Saira Condensed labels, rivets,
-  a light wrangler/ranch seasoning) and its enforcement machinery (the §5
-  builders, the R0–R24 stamped rulebook, the R0 flash-lint, the CI gates). Exists
-  to keep UI unmistakably OURS and never generic, AI-detectable slop. Triggers:
-  "add a column to the units card", "restyle the rentals popup", "make a new
-  status pill", "make this work on phones", "wire a long-press", "scaffold a
-  DESIGN.md", "run /role on this spec", "run it through the design language". Do
-  NOT use for: marketing/landing pages, backend Apps Script (Code.gs), or non-UI
-  logic. Apply only to NEW or RESHAPED UI — never retroactively restyle untouched
-  parts unless Jac asks for a site-wide pass.
+  reshape, or restyle ANY UI — screen, column, card, section, pill, flag, button,
+  field, popup, menu, date picker, or any visible element in app.js / style.css —
+  and for ALL chart / graph / KPI / stat-tile / dashboard / trend work (the house
+  Graph V2 chart language). Also covers: aesthetic direction & anti-slop; MOBILE
+  (phone reflow of the yard grid, bottom sheets, viewport/safe-area, touch
+  gestures + haptics); DESIGN.md scaffolding/linting; and the /role audit (15
+  role lenses + authority / data-sensitivity gates that catch margin/PII leaks
+  BEFORE building). Governs the "yard data-plate" language (dark industrial
+  steel, ONE safety-orange accent, stamped Saira Condensed labels, a light
+  wrangler seasoning) and its enforcement (§5 builders, the R0–R24 rulebook, CI
+  gates) — plus Jac's revealed taste: dense, quiet, data-forward. Triggers: "add
+  a column to the units card", "restyle the rentals popup", "add a graph/trend to
+  a card", "make this work on phones", "scaffold a DESIGN.md", "run /role on this
+  spec". NOT for marketing pages, backend Apps Script, or non-UI logic. Apply
+  only to NEW or RESHAPED UI — never retro-restyle untouched parts unless Jac
+  asks for a site-wide pass.
 ---
 
 # JacTec UI — the yard data-plate design system
 
-JacTec is a **dense, dark, industrial equipment-rental operations app** — not a
-marketing site. Every screen should read like a steel **data-plate** bolted to a
-machine in the yard: quiet steel surfaces, one safety-orange ignition accent, the
-hi-vis hazard stripe as the signature, stamped condensed labels, a light wrangler
-twist in the copy. The whole system is already encoded in the codebase. **Your job
-is to EXTEND it, never to invent a parallel one.** When in doubt, match what's
-there and speak in rule numbers.
+JacTec is a **dense, dark, industrial equipment-rental ops app** — a steel
+data-plate bolted to a machine, not a marketing site. The system is already
+encoded in the codebase: tokens, §5 builders, the R0–R24 rulebook, the Graph V2
+chart engine. **Your job is to EXTEND it, never to invent a parallel one** — and
+to match **Jac's revealed taste: dense, quiet, data-forward.** When in doubt,
+match what's there, speak in rule numbers, and ask Jac via popup.
 
-**This is the one design skill** — it absorbed the former `frontend`, `mobile-*`,
-`design-md`, and `role` skills. The **build language below is the dominant content**;
-the four folded sub-capabilities each live behind a reference and have their own
-section near the end: **Aesthetic direction**, **Mobile**, **DESIGN.md**, and the
-**/role audit**. Jump to the section you need; everything visual still routes through
-the rulebook.
+## Router — load only what the task needs
 
-> Load the right reference for depth.
-> **Build language:** [`references/tokens.md`](references/tokens.md)
-> (every color/size literal, all themes) · [`references/rulebook.md`](references/rulebook.md)
-> (the full R0–R24 catalog) · [`references/signature-recipes.md`](references/signature-recipes.md)
-> (copy-paste hazard stripe / rivets / ignition / rings / focus / reduced-motion)
-> · [`references/anti-slop.md`](references/anti-slop.md) (the banned looks + tells)
-> · [`references/checklists.md`](references/checklists.md) (pre-ship gate).
-> **Folded sub-capabilities:** [`references/frontend-design.md`](references/frontend-design.md)
-> (aesthetic-direction method) · [`references/mobile.md`](references/mobile.md)
-> (viewport + reflow + touch/haptics) · [`references/designmd-guide.md`](references/designmd-guide.md)
-> + [`references/designmd-spec.md`](references/designmd-spec.md) +
-> [`references/designmd-lint.md`](references/designmd-lint.md) +
-> [`references/jactec.design.md`](references/jactec.design.md) (DESIGN.md) ·
-> [`references/role-framework.md`](references/role-framework.md) +
-> [`references/role-roles.md`](references/role-roles.md) (/role audit).
+| Task | Load |
+|---|---|
+| **ANY UI task** | [`taste.md`](references/taste.md) **FIRST** — it's short; it is Jac's actual taste |
+| Small edit to an existing element | [`rulebook.md`](references/rulebook.md) (element → builder → rule map) + [`tokens.md`](references/tokens.md); build directly |
+| New / reshaped section, screen, or popup | the **options-first loop** below + [`craft.md`](references/craft.md) + [`anti-slop.md`](references/anti-slop.md) (+ [`signature-recipes.md`](references/signature-recipes.md) only if extending an existing signature surface) |
+| Any chart / graph / KPI / stat / trend | [`charts.md`](references/charts.md) — the house Graph V2 language |
+| Phone / touch / haptics | [`mobile.md`](references/mobile.md) |
+| DESIGN.md scaffold or lint | [`designmd-guide.md`](references/designmd-guide.md) (+ spec/lint/stub files beside it) |
+| Spec review / `/role` | [`role-framework.md`](references/role-framework.md) + [`role-roles.md`](references/role-roles.md) |
+| Greenfield surface with no existing language (rare) | [`frontend-design.md`](references/frontend-design.md) — the general aesthetic-direction method; on existing surfaces the data-plate language already IS the direction |
+| Pre-ship | [`checklists.md`](references/checklists.md) |
 
-## Requirements — non-negotiable, read before touching any UI
+## The ten core laws (always on)
 
-1. **Tokens are law.** Derive every color, size, radius, shadow, and font from the
-   CSS custom properties in `style.css` `:root`. **Never** hardcode a hex, px
-   shadow, or font-name in `app.js` markup or new CSS. Dark `:root` is the default;
-   `[data-theme="light"]` and `[data-theme="yard"]`/`[data-theme="ranch"]` override
-   the **same** token names — so a treatment expressed in tokens themes itself for
-   free. Mirror every new treatment across dark + light (+ the active yard theme)
-   and confirm parity. Literals live in `references/tokens.md`.
-2. **Emit from a §5 builder with a `data-r` stamp.** Any new/changed pill · flag ·
-   add · button · field · date picker · file-drop · close-✕ MUST be produced by a
-   §5 builder in `app.js` that outputs `data-r="Rxx"`. Never hand-roll a
-   `.pill`/`.flag`/`.add-field`/`.req`/`.linkname` inline — extend the matching
-   builder so the fix lands everywhere. **Build target = ZERO R0 flash-lint
-   violations** (the lint pulses any un-stamped lint-family element red).
-3. **One orange, one meaning.** `--accent #ff7a1a` (ink `--on-orange #1a1205`) is
-   reserved for exactly three things: the **selected tab**, the **ignition/primary
-   action**, and **linked-record** affordances (R2). Never decorative, never a
-   second status color, never a hero gradient. Selected = solid orange + dark ink;
-   armed = orange **outline**, not fill. Orange surfaces always carry dark ink,
-   never white.
-4. **Two type voices, strictly separated.** `Saira Condensed` (UPPERCASE,
-   ~1.4–2px tracking, 600–800) is the **stamped** voice — wordmarks, column/section
-   tabs, KPI/micro labels, section headers, ignition buttons ONLY. `Geist`
-   (`var(--font)`) is body for everything you **read**; record names are Geist
-   bold, not caps. `ui-monospace` is only for the Inspector tag + builder names.
-   Body in the condensed face reads shouty; a stamped label in a neutral sans reads
-   generic. (Under `[data-theme="ranch"]` the stamped voice swaps to `Zilla Slab`
-   via the theme block — don't fight it.)
-5. **Status registry + action-color law are fixed and separate.** Registry colors
-   carry one meaning everywhere: `--green` ready · `--yellow` caution · `--red`
-   danger · `--blue` link · `--purple` scheduled · `--gray` plain fact. Action
-   *intent* is separate: blue = commit/save, green = takes money, red =
-   destructive-confirm (R17). Never invent or repurpose a color.
-6. **Accessibility is a gate, not a nicety.** Meet WCAG AA — ≥4.5:1 text, ≥3:1
-   large/UI — in dark **and** light **and** ranch. Never encode meaning in color
-   alone (always color + label + parent-card icon). Every interactive element has a
-   visible `:focus-visible`. Every animation degrades to a steady state under
-   `prefers-reduced-motion`.
-7. **Keep the rulebook truthful.** When you add or change a rule or token, update
-   `RULE_META` + `RB_FOUNDATION` + `RB_TABS` in the **same edit**, and speak/debug
-   in rule language ("that violates R4 — fix `dPill`") — fix the one builder, never
-   patch a single instance.
-8. **Route native UI through the styled path.** No native `title=` (use R23
-   `data-tip`), no native date picker (R22 `dateField`), no `alert()`/raw error
-   text (R19 attention-flash that points at the on-screen fix). Reaching for a
-   browser default is a tell.
+1. **Tokens are law.** Every color/size/radius/shadow/font derives from the
+   `style.css` `:root` custom properties — never a hardcoded literal. Dark is
+   default; light + yard/ranch override the same names, so token-expressed work
+   themes itself. Mirror every treatment across themes. Literals: `tokens.md`.
+2. **Emit from a §5 builder with a `data-r` stamp.** Any new/changed pill · flag
+   · add · button · field · date picker · file-drop · ✕ comes from a §5 builder
+   stamping `data-r="Rxx"` — never hand-rolled markup. Build target = **ZERO R0
+   flash-lint violations**. If a rule/token changes, update `RULE_META` +
+   `RB_FOUNDATION` + `RB_TABS` in the same edit; debug in rule language ("that
+   violates R4 — fix `dPill`"), fixing the builder, never one instance.
+3. **One orange, one meaning.** `--accent` = selected tab · ignition/primary ·
+   linked (R2) — nothing else, never decorative. Orange surfaces carry dark
+   `--on-orange` ink. **Armed = orange OUTLINE, never fill.**
+4. **Two type voices.** Saira Condensed (UPPERCASE, tracked, 600–800) is the
+   stamped voice — labels, tabs, section headers, ignition buttons only. Geist is
+   everything you read; record names are Geist bold, not caps.
+5. **Status registry + action-color law are fixed.** Registry: green ready ·
+   yellow caution · red danger · blue link/calm-trend · purple scheduled · gray
+   fact. Action intent: blue commit · green money · red destructive (R17). Never
+   invent or repurpose a color.
+6. **Accessibility is a gate.** AA contrast in dark AND light AND ranch; never
+   meaning by color alone; visible `:focus-visible` everywhere; animations
+   degrade under `prefers-reduced-motion`. Depth: `craft.md`.
+7. **Quiet is correct.** Data surfaces stay calm. Decoration NEVER fixes
+   "generic" — identity comes from tokens, type, and builders. **Signature
+   devices (the hazard stripe above all) are OPT-IN: apply only when Jac
+   explicitly asks.** If something "looks plain," the answer is density, data,
+   or a popup asking Jac — not chrome.
+8. **Dense by default.** Vertical footprint is a cost. No legends; no titles
+   that repeat the tab; counts folded onto the data; hover `data-tip` + aria
+   carry naming; marks sized UP when chrome is removed; single-line chips;
+   top-aligned tight spacing. (But density never becomes cramped — split views
+   rather than shrink past legible.)
+9. **Native UI is banned.** No `title=` (R23 `data-tip`), no native date picker
+   (R22 `dateField`), no `alert()` (R19 attention-flash at the fix).
+10. **Ask Jac via AskUserQuestion popups, never inline** (CLAUDE.md rule).
 
-## The element → builder → rule map (use the builder, never hand-roll)
+## Options-first loop (new / reshaped UI only)
 
-| You need… | Builder | Rule |
-|---|---|---|
-| Status DROPDOWN that advances a record (big shape + chevron) | `gatePill`/`gatePillRaw`/`funnelPill`/`masterGate`/`unitStatusGate` | **R1** |
-| LINKED record (orange-outline / R10-chip, opens a record, optional ✕) | `refPill` / `unitPill` | **R2** |
-| Informational STATUS badge (registry color, parent-card icon, never an action) | `statusPill` | **R3** |
-| Plain FACT chip (`480 HRS`, `No GPS` — gray, no icon, no hover) | `badge` | **R3b** |
-| DERIVED pill riding its parent (ink+icon only, right of parent) | `dPill` | **R4** · `dPill({alert})` → **R4b** (pulses) |
-| BLUE dashed `+Thing` (links/creates a record OR adds a line item) | `addBtn({link\|line\|anchor})` | **R5b** |
-| GRAY dashed `+Thing` (a normal empty field) | `addBtn()` | **R5c** |
-| Required-until-entered (white bg + dark ink, stays loud) | `reqBtn` | **R6** |
-| Hyperlink (blue · italic · not bold · permanent underline) | `linkName` | **R7** |
-| Derived/computed VALUE (italic — you didn't type it) | `kv({derived})` / `.derived` | **R8** |
-| Title mini-flags (≤2 stacked, no backgrounds) | `flagEl` / `flagsStack` | **R9** · `flagEl({alert})` → **R9b** (pulses) |
-| S1 title chip (dark chip · white bold · plain orange icon · orange border) | `.c-titlecard` (`cardEl`) | **R10** |
-| Section (centered header; header+border follow live status) | `.section` + `sec-green/yellow/red` | **R11** |
-| Notes line (boxless; filled→top, empty→bottom) | `notesSection` | **R12** |
-| History (count chips above an inline filter) | `historySection` | **R13** |
-| 3-state segmented toggle | `segCtl` | **R14** |
-| Journey (yard +Start/+FC/+End · transport) | `yardToolHtml` / `miniJourneyHtml` | **R15** |
-| Day timeline (window in day cells) | the rentals `timeline` | **R16** |
-| Forward-action button (blue commit / green money / red danger) | `actionPill` | **R17** |
-| The ONE quiet action (Cancel/Close/Exit/Clear) | `ghostPill` | **R18** |
-| Attention flash that points AT the fix (replaces an error toast) | `attnFlash` / `flashOr` | **R19** |
-| Right-click / long-press menu | `openCtxMenu` | **R20** |
-| Massive popup add-file zone | `fileDrop` | **R21** |
-| The ONE app-styled single date/time picker | `dateField` | **R22** |
-| Tooltip (NEVER native `title=`) | `data-tip` attribute | **R23** |
-| Deliberate close/remove ✕ (red circle, white ✕) | `closeX` | **R24** |
+1. **Frame the brief** in one paragraph: subject, job, constraints, where the
+   density lands.
+2. **Build 2–3 genuinely different variants** — layout/structure differences,
+   not palette tweaks — as real markup in the app.
+3. **Screenshot each:** serve the repo on port 9147, drive headless Chromium via
+   Playwright / `webapp-testing` at 1440×900 (+390×844 if mobile-relevant).
+   Cloud sessions CAN do this — Chromium is pre-installed.
+4. **Present via AskUserQuestion** — one option per variant, screenshots
+   attached/described. Jac picks.
+5. **Build out the winner; polish; self-critique screenshot** (review against
+   `taste.md` + `anti-slop.md`, remove one accessory); then the gates.
 
-Full one-liners + do/don't per rule: [`references/rulebook.md`](references/rulebook.md).
-If an element genuinely has no rule, that's a decision to make WITH a new builder +
-a new `RULE_META` row + a `data-r` stamp — not an excuse to drop raw markup.
+**Skip the loop** for single-element edits, copy changes, token-value tweaks,
+and bugfixes — but the self-critique screenshot still runs on every visual
+change.
 
-## The objective safe-rules layer (apply unless you state a reason to override)
+## Feedback loop — keep `taste.md` current
 
-Anthony Hobday's near-always-safe visual rules, adapted for a dense dark ops UI.
-They sharpen the system; they don't replace it.
-
-- **Near-black, near-white, never pure.** `--bg #0b0c0f` / `--txt #e9edf4` already
-  satisfy this — never introduce `#000` or `#fff`. Reserve max contrast for orange.
-- **Saturate neutrals one temperature.** Keep new neutrals on the existing yard
-  cast; never drop a dead `#888` gray in, never mix warm + cool.
-- **High contrast only for what leads.** Lines, `--txt-3` micro-labels, and panel
-  edges stay low-contrast; spend high contrast on data values, status, and orange.
-  Avoid both the even-grey-soup and the low-contrast fad.
-- **Depth by lightness, not shadow, on dark.** Closer = lighter. Use only the two
-  defined elevations (`--shadow` floats cards/popups; `--chip-shadow` lifts
-  chips/rows) plus the orange halo ring on menus/pop-ups and the `#18b6ff` neon ring
-  for an anchored "you are here" record. **No new drop shadows on dark cards**;
-  don't mix shadow/border/flat across sibling panels. Delineate sections with
-  `--line` borders that contrast both surfaces, not big fills.
-- **One math spacing scale.** Pull every gap/pad from the rhythm (grid 12 · list 7
-  · section pad 12 · row pad 9–11; radius `--radius 14–16` / `--chip-radius 11–12` /
-  8–10 controls / 999 pills). No one-off 13px/7px values. **Outer padding ≥ inner.**
-- **Nest radii properly:** inner = outer − gap. **Dim icons** to match the text
-  weight beside them. **Collapse redundant dividers** — one divide per boundary.
-  **Optical-align** glyphs whose visual center ≠ geometric (chevron, ▸).
-- **Deliberate overrides, named.** We legitimately override Hobday's marketing-tuned
-  16px-body / ~70-char-line rules: a dense yard grid runs smaller, tighter type (the
-  28/15/13/12/11/10/9.5px scale, 11px badges) and narrow numeric columns on purpose.
-  Enforce a minimum **legible** size and split into more views rather than shrink
-  past it — never let density become cramped. This is the one place we deviate.
-
-## Accessibility & contrast (hard)
-
-- **Check ratios, don't eyeball.** AA in dark **and** light **and** ranch. Light
-  theme darkens status colors so pill TEXT reads on the soft `-bg` fills — preserve
-  that when adding/altering a status.
-- **Orange ink is fixed:** orange surfaces carry dark `--on-orange`, never `--txt`.
-- **Never color alone** — color + label + parent-card icon, always.
-- **Visible `:focus-visible`** on every interactive element (`outline: 2px solid
-  var(--accent); outline-offset: 2px`).
-- **Respect `prefers-reduced-motion`** — pulses/barber-poles freeze to steady.
-- **Don't rely on hover** for critical info; long-press (R20) + tap reach it too.
-
-## Layout — flexible grids, recognition over recall
-
-- **The yard grid is fixed 3-equal-column** (Units / Rentals / Customers), 12px gap,
-  with a desktop floor. Below the floor the page **pans** horizontally — it never
-  squishes the columns, and the body never scrolls vertically. Don't introduce a
-  vertical-scroll page.
-- **Modern layout only:** CSS Grid + container queries (`@container`) for anything
-  that adapts to its container — never a 12-col bootstrap clone. Section headers are
-  centered Saira caps with flags pinned absolutely so the title stays true-center.
-- **Recognition over recall.** Reuse established shapes so a status pill looks like
-  every status pill and an add like every add. Consistency *is* grouping: repeat the
-  exact treatment for related items rather than improvising a variant.
-- **Button order & flow.** Keep confirm/cancel in the established order/position;
-  the ignition/commit action gets the weight, the ghost (R18) stays quiet. Order by
-  visual weight, heaviest toward the outer edge. **Minimize clicks** — a one-gate
-  move should never become a multi-step dialog.
-
-## Signature, motion & the ranch seasoning
-
-- **Spend boldness in ONE place: the hi-vis hazard stripe** —
-  `repeating-linear-gradient(135deg, var(--yellow) 0 13px, #14181d 13px 26px)` (red
-  variant for danger/abort). Apply it as plate **chrome** — the card cap, the login
-  band, drop zones, the R4b hazard cap — and keep everything around it quiet. Stripes
-  + rivets are intentional "complex" texture: keep DATA and reading content on calm
-  fields (simple-on-complex), never behind text. Supporting devices: corner rivets,
-  recessed detent wells, stamped labels, the ignition button. Reference
-  implementations live in the `.login-*` and `.cancel-arc` blocks in `style.css` —
-  match them. Snippets: [`references/signature-recipes.md`](references/signature-recipes.md).
-- **Motion is fast + functional, one orchestrated moment.** .12s controls · .15s
-  surfaces · .5s rings/timeline. Use the named keyframes only (`attnGlow`, `plateIn`,
-  `flagPulse`, `rwLint`). **Forbidden:** generic `transition: all 0.2s ease`,
-  bouncy/overshoot easing, scattered ambient micro-interactions — those read
-  consumer-marketing. Default crisp ease-out; reserve the one beat (the attnGlow that
-  REPLACES an error by pointing at the fix).
-- **Ranch is a seasoning, never the meal.** Carry it mostly through VOICE/COPY in the
-  yard/wrangler register (Wrangle · Round up · Corral · Brand · Saddle up · Rein in).
-  Restrained visual cues only: worn leather-tan (`--tan`) for tiny touches +
-  saddle-stitch dashed dividers; a rare brand/star marker. **Litmus: if a glance
-  reads "western" before "industrial rental yard," dial it back.** Never add
-  wood/rope/saloon-serif as a dominant skin in the dark/light themes.
-- **Copy is design material.** Active voice; an action keeps its name through the
-  whole flow ("Release to cancel" → matching toast). Errors say what's wrong and how
-  to fix it in the interface's voice — never apologize, never vague. Empty states
-  invite action.
-
-## Workflow: structure → tidy → responsive → polish → self-critique
-
-0. **Plan tokens first** (the aesthetic-direction method — [`references/frontend-design.md`](references/frontend-design.md)). Name the surfaces, status
-   colors, type roles, layout concept, and where the ONE signature beat lands.
-   Confirm it dodges the three AI defaults (cream+serif+terracotta /
-   near-black+acid-green / broadsheet hairlines). If `brainstorming` is opted in, its
-   HARD-GATE forbids code before an approved design+spec. **Ask Jac any decision via
-   the AskUserQuestion popup, never inline** (CLAUDE.md rule).
-1. **Structure** — right builders, right stamped elements, correct rules + data.
-   Make it correct in rule language before styling.
-2. **Tidy** — one spacing scale, align everything to something, nested radii,
-   collapsed dividers, outer ≥ inner padding, weight ordering. Reason for every choice.
-3. **Responsive** — grid pans (never squishes); container queries where a piece
-   adapts; minimum-legible-size honored (split, don't shrink); touch reaches every action.
-4. **Polish** — dim icons, optical-align glyphs, tune the one motion moment, wire the
-   halo / anchored ring, mirror into light (+ ranch).
-5. **Self-critique before showing Jac** — screenshot and review against this skill
-   (a picture is worth 1000 tokens); "remove one accessory"; run the anti-slop
-   checklist; then the gates.
-
-## Anti-slop checklist (catch these before you ship)
-
-The three banned AI-default looks: ① cream `#F4F1EA` + high-contrast serif +
-terracotta · ② near-black + a single acid-green/vermilion accent · ③ broadsheet
-hairlines + zero radius + dense newspaper columns. We are none of them. Then:
-
-- [ ] Any pill/flag/add/button/field **without a `data-r` stamp** (#1 tell) → route through a §5 builder.
-- [ ] Pure `#000` surface or `#fff` text anywhere → use the near-black/near-white tokens.
-- [ ] Orange as decoration, a 2nd status color, or a hero gradient → accent = selected · ignition · linked only.
-- [ ] New drop shadow on a dark card, or mixed elevation across siblings → lightness + the two defined elevations.
-- [ ] A dead `#888` / off-temperature gray instead of a token.
-- [ ] Body set in Saira Condensed, or a label in a neutral/system sans → keep the two voices separate (Inter/Roboto/Arial/system/Space Grotesk are banned for labels).
-- [ ] Arbitrary one-off spacing instead of the scale; inner padding tighter than outer.
-- [ ] Mismatched nested radii; full-strength icon out-shouting its label; stacked redundant dividers; mathematically-centered chevron that looks off.
-- [ ] Native `title=` / native date picker / `alert()` → R23 / R22 / R19.
-- [ ] Generic `transition: all .2s`, bouncy easing, scattered micro-interactions, or the template hero / ornamental 01·02·03 markers.
-- [ ] Ranch reading western-first; a treatment shipped in one theme only; a new rule with no `RULE_META` entry; missing `:focus-visible`; contrast under AA; meaning in color alone.
+When Jac corrects any design call in-session, append ONE generalized entry to
+`references/taste.md` (date · what was corrected → the rule) **in the same PR**.
+Never delete; supersede. This is how corrections outlive the session.
 
 ## Gates before push (push to `main` = live)
 
-`node ci/smoke.mjs` · `node ci/logic-test.mjs` · `node ci/gen-rule-usage.mjs --check`
-(regenerate without `--check` only when rule USAGE changed) · **zero R0 violations** ·
-a self-critique screenshot pass. Deploy = feature branch → PR → squash-merge (main is
-branch-protected). Never push a failing gate or a red lint; never put model ids /
-secrets / passwords in the repo (it's public via Pages). Full pre-ship list:
-[`references/checklists.md`](references/checklists.md).
-
----
-
-# Folded sub-capabilities
-
-Everything above is the **build language** — the dominant job. The four sections below
-are the skills that merged in. Each is a different *mode* of design work; read the one
-that matches the request, then come back to the rulebook when you touch real UI.
-
-## ① Aesthetic direction (the taste layer)
-
-Before you reach for a builder, frame the *direction*. The general method —
-design-lead framing, the two-pass plan (token system → critique against the brief →
-build), the writing-as-design-material rules, and the "remove one accessory"
-self-critique — lives in [`references/frontend-design.md`](references/frontend-design.md).
-For JacTec it's **not** a free hand: the yard data-plate language already IS the
-direction. Use the method to make *intentional* choices within it (where the ONE bold
-beat lands, how the copy reads, which AI-default to dodge), never to invent a parallel
-look. Plan-tokens-first (Workflow step 0) is this layer in action.
-
-## ② Mobile — reflow, viewport, touch
-
-Making any screen work on a phone. **Mobile is a reflow of the data-plate language, not
-a re-theme** — tokens, rules, and the signature stay intact. Full detail in
-[`references/mobile.md`](references/mobile.md), which covers three domains:
-- **Viewport & ratio** — `viewport-fit=cover`, never `100vh` (use `dvh`/`svh`),
-  `env(safe-area-inset-*)` for the notch/home-bar, `aspect-ratio` to kill layout shift,
-  the ≥44×44px touch-target floor, no horizontal overflow.
-- **Navigation & reflow** — the 3-equal-column yard grid collapses to **one active
-  column + a segmented switcher** (reuses `revealCol`); overlays/winpicker/chat-dock
-  become bottom sheets; one predictable Esc/back chain; one primary scroll region.
-- **Touch & haptics** — extend the existing `app.js` §15 pointer drag engine
-  (tap = action, 400ms long-press/drag = grab); `touch-action` is load-bearing; no
-  hover-only actions; optional swipe; a guarded `haptic()` helper (best-effort —
-  **iOS Safari has no Vibration API**, never rely on it for meaning).
-Verify with `webapp-testing` at a phone context (390×844 + 320px).
-
-## ③ DESIGN.md — the portable token file
-
-Scaffold or lint a `DESIGN.md` — the portable YAML-tokens + markdown-rationale file
-(Google Labs alpha spec) that any agent reads to stay on-brand. Full procedure, the
-rails, the CLI, and the offline spec/lint rules are in
-[`references/designmd-guide.md`](references/designmd-guide.md) (with
-[`references/designmd-spec.md`](references/designmd-spec.md),
-[`references/designmd-lint.md`](references/designmd-lint.md), and the ready JacTec stub
-[`references/jactec.design.md`](references/jactec.design.md)). **The load-bearing rail:**
-scaffolding/linting is safe, but **the moment its tokens would fan out into real files,
-STOP — surface the file, get Jac's OK first.** A DESIGN.md is a *projection* of our canon
-(CLAUDE.md + this skill + the R-rulebook), never a competing rulebook; propagating it
-back into UI is a full build job under the rules above, never a silent rewrite. Not a CI
-gate (needs network) — dev-time only.
-
-## ④ The /role audit — role-lens spec review
-
-Audit a spec/design/screen against the real Jac Rentals org **before building**: 15 role
-lenses (Dispatcher → Customer/Contractor) + a 12-step authority / data-sensitivity / gate
-checklist. Catches the leaks a single-perspective spec misses. Load both
-[`references/role-framework.md`](references/role-framework.md) (the hierarchy, the 9-tier
-data-sensitivity matrix, the 12-step checklist) and
-[`references/role-roles.md`](references/role-roles.md) (the 15 cards with each role's
-`spec_audit_questions`) before auditing.
-
-**When:** right after a SPEC is generated, before a new feature/screen, or after any
-change to permissions, pricing visibility, customer-facing surfaces, or status/gate
-logic. Anytime someone types `/role` (no spec named → audit the most recent spec or the
-feature under discussion).
-
-**Hard-fail gates (🔴 blockers, not suggestions):** data-sensitivity (step 3) and
-customer isolation (step 4). **Margin floors are radioactive** — Bottom Dollar, True
-Cost, ROI, part cost on any Sales-shared or customer-facing surface is an automatic 🔴.
-Customer isolation and gates are **server-side** concerns — "the UI hides it" is never an
-acceptable answer.
-
-Output: lead with blockers, then gaps, then per-role pass/fail, then clears, then ordered
-fixes. **Silence = pass** (don't pad). This audit produces findings — it does **not** write
-code or change the spec; offer to apply fixes only after presenting them.
-
-```
-# /role audit — <spec name>
-## Roles touched
-<primary actor(s)> · <incidental readers> — one line each on their lens
-## 🔴 Blockers (HARD-FAIL)
-- <data-sensitivity / isolation / authority violation> — role, field, why, fix
-## 🟡 Gaps
-- <missing gate / audit trail / cascade / mobile / KPI issue> — role, why, fix
-## Per-role audit questions
-**<Role>** — ✅/❌/⚠️ per question, one line each
-## ✅ Clears
-- <what the spec already handles well>
-## Recommended fixes (ordered)
-1. <concrete change>
-```
+`node ci/smoke.mjs` · `node ci/logic-test.mjs` · `node ci/gen-rule-usage.mjs
+--check` (regen without `--check` when rule usage changed) ·
+`node ci/check-window-catalog.mjs` · `node tools/gen-code-map.mjs --check` ·
+**zero R0 violations** · self-critique screenshot. Deploy = feature branch → PR →
+squash-merge (main is branch-protected). Never push a failing gate; never put
+model ids / secrets / passwords in the repo (it's public via Pages). Full list:
+[`checklists.md`](references/checklists.md).

--- a/.claude/skills/jactec-ui/references/anti-slop.md
+++ b/.claude/skills/jactec-ui/references/anti-slop.md
@@ -5,6 +5,17 @@ inconsistent details. Our defense is a strong, specific identity (the yard
 data-plate) plus the discipline below. The goal isn't novelty for its own sake — it's
 that every element is **deliberate** and **part of one system**.
 
+## Quiet is correct — genericness is never fixed with chrome
+
+The instinct "this looks plain, add visual interest" is itself a slop tell — it's
+how the hazard-stripe seam got added to the Graph V2 section and stripped by Jac
+within minutes (#450). Identity here comes from the tokens, the two type voices,
+the builders, and dense data-forward composition — which every element already
+wears. If a surface still reads generic, the fix is structural (density, real
+data on the marks, tighter composition per `taste.md`) or a popup asking Jac what
+feels plain — **never** stripe, texture, gradients, ornaments, or any signature
+device (those are opt-in: Jac asks, or they don't ship).
+
 ## The three banned AI-default looks
 
 Current generated design clusters around three looks. We are **none** of them:

--- a/.claude/skills/jactec-ui/references/charts.md
+++ b/.claude/skills/jactec-ui/references/charts.md
@@ -1,0 +1,92 @@
+# charts.md — the house chart language (Graph V2)
+
+Load for ANY chart / graph / KPI / stat-tile / leaderboard / trend work. The
+language was converged with Jac across PR #450 (Units redesign) and #456 (rollout
+to every card); the full design rationale is
+`docs/superpowers/specs/2026-07-03-units-graph-redesign-design.md`. The engine is
+`GV2` + the V2 renderers (`APP-24/25`, `app.js` §13.3–13.5). **Extend that engine —
+never build a parallel chart stack.**
+
+## Anatomy of a graph section
+
+```
+┌───────────────────────────────────────────────┐
+│  INSPECTION   FLEET   WO   #S                  │  group TABS (top; solid orange = selected)
+├──────┬─────────────────────────────────────────┤
+│ WK   │   donut ←→ stacked area / trajectory    │  time-RAIL (left, single-line chips)
+│ MO   │   counts ON the chart · center total    │  — only where a DATED source exists
+│ 30D… │                                          │
+└──────┴─────────────────────────────────────────┘
+```
+
+- **Group tabs on top** replace any chevron/carousel/dots navigation. Selected
+  tab = solid orange + dark ink. Naturally-related data sets ride together in ONE
+  tab as a **fixed side-by-side pair** (Inspection + Service, WO + Field Calls) —
+  never a user-facing compare/config control.
+- **Left time-rail** — single-line chips `WK / MO / 30D / 60D / 90D` (full meaning
+  on hover), **only where a dated event source exists**. A snapshot-only metric
+  (no history) shows Current alone with the rail collapsed — never a broken or
+  faked time-series.
+- **Snapshot → trend morph:** Current = the snapshot form (donut / tiles /
+  leaderboard). Picking a window morphs the SAME metric into a time-series —
+  **trajectory line** for single-value counts, **stacked proportional-area** for
+  status breakdowns — with today's reality pinned at the right edge.
+
+## Honest denominators
+
+A windowed series derived from an event log answers a different question than the
+snapshot ("outcomes of N events in the window" vs "state of the fleet now").
+That's acceptable — but **name the shift** (the selected chip + caption/aria carry
+it) and **never fabricate history** a source doesn't store. If a metric has no
+dated source, it gets no rail; if Jac wants its trend, that's a backend
+snapshot-recording feature (via `/clasp`), not a chart trick.
+
+## Labels, not legends
+
+- **No legends. No chart titles. No static period label.** The selected tab + rail
+  chip already say what and when; a title repeating them is deleted chrome.
+- **Direct labels:** counts on the slices (inside when wide enough, else a short
+  leader line), band values at the right edge of stacked areas, center = total +
+  unit noun, emphasized endpoint dot + today value on trajectories.
+- **Hover + aria carry the rest:** every mark gets `data-tip` (R23) and an aria
+  name; marks are keyboard-focusable. A single compact caption row of series
+  names is the accessible/click filter path when slices are too small to hit.
+
+## Interaction
+
+- **No auto-select on open.** Default = the whole picture, nothing filtered.
+- **Armed/selected = orange OUTLINE** (+ the series' own status color), never an
+  orange fill on a status-colored mark (the color law).
+- Slices / bands / caption chips toggle the list filter (the `g`-tagged
+  `cs.filterTerms` mechanic); per-source tab + timeframe state persists
+  (`cs.gvm`/`cs.gvp`, `localStorage`).
+- **Empty states always:** "No data in this window." — never bare axes, zero-stub
+  bars, or red baseline artifacts. Zero-value bars = faint baseline gridline.
+
+## Color
+
+- **Status data wears registry colors** (green ready · yellow caution · red danger
+  · purple scheduled · gray fact) — identical meaning to the pills.
+- **Blue is the calm trend hue** for neutral time-series (bookings, opened-WOs,
+  Field-Call trajectories) — matching the app's other monthly bars.
+- **Red = attention leaderboards only** (Most Field Calls, Biggest Balances).
+- Revenue bars: `$k` compact labels, full `$` on hover, red cap = uncollected.
+- Orange is NEVER a series color — it means selected/armed/ignition only.
+
+## Size & density
+
+- Donut diameters: **196px single**, **144px paired** (side-by-side). When chrome
+  (legend/title) is removed, size marks UP to use the room — no small mark
+  floating in whitespace.
+- Top-align the section; single-line rail chips; no empty vertical bands. Faint
+  gridlines; 2px surface gaps between stacked bands; 2–2.4px trajectory lines
+  with a faint area fill.
+- AA contrast for on-mark labels (dark ink on green/yellow, white on red);
+  `prefers-reduced-motion` freezes any morph/animation to the steady state.
+
+## $-visibility
+
+Revenue / balance / spend views are Office+Owner-sensitive. Before adding any $
+chart to a shared or role-ambiguous surface, run the `/role` data-sensitivity
+check — margin floors (Bottom Dollar, True Cost, ROI, part cost) on any
+Sales-shared or customer-facing surface are an automatic 🔴.

--- a/.claude/skills/jactec-ui/references/checklists.md
+++ b/.claude/skills/jactec-ui/references/checklists.md
@@ -26,16 +26,26 @@ Run this before showing Jac and before any push. If a box can't be ticked, it's 
 - [ ] Icons dimmed to text weight; one divide per boundary; glyphs optically aligned.
 - [ ] Density honors a minimum legible size — split views rather than shrink past it.
 
+## Density & charts (Jac's revealed taste — `taste.md`)
+- [ ] No legends; no chart/section titles that repeat the tab; no static period labels.
+- [ ] Counts/values folded ONTO the data (slices, band edges, center totals); hover `data-tip` + aria carry naming.
+- [ ] Vertical footprint reclaimed: single-line chips, top-aligned, no empty bands; marks sized UP where chrome was removed.
+- [ ] Chart work follows `charts.md`: time-rail only where a dated source exists; honest denominators; empty states ("No data in this window."); no auto-select on open; armed = orange OUTLINE.
+- [ ] Fixed opinionated pairings — no user-facing compare/config toggles.
+
 ## Identity & motion
-- [ ] Boldness spent in ONE place (hazard stripe as chrome, not behind text).
+- [ ] NO signature device (hazard stripe, rivets, texture) added unless Jac explicitly asked; existing uses untouched. Where asked-for: chrome only, never behind text.
+- [ ] Nothing decorative added to "fix plain" — quiet is correct; genericness addressed structurally or asked via popup.
 - [ ] Motion fast + crisp, named keyframes only; no `transition: all .2s`, no bounce, no scattered micro-interactions.
 - [ ] Ranch reads industrial-first (copy + a little tan); no western skin.
 - [ ] No template hero / ornamental 01·02·03 / decorative gradient-glass.
 - [ ] Treatment mirrored across themes (not shipped in one only).
 
 ## Process & ship
-- [ ] Token plan made first; design approved (if `brainstorming` opted in, spec saved to `docs/superpowers/specs/`).
+- [ ] `taste.md` read before designing; any in-session Jac correction appended to it in this same PR.
+- [ ] Options-first loop fired for new/reshaped UI (2–3 variants → Jac picked via popup) — and correctly SKIPPED for single-element edits/copy/token tweaks/bugfixes.
+- [ ] Design approved (if `brainstorming` opted in, spec saved to `docs/superpowers/specs/`).
 - [ ] Decisions asked via `AskUserQuestion` popup, not inline.
 - [ ] Self-critique screenshot reviewed; "removed one accessory."
-- [ ] Gates green: `node ci/smoke.mjs` · `node ci/logic-test.mjs` · `node ci/gen-rule-usage.mjs --check` (regen without `--check` only if rule USAGE changed).
+- [ ] Gates green: `node ci/smoke.mjs` · `node ci/logic-test.mjs` · `node ci/gen-rule-usage.mjs --check` (regen without `--check` only if rule USAGE changed) · `node ci/check-window-catalog.mjs` · `node tools/gen-code-map.mjs --check`.
 - [ ] Ship via feature branch → PR → squash-merge to `main` (branch-protected; push = live). No model ids / secrets / passwords in the repo.

--- a/.claude/skills/jactec-ui/references/craft.md
+++ b/.claude/skills/jactec-ui/references/craft.md
@@ -1,0 +1,113 @@
+# craft.md — composition, the safe-rules layer, motion, ranch
+
+Load for any NEW or RESHAPED section, screen, or popup (alongside `taste.md` and
+`anti-slop.md`). This is the depth behind SKILL.md's laws: how to compose surfaces
+that read as one shop.
+
+## The objective safe-rules layer (apply unless you name a reason to override)
+
+Anthony Hobday's near-always-safe visual rules, adapted for a dense dark ops UI:
+
+- **Near-black, near-white, never pure.** `--bg #0b0c0f` / `--txt #e9edf4` already
+  satisfy this — never introduce `#000` or `#fff`. Reserve max contrast for orange.
+- **Saturate neutrals one temperature.** Keep new neutrals on the existing yard
+  cast; never a dead `#888`, never warm + cool mixed.
+- **High contrast only for what leads.** Lines, `--txt-3` micro-labels, and panel
+  edges stay low-contrast; spend high contrast on data values, status, and orange.
+  Avoid the even-grey soup and the low-contrast fad both.
+- **Depth by lightness, not shadow, on dark.** Closer = lighter. Only the two
+  defined elevations (`--shadow` floats cards/popups; `--chip-shadow` lifts
+  chips/rows), the orange halo ring on menus/popups, and the `#18b6ff` anchored
+  ring. No new drop shadows on dark cards; don't mix shadow/border/flat across
+  sibling panels. Delineate with `--line` borders, not big fills.
+- **One math spacing scale.** Grid 12 · list 7 · section pad 12 · row pad 9–11;
+  radius `--radius 14–16` / `--chip-radius 11–12` / 8–10 controls / 999 pills. No
+  one-off 13px/7px values. **Outer padding ≥ inner.**
+- **Nest radii properly** (inner = outer − gap). **Dim icons** to the text weight
+  beside them. **Collapse redundant dividers** — one divide per boundary.
+  **Optical-align** glyphs whose visual center ≠ geometric (chevron, ▸).
+- **The named deviation: density.** We deliberately override the 16px-body /
+  ~70-char-line marketing rules — a dense yard grid runs the
+  28/15/13/12/11/10/9.5px scale, 11px badges, narrow numeric columns. Enforce a
+  minimum LEGIBLE size and split into more views rather than shrink past it;
+  density must never become cramped.
+
+## Accessibility & contrast (hard gate, verify — don't eyeball)
+
+- AA (≥4.5:1 text, ≥3:1 large/UI) in dark **and** light **and** yard/ranch. Light
+  theme darkens status colors so pill text reads on the soft `-bg` fills —
+  preserve that when touching a status.
+- Orange surfaces carry dark `--on-orange` ink, never `--txt`.
+- Never meaning by color alone — color + label + parent-card icon, always.
+- Visible `:focus-visible` on every interactive element
+  (`outline: 2px solid var(--accent); outline-offset: 2px`).
+- `prefers-reduced-motion`: every pulse/barber-pole freezes to a steady,
+  still-meaningful state.
+- Nothing that matters is hover-only; long-press (R20) + tap reach it too.
+
+## Layout
+
+- **The yard grid is fixed 3-equal-column** (Units / Rentals / Customers), 12px
+  gap, desktop floor. Below the floor the page **pans** horizontally — it never
+  squishes columns, and the body never scrolls vertically. Don't introduce a
+  vertical-scroll page.
+- **Modern layout only:** CSS Grid + container queries for anything that adapts —
+  never a 12-col bootstrap clone. Section headers are centered Saira caps with
+  flags pinned absolutely so the title stays true-center.
+- **Recognition over recall.** Reuse established shapes; repeat the exact
+  treatment for related items rather than improvising a variant. Consistency IS
+  grouping.
+- **Button order & flow.** Confirm/cancel keep the established order; the
+  ignition/commit action gets the weight, the ghost (R18) stays quiet; heaviest
+  toward the outer edge. Minimize clicks — a one-gate move never becomes a
+  multi-step dialog.
+
+## Signature devices — OPT-IN ONLY
+
+The hazard stripe, rivets, detent wells, and plate texture are **structural
+chrome** that already lives where it belongs (card caps, the login plate, drop
+zones, the R4b cap). **Never add a signature device to new work unless Jac
+explicitly asks for it.** They are not a fix for "looks plain" — inside data
+surfaces, quiet is correct, and identity comes from the tokens, the type voices,
+and the builders, which every element already wears. When Jac does ask, copy the
+canonical recipes (`signature-recipes.md`) — don't reinvent.
+
+## Motion
+
+Fast + functional, ONE orchestrated moment. **.12s** controls · **.15s** surfaces
+· **.5s** rings/timeline; crisp ease-out; the named keyframes only (`attnGlow`,
+`plateIn`, `flagPulse`, `rwLint`). Forbidden: `transition: all .2s ease`,
+bouncy/overshoot easing, scattered ambient micro-interactions — those read
+consumer-marketing. The one beat worth spending: the attnGlow that REPLACES an
+error by pointing at the fix.
+
+## Ranch — a seasoning, never the meal
+
+Carry it through VOICE/COPY in the wrangler register (Wrangle · Round up · Corral
+· Brand · Saddle up · Rein in), used naturally, never campy. Visual cues stay
+restrained: leather-tan (`--tan`) tiny touches, the saddle-stitch dashed divider,
+a rare brand/star mark. **Litmus: if a glance reads "western" before "industrial
+rental yard," dial it back.** Never wood/rope/saloon-serif as a skin.
+
+## Copy is design material
+
+Active voice; an action keeps its name through the whole flow ("Release to
+cancel" → matching toast). Errors say what's wrong and how to fix it in the
+interface's voice — never apologize, never vague. Empty states invite action.
+Record names are Geist bold, not caps; stamped labels are Saira, short, and
+factual.
+
+## Build order: structure → tidy → responsive → polish → self-critique
+
+1. **Structure** — right builders, right stamped elements, correct rules + data.
+   Correct in rule language before styling.
+2. **Tidy** — one spacing scale, align everything to something, nested radii,
+   collapsed dividers, outer ≥ inner, weight ordering. A reason for every choice.
+3. **Responsive** — grid pans (never squishes); container queries where a piece
+   adapts; minimum-legible-size honored (split, don't shrink); touch reaches
+   every action.
+4. **Polish** — dim icons, optical-align glyphs, tune the one motion moment, wire
+   halo/anchored rings, mirror into light (+ ranch).
+5. **Self-critique screenshot** — the procedure in SKILL.md's options-first loop
+   (serve on 9147, headless Chromium at 1440×900). Review against `taste.md` +
+   `anti-slop.md`; remove one accessory; then the gates.

--- a/.claude/skills/jactec-ui/references/signature-recipes.md
+++ b/.claude/skills/jactec-ui/references/signature-recipes.md
@@ -2,7 +2,11 @@
 
 The canonical implementations live in `style.css` (the `.login-*` block, the
 `.cancel-arc` block, and the `[data-theme="yard"] .col > .card` block). Match them.
-Spend boldness in ONE place (the hazard stripe); keep everything else quiet.
+
+**Signature devices are OPT-IN (Jac, 2026-07-03).** Load this file only when
+extending a surface that ALREADY wears a device, or when Jac explicitly asks for
+one. Never reach for a recipe because something "looks plain" — quiet is correct,
+and decoration never fixes generic (see `taste.md`).
 
 ## Blued Steel card plate (the `[data-theme="bluedsteel"]` surface system)
 
@@ -46,9 +50,13 @@ Keep DATA on these calm fields — never put the texture behind text.
 
 ---
 
-## Hi-vis hazard stripe (the signature)
+## Hi-vis hazard stripe (the signature — OPT-IN ONLY)
 
-The one bold motif. Use as plate CHROME — never behind text.
+**NEVER apply the stripe unless Jac explicitly asks.** Existing uses stay (card
+cap, login band, drop zones, the R4b cap) — the stripe is structural plate
+chrome, not a garnish; the one time it was added to a data surface unprompted
+(the Graph V2 seam, #450) Jac stripped it within minutes. When asked for, use as
+plate CHROME — never behind text.
 
 ```css
 /* yellow caution band (default) */

--- a/.claude/skills/jactec-ui/references/taste.md
+++ b/.claude/skills/jactec-ui/references/taste.md
@@ -1,0 +1,49 @@
+# taste.md — Jac's revealed preferences (READ FIRST on any UI task)
+
+This is the ledger of what Jac has **actually corrected**, distilled into rules.
+It outranks your own aesthetic priors and any generic dashboard instinct. When a
+judgment call isn't covered by a token, a rule number, or a law in SKILL.md, the
+answer is in here — and if it isn't, the default is **denser and quieter than you
+think**, then ask via popup.
+
+## The ledger
+
+Format: `date · what was corrected → the rule`. Never delete an entry; when a later
+correction supersedes an earlier one, add the new entry and mark the old one
+`(superseded YYYY-MM-DD)`.
+
+- **2026-07-03 · Graph V2 (#450): legend pill column stripped** → Legends and
+  chart/section titles are chrome. The selected tab, hover `data-tip`, and `aria`
+  names carry naming; series names live in one compact caption row at most — never
+  a separate legend column, never a title that repeats the tab.
+- **2026-07-03 · Graph V2 (#450): counts moved onto the chart** → Numbers live ON
+  the data (slice labels, band-edge values, center totals), not beside it in pills
+  or side columns.
+- **2026-07-03 · Graph V2 (#450): "Current" label + per-chart titles deleted;
+  date-range chips compressed to single-line WK/MO/30D/60D/90D** → Vertical
+  footprint is a core cost. Reclaim it: single-line chips, top-aligned layouts,
+  kill empty bands and redundant caption lines; full meaning goes on hover.
+- **2026-07-03 · Graph V2 (#450): donuts enlarged after the legends were removed**
+  → When chrome is removed, size the data marks UP to use the reclaimed room. Don't
+  leave a small mark floating in new whitespace.
+- **2026-07-03 · Graph V2 (#456): user-facing "compare / Show: A + B" control
+  rejected as overkill** → Fixed, opinionated pairings beat user-facing
+  compare/config toggles. Decide which data sets ride together (Inspection +
+  Service, WO + Field Calls) and ship the pairing; don't ship a configurator.
+- **2026-07-03 · Graph V2 (#450): the hazard-stripe seam on the graph section was
+  stripped by Jac within minutes of being added** → The stripe is structural plate
+  chrome (card cap, login band, drop zones, R4b cap) and is now **opt-in only,
+  everywhere**: never apply it — or any signature decoration — unless Jac
+  explicitly asks. Inside data surfaces, quiet is correct.
+- **2026-07-03 · Graph V2 (#450): auto-select of the smallest slice in orange fill
+  removed** → Armed/selected inside a data surface = orange **outline** (+ the
+  series' own status color), never an orange fill on a status-colored mark. And
+  nothing is auto-selected on open — the default is the whole picture, unfiltered.
+
+## Append protocol (mandatory, same PR)
+
+When Jac corrects a design call in-session — a popup answer that reverses your
+choice, a "remove that", a redo — add ONE generalized entry to the ledger above
+**in the same PR** as the fix, so the correction is visible in the diff and never
+evaporates with the session. Generalize the lesson (the rule a future session
+needs), not the incident. Never delete; supersede.

--- a/docs/superpowers/specs/2026-07-03-jactec-ui-respec-design.md
+++ b/docs/superpowers/specs/2026-07-03-jactec-ui-respec-design.md
@@ -1,0 +1,151 @@
+# jactec-ui re-spec — router core · taste ledger · chart language · options-first
+
+- **Date:** 2026-07-03
+- **Status:** Draft for Jac's redline (co-specced in-session)
+- **Branch:** `claude/bugs-improvements-0bocof`
+- **Driver:** Jac: the skill "often does not produce the outcome I'm looking for."
+  Evidence: PR #450 (Units graph redesign) — five consecutive "Per Jac:" correction
+  commits all pulling toward denser, quieter, data-forward UI, plus the hazard-stripe
+  seam the skill itself prompted (added a3f7ba7, stripped by Jac 034504b two minutes
+  later). PR #456 confirmed the corrected pattern generalizes.
+
+## 1. Diagnosis (what the audit found)
+
+1. **Rule engine, no taste.** ~90% of the skill is constraints (tokens, R-map, bans,
+   checklists); nothing teaches composition or Jac's actual density/quietness
+   preferences — so Claude's airy-dashboard priors won on every judgment call.
+2. **The signature mandate backfires.** "Spend boldness in ONE place (the hazard
+   stripe)" reads as an instruction to ADD stripe when something looks plain. Jac's
+   revealed preference: quiet is correct inside data surfaces.
+3. **Charts are a blind spot.** R1–R24 covers pills/buttons/fields; Graph V2 was 100%
+   dataviz. The house chart language Jac converged on exists only in commit messages.
+4. **Five jobs, one 368-line body + ~330-word description** — low signal-to-task
+   ratio for small edits.
+5. **Screenshot self-critique is a mandate with no procedure** — the most-skipped step.
+6. **No feedback loop** — Jac's corrections evaporate after each session.
+
+## 2. Decisions (Jac, 2026-07-03, via popup)
+
+| Decision | Call |
+|---|---|
+| Hazard stripe | **Opt-in only. NEVER apply it unless Jac explicitly asks.** Existing uses stay. |
+| Density priors | Encode as first-class law (no legends/titles, counts on chart, minimal vertical footprint, big marks, tight spacing). |
+| Signature restraint | "Quiet is correct" — decoration never fixes genericness. |
+| Chart language | New `references/charts.md` encoding the Graph V2 pattern. |
+| Structure | **Router + lean core** — short SKILL.md routes by task type; depth in references. |
+| Process | **Options-first** — for non-trivial UI, 2–3 screenshot variants → Jac picks via popup → then polish. Small edits skip. |
+| Taste ledger | **`references/taste.md`, auto-append** — every in-session correction distilled into the same PR, visible in the diff. |
+
+## 3. The new shape
+
+```
+jactec-ui/
+├── SKILL.md                 ~150 lines: identity · router · core laws · options-first loop · gates
+└── references/
+    ├── taste.md             NEW — the revealed-preference ledger (seeded from Graph V2) + append protocol
+    ├── charts.md            NEW — the house chart language (from #450/#456 + the graph spec)
+    ├── craft.md             NEW — the Hobday safe-rules layer + layout + motion + ranch (moved out of SKILL.md)
+    ├── tokens.md            unchanged
+    ├── rulebook.md          unchanged
+    ├── signature-recipes.md EDIT — stripe section carries the opt-in law
+    ├── anti-slop.md         EDIT — reframe: quiet-is-correct; genericness is never fixed with chrome
+    ├── checklists.md        EDIT — density/chart/options-first boxes; boldness line rewritten
+    ├── frontend-design.md   unchanged (vendored) — router scopes it to greenfield surfaces only
+    ├── mobile.md            unchanged
+    ├── designmd-*.md        unchanged (4 files)
+    └── role-*.md            unchanged (2 files)
+```
+
+### SKILL.md core laws (the always-on set, compressed)
+1. Tokens are law (no hardcoded literals; theme parity).
+2. §5 builders + `data-r` stamps; zero R0; rulebook kept truthful.
+3. One orange, one meaning (selected · ignition · linked; dark ink on orange).
+4. Two type voices (Saira stamped vs Geist read).
+5. Status registry + action-color law fixed.
+6. AA accessibility gate (contrast · not-color-alone · focus-visible · reduced-motion).
+7. **Quiet is correct.** Data surfaces stay calm. Decoration never fixes "generic."
+   **Signature devices (hazard stripe above all) are opt-in: only when Jac asks.**
+8. **Dense by default.** Vertical footprint is a cost. No legends (hover + aria name
+   things), no chart/section titles that repeat the tab, counts folded onto the data,
+   marks sized up when chrome is removed, top-aligned tight spacing.
+9. Native UI banned (R22/R23/R19 styled paths).
+10. Questions to Jac via AskUserQuestion popups, never inline.
+
+### The router (task type → what to load)
+- **Any UI task** → read `taste.md` FIRST (it's short; it is Jac's actual taste).
+- Small edit to an existing element → `rulebook.md` + `tokens.md`; build directly.
+- New/reshaped section, screen, or popup → options-first loop + `craft.md` +
+  `anti-slop.md` (+ `signature-recipes.md` only if extending an existing signature surface).
+- Any chart/graph/KPI/stat work → `charts.md`.
+- Phone/touch work → `mobile.md`. DESIGN.md work → `designmd-guide.md`.
+  Spec review → `role-framework.md` + `role-roles.md`. Pre-ship → `checklists.md`.
+
+### Options-first loop (new/reshaped UI only)
+1. Frame the brief in one paragraph (subject, job, constraints, where density lands).
+2. Build 2–3 genuinely different variants (layout/structure differences, not palette
+   tweaks) as real markup in the app.
+3. Screenshot each: serve the repo (`node <scratch>/serve.mjs`, port 9147), drive with
+   Playwright/`webapp-testing` headless Chromium at 1440×900 (+390×844 if mobile-relevant);
+   cloud sessions CAN do this — Chromium is pre-installed.
+4. Present via AskUserQuestion (one option per variant, screenshots attached/described).
+5. Build out the winner; polish; self-critique screenshot; gates.
+Skip for: single-element edits, copy changes, token-value tweaks, bugfixes — but the
+self-critique screenshot still runs on every visual change.
+
+### taste.md seed entries (from Graph V2, generalized)
+- Legends/titles are chrome → hover + aria + the selected tab carry naming.
+- Counts live on the chart, not beside it.
+- Vertical height is a core cost; reclaim it (single-line chips, top-align, kill gaps).
+- When chrome is removed, size the data marks UP to use the room.
+- Fixed, opinionated pairings beat user-facing compare/config toggles (the 2-Up lesson).
+- The hazard-stripe seam on the graph section was rejected within minutes → stripe is
+  structural chrome (card cap, login, drop zones) and now **opt-in only, everywhere**.
+- Armed/selected inside data = orange OUTLINE, never fill.
+**Append protocol:** when Jac corrects a design call, add one generalized entry (date ·
+what was corrected → the rule) in the same PR. Never delete; supersede.
+
+### charts.md contents (from #450/#456 + `2026-07-03-units-graph-redesign-design.md`)
+Group tabs on top · left time-rail (Wk/Mo/30d/60d/90d) only where a dated source exists ·
+snapshot→trend morph (donut→stacked proportional-area / trajectory) · honest denominators
+(name the shift; never fake history) · direct labels (slices carry counts, band-edge %,
+center total + noun) · no legends/titles · hover `data-tip` + aria + keyboard-focusable
+marks · fixed side-by-side pairs · empty states always ("No data in this window.") ·
+no auto-select on open · armed = orange outline · registry colors for status; blue =
+calm trend hue; red = attention leaderboards only · donut sizes (196 single / 144 paired) ·
+extend the `GV2` per-source config + V2 renderers (`APP-24/25`, `app.js` §13.3–13.5),
+never a parallel chart engine.
+
+### Description rewrite
+Same trigger coverage (build/restyle/mobile/DESIGN.md//role, "make this work on phones",
+etc.) at roughly half the length; adds chart/graph/KPI triggers explicitly.
+
+## 4. Eval plan (skill-creator loop)
+
+Baseline = the pre-edit snapshot (already copied to the session workspace). Four test
+prompts, each run old-skill vs new-skill by parallel subagents in isolated worktrees,
+producing a design plan + diff (graded on decisions, not pixels):
+
+1. **Chart class:** "Add a graph section to the Invoices card popup showing invoice
+   aging (current/30/60/90) and how collections trend over time."
+   → Expect: charts.md pattern, no legends/titles, honest-denominator note, time-rail
+   only where dated data exists.
+2. **New section:** "Add a Fuel Log section to the unit record — mechanics log fill-ups,
+   we track cost per unit." → Expect: options-first popup with 2–3 variants, §5 builders,
+   R11 section, density.
+3. **Small edit:** "Make overdue rentals stand out more in the rentals list."
+   → Expect: registry red via existing builders (R3/R4b/R9b family), no new chrome,
+   no options popup (correctly skipped).
+4. **The trap (the Graph V2 failure replayed):** "The customers card graphs look a bit
+   plain — give them some visual interest." → Expect: NO hazard stripe, no decoration;
+   data-forward suggestions and/or a popup asking Jac what feels plain. Old skill is
+   predicted to reach for the stripe.
+
+Grading: per-prompt assertion checklist (stripe absent unless asked · no legends/titles ·
+builders used · options-first fired only where it should · taste.md consulted). Results
+in a side-by-side review for Jac; iterate on misses.
+
+## 5. Out of scope
+
+- Retro-restyling any shipped UI (CLAUDE.md rule stands).
+- Un-folding the skill back into separate skills (rejected in the popup).
+- The `?v=` cache token / deploy machinery (no runtime files change in this PR).


### PR DESCRIPTION
## What & why

Jac: the design skill "often does not produce the outcome I'm looking for." This PR carries the audit + re-spec of `.claude/skills/jactec-ui`, and (once the spec passes Jac's redline) the skill rewrite itself.

## The audit (evidence: the Graph V2 trail, #450/#456)

- Five consecutive "Per Jac:" correction commits on #450 all pulled the same direction — denser, quieter, data-forward (drop legends, counts on the chart, kill the title gap, bigger donuts, single-line chips).
- The skill's own "signature pass" added a hazard-stripe seam Jac stripped two minutes later — the "spend boldness in ONE place" mandate actively causes decoration.
- Charts were a total blind spot (R1–R24 covers pills/buttons/fields; Graph V2 was 100% dataviz).
- 368-line body + ~330-word description covering 5 jobs; screenshot self-critique mandated but no procedure; no mechanism to retain Jac's corrections.

## The re-spec (co-decided with Jac in-session)

- **Hazard stripe becomes opt-in only** — never applied unless Jac explicitly asks.
- **Density priors + "quiet is correct"** become core law.
- **`references/taste.md`** — an auto-appending revealed-preference ledger, seeded from the Graph V2 corrections.
- **`references/charts.md`** — the house chart language (group tabs · time-rail · counts-on-chart · no legends/titles · honest denominators · fixed pairs), extending the `GV2` engine.
- **Router + lean core** SKILL.md; **options-first** loop (2–3 screenshot variants → Jac picks → polish) for non-trivial UI.
- Eval: 4 test prompts run old-skill vs new-skill (plan+diff grading), including a trap prompt replaying the Graph V2 failure.

## Status

- [x] Audit + co-spec (popup decisions)
- [x] Spec doc: `docs/superpowers/specs/2026-07-03-jactec-ui-respec-design.md`
- [ ] Jac's close redline of the spec (in progress — doc sent)
- [ ] Skill rewrite per approved spec
- [ ] Old-vs-new eval run + review

No runtime files change in this PR (skill + docs only), so no `?v=` cache-bust is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmuVyV2wBQeUm1UREed5jX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmuVyV2wBQeUm1UREed5jX)_