### PR TITLE
Round-Up Phase D — d3-shape donuts, stat tiles, every section live

### DIFF
--- a/app.js
+++ b/app.js
@@ -9856,6 +9856,117 @@ function ruFieldCalls(rg) {
   if (lead.length) { const h2 = document.createElement('div'); h2.className = 'ru-sub-h'; h2.textContent = 'Worst offenders'; d.append(h2, ruLeadNode(lead, '')); }
   return d;
 }
+// ── Phase D: d3-shape donuts + stat tiles (Plot has no pie mark — pie()/arc() build the annulus) ──
+function ruDonutSVG({ segs, size = 190, noun = 'UNITS' }) {
+  const total = segs.reduce((a, s2) => a + (s2.count || 0), 0);
+  const live = segs.filter((s2) => s2.count > 0);
+  const r = size / 2, inner = r * 0.58, mid = (inner + r - 1) / 2, pad = 30;
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('viewBox', `${-pad} ${-pad} ${size + pad * 2} ${size + pad * 2}`);
+  svg.setAttribute('class', 'ru-donut');
+  const g = document.createElementNS(NS, 'g');
+  g.setAttribute('transform', `translate(${r},${r})`);
+  svg.append(g);
+  const txt = (x, y, s2, fill, cls, anchor) => { const e = document.createElementNS(NS, 'text'); e.setAttribute('x', x.toFixed(1)); e.setAttribute('y', y.toFixed(1)); e.setAttribute('text-anchor', anchor || 'middle'); e.setAttribute('fill', fill); if (cls) e.setAttribute('class', cls); e.textContent = s2; g.append(e); };
+  const at = (ang, rad) => [Math.sin(ang) * rad, -Math.cos(ang) * rad];   // d3 angles: 0 at 12 o'clock, clockwise
+  const arcs = d3pie().value((d) => d.count).sort(null)(live);            // sort:null keeps input order — slice i IS seg i
+  const arcGen = d3arc().innerRadius(inner).outerRadius(r - 1);
+  const outLbls = [];
+  arcs.forEach((a) => {
+    const s2 = a.data, p = document.createElementNS(NS, 'path');
+    p.setAttribute('d', live.length === 1 ? arcGen({ startAngle: 0, endAngle: Math.PI * 2 }) : arcGen(a));
+    p.setAttribute('fill', ruColor('--' + s2.color));
+    p.setAttribute('class', 'ru-slice');
+    if (s2.card) { p.classList.add('js-ru-nav'); p.setAttribute('tabindex', '0'); p.setAttribute('role', 'button'); p.setAttribute('data-navcard', s2.card); p.setAttribute('data-navcol', s2.col); p.setAttribute('data-navvalue', String(s2.navValue)); if (s2.seg) p.setAttribute('data-navseg', s2.seg); }
+    p.setAttribute('aria-label', s2.name); p.setAttribute('data-tip', s2.tip || s2.name);
+    g.append(p);
+    const am = (a.startAngle + a.endAngle) / 2, frac = s2.count / total;
+    if (frac >= 0.14) { const [lx, ly] = at(am, mid); txt(lx, ly + 4.5, String(s2.count), U_DARKINK.has(s2.color) ? '#0c0e12' : '#fff', 'ru-slice-n'); }
+    else { const [ix, iy] = at(am, r - 3); outLbls.push({ s: s2, am, ix, iy }); }
+  });
+  // callout fan — spread thin slivers angularly (≥13px arc gap) so a cluster never overprints
+  if (outLbls.length) {
+    const rr = r + 10, gap = 13 / rr;
+    outLbls.sort((a, b) => a.am - b.am);
+    for (let i = 1; i < outLbls.length; i++) if (outLbls[i].am < outLbls[i - 1].am + gap) outLbls[i].am = outLbls[i - 1].am + gap;
+    outLbls.forEach((o) => {
+      const [ox, oy] = at(o.am, rr);
+      const ln = document.createElementNS(NS, 'line');
+      ln.setAttribute('x1', o.ix.toFixed(1)); ln.setAttribute('y1', o.iy.toFixed(1)); ln.setAttribute('x2', ox.toFixed(1)); ln.setAttribute('y2', oy.toFixed(1));
+      ln.setAttribute('stroke', ruColor('--' + o.s.color)); ln.setAttribute('stroke-width', '1.2'); ln.setAttribute('opacity', '.9');
+      g.append(ln);
+      txt(ox, oy + (oy < 0 ? -3 : 9), String(o.s.count), ruColor('--' + o.s.color), 'ru-slice-n', ox < 0 ? 'end' : 'start');
+    });
+  }
+  txt(0, -2, String(total), ruColor('--txt'), 'ru-donut-tot');
+  txt(0, 14, noun, ruColor('--txt-3'), 'ru-donut-sub');
+  return svg;
+}
+// ── Phase D panels ──
+function ruInvoiceStatus(rg) {
+  const ic = {};
+  DATA.rentals.forEach((r2) => { if (ruBounded(rg) && !ruIn(r2.startDate, rg)) return; const inv = r2.invoiceId && IDX.invoice.get(r2.invoiceId); const s = inv ? invoiceTotals(inv).status : 'No invoice'; ic[s] = (ic[s] || 0) + 1; });
+  const segs = Object.entries(ic).sort((a, b) => b[1] - a[1]).map(([s, n2]) => ({
+    name: s, count: n2, color: s === 'No invoice' ? 'gray' : (getStatus('invoiceStatus', s).color || 'gray'),
+    card: 'rentals', col: 'invoice', navValue: s === 'No invoice' ? '' : s, tip: `${s} — ${n2} rentals` }));
+  if (!segs.length) return ruEmpty('No rentals in this range.');
+  return ruDonutSVG({ segs, noun: 'RENTALS' });
+}
+function ruRentTiles() {   // the counts are inherently CURRENT — the range does not apply
+  const sc = {}; DATA.rentals.forEach((r2) => { const s = rentalDisplayStatus(r2); sc[s] = (sc[s] || 0) + 1; });
+  const ym = TODAY_ISO.slice(0, 7);
+  const items = [
+    { label: 'On Rent', count: sc['On Rent'] || 0, color: 'green', col: 'status', navValue: 'On Rent' },
+    { label: 'Quotes', count: sc['Quote'] || 0, color: 'gray', col: 'status', navValue: 'Quote' },
+    { label: 'No Show', count: sc['No Show'] || 0, color: 'red', col: 'status', navValue: 'No Show' },
+    { label: 'This Month', count: DATA.rentals.filter((r2) => (r2.startDate || '').slice(0, 7) === ym).length, color: 'blue', col: '__rentmonth', navValue: ym },
+  ];
+  const d = document.createElement('div'); d.className = 'ru-tiles';
+  d.innerHTML = items.map((it) => `<button class="ru-tile js-ru-nav" data-navcard="rentals" data-navcol="${esc(it.col)}" data-navvalue="${esc(String(it.navValue))}" data-tip="${esc(it.label)} — ${it.count}" aria-label="${esc(it.label)}"><span class="ru-tile-n" style="color:var(--${it.color})">${it.count}</span><span class="ru-tile-l">${esc(it.label)}</span></button>`).join('');
+  return d;
+}
+function ruWoPhase() {   // open WOs by bottleneck phase — open = inherently current
+  const openWO = DATA.workOrders.filter((w) => w.phase !== 'Complete' && !w.cancelled);
+  if (!openWO.length) return ruEmpty('No open work orders.');
+  const byPhase = {}; openWO.forEach((w) => { const ph = w.phase || '—'; byPhase[ph] = (byPhase[ph] || 0) + 1; });
+  const order = Object.keys(STATUS.woPhase).filter((ph) => ph !== 'Complete');
+  const phs = order.filter((ph) => byPhase[ph]).concat(Object.keys(byPhase).filter((ph) => ph !== 'Complete' && !order.includes(ph)));
+  const segs = phs.map((ph) => { const lbl = getStatus('woPhase', ph).label || ph; return { name: lbl, count: byPhase[ph], color: getStatus('woPhase', ph).color || 'gray', card: 'units', col: '__wop', navValue: ph, tip: `${lbl} — ${byPhase[ph]} WOs` }; });
+  return ruDonutSVG({ segs, noun: 'WOs' });
+}
+function ruSvcUrgency() {   // a unit's service urgency — snapshot by nature
+  let over = 0, soon = 0, ok = 0, wash = 0;
+  DATA.units.forEach((u) => { if (u.washRequested) { wash++; return; } const s = topServiceForUnit(u); if (!s) { ok++; return; } if (s.status === 'past-due') over++; else if (s.status === 'due-soon') soon++; else ok++; });
+  const mk = (v, lbl, count, color) => ({ name: lbl, count, color, card: 'shop', seg: 'serviceOrders', col: '__svcstat', navValue: v, tip: `${lbl} — ${count} units` });
+  const segs = [mk('past-due', 'Overdue', over, 'red'), mk('due-soon', 'Due Soon', soon, 'yellow'), mk('on-schedule', 'On Schedule', ok, 'green'), mk('wash', 'Wash', wash, 'blue')];
+  if (!DATA.units.length) return ruEmpty('No units yet.');
+  return ruDonutSVG({ segs, noun: 'UNITS' });
+}
+function ruFleetMix() {   // fleet status — snapshot by nature
+  if (!DATA.units.length) return ruEmpty('No units yet.');
+  const fn = {}; DATA.units.forEach((u) => { const s = u.fleetStatus || '—'; fn[s] = (fn[s] || 0) + 1; });
+  const segs = Object.entries(fn).sort((a, b) => b[1] - a[1]).map(([s, n2]) => ({ name: s, count: n2, color: getStatus('unitFleetStatus', s).color || 'gray', card: 'units', col: 'fleet', navValue: s, tip: `${s} — ${n2} units` }));
+  return ruDonutSVG({ segs, noun: 'UNITS' });
+}
+function ruAccounts() {   // two donuts: account types + pay status — snapshots by nature
+  if (!DATA.customers.length) return ruEmpty('No customers yet.');
+  const ac = {}, pc = {};
+  DATA.customers.forEach((c) => { const t2 = c.accountType || 'Non-Business'; ac[t2] = (ac[t2] || 0) + 1; const p = c.payStatus || ''; pc[p] = (pc[p] || 0) + 1; });
+  const mk = (obj, col, set) => Object.entries(obj).sort((a, b) => b[1] - a[1]).map(([k, n2]) => ({ name: k || 'None', count: n2, color: getStatus(set, k).color || 'gray', card: 'customers', col, navValue: k, tip: `${k || 'None'} — ${n2} customers` }));
+  const cell = (svg2, lbl) => { const c = document.createElement('div'); c.className = 'ru-donut-cell'; c.append(svg2); const h2 = document.createElement('div'); h2.className = 'ru-sub-h ru-sub-c'; h2.textContent = lbl; c.append(h2); return c; };
+  const wrap = document.createElement('div'); wrap.className = 'ru-donut-pair';
+  wrap.append(cell(ruDonutSVG({ segs: mk(ac, 'account', 'customerAccountType'), size: 150, noun: 'CUST' }), 'Account type'),
+    cell(ruDonutSVG({ segs: mk(pc, 'pay', 'customerPayStatus'), size: 150, noun: 'CUST' }), 'Pay status'));
+  return wrap;
+}
+function ruCardHealth() {   // card on file — snapshot by nature; values match the list's Card column
+  if (!DATA.customers.length) return ruEmpty('No customers yet.');
+  const cc = { ok: 0, expiring: 0, none: 0 };
+  DATA.customers.forEach((c) => { cc[cardFlag(c)]++; });
+  const segs = ['none', 'expiring', 'ok'].map((k) => { const m = CARD_FLAG_META[k]; return { name: m.label, count: cc[k], color: m.color, card: 'customers', col: 'card', navValue: m.label, tip: `${m.label} — ${cc[k]} customers` }; });
+  return ruDonutSVG({ segs, noun: 'CUST' });
+}
 // panel builders land here phase by phase; sections list what is coming so the board is honest
 const RU_PANELS = {
   'units-per-cat': { build: ruUnitsPerCategory },
@@ -9863,6 +9974,9 @@ const RU_PANELS = {
   'top-spend': { build: ruTopSpend }, 'balances': { build: ruBalances },
   'bookings': { build: ruBookings }, 'insp-trend': { build: ruInspTrend },
   'wo-trend': { build: ruWoTrend }, 'field-calls': { build: ruFieldCalls },
+  'inv-status': { build: ruInvoiceStatus }, 'rent-tiles': { build: ruRentTiles },
+  'wo-phase': { build: ruWoPhase }, 'svc-urgency': { build: ruSvcUrgency },
+  'fleet-mix': { build: ruFleetMix }, 'accounts': { build: ruAccounts }, 'card-health': { build: ruCardHealth },
 };
 const RU_SECTIONS = [
   { id: 'money', label: 'Money', panels: [

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 17916 lines, 38 chapters
+## app.js — 18030 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -32,20 +32,20 @@
 | APP-22 | 7619–7840 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
 | APP-23 | 7841–8677 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+72) |
 | APP-24 | 8678–8783 | §13.3 | §13.3 CARD GRAPH VIEW (Phase 4) — a per-card charts overlay, sibling to the | pieSVG, gvLegend, gvBars, unitGraphData, gvNumTile, gvPieTile, gvBarTile, gvLeadTile, gvTableTile, gvMonths6, GV_WIN_OPTS, GV_WIN_KEY, …(+6) |
-| APP-25 | 8784–10030 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+69) |
-| APP-26 | 10031–10977 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10978–11074 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 11075–11534 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-29 | 11535–12585 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 12586–12855 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 12856–12986 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 12987–12990 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 12991–14589 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 14590–15518 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15519–16559 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 16560–17006 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 17007–17009 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 17010–17916 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-25 | 8784–10144 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+77) |
+| APP-26 | 10145–11091 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 11092–11188 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 11189–11648 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-29 | 11649–12699 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 12700–12969 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 12970–13100 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 13101–13104 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 13105–14703 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 14704–15632 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 15633–16673 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 16674–17120 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 17121–17123 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 17124–18030 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 558 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703o" />
+  <link rel="stylesheet" href="style.css?v=20260703p" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703o"></script>
-  <script type="module" src="app.js?v=20260703o"></script>
+  <script src="rule-usage.js?v=20260703p"></script>
+  <script type="module" src="app.js?v=20260703p"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2057,6 +2057,24 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .ru-real-bar { display: flex; height: 8px; border-radius: 4px; overflow: hidden; margin-top: 5px; }
 .ru-real-seg { min-width: 3px; }
 .ru-sub-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 10px; color: var(--txt-3); margin: 6px 0 2px; }
+.ru-sub-c { text-align: center; }
+.ru-plotmount svg.ru-donut { display: block; max-width: 250px; margin: 0 auto; }
+.ru-donut text { font-family: 'Saira Condensed', system-ui, sans-serif; }
+.ru-donut .ru-slice-n { font-size: 13px; font-weight: 700; }
+.ru-donut .ru-donut-tot { font-size: 27px; font-weight: 800; }
+.ru-donut .ru-donut-sub { font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; }
+.ru-plotmount path.js-ru-nav { cursor: pointer; }
+.ru-plotmount path.js-ru-nav:hover { filter: brightness(1.18); }
+.ru-plotmount path.js-ru-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ru-donut-pair { display: flex; gap: 10px; justify-content: center; }
+.ru-donut-cell { flex: 1; min-width: 0; }
+.ru-donut-cell svg.ru-donut { max-width: 190px; }
+.ru-tiles { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; padding: 8px 0; }
+.ru-tile { display: flex; flex-direction: column; align-items: center; gap: 2px; padding: 14px 8px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); cursor: pointer; }
+.ru-tile:hover { border-color: var(--accent-line); }
+.ru-tile:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.ru-tile-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 30px; line-height: 1; }
+.ru-tile-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
 @media (max-width: 900px) { .ru-layout { grid-template-columns: 1fr; } .ru-spine { flex-direction: row; flex-wrap: wrap; border-right: none; border-bottom: 1px solid var(--line); padding: 10px 12px; } .ru-grid { grid-template-columns: 1fr; } }
 @media (prefers-reduced-motion: reduce) { .ru-per { transition: none; } }
 


### PR DESCRIPTION
Phase D of the Round-Up plan — the proportion panels land and **every section of the board now renders live**.

## Panels
- **Invoice Status** (Rentals, range-aware) — rentals' invoice mix as a donut.
- **By the Numbers** (Rentals) — stat tiles: On Rent / Quotes / No Show / This Month.
- **Work Orders by Bottleneck** (Shop) — open WOs by stuck phase.
- **Service Urgency** (Shop) — Overdue / Due Soon / On Schedule / Wash.
- **Fleet Mix** (Fleet) — units by fleet status.
- **Account Types · Pay Status** (Customers) — side-by-side donut pair.
- **Card Health** (Customers) — Card OK / Expiring / No Card.

## The donut engine
Plot has no pie mark (verified in the library-selection spec), so `ruDonutSVG` builds the annulus with d3-shape `pie()`/`arc()` — `sort: null` keeps slice order = input order. Center carries the stamped total + noun; counts render in-slice at ≥14% share, thinner slivers fan out angularly on leader lines with a ≥13px arc-gap collision pass (ported from the retired hand-built renderer onto d3 angles — verified live against a 270/19/9-sliver cluster on Account Types).

## Navigation
Donut slices and stat tiles are nav targets like bars and dots: Fleet Mix slice → Units filtered to that status; Service Urgency → Shop with the Service segment armed; tiles → Rentals with the matching pill.

## Deviation from the plan, recorded
The plan's separate "inspections queue donut" (panel 9-queue) is served by the trend panel's pinned **Ready now** column from Phase C instead of duplicating the same two numbers as a donut.

## Verification (real-login audit, live data)
- All 17 panels healthy across All / 30d / 90d / custom range.
- Nav smoke on all three mark types: bar → `8k Excavator`, dot → `5/1–5/7`, slice → `Active` pill on Units.
- Zero console/page errors; V2 regression sweep unchanged.
- Gates: rule-usage ✓ window-catalog ✓ code-map ✓ (smoke/logic in CI).

Cache-bust `?v=20260703o → p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr

---
_Generated by [Claude Code](https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr)_