### PR TITLE
Round-Up Phase C — trends + today's-reality snapshots

### DIFF
--- a/app.js
+++ b/app.js
@@ -9638,13 +9638,14 @@ const ruEmpty = (msg) => { const d = document.createElement('div'); d.className 
 /* stamp rendered marks as NAVIGATION targets. Plot renders one element per datum per mark,
    in input order — callers pass the concatenated row list matching the rect order (base layer
    first, then overlay layers). Verified against live data in the harness. */
-function ruWireNav(node, rows) {
-  const rects = node.querySelectorAll('rect');
+function ruWireNav(node, rows, sel = 'rect') {
+  const rects = node.querySelectorAll(sel);
   rows.forEach((row, i) => {
     const r2 = rects[i]; if (!r2) return;
     r2.classList.add('js-ru-nav');
     r2.setAttribute('tabindex', '0'); r2.setAttribute('role', 'button');
     r2.setAttribute('data-navcard', row.card); r2.setAttribute('data-navcol', row.col); r2.setAttribute('data-navvalue', String(row.navValue));
+    if (row.seg) r2.setAttribute('data-navseg', row.seg);
     r2.setAttribute('aria-label', row.name); r2.setAttribute('data-tip', row.tip || row.name);
   });
   return node;
@@ -9659,11 +9660,11 @@ function ruLeadNode(rows, empty) {
 }
 // close the board and land on the owning card with the filter pill applied — the board is a
 // launchpad into the records, not a dead end (generalizes the js-notready pattern)
-function ruNavigate(card, col, value) {
+function ruNavigate(card, col, value, seg) {
   closeOverlay();
   const s = activeSession();
   const colId = COLUMN_OF[card]; if (colId && s.cols) { s.cols[colId] = card; const idx = COLUMNS.findIndex((c) => c.id === colId); if (idx >= 0) state.mobileCol = idx; }
-  const cs = s.cards[card]; if (cs) { cs.mode = 'list'; cs.recId = null; cs.recType = null; cs.graphView = false; }
+  const cs = s.cards[card]; if (cs) { cs.mode = 'list'; cs.recId = null; cs.recType = null; cs.graphView = false; if (seg) cs.segment = seg; }
   addColFilter(card, col, value);
 }
 // ── Money rollups (range-aware; the §13.5 cutoff-only versions retire in Phase E) ──
@@ -9746,11 +9747,122 @@ function ruBalances() {   // open balances are inherently CURRENT — the range 
   const rows = Object.entries(by).sort((a, b) => b[1] - a[1]).slice(0, 8).map(([n, bal]) => ({ name: n, disp: money(bal), card: 'invoices', col: 'customer', navValue: n, tip: `${n} — ${money(bal)} open` }));
   return ruLeadNode(rows, 'No open balances.');
 }
+// ── Phase C: trend engines + today's-reality snapshots (reference image: trend left, 'right now' right) ──
+// buckets over an arbitrary range (custom ranges have real edges; gvBuckets only walks back from today)
+function ruBuckets(rg) {
+  if (!ruBounded(rg)) return gvBuckets(null);   // All time → last 6 months
+  const A = parseISO(rg.a), B = parseISO(rg.b);
+  const days = Math.max(1, Math.round((B - A) / 86400000));
+  const clamp = (x) => (x < rg.a ? rg.a : x > rg.b ? rg.b : x);
+  const out = [], push = (a, b, label) => { const aa = clamp(a), bb = clamp(b); if (aa < bb) out.push({ key: aa + '|' + bb, label, a: aa, b: bb }); };
+  if (days <= 14) for (let i = 0; i < days; i++) { const a = new Date(A); a.setDate(a.getDate() + i); const b = new Date(a); b.setDate(b.getDate() + 1); push(uISO(a), uISO(b), `${a.getMonth() + 1}/${a.getDate()}`); }
+  else if (days <= 92) for (let t = new Date(A); t < B; t.setDate(t.getDate() + 7)) { const b = new Date(t); b.setDate(b.getDate() + 7); push(uISO(t), uISO(b), `${t.getMonth() + 1}/${t.getDate()}`); }
+  else for (let t = new Date(A.getFullYear(), A.getMonth(), 1); t < B; t = new Date(t.getFullYear(), t.getMonth() + 1, 1)) { const b = new Date(t.getFullYear(), t.getMonth() + 1, 1); push(uISO(t), uISO(b), t.toLocaleString('en-US', { month: 'short' })); }
+  return out;
+}
+// trajectory line: endpoint emphasized, counts above points, dots are the nav targets
+function ruLineSVG({ bk, vals, color, w = 620, h = 230 }) {
+  const n = bk.length, pts = bk.map((b, i) => ({ i, label: b.label, v: vals[i] }));
+  const show = new Set(n <= 6 ? pts.map((p) => p.i) : [0, 1, 2, 3, 4].map((k) => Math.round(k * (n - 1) / 4)));
+  const ink = ruColor(color);
+  return Plot.plot({
+    width: w, height: h, marginLeft: 40, marginRight: 18, marginTop: 22, marginBottom: 28,
+    style: { background: 'transparent', fontFamily: "'Saira Condensed', system-ui, sans-serif", fontSize: '11.5px' },
+    x: { type: 'point', label: null, tickSize: 0, domain: pts.map((p) => p.i), tickFormat: (i) => (show.has(i) ? bk[i].label : '') },
+    y: { label: null, nice: true, tickFormat: (v) => (Number.isInteger(v) ? String(v) : '') },
+    marks: [
+      Plot.gridY({ stroke: ruColor('--line'), strokeDasharray: '2,3', strokeOpacity: 0.8 }),
+      Plot.areaY(pts, { x: 'i', y: 'v', fill: ink, fillOpacity: 0.1 }),
+      Plot.line(pts, { x: 'i', y: 'v', stroke: ink, strokeWidth: 2 }),
+      Plot.dot(pts, { x: 'i', y: 'v', r: (d) => (d.i === n - 1 ? 5 : 3.5), fill: ink, title: 'label' }),
+      Plot.text(pts.filter((p) => p.v > 0), { x: 'i', y: 'v', text: (d) => String(d.v), dy: -11, fill: ruColor('--txt-2'), fontWeight: 700 }),
+      Plot.ruleY([0], { stroke: ruColor('--line-soft') }),
+    ],
+  });
+}
+// stacked proportional area (read-only): bands of a running mix, right-edge % labels
+function ruAreaSVG({ bk, bands, w = 620, h = 230 }) {
+  // bands: [{name, color, vals(fractions per bucket, bands sum ≤1)}] bottom-up
+  const n = bk.length;
+  const show = new Set(n <= 6 ? bk.map((_, i) => i) : [0, 1, 2, 3, 4].map((k) => Math.round(k * (n - 1) / 4)));
+  let base = bk.map(() => 0);
+  const areas = [], labels = [];
+  bands.forEach((bd) => {
+    const pts = bk.map((b, i) => ({ i, y0: base[i], y1: base[i] + bd.vals[i] }));
+    areas.push(Plot.areaY(pts, { x: 'i', y1: 'y0', y2: 'y1', fill: ruColor(bd.color), fillOpacity: 0.85, title: () => bd.name }));
+    const lastPct = Math.round(bd.vals[n - 1] * 100);
+    if (lastPct >= 8) labels.push(Plot.text([{ i: n - 1, y: base[n - 1] + bd.vals[n - 1] / 2 }], { x: 'i', y: 'y', text: () => lastPct + '%', dx: -4, textAnchor: 'end', fill: bd.ink || '#0c0e12', fontWeight: 800 }));
+    base = base.map((v, i) => v + bd.vals[i]);
+  });
+  return Plot.plot({
+    width: w, height: h, marginLeft: 40, marginRight: 18, marginTop: 14, marginBottom: 28,
+    style: { background: 'transparent', fontFamily: "'Saira Condensed', system-ui, sans-serif", fontSize: '11.5px' },
+    x: { type: 'point', label: null, tickSize: 0, domain: bk.map((_, i) => i), tickFormat: (i) => (show.has(i) ? bk[i].label : '') },
+    y: { label: null, domain: [0, 1], ticks: [0, 0.5, 1], tickFormat: (v) => Math.round(v * 100) + '%' },
+    marks: [Plot.gridY({ stroke: ruColor('--line'), strokeDasharray: '2,3', strokeOpacity: 0.8 }), ...areas, ...labels],
+  });
+}
+// the pinned 'right now' column — big stamped number + mini status bar (the reference's right edge)
+function ruReality({ num, noun, segs }) {
+  const live = (segs || []).filter((s2) => s2.count > 0);
+  const bar = live.length ? `<div class="ru-real-bar">${live.map((s2) => `<span class="ru-real-seg" style="flex:${s2.count};background:var(--${s2.color})" data-tip="${esc(s2.label)} — ${s2.count}"></span>`).join('')}</div>` : '';
+  const d = document.createElement('div'); d.className = 'ru-real';
+  d.innerHTML = `<div class="ru-real-n">${num}</div><div class="ru-real-l">${esc(noun)}</div>${bar}`;
+  return d;
+}
+function ruDuo(chart, right) { const d = document.createElement('div'); d.className = 'ru-duo'; const c = document.createElement('div'); c.className = 'ru-duo-chart'; c.append(chart); d.append(c); if (right) d.append(right); return d; }
+// ── Phase C panels ──
+function ruBookings(rg) {
+  const bk = ruBuckets(rg);
+  const vals = bk.map((b) => DATA.rentals.filter((r2) => { const d = (r2.startDate || '').slice(0, 10); return d >= b.a && d < b.b; }).length);
+  const rows = bk.map((b, i) => ({ card: 'rentals', col: '__rentrange', navValue: b.key, name: `${b.label} — ${vals[i]} booked`, tip: `${b.label} — ${vals[i]} booked` }));
+  const chart = vals.some((v) => v > 0) ? ruWireNav(ruLineSVG({ bk, vals, color: '--blue' }), rows, 'circle') : ruEmpty('No rentals booked in this window.');
+  const sc = {}; DATA.rentals.forEach((r2) => { const s = rentalDisplayStatus(r2); sc[s] = (sc[s] || 0) + 1; });
+  const seg = (st) => ({ label: st, count: sc[st] || 0, color: getStatus('rentalStatus', st).color || 'gray' });
+  return ruDuo(chart, ruReality({ num: sc['On Rent'] || 0, noun: 'On Rent now', segs: ['On Rent', 'Today', 'Tomorrow', 'Reserved'].map(seg) }));
+}
+function ruInspTrend(rg) {
+  const bk = ruBuckets(rg);
+  let cg = 0, cy = 0;   // running outcome STATE through the window (Fail folds into Not Ready — honest denominator)
+  const mix = bk.map((b) => { DATA.inspections.forEach((n2) => { const d = (n2.date || '').slice(0, 10); if (d >= b.a && d < b.b) { if (inspResult(n2).color === 'green') cg++; else cy++; } }); const t = cg + cy; return { g: t ? cg / t : 0, y: t ? cy / t : 0, t }; });
+  const chart = mix.some((m) => m.t) ? ruAreaSVG({ bk, bands: [
+    { name: 'Passed', color: '--green', vals: mix.map((m) => m.g) },
+    { name: 'Not Ready', color: '--yellow', vals: mix.map((m) => m.y) },
+  ] }) : ruEmpty('No inspections in this window.');
+  const f = fleetInsp(), ready = f.Ready || 0, nr = (f['Not Ready'] || 0) + (f.Failed || 0);
+  return ruDuo(chart, ruReality({ num: ready, noun: 'Ready now', segs: [{ label: 'Passed', count: ready, color: 'green' }, { label: 'Not Ready', count: nr, color: 'yellow' }] }));
+}
+function ruWoTrend(rg) {
+  const bk = ruBuckets(rg);
+  const W = DATA.workOrders.filter((w) => !w.cancelled);
+  const vals = bk.map((b) => W.filter((w) => { const d = (w.date || '').slice(0, 10); return d >= b.a && d < b.b; }).length);
+  const rows = bk.map((b, i) => ({ card: 'shop', seg: 'workOrders', col: '__daterange', navValue: b.key, name: `${b.label} — ${vals[i]} opened`, tip: `${b.label} — ${vals[i]} WOs opened` }));
+  const chart = vals.some((v) => v > 0) ? ruWireNav(ruLineSVG({ bk, vals, color: '--yellow' }), rows, 'circle') : ruEmpty('No work orders in this window.');
+  const open = W.filter((w) => w.phase !== 'Complete');
+  const byPhase = {}; open.forEach((w) => { const ph = w.phase || '—'; byPhase[ph] = (byPhase[ph] || 0) + 1; });
+  const segs = Object.entries(byPhase).sort((a, b) => b[1] - a[1]).map(([ph, n2]) => ({ label: getStatus('woPhase', ph).label || ph, count: n2, color: getStatus('woPhase', ph).color || 'gray' }));
+  return ruDuo(chart, ruReality({ num: open.length, noun: 'Open now', segs }));
+}
+function ruFieldCalls(rg) {
+  const fc = DATA.workOrders.filter((w) => w.woType === 'Field Call');
+  const bk = ruBuckets(rg);
+  const vals = bk.map((b) => new Set(fc.filter((w) => { const d = (w.date || '').slice(0, 10); return d >= b.a && d < b.b; }).map((w) => w.unitId)).size);
+  const rows = bk.map((b, i) => ({ card: 'units', col: '__fcrange', navValue: b.key, name: `${b.label} — ${vals[i]} units called`, tip: `${b.label} — ${vals[i]} units with field calls` }));
+  const chart = vals.some((v) => v > 0) ? ruWireNav(ruLineSVG({ bk, vals, color: '--red' }), rows, 'circle') : ruEmpty('No field calls in this window.');
+  const by = {}; fc.forEach((w) => { if (!w.unitId) return; if (ruBounded(rg) && !ruIn(w.date, rg)) return; by[w.unitId] = (by[w.unitId] || 0) + 1; });
+  const lead = Object.entries(by).sort((a, b) => b[1] - a[1]).slice(0, 5)
+    .map(([uid, n2]) => { const nm = IDX.unit.get(uid)?.name || uid; return { name: nm, disp: String(n2), card: 'units', col: 'name', navValue: nm, tip: `${nm} — ${n2} field calls` }; });
+  const d = document.createElement('div'); d.append(chart);
+  if (lead.length) { const h2 = document.createElement('div'); h2.className = 'ru-sub-h'; h2.textContent = 'Worst offenders'; d.append(h2, ruLeadNode(lead, '')); }
+  return d;
+}
 // panel builders land here phase by phase; sections list what is coming so the board is honest
 const RU_PANELS = {
   'units-per-cat': { build: ruUnitsPerCategory },
   'rev-cat': { build: ruRevByCat }, 'exp-cat': { build: ruExpByCat }, 'rev-status': { build: ruRevByStatus },
   'top-spend': { build: ruTopSpend }, 'balances': { build: ruBalances },
+  'bookings': { build: ruBookings }, 'insp-trend': { build: ruInspTrend },
+  'wo-trend': { build: ruWoTrend }, 'field-calls': { build: ruFieldCalls },
 };
 const RU_SECTIONS = [
   { id: 'money', label: 'Money', panels: [
@@ -9761,7 +9873,8 @@ const RU_SECTIONS = [
     { id: 'bookings', title: 'Bookings Over Time', phase: 'C' }, { id: 'inv-status', title: 'Invoice Status', phase: 'D' },
     { id: 'rent-tiles', title: 'By the Numbers', phase: 'D' } ] },
   { id: 'shop', label: 'Shop', panels: [
-    { id: 'insp-trend', title: 'Inspections Over Time', phase: 'C' }, { id: 'wo-phase', title: 'Work Orders by Bottleneck', phase: 'D' },
+    { id: 'insp-trend', title: 'Inspections Over Time', phase: 'C' }, { id: 'wo-trend', title: 'Work Orders Opened', phase: 'C' },
+    { id: 'wo-phase', title: 'Work Orders by Bottleneck', phase: 'D' },
     { id: 'field-calls', title: 'Field Calls', phase: 'C' }, { id: 'svc-urgency', title: 'Service Urgency', phase: 'D' } ] },
   { id: 'fleet', label: 'Fleet', panels: [
     { id: 'fleet-mix', title: 'Fleet Mix', phase: 'D' }, { id: 'units-per-cat', title: 'Units per Category' } ] },
@@ -13845,7 +13958,7 @@ function onClick(e) {
   if (closest('.js-ru-custom')) { e.stopPropagation(); const o = state.overlay; if (o) { o.ruCustomOpen = !o.ruCustomOpen; if (o.ruCustomOpen) { const r = ruResolve(); o.ruFrom = o.ruFrom || r.a || TODAY_ISO; o.ruTo = o.ruTo || (r.b ? addDaysISO(r.b, -1) : TODAY_ISO); } else state.datepick = null; } return renderOverlay(); }
   if (closest('.js-ru-apply')) { e.stopPropagation(); return ruApplyCustom(state.overlay); }
   if (closest('.js-ru-cancel')) { e.stopPropagation(); const o = state.overlay; if (o) { o.ruCustomOpen = false; state.datepick = null; } return renderOverlay(); }
-  if (closest('.js-ru-nav')) { e.stopPropagation(); const b = closest('.js-ru-nav'); return ruNavigate(b.dataset.navcard, b.dataset.navcol, b.dataset.navvalue); }   // §13.6 — board mark → the owning card, filtered
+  if (closest('.js-ru-nav')) { e.stopPropagation(); const b = closest('.js-ru-nav'); return ruNavigate(b.dataset.navcard, b.dataset.navcol, b.dataset.navvalue, b.dataset.navseg); }   // §13.6 — board mark → the owning card, filtered
   if (closest('.js-bv-sort') && !closest('.js-bv-inscol')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { const key = closest('.js-bv-sort').dataset.col; if (o.sort?.key === key) o.sort.dir = o.sort.dir === 'asc' ? 'desc' : 'asc'; else o.sort = { key, dir: 'asc' }; renderOverlay(); } return; }
   if (closest('.js-bv-addcol')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview') { o.colOrder = o.colOrder || []; o.colOrder.push({ kind: 'extra', id: 'xc' + (++o.seq), label: '' }); renderOverlay(); } return; }
   if (closest('.js-bv-inscol')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'boardview' && o.colOrder) { const after = Number(closest('.js-bv-inscol').dataset.after); o.colOrder.splice(after + 1, 0, { kind: 'extra', id: 'xc' + (++o.seq), label: '' }); renderOverlay(); } return; }

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 17803 lines, 38 chapters
+## app.js — 17916 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -32,20 +32,20 @@
 | APP-22 | 7619–7840 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
 | APP-23 | 7841–8677 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+72) |
 | APP-24 | 8678–8783 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8784–9917 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+60) |
-| APP-26 | 9918–10864 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10865–10961 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 10962–11421 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-29 | 11422–12472 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 12473–12742 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 12743–12873 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 12874–12877 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 12878–14476 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 14477–15405 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15406–16446 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 16447–16893 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16894–16896 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16897–17803 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-25 | 8784–10030 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+69) |
+| APP-26 | 10031–10977 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 10978–11074 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 11075–11534 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-29 | 11535–12585 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 12586–12855 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 12856–12986 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 12987–12990 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 12991–14589 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 14590–15518 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 15519–16559 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 16560–17006 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 17007–17009 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 17010–17916 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 558 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703n" />
+  <link rel="stylesheet" href="style.css?v=20260703o" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703n"></script>
-  <script type="module" src="app.js?v=20260703n"></script>
+  <script src="rule-usage.js?v=20260703o"></script>
+  <script type="module" src="app.js?v=20260703o"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2045,10 +2045,18 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .ru-lead-n { color: var(--txt-3); font-weight: 700; font-size: 11px; }
 .ru-lead-name { font-weight: 600; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .ru-lead-c { font-weight: 800; font-size: 13px; color: var(--txt-2); font-variant-numeric: tabular-nums; }
-.ru-plotmount rect.js-ru-nav { cursor: pointer; }
-.ru-plotmount rect.js-ru-nav:hover { filter: brightness(1.18); }
-.ru-plotmount rect.js-ru-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ru-plotmount rect.js-ru-nav, .ru-plotmount circle.js-ru-nav { cursor: pointer; }
+.ru-plotmount rect.js-ru-nav:hover, .ru-plotmount circle.js-ru-nav:hover { filter: brightness(1.18); }
+.ru-plotmount rect.js-ru-nav:focus-visible, .ru-plotmount circle.js-ru-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .ru-plotmount text { pointer-events: none; }
+.ru-duo { display: flex; gap: 14px; align-items: stretch; }
+.ru-duo-chart { flex: 1; min-width: 0; }
+.ru-real { width: 92px; flex: none; display: flex; flex-direction: column; justify-content: center; gap: 3px; padding-left: 14px; border-left: 1px dashed var(--tan, #c2925a); }   /* saddle-stitch divider — trend left, "right now" right */
+.ru-real-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 34px; line-height: 1; color: var(--txt); }
+.ru-real-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
+.ru-real-bar { display: flex; height: 8px; border-radius: 4px; overflow: hidden; margin-top: 5px; }
+.ru-real-seg { min-width: 3px; }
+.ru-sub-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 10px; color: var(--txt-3); margin: 6px 0 2px; }
 @media (max-width: 900px) { .ru-layout { grid-template-columns: 1fr; } .ru-spine { flex-direction: row; flex-wrap: wrap; border-right: none; border-bottom: 1px solid var(--line); padding: 10px 12px; } .ru-grid { grid-template-columns: 1fr; } }
 @media (prefers-reduced-motion: reduce) { .ru-per { transition: none; } }
 


### PR DESCRIPTION
Phase C of the Round-Up plan — the trend panels land, in the reference image's shape: **trend on the left, "right now" pinned on the right**.

## Panels
- **Bookings Over Time** (Rentals) — Plot trajectory line, endpoint emphasized, counts above points; reality column shows On Rent now + a mini bar of the active status mix.
- **Inspections Over Time** (Shop) — stacked proportional area of the running outcome mix (Passed / Not Ready, honest denominator carried from GV2), right-edge % labels; reality shows Ready now.
- **Work Orders Opened** (Shop) — line of WOs opened per bucket; reality shows open WOs now + phase-mix bar.
- **Field Calls** (Shop) — unique-units trend + a **Worst Offenders** leaderboard.

## Mechanics
- `ruBuckets(range)` derives granularity from the active range itself (daily ≤14d, weekly ≤92d, else monthly; All → last 6 months) — custom ranges get honest buckets instead of walking back from today.
- Line **dots are nav targets**: a bookings dot lands on Rentals filtered to that bucket (`__rentrange`), WO dots land on Shop with the segment switched to Work Orders (`ruNavigate` learned an optional segment), FC dots land on Units (`__fcrange`).
- Reality column split off with the tan saddle-stitch dashed divider (the design language's ranch seasoning, used as a divider exactly as prescribed).

## Verification (real-login audit, live data)
- All ten live panels healthy across All / 30d / 90d / custom May 1 → Jul 3; bucket counts adapt (6 monthly at All, 13 weekly at 90d, 10 weekly at custom).
- Dot-nav smoke: bookings dot → board closed → Rentals with the `5/1–5/7` pill.
- Bar-nav regression: revenue bar → Categories with the `8k Excavator` pill.
- Zero console/page errors; full V2 regression sweep unchanged.
- Gates: rule-usage ✓ window-catalog ✓ code-map ✓ (smoke/logic in CI).

Cache-bust `?v=20260703n → o`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr

---
_Generated by [Claude Code](https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr)_