### PR TITLE
§13.7 gauge strip — card graphs open in-column at 25% of the column

### DIFF
--- a/app.js
+++ b/app.js
@@ -6948,6 +6948,7 @@ function columnEl(col, session) {
   if (!document.body.classList.contains('is-phone')) {
     const lb = card.querySelector('.card-body .listbar'), body = card.querySelector('.card-body');
     if (lb && body) card.insertBefore(lb, body);
+    const st = card.querySelector('.card-body .rus'); if (st && body) card.insertBefore(st, body);   // §13.7 — flex-basis 25% resolves against .card, the full column
   }
   wrap.appendChild(card);
   return wrap;
@@ -7077,7 +7078,7 @@ function listView(cardDef, session) {
   wrap.appendChild(bar);
   // §13.4 — Graph carousel: an interactive panel ABOVE the list (the list renders below,
   // filtered by the chart's g-tagged search terms). Legacy cards still full-replace the list.
-  if (cs.graphView) { cs.graphView = false; gvStripTerms(cs); }   // §13.6 — in-column graphs retired (stale pre-Round-Up session state)
+  if (cs.graphView && !state.searchMode && RUS_TABS[card]) { const g = el('div', 'rus'); g.innerHTML = rusHtml(card, card, cs); wrap.appendChild(g); }   // §13.7 gauge strip — this card's Round-Up charts, 25% of the column
   // Phase 4 — Units narrowed to an invoice's linked units (Invoice +WO) → removable chip
   if (card === 'units' && state.unitPick) {
     const n = state.unitPick.ids.length;
@@ -7297,7 +7298,8 @@ function shopListView(session, byType, forcedSeg) {
   // interactive carousel ABOVE the list (list filters to the graph terms below); the
   // 'all' overview (and column-pinned shop tabs) keep the legacy combined dashboard.
   if (cs.graphView && !state.searchMode) {
-    if (graphViewsFor(gsrc)) { const g = el('div', 'gv-panel'); g.innerHTML = graphPanelHtml('shop', gsrc, cs); wrap.appendChild(g); }   // 'all' → the stackbars worklist (mechanic landing); segments have no in-column graph (§13.6)
+    if (graphViewsFor(gsrc)) { const g = el('div', 'gv-panel'); g.innerHTML = graphPanelHtml('shop', gsrc, cs); wrap.appendChild(g); }   // 'all' → the stackbars worklist (mechanic landing) — untouched
+    else if (RUS_TABS[gsrc]) { const g = el('div', 'rus'); g.innerHTML = rusHtml('shop', gsrc, cs); wrap.appendChild(g); }   // §13.7 — a segment's gauge strip
     else { cs.graphView = false; gvStripTerms(cs); }
   }
 
@@ -8867,6 +8869,7 @@ function openGvWinMenu(anchorEl, card, src) {
   openDropdown(anchorEl, opt(0, 'All time') + GV_WIN_OPTS.map((d) => opt(d, `Last ${d} days`)).join(''));
 }
 
+let _ruSize = null;   // §13.7 ambient size hint — set around a gauge-strip mount so engines fit the 25% box
 // shared chart helpers (born in the retired §13.5 Graph V2; the Round-Up inherits them)
 const U_DARKINK = new Set(['green', 'yellow', 'orange', 'brown', 'gray']);   // slices that carry dark ink labels (else white)
 const uISO = (d) => d.toISOString().slice(0, 10);
@@ -8921,6 +8924,7 @@ const ruColor = (name) => getComputedStyle(document.documentElement).getProperty
 /* Plot bar panel — Jac's chart law baked in: value rides the bar (never a detached row),
    dotted gridlines + Y axis on a nice scale, bottom-anchored, no legend (hover = plain name). */
 function ruBarsSVG({ data, money = false, w = 620, h = 250, overlayMarks = [], labelMarks = [] }) {
+  if (_ruSize) { w = _ruSize.w; h = _ruSize.h; }
   return Plot.plot({
     width: w, height: h, marginLeft: 48, marginRight: 12, marginTop: 22, marginBottom: data.length > 6 ? 54 : 28,
     style: { background: 'transparent', fontFamily: "'Saira Condensed', system-ui, sans-serif", fontSize: '11.5px' },
@@ -8979,7 +8983,7 @@ function ruNavigate(card, col, value, seg) {
   closeOverlay();
   const s = activeSession();
   const colId = COLUMN_OF[card]; if (colId && s.cols) { s.cols[colId] = card; const idx = COLUMNS.findIndex((c) => c.id === colId); if (idx >= 0) state.mobileCol = idx; }
-  const cs = s.cards[card]; if (cs) { cs.mode = 'list'; cs.recId = null; cs.recType = null; cs.graphView = false; if (seg) cs.segment = seg; }
+  const cs = s.cards[card]; if (cs) { cs.mode = 'list'; cs.recId = null; cs.recType = null; if (seg) cs.segment = seg; }   // graphView survives — a strip mark filters the list below it
   addColFilter(card, col, value);
 }
 // ── Money rollups (range-aware; the §13.5 cutoff-only versions retire in Phase E) ──
@@ -9077,6 +9081,7 @@ function ruBuckets(rg) {
 }
 // trajectory line: endpoint emphasized, counts above points, dots are the nav targets
 function ruLineSVG({ bk, vals, color, w = 620, h = 230 }) {
+  if (_ruSize) { w = _ruSize.w; h = _ruSize.h; }
   const n = bk.length, pts = bk.map((b, i) => ({ i, label: b.label, v: vals[i] }));
   const show = new Set(n <= 6 ? pts.map((p) => p.i) : [0, 1, 2, 3, 4].map((k) => Math.round(k * (n - 1) / 4)));
   const ink = ruColor(color);
@@ -9097,6 +9102,7 @@ function ruLineSVG({ bk, vals, color, w = 620, h = 230 }) {
 }
 // stacked proportional area (read-only): bands of a running mix, right-edge % labels
 function ruAreaSVG({ bk, bands, w = 620, h = 230 }) {
+  if (_ruSize) { w = _ruSize.w; h = _ruSize.h; }
   // bands: [{name, color, vals(fractions per bucket, bands sum ≤1)}] bottom-up
   const n = bk.length;
   const show = new Set(n <= 6 ? bk.map((_, i) => i) : [0, 1, 2, 3, 4].map((k) => Math.round(k * (n - 1) / 4)));
@@ -9172,7 +9178,8 @@ function ruFieldCalls(rg) {
   return d;
 }
 // ── Phase D: d3-shape donuts + stat tiles (Plot has no pie mark — pie()/arc() build the annulus) ──
-function ruDonutSVG({ segs, size = 190, noun = 'UNITS' }) {
+function ruDonutSVG({ segs, size = 0, noun = 'UNITS' }) {
+  size = size || (_ruSize ? Math.max(110, Math.min(_ruSize.h - 40, _ruSize.w - 70, 220)) : 190);
   const total = segs.reduce((a, s2) => a + (s2.count || 0), 0);
   const live = segs.filter((s2) => s2.count > 0);
   const r = size / 2, inner = r * 0.58, mid = (inner + r - 1) / 2, pad = 30;
@@ -9310,7 +9317,45 @@ const RU_SECTIONS = [
   { id: 'customers', label: 'Customers', panels: [
     { id: 'accounts', title: 'Account Types · Pay Status', phase: 'D' }, { id: 'card-health', title: 'Card Health', phase: 'D' } ] },
 ];
-const RU_SECTION_OF = { units: 'fleet', categories: 'money', shop: 'shop', rentals: 'rentals', customers: 'customers', invoices: 'money' };   // card graph icon → its board section
+/* §13.7 GAUGE STRIP (Jac 2026-07-03) — the card's Round-Up charts IN-COLUMN, at the top
+   of the list rows, strictly 25% of the card column's height. One panel at a time behind
+   stamped tabs (orange INK when selected, never a chip); a slim left rail is the board's
+   time spine shrunk down — it drives the SAME global range as the board (one timeframe
+   everywhere). Picking a NEW custom range stays a board power; an active custom range
+   shows here as stamped orange text (click clears to All). Marks stay nav targets — in
+   the strip a click filters the list right below it. The Round-Up board itself remains
+   on the header Round-Up button. */
+const RUS_TABS = {
+  units: [{ p: 'fleet-mix', l: 'Fleet' }, { p: 'units-per-cat', l: 'Categories' }, { p: 'field-calls', l: 'Field Calls' }],
+  categories: [{ p: 'rev-cat', l: 'Revenue' }, { p: 'exp-cat', l: 'Expenses' }],
+  rentals: [{ p: 'bookings', l: 'Bookings' }, { p: 'rev-status', l: 'Revenue' }, { p: 'inv-status', l: 'Invoices' }, { p: 'rent-tiles', l: '#s' }],
+  customers: [{ p: 'accounts', l: 'Accounts' }, { p: 'card-health', l: 'Cards' }, { p: 'top-spend', l: 'Top Spend' }],
+  invoices: [{ p: 'balances', l: 'Balances' }, { p: 'top-spend', l: 'Top Spend' }],
+  inspections: [{ p: 'insp-trend', l: 'Inspections' }],
+  workOrders: [{ p: 'wo-trend', l: 'Opened' }, { p: 'wo-phase', l: 'Bottleneck' }],
+  serviceOrders: [{ p: 'svc-urgency', l: 'Urgency' }],
+};
+const RUS_PER_LABEL = { today: 'Td', wk: 'Wk', mo: 'Mo', 30: '30d', 60: '60d', 90: '90d', all: 'All' };
+function rusHtml(card, src, cs) {
+  const tabs = RUS_TABS[src] || []; if (!tabs.length) return '';
+  let sel = (cs.rusTab || {})[src]; if (!tabs.some((t) => t.p === sel)) sel = tabs[0].p;
+  const r = ruResolve();
+  const tabBtns = tabs.map((t) => `<button class="rus-tab${t.p === sel ? ' on' : ''} js-rus-tab" data-card="${card}" data-src="${esc(src)}" data-panel="${t.p}">${esc(t.l)}</button>`).join('');
+  const rail = RU_PERIODS.map((p) => `<button class="rus-per${r.k === p.k ? ' on' : ''} js-rus-per" data-k="${p.k}" data-tip="${esc(p.label)}">${RUS_PER_LABEL[p.k] || p.k}</button>`).join('')
+    + (r.k === 'custom' ? `<button class="rus-per on js-rus-per" data-k="all" data-tip="Custom range (set on the Round-Up) — click to clear back to All">${esc(r.label)}</button>` : '');
+  return `<div class="rus-tabs" role="tablist">${tabBtns}</div><div class="rus-body"><nav class="rus-rail" aria-label="Timeframe">${rail}</nav><div class="rus-mount" data-panel="${sel}"></div></div>`;
+}
+// post-render mount pass for the strips (the board's pass walks .ru-plotmount; this one
+// measures the 25% box first so the engines render at native text size instead of scaling)
+function ruMountStrips() {
+  document.querySelectorAll('.rus-mount[data-panel]').forEach((m) => {
+    const p = RU_PANELS[m.dataset.panel]; if (!p) return;
+    _ruSize = { w: Math.max(220, m.clientWidth - 8), h: Math.max(110, m.clientHeight - 6) };
+    try { m.replaceChildren(p.build(ruResolve())); }
+    catch (e) { m.innerHTML = `<div class="ru-err">Chart failed — ${esc(String(e && e.message || e))}</div>`; }
+    _ruSize = null;
+  });
+}
 function roundupBody(o) {
   const r = ruResolve();
   const spine = RU_PERIODS.map((p) => `<button class="ru-per${r.k === p.k ? ' on' : ''} js-ru-per" data-k="${p.k}">${esc(p.label)}</button>`).join('')
@@ -12243,6 +12288,7 @@ function render() {
   mountTransportEditor();   // inline transport editor: mount the live map + wire the address field
   mountWranglerDock();   // §18 wire paste + drag-drop image input on the wrangler dock after each render
   mountDispatchMap();   // §2.3 office cockpit: re-parent the singleton dispatch map + refresh pins/route/truck
+  ruMountStrips();   // §13.7 gauge strips — build each open strip's chart into its measured 25% box
   applyTitles();   // full text on hover wherever we truncate (custom ~0.5s tooltip)
   drawDispatchArrows();   // §2.3 — paint free-form route legs over the dispatch run (needs live geometry)
   scoreTick();     // §11 gamification — pop +X over any ring whose metric just rose
@@ -13256,14 +13302,13 @@ function onClick(e) {
   if (closest('.js-ff-cancel')) { e.stopPropagation(); const o = state.overlay; if (o?.kind === 'board') { o.fileForm = false; o.fileUpload = null; renderOverlay(); } return; }
   if (closest('.js-ff-save')) { e.stopPropagation(); return saveFileForm(); }
   if (closest('.js-vendor-tax')) { e.stopPropagation(); const b = closest('.js-vendor-tax'); const v = recOf('vendors', b.dataset.rec); if (v) { const ex = b.dataset.val === '1'; if (!!v.salesTaxExempt !== ex) { v.salesTaxExempt = ex; reindex('vendors', v); logAction(v, `Sales tax → ${ex ? 'Exempt' : 'Taxed'}`); } if (state.overlay?.kind === 'board') renderOverlay(); render(); } return; }
-  if (closest('.js-cardgraph')) { e.stopPropagation(); const b = closest('.js-cardgraph'); const card = b.dataset.card, src = b.dataset.src || card; const cs = activeSession().cards[card];
-    if (card === 'shop' && src === 'shop') { if (!cs.graphView) return gvOpen('shop', 'shop'); cs.graphView = false; return render(); }   // the 'all' stackbars worklist (mechanic landing) — untouched
-    if (cs && cs.graphView) { cs.graphView = false; gvStripTerms(cs); }
-    return openOverlay({ kind: 'roundup', section: RU_SECTION_OF[card] || null }); }   // §13.6 — the chart icon opens the Round-Up at this card's section
+  if (closest('.js-cardgraph')) { e.stopPropagation(); const b = closest('.js-cardgraph'); const card = b.dataset.card, src = b.dataset.src || card; const cs = activeSession().cards[card]; if (!cs.graphView) { if (graphViewsFor(src)) return gvOpen(card, src); cs.graphView = true; return render(); } cs.graphView = false; return render(); }   // §13.7 gauge-strip toggle (Shop 'all': the stackbars worklist)
   if (closest('.js-gv-chev')) { e.stopPropagation(); const b = closest('.js-gv-chev'); return gvChevron(b.dataset.card, b.dataset.src || b.dataset.card, Number(b.dataset.dir)); }   // §13.4 cycle the active graph view
   if (closest('.js-gv-seg')) { e.stopPropagation(); const b = closest('.js-gv-seg'); return toggleGraphSeg(b.dataset.card, b.dataset.src || b.dataset.card, b.dataset.col, b.dataset.value, b.dataset.label); }   // §13.4 toggle a slice/bar/row/number → search entry
   if (closest('.js-gvwin')) { e.stopPropagation(); const b = closest('.js-gvwin'); return openGvWinMenu(b, b.dataset.card, b.dataset.src); }   // §13.4 open the timeline window menu
   if (closest('.js-gvwin-opt')) { e.stopPropagation(); const b = closest('.js-gvwin-opt'); document.querySelectorAll('.dropdown-menu').forEach((n) => n.remove()); const cs = activeSession().cards[b.dataset.card]; if (cs) { gvStripTerms(cs); cs.listLimit = undefined; } saveGvWin(b.dataset.src, Number(b.dataset.win)); return render(); }   // §13.4 pick a window → clear stale bucket filters + re-render
+  if (closest('.js-rus-tab')) { e.stopPropagation(); const b = closest('.js-rus-tab'); const cs = activeSession().cards[b.dataset.card]; if (cs) { (cs.rusTab = cs.rusTab || {})[b.dataset.src] = b.dataset.panel; render(); } return; }   // §13.7 strip panel tab
+  if (closest('.js-rus-per')) { e.stopPropagation(); const k = closest('.js-rus-per').dataset.k; ruSave(k === 'all' ? { k: 'all', a: null, b: null } : { k }); return render(); }   // §13.7 strip rail → the same global range the board reads
   if (closest('.js-ru-open')) { e.stopPropagation(); return openOverlay({ kind: 'roundup', section: closest('.js-ru-open').dataset.section || null }); }   // §13.6 Round-Up
   if (closest('.js-ru-per')) { e.stopPropagation(); const k = closest('.js-ru-per').dataset.k; ruSave(k === 'all' ? { k: 'all', a: null, b: null } : { k }); return renderOverlay(); }
   if (closest('.js-ru-custom')) { e.stopPropagation(); const o = state.overlay; if (o) { o.ruCustomOpen = !o.ruCustomOpen; if (o.ruCustomOpen) { const r = ruResolve(); o.ruFrom = o.ruFrom || r.a || TODAY_ISO; o.ruTo = o.ruTo || (r.b ? addDaysISO(r.b, -1) : TODAY_ISO); } else state.datepick = null; } return renderOverlay(); }
@@ -13507,7 +13552,7 @@ function onClick(e) {
   if (xEl) { e.stopPropagation(); return handlePillX(xEl); }
 
   // shop segment switch — clicking the active segment toggles back to All
-  if (closest('.js-shopseg')) { const seg = closest('.js-shopseg').dataset.seg; const cs = activeSession().cards.shop; const next = (cs.segment === seg) ? 'all' : seg; if (cs.graphView) { gvStripTerms(cs); if (next !== 'all') cs.graphView = false; }   /* §13.6 — segment graphs live on the Round-Up; 'all' returns to the worklist */ cs.segment = next; cs.listLimit = undefined; return render(); }
+  if (closest('.js-shopseg')) { const seg = closest('.js-shopseg').dataset.seg; const cs = activeSession().cards.shop; const next = (cs.segment === seg) ? 'all' : seg; if (cs.graphView) gvStripTerms(cs);   /* §13.7 — the strip (or 'all' worklist) stays open across a segment switch */ cs.segment = next; cs.listLimit = undefined; return render(); }
 
   // row / header action buttons (anchor / new tab) — recType is set for Shop items
   const anchorBtn = closest('.js-anchor');

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 17227 lines, 38 chapters
+## app.js — 17272 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -25,27 +25,27 @@
 | APP-15 | 5248–5444 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
 | APP-16 | 5445–6781 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
 | APP-17 | 6782–6875 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6876–7155 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 7156–7349 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 7350–7474 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7475–7639 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7640–7861 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7862–8698 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+72) |
-| APP-24 | 8699–8741 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-25 | 8742–9341 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+53) |
-| APP-26 | 9342–10288 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10289–10385 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 10386–10845 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-29 | 10846–11896 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 11897–12166 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 12167–12297 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 12298–12301 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 12302–13900 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 13901–14829 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 14830–15870 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 15871–16317 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16318–16320 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16321–17227 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-18 | 6876–7156 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 7157–7351 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 7352–7476 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7477–7641 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7642–7863 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7864–8700 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+72) |
+| APP-24 | 8701–8743 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-25 | 8744–9386 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+57) |
+| APP-26 | 9387–10333 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 10334–10430 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 10431–10890 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-29 | 10891–11941 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 11942–12211 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 12212–12343 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 12344–12347 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 12348–13945 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 13946–14874 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 14875–15915 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 15916–16362 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 16363–16365 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 16366–17272 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 558 lines, 0 chapters
 

--- a/docs/superpowers/specs/2026-07-03-manager-metrics-design.md
+++ b/docs/superpowers/specs/2026-07-03-manager-metrics-design.md
@@ -1,0 +1,92 @@
+# Manager metrics package — the boss's visualization list, mapped onto the Round-Up
+
+- **Date:** 2026-07-03
+- **Status:** Draft for Jac's (and his manager's) review
+- **Branch:** `claude/units-card-graphs-review-n5c67n`
+- **Directive:** Jac forwarded his manager's list of wanted visualizations, including a
+  written Time-Utilization formula. Jac's calls (popup, 2026-07-03): **spec first**;
+  "Units of Work" = *completed work of all the staff roles*; Active/Inactive = the
+  **activity meter** on customer profiles (`_digest.activePct`); hours source =
+  **proxy now + start backend hour snapshots** so the exact formula takes over.
+- **Builds on:** `2026-07-03-roundup-reporting-board-design.md` (the board + §13.6 data
+  assembly) and the §13.7 gauge strip (PR #468). New panels land on the **board
+  sections** and join the matching card's **strip tabs** — one panel registry serves both.
+
+---
+
+## 1. Already covered today (no build needed — show the manager where)
+
+| Manager ask | Where it lives now |
+|---|---|
+| Field Call Count | Round-Up · Shop — **Field Calls** trend + worst-offender leaderboard; also the Units strip's Field Calls tab |
+| Spending on Parts | Round-Up · Money — **Expenses by Category** (WO part costs, range-scoped) |
+| Cancellations/No Shows (revenue lens) | Round-Up · Money — **Revenue by Status** carries Cancelled / No Show bars |
+| Units of Work (live lens) | The **§11 KPI rings** already track each role's completed work in real time — mechanic (units ready, WOs completed, billable WOs), driver (deliveries, washes), office (collected $, active rentals), sales (revenue, actives, members). Admin-definable via Settings → KPIs & Rings |
+| Billed Work Orders (live lens) | Mechanic ring #3 counts billable WOs today |
+
+## 2. New panels (computable from data we already have)
+
+| # | Panel | Section / strip | Formula & source | Mark → nav |
+|---|---|---|---|---|
+| N1 | **Net Sales** | Money / Invoices strip | Σ payments − refunds per time bucket (`invoiceTotals(i).paid − refundedAmount`, bucketed by invoice date) | bar → Invoices, period pill |
+| N2 | **Refunds** | Money / Invoices strip | Σ `refundedAmount` per bucket | bar → Invoices, `Refunded` |
+| N3 | **Invoice Aging** | Money / Invoices strip | open balances bucketed 0–30 / 31–60 / 61–90 / 90+ days past `dueDate` | bar → Invoices, `Late` |
+| N4 | **Cancellations & No-Shows (count)** | Rentals | count of rentals hitting Cancelled / No Show per bucket | dot → Rentals, status pill |
+| N5 | **Successful Rentals** | Rentals | count of rentals reaching Returned (not voided) per bucket — overlay on the Bookings trend | dot → Rentals, `Returned` |
+| N6 | **Active / Inactive customers** | Customers | donut: `activePct > 0` = Active (the profile activity meter, server digest), split Members vs non | slice → Customers, `Active %` sort |
+| N7 | **Memberships** | Customers | funnel/status counts from the membership engine (`memberStatus()`): Active · Past Due · Lapsed · **Cancelled** (cancellation-invoice holders) | slice → Customers, stage pill |
+| N8 | **Billed Work Orders** | Shop | count + $ of WOs with `billCustomer='Yes'` and billed lines, per bucket | bar → Shop, `Bill: Yes` |
+| N9 | **Days Since Last Field Call** | Shop | stat tile (was on the pre-redesign dashboard; returns as a Today's-Reality tile) | tile → Rentals, `field call` |
+| N10 | **Work by Role** | Shop | the manager's "Units of Work" over TIME: completed WOs, inspections, deliveries/returns, collected invoices per bucket, one line per role-metric (the rings' numerators, historized from record dates) | dot → the owning card |
+| N11 | **Dollar Utilization / category** | Fleet | range revenue per category ÷ fleet cost basis (Σ unit `purchasePrice`), annualized to the range | bar → Units, category pill |
+| N12 | **Unit Cost per Hour** | Fleet | per unit: Σ WO part/labor cost ÷ (`currentHours − purchaseHours`) — leaderboard of the worst, flagging "problem units to get rid of" | row → that unit |
+
+## 3. Time Utilization — his formula, and the data gap
+
+> Every category has a useful-life hour total and an end-of-life year count →
+> **expected hours/month**. `(actual ÷ expected) × 100 = utilization %`, rolling 30
+> days. >100% → buy/fix; <100% → drum up demand.
+
+- **New category fields** (schema-less, additive): `usefulLifeHours`, `endOfLifeYears`.
+  `expectedMonthlyHours = usefulLifeHours ÷ (endOfLifeYears × 12)`. Jac enters the
+  numbers per category (same values as WranglerGPS).
+- **The gap:** actual hours per rolling 30 days needs hour *history*; we store one
+  lifetime `currentHours` per unit. **Decision (Jac): both paths.**
+  - **Proxy now (T1):** classic time utilization = days-on-rent ÷ available days per
+    category, from rentals — ships immediately, clearly labeled "on-rent basis".
+  - **Exact later (T2):** a daily backend snapshot `{date, unitId, currentHours,
+    fleetStatus}` — the SAME job fleet-history #454 needs (one time-driven GAS
+    trigger serves both). Once ≥30 days accumulate, the panel switches to
+    `(Δhours ÷ expectedMonthlyHours) × 100` per category, 100% target rule drawn on
+    the chart. Backend is additive, deployed via `/clasp` with its STOP gate.
+
+## 4. Sensitivity flag (role lens — decide before build)
+
+N11/N12 and the cost basis expose **purchase price / true cost / margin-adjacent**
+numbers, and the Round-Up + strips are currently visible to any logged-in role. The
+board's $-section role-gating decision is still open with Jac — these Fleet panels
+join that decision: **recommend Admin/Office-only** for N11/N12 (server-digest or
+role-gated render) before they ship. The rest of the package is operational data
+already visible in the app.
+
+## 5. Build order
+
+1. **Phase M1** — Money + Rentals + Customers panels (N1–N7): pure front-end, data
+   already assembled in §13.6 (add refund/aging/membership assemblers).
+2. **Phase M2** — Shop panels (N8–N10) + the Days-since-FC tile.
+3. **Phase M3** — Fleet: category life fields (+ category editor inputs), proxy Time
+   Utilization + Dollar Utilization + Cost per Hour — behind the role-gating call.
+4. **Phase M4 (backend)** — the daily snapshot trigger (serves #454 + exact hours);
+   swap Time Utilization to the exact formula when history suffices.
+
+Each phase: gates + real-login screenshot audit + squash-merge, same loop as the
+Round-Up phases. Every new panel registers in `RU_PANELS` once and appears on the
+board section *and* the owning card's strip tabs.
+
+## 6. Open items
+
+- Manager's "Units of Work" — N10 charts completed work per role over time; confirm
+  that matches his intent (Jac: "I think we may have this covered already").
+- Role-gating for N11/N12 (§4) — Jac's call.
+- `usefulLifeHours` / `endOfLifeYears` values per category — Jac to supply (or import
+  from WranglerGPS).

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703q" />
+  <link rel="stylesheet" href="style.css?v=20260703r" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703q"></script>
-  <script type="module" src="app.js?v=20260703q"></script>
+  <script src="rule-usage.js?v=20260703r"></script>
+  <script type="module" src="app.js?v=20260703r"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1960,10 +1960,10 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .ru-lead-n { color: var(--txt-3); font-weight: 700; font-size: 11px; }
 .ru-lead-name { font-weight: 600; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .ru-lead-c { font-weight: 800; font-size: 13px; color: var(--txt-2); font-variant-numeric: tabular-nums; }
-.ru-plotmount rect.js-ru-nav, .ru-plotmount circle.js-ru-nav { cursor: pointer; }
-.ru-plotmount rect.js-ru-nav:hover, .ru-plotmount circle.js-ru-nav:hover { filter: brightness(1.18); }
-.ru-plotmount rect.js-ru-nav:focus-visible, .ru-plotmount circle.js-ru-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-.ru-plotmount text { pointer-events: none; }
+.ru-plotmount .js-ru-nav, .rus-mount .js-ru-nav { cursor: pointer; }
+.ru-plotmount svg .js-ru-nav:hover, .rus-mount svg .js-ru-nav:hover { filter: brightness(1.18); }
+.ru-plotmount svg .js-ru-nav:focus-visible, .rus-mount svg .js-ru-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ru-plotmount text, .rus-mount text { pointer-events: none; }
 .ru-duo { display: flex; gap: 14px; align-items: stretch; }
 .ru-duo-chart { flex: 1; min-width: 0; }
 .ru-real { width: 92px; flex: none; display: flex; flex-direction: column; justify-content: center; gap: 3px; padding-left: 14px; border-left: 1px dashed var(--tan, #c2925a); }   /* saddle-stitch divider — trend left, "right now" right */
@@ -1978,9 +1978,6 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .ru-donut .ru-slice-n { font-size: 13px; font-weight: 700; }
 .ru-donut .ru-donut-tot { font-size: 27px; font-weight: 800; }
 .ru-donut .ru-donut-sub { font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; }
-.ru-plotmount path.js-ru-nav { cursor: pointer; }
-.ru-plotmount path.js-ru-nav:hover { filter: brightness(1.18); }
-.ru-plotmount path.js-ru-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .ru-donut-pair { display: flex; gap: 10px; justify-content: center; }
 .ru-donut-cell { flex: 1; min-width: 0; }
 .ru-donut-cell svg.ru-donut { max-width: 190px; }
@@ -1992,6 +1989,27 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .ru-tile-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
 @media (max-width: 900px) { .ru-layout { grid-template-columns: 1fr; } .ru-spine { flex-direction: row; flex-wrap: wrap; border-right: none; border-bottom: 1px solid var(--line); padding: 10px 12px; } .ru-grid { grid-template-columns: 1fr; } }
 @media (prefers-reduced-motion: reduce) { .ru-per { transition: none; } }
+
+/* ── §13.7 gauge strip — the card's Round-Up charts in-column, 25% of the column ── */
+.rus { flex: 0 0 25%; min-height: 0; display: flex; flex-direction: column; margin: 0 8px 4px; border: 1px solid var(--line); border-radius: 12px; background: linear-gradient(180deg, var(--card-head), var(--card)); color: var(--txt-3); overflow: hidden; }   /* color themes Plot's currentColor axes */
+.is-phone .rus { flex: none; height: 25dvh; }   /* phone: the strip rides inside the scroll column — 25% of the viewport ≈ the column */
+.rus-tabs { display: flex; gap: 2px; padding: 3px 8px 2px; border-bottom: 1px solid var(--line-soft); overflow-x: auto; scrollbar-width: none; justify-content: center; justify-content: safe center; flex: none; }
+.rus-tabs::-webkit-scrollbar { display: none; }
+.rus-tab { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10.5px; padding: 1px 7px; border: none; background: none; color: var(--txt-3); white-space: nowrap; cursor: pointer; transition: color .12s; }
+.rus-tab:hover { color: var(--txt); }
+.rus-tab.on { color: var(--accent); }
+.rus-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.rus-body { flex: 1; min-height: 0; display: flex; gap: 6px; padding: 2px 8px 5px; }
+.rus-rail { display: flex; flex-direction: column; justify-content: center; gap: 1px; flex: none; min-width: 30px; }
+.rus-per { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 9.5px; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 72px; padding: 0 2px; border: none; background: none; color: var(--txt-3); cursor: pointer; transition: color .12s; }
+.rus-per:hover { color: var(--txt); }
+.rus-per.on { color: var(--accent); }
+.rus-per:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.rus-mount { flex: 1; min-width: 0; min-height: 0; overflow: auto; }
+.rus-mount svg { display: block; max-width: 100%; max-height: 100%; width: auto; height: auto; margin: 0 auto; }
+.rus-mount .ru-duo { height: 100%; }
+.rus-mount .ru-empty { padding: 10px 4px; }
+@media (prefers-reduced-motion: reduce) { .rus-tab, .rus-per { transition: none; } }
 
 .board-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .board-table th { position: sticky; top: 0; z-index: 1; text-align: left; padding: 10px 14px; background: var(--card-head); color: var(--txt-3); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; border-bottom: 1px solid var(--line); white-space: nowrap; }


### PR DESCRIPTION
Per Jac's redirect after the Round-Up shipped: the card chart icons no longer open the Round-Up popup — each card's charts now open **in-column at the top of the list rows, strictly 25% of the card column's height**. The Round-Up board itself stays on the header **Round-Up** button.

## The gauge strip (§13.7)

- **One panel at a time behind stamped tabs** — Saira caps, orange *ink* when selected (no chips). Per-card panel sets: Units → Fleet / Categories / Field Calls · Categories → Revenue / Expenses · Rentals → Bookings / Revenue / Invoices / #s · Customers → Accounts / Cards / Top Spend · Invoices → Balances / Top Spend · shop segments → their trend/phase/urgency panels.
- **Slim left time rail** — the board's spine shrunk down (Td/Wk/Mo/30d/60d/90d/All), driving the **same global range** the board reads. Picking a *new* custom range stays a board power; an active one shows in the rail as stamped orange text (click clears to All).
- **Strict 25%**: the strip is lifted to a direct `.card` child (next to the already-lifted listbar) so `flex: 0 0 25%` resolves against the full column; `25dvh` on phones. Charts render at native text size via an ambient size hint (`_ruSize`) measured from the box post-render — no shrunk-SVG squint.
- **Marks stay nav targets**: clicking a bar/slice/dot in the strip pins the filter pill on the list *below it* — `ruNavigate` no longer force-closes graph view.
- **Shop**: 'all' keeps the stackbars worklist (mechanic landing, untouched); segments get their own strips that survive segment switches.

## Verified on live data (real-login Playwright audit)

All five card strips + two shop segment strips measured at exactly **0.25** column fraction; per-panel health `svg/lead/tiles` for every tab; in-strip slice nav pinned `Active` on Units with the strip still open; rail + tab switches re-render; Shop 'all' worklist regression green; board unchanged. Full gate suite passes (smoke, 404/404 logic, rule-usage, window catalog, code-map). Cache-bust `20260703q→r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr

---
_Generated by [Claude Code](https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr)_