### PR TITLE
M4 handoff — unit daily snapshot backend additions (unitDaily tab + trigger)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6523,7 +6523,10 @@ const DETAIL = {
           ${st.roi != null ? kv(`${st.roi}%`, { sfx: 'ROI', derived: true }) : ''}
           ${kv(money(st.avgRevUnit), { sfx: '/unit revenue', derived: true })}${kv(money(st.avgExpUnit), { sfx: '/unit expenses', derived: true })}
           ${kv(money(c.msrp), { sfx: 'MSRP' })}${kv(money(c.askPrice), { sfx: 'ask' })}${kv(money(c.bottomDollar), { sfx: 'bottom dollar' })}
-          ${kv('—', { sfx: 'time / dollar util (backend)', derived: true })}
+          ${catUtilKv(c)}
+          ${efld('categories', c, 'categoryId', 'usefulLifeHours', 'Useful life (hrs)', { type: 'number', admin: true, fmt: (v) => num(v) + ' HRS', sfx: 'useful life' })}
+          ${efld('categories', c, 'categoryId', 'endOfLifeYears', 'End of life (yrs)', { type: 'number', admin: true, fmt: (v) => v + ' YRS', sfx: 'end of life' })}
+          ${c.usefulLifeHours > 0 && c.endOfLifeYears > 0 ? kv(`${num(Math.round(c.usefulLifeHours / (c.endOfLifeYears * 12)))} HRS/MO`, { sfx: 'expected pace', derived: true }) : ''}
         </div>
         <div class="side r">${unitRows || '<span class="muted" style="font-size:12px">No units</span>'}</div>
       </div></div>`;
@@ -8928,7 +8931,7 @@ function ruApplyCustom(o) {
 const ruColor = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim() || '#8b94a3';
 /* Plot bar panel — Jac's chart law baked in: value rides the bar (never a detached row),
    dotted gridlines + Y axis on a nice scale, bottom-anchored, no legend (hover = plain name). */
-function ruBarsSVG({ data, money = false, w = 620, h = 250, overlayMarks = [], labelMarks = [] }) {
+function ruBarsSVG({ data, money = false, w = 620, h = 250, overlayMarks = [], labelMarks = [], fmt = null }) {
   if (_ruSize) { w = _ruSize.w; h = _ruSize.h; }
   return Plot.plot({
     width: w, height: h, marginLeft: 48, marginRight: 12, marginTop: 22, marginBottom: data.length > 6 ? 54 : 28,
@@ -8941,7 +8944,7 @@ function ruBarsSVG({ data, money = false, w = 620, h = 250, overlayMarks = [], l
       Plot.gridY({ stroke: ruColor('--line'), strokeDasharray: '2,3', strokeOpacity: 0.8 }),
       Plot.barY(data, { x: 'label', y: 'value', fill: 'fill', rx: 4, title: 'name' }),
       ...overlayMarks,
-      Plot.text(data, { x: 'label', y: 'value', text: (d) => (money ? uMoneyK(d.value) : String(d.value)), dy: -8, fill: ruColor('--txt-2'), fontWeight: 700 }),
+      Plot.text(data, { x: 'label', y: 'value', text: (d) => (fmt ? fmt(d.value) : money ? uMoneyK(d.value) : String(d.value)), dy: -8, fill: ruColor('--txt-2'), fontWeight: 700 }),
       ...labelMarks,
       Plot.ruleY([0], { stroke: ruColor('--line-soft') }),
     ],
@@ -9311,6 +9314,76 @@ function ruCardHealth() {   // card on file — snapshot by nature; values match
   return ruDonutSVG({ segs, noun: 'CUST' });
 }
 // panel builders land here phase by phase; sections list what is coming so the board is honest
+/* ── Manager metrics M3 — Fleet utilization (spec §3, proxy basis until the M4
+   hour snapshots accumulate; Jac 2026-07-03: visible to every logged-in role) ── */
+// per-category on-rent day rollup over a bounded window (the proxy for time utilization)
+function catUtilKv(c) {
+  const { days, note, rented, fleet } = ruCatUtilProxy({ k: 'all', a: null, b: null });
+  const n2 = fleet[c.categoryId] || 0; if (!n2) return '';
+  const t = Math.min(100, Math.round((rented[c.categoryId] || 0) / (n2 * days) * 100));
+  return kv(`${t}%`, { sfx: `time util${note}`, derived: true });
+}
+function ruUtilWindow(rg) {
+  // his formula is a rolling 30 days — unbounded ranges fall back to exactly that
+  if (ruBounded(rg) && rg.a && rg.b) return { a: rg.a, b: rg.b, note: '' };
+  const b = TODAY_ISO, a0 = parseISO(TODAY_ISO); a0.setDate(a0.getDate() - 30);
+  return { a: uISO(a0), b, note: ' (rolling 30d)' };
+}
+function ruCatUtilProxy(rg) {
+  const { a, b, note } = ruUtilWindow(rg);
+  const days = Math.max(1, Math.round((parseISO(b) - parseISO(a)) / 86400000));
+  const rented = {};   // categoryId → Σ on-rent days inside [a,b)
+  DATA.rentals.forEach((r2) => {
+    const s = rentalDisplayStatus(r2); if (s === 'Cancelled' || s === 'No Show' || s === 'Quote') return;
+    const rs = (r2.startDate || '').slice(0, 10), re = (r2.endDate || r2.startDate || '').slice(0, 10);
+    if (!rs) return;
+    const lo = rs > a ? rs : a, hi = re < b ? re : b; if (lo >= hi) return;
+    const d = Math.round((parseISO(hi) - parseISO(lo)) / 86400000); if (d <= 0) return;
+    rentalUnits(r2).forEach((eu) => { const u = IDX.unit.get(eu.unitId); if (u && u.categoryId) rented[u.categoryId] = (rented[u.categoryId] || 0) + d; });
+  });
+  const fleet = {};   // categoryId → unit count (available days = units × window days)
+  DATA.units.forEach((u) => { if (u.categoryId) fleet[u.categoryId] = (fleet[u.categoryId] || 0) + 1; });
+  return { days, note, rented, fleet };
+}
+function ruTimeUtil(rg) {   // proxy: days on rent ÷ available days per category — swaps to (Δhours ÷ expected)×100 once M4 history exists
+  const { days, note, rented, fleet } = ruCatUtilProxy(rg);
+  const blue = ruColor('--blue');
+  const rows = Object.keys(fleet).map((id) => {
+    const nm = IDX.category.get(id)?.name || id;
+    const pct = Math.min(100, Math.round((rented[id] || 0) / (fleet[id] * days) * 100));
+    return { label: nm, name: `${nm} — ${pct}% time utilization${note}`, value: pct, fill: blue, card: 'categories', col: 'name', navValue: nm, tip: `${nm}: on rent ${rented[id] || 0} of ${fleet[id] * days} unit-days${note} — ${pct}%` };
+  }).filter((d) => d.value > 0).sort((x, y) => y.value - x.value).slice(0, 12);
+  if (!rows.length) return ruEmpty('Nothing on rent in this window.');
+  return ruWireNav(ruBarsSVG({ data: rows, fmt: (v) => v + '%' }), rows);
+}
+function ruDollarUtil(rg) {   // annualized range revenue ÷ fleet cost basis, per category
+  const { a, b, note } = ruUtilWindow(rg);
+  const days = Math.max(1, Math.round((parseISO(b) - parseISO(a)) / 86400000));
+  const A = ruCatMoney({ k: 'x', a, b });
+  const green = ruColor('--green');
+  const rows = Object.entries(A.rev).map(([id, rev]) => {
+    const basis = A.basis[id] || 0;   // same trueCost-||-purchasePrice basis the board's ROI already shows
+    if (basis <= 0) return null;
+    const pct = Math.round((rev / days * 365) / basis * 100);
+    const nm = IDX.category.get(id)?.name || id;
+    return { label: nm, name: `${nm} — ${pct}% dollar utilization`, value: pct, fill: green, card: 'categories', col: 'name', navValue: nm, tip: `${nm}: ${money(rev)} rev${note} annualized ÷ ${money(basis)} fleet cost — ${pct}%` };
+  }).filter((d) => d && d.value > 0).sort((x, y) => y.value - x.value).slice(0, 12);
+  if (!rows.length) return ruEmpty('No revenue against a recorded cost basis yet — set true cost or purchase price on units.');
+  return ruWireNav(ruBarsSVG({ data: rows, fmt: (v) => v + '%' }), rows);
+}
+function ruCostPerHour() {   // per-unit maintenance $ per meter hour — the manager's problem-unit finder (snapshot)
+  const spend = {};
+  DATA.workOrders.forEach((w) => { if (w.cancelled || !w.unitId) return; const c = (w.lineItems || []).reduce((x, li) => x + (Number(li.cost) || 0), 0); if (c > 0) spend[w.unitId] = (spend[w.unitId] || 0) + c; });
+  const rows = Object.entries(spend).map(([uid, cost]) => {
+    const u = IDX.unit.get(uid); if (!u) return null;
+    const hrs = Math.max(0, (Number(u.currentHours) || 0) - (Number(u.purchaseHours) || 0));
+    if (hrs < 50) return null;   // too few metered hours to judge — noise, not signal
+    const cph = cost / hrs;
+    return { name: u.name, disp: money(cph) + '/hr', v: cph, card: 'units', col: 'name', navValue: u.name, tip: `${u.name}: ${money(cost)} maintenance over ${num(hrs)} hrs — ${money(cph)}/hr` };
+  }).filter(Boolean).sort((x, y) => y.v - x.v).slice(0, 8);
+  if (!rows.length) return ruEmpty('No unit has both maintenance spend and ≥50 metered hours yet.');
+  return ruLeadNode(rows, '');
+}
 /* ── Manager metrics M2 — Shop (spec 2026-07-03-manager-metrics-design.md) ── */
 function ruBilledWos(rg) {   // N8 — WOs billed to a customer, per bucket (count; parts $ rides the tip)
   const bk = ruBuckets(rg);
@@ -9425,6 +9498,7 @@ const RU_PANELS = {
   'fleet-mix': { build: ruFleetMix }, 'accounts': { build: ruAccounts }, 'card-health': { build: ruCardHealth },
   'net-sales': { build: ruNetSales }, 'refunds': { build: ruRefunds }, 'aging': { build: ruAging },
   'billed-wos': { build: ruBilledWos }, 'work-by-role': { build: ruWorkByRole },
+  'time-util': { build: ruTimeUtil }, 'dollar-util': { build: ruDollarUtil }, 'cost-hour': { build: ruCostPerHour },
   'voided': { build: ruVoided }, 'cust-active': { build: ruCustActive }, 'memberships': { build: ruMemberships },
 };
 const RU_SECTIONS = [
@@ -9444,7 +9518,9 @@ const RU_SECTIONS = [
     { id: 'work-by-role', title: 'Work by Role', phase: 'M2' },
     { id: 'field-calls', title: 'Field Calls', phase: 'C' }, { id: 'svc-urgency', title: 'Service Urgency', phase: 'D' } ] },
   { id: 'fleet', label: 'Fleet', panels: [
-    { id: 'fleet-mix', title: 'Fleet Mix', phase: 'D' }, { id: 'units-per-cat', title: 'Units per Category' } ] },
+    { id: 'fleet-mix', title: 'Fleet Mix', phase: 'D' }, { id: 'units-per-cat', title: 'Units per Category' } ,
+    { id: 'time-util', title: 'Time Utilization', phase: 'M3' }, { id: 'dollar-util', title: 'Dollar Utilization', phase: 'M3' },
+    { id: 'cost-hour', title: 'Unit Cost per Hour', phase: 'M3' } ] },
   { id: 'customers', label: 'Customers', panels: [
     { id: 'accounts', title: 'Account Types · Pay Status', phase: 'D' }, { id: 'card-health', title: 'Card Health', phase: 'D' },
     { id: 'cust-active', title: 'Active vs Inactive', phase: 'M1' }, { id: 'memberships', title: 'Memberships', phase: 'M1' } ] },
@@ -9458,8 +9534,8 @@ const RU_SECTIONS = [
    the strip a click filters the list right below it. The Round-Up board itself remains
    on the header Round-Up button. */
 const RUS_TABS = {
-  units: [{ p: 'fleet-mix', l: 'Fleet' }, { p: 'units-per-cat', l: 'Categories' }, { p: 'field-calls', l: 'Field Calls' }],
-  categories: [{ p: 'rev-cat', l: 'Revenue' }, { p: 'exp-cat', l: 'Expenses' }],
+  units: [{ p: 'fleet-mix', l: 'Fleet' }, { p: 'units-per-cat', l: 'Categories' }, { p: 'field-calls', l: 'Field Calls' }, { p: 'cost-hour', l: '$/Hr' }],
+  categories: [{ p: 'rev-cat', l: 'Revenue' }, { p: 'exp-cat', l: 'Expenses' }, { p: 'time-util', l: 'Time Util' }, { p: 'dollar-util', l: '$ Util' }],
   rentals: [{ p: 'bookings', l: 'Bookings' }, { p: 'voided', l: 'Voided' }, { p: 'rev-status', l: 'Revenue' }, { p: 'inv-status', l: 'Invoices' }, { p: 'rent-tiles', l: '#s' }],
   customers: [{ p: 'accounts', l: 'Accounts' }, { p: 'cust-active', l: 'Active' }, { p: 'memberships', l: 'Members' }, { p: 'card-health', l: 'Cards' }, { p: 'top-spend', l: 'Top Spend' }],
   invoices: [{ p: 'balances', l: 'Balances' }, { p: 'net-sales', l: 'Net' }, { p: 'refunds', l: 'Refunds' }, { p: 'aging', l: 'Aging' }, { p: 'top-spend', l: 'Top Spend' }],

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 17404 lines, 38 chapters
+## app.js — 17480 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -23,29 +23,29 @@
 | APP-13 | 4780–4939 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, unitRentalInspPill, …(+1) |
 | APP-14 | 4940–5252 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
 | APP-15 | 5253–5449 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 5450–6786 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
-| APP-17 | 6787–6880 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
-| APP-18 | 6881–7161 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 7162–7356 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
-| APP-20 | 7357–7481 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-21 | 7482–7646 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7647–7868 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 7869–8705 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+72) |
-| APP-24 | 8706–8748 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-25 | 8749–9518 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+65) |
-| APP-26 | 9519–10465 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10466–10562 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 10563–11022 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-29 | 11023–12073 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
-| APP-30 | 12074–12343 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 12344–12475 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 12476–12479 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 12480–14077 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 14078–15006 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15007–16047 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 16048–16494 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16495–16497 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16498–17404 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-16 | 5450–6789 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+38) |
+| APP-17 | 6790–6883 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, detailTitle |
+| APP-18 | 6884–7164 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, shopAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 7165–7359 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
+| APP-20 | 7360–7484 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-21 | 7485–7649 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-22 | 7650–7871 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
+| APP-23 | 7872–8708 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+72) |
+| APP-24 | 8709–8751 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-25 | 8752–9594 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-26 | 9595–10541 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 10542–10638 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 10639–11098 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-29 | 11099–12149 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+99) |
+| APP-30 | 12150–12419 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 12420–12551 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 12552–12555 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 12556–14153 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 14154–15082 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 15083–16123 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 16124–16570 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 16571–16573 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 16574–17480 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 558 lines, 0 chapters
 

--- a/docs/handoffs/unit-daily-snapshots.gs
+++ b/docs/handoffs/unit-daily-snapshots.gs
@@ -1,0 +1,93 @@
+/* Unit daily snapshots — backend additions (M4, prepared 2026-07-03)
+ * ------------------------------------------------------------------
+ * Secret-free record of the ADDITIVE Code.gs changes for the daily
+ * unit-hours/fleet-status snapshot job (Code.gs is gitignored; this is
+ * the tracked copy per the /clasp rules).
+ * Spec: docs/superpowers/specs/2026-07-03-manager-metrics-design.md §3
+ * Also serves fleet-history #454 (fleetStatus rides the same rows).
+ *
+ * WHY: the manager's Time Utilization formula needs actual meter hours
+ * per rolling 30 days — we only store one lifetime currentHours per
+ * unit. A daily snapshot builds the history: after ~30 days the
+ * front-end swaps its days-on-rent proxy for (Δhours ÷ expected) × 100.
+ *
+ * STORAGE: a 'unitDaily' tab with FLAT columns (date · unitId ·
+ * currentHours · fleetStatus) — one row per unit per day. Flat beats
+ * the JSON-blob entity convention here: it's a time series (~36.5k
+ * rows/yr at 100 units), and flat ranges read in one getValues() pass.
+ *
+ * INSTALL (three additive steps, nothing existing changes):
+ *   1. Paste this whole file at the END of Code.gs.
+ *   2. Add ONE route line inside handle(), anywhere after the
+ *      `if (!role) return json({ ok:false, error:'unauthorized' });`
+ *      gate (so any signed-in role can read — Jac's 2026-07-03 call):
+ *        if (action === 'unitDaily') return json(unitDaily_(body));
+ *   3. Run installUnitDailyTrigger() ONCE from the Apps Script editor
+ *      (or transiently via a temp menu) — it self-deduplicates.
+ */
+
+var UNITDAILY_TAB = 'unitDaily';
+
+/* the daily job — installable time-driven trigger target (~5am America/Chicago).
+ * Idempotent per day: re-runs (or a manual run after the trigger) no-op. */
+function snapshotUnitsDaily() {
+  var lock = LockService.getScriptLock();
+  if (!lock.tryLock(20000)) return;
+  try {
+    var today = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+    var s = ss().getSheetByName(UNITDAILY_TAB);
+    if (!s) { s = ss().insertSheet(UNITDAILY_TAB); s.appendRow(['date', 'unitId', 'currentHours', 'fleetStatus']); }
+    var last = s.getLastRow();
+    if (last >= 2) {
+      var lastDate = s.getRange(last, 1).getValue();
+      var lastIso = (lastDate instanceof Date) ? Utilities.formatDate(lastDate, Session.getScriptTimeZone(), 'yyyy-MM-dd') : String(lastDate);
+      if (lastIso === today) return;   // already snapped today
+    }
+    // read the units entity the same way doLoad() does (JSON blob per row)
+    var units = [], us = ss().getSheetByName('units');
+    if (us) {
+      var ulast = us.getLastRow(), ucols = us.getLastColumn();
+      if (ulast >= 2 && ucols >= 1) {
+        var vals = us.getRange(2, 1, ulast - 1, ucols).getValues();
+        for (var i = 0; i < vals.length; i++) {
+          for (var c = vals[i].length - 1; c >= 0; c--) {
+            var cell = vals[i][c];
+            if (typeof cell === 'string' && cell.charAt(0) === '{') { try { units.push(JSON.parse(cell)); break; } catch (e2) {} }
+          }
+        }
+      }
+    }
+    if (!units.length) return;
+    var rows = [];
+    for (var j = 0; j < units.length; j++) {
+      var u = units[j]; if (!u || !u.unitId) continue;
+      rows.push([today, String(u.unitId), Number(u.currentHours) || 0, String(u.fleetStatus || '')]);
+    }
+    if (rows.length) s.getRange(s.getLastRow() + 1, 1, rows.length, 4).setValues(rows);
+  } finally { lock.releaseLock(); }
+}
+
+/* read handler — returns snapshot rows, optionally floored by body.since
+ * (ISO date). Auth: rides handle()'s existing role gate (any signed-in
+ * role; no money data in these rows). */
+function unitDaily_(body) {
+  var s = ss().getSheetByName(UNITDAILY_TAB);
+  if (!s || s.getLastRow() < 2) return { ok: true, rows: [] };
+  var since = String((body && body.since) || '');
+  var vals = s.getRange(2, 1, s.getLastRow() - 1, 4).getValues(), out = [];
+  for (var i = 0; i < vals.length; i++) {
+    var d = (vals[i][0] instanceof Date) ? Utilities.formatDate(vals[i][0], Session.getScriptTimeZone(), 'yyyy-MM-dd') : String(vals[i][0]);
+    if (since && d < since) continue;
+    out.push({ date: d, unitId: String(vals[i][1]), hours: Number(vals[i][2]) || 0, fleetStatus: String(vals[i][3]) });
+  }
+  return { ok: true, rows: out };
+}
+
+/* one-time trigger install — safe to re-run (dedupes on handler name) */
+function installUnitDailyTrigger() {
+  var trigs = ScriptApp.getProjectTriggers();
+  for (var i = 0; i < trigs.length; i++) {
+    if (trigs[i].getHandlerFunction() === 'snapshotUnitsDaily') return;
+  }
+  ScriptApp.newTrigger('snapshotUnitsDaily').timeBased().everyDays(1).atHour(5).create();
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703u" />
+  <link rel="stylesheet" href="style.css?v=20260703v" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703u"></script>
-  <script type="module" src="app.js?v=20260703u"></script>
+  <script src="rule-usage.js?v=20260703v"></script>
+  <script type="module" src="app.js?v=20260703v"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Phase **M4** of the manager metrics package — the backend snapshot job, as a **secret-free tracked handoff** (`Code.gs` is gitignored per the /clasp rules; docs-only diff).

**What the additions do** (all additive, nothing existing changes):
- `snapshotUnitsDaily()` — a time-driven daily job (~5am America/Chicago) appending one flat row per unit (`date · unitId · currentHours · fleetStatus`) to a new `unitDaily` tab. Script-locked and idempotent per day.
- `unitDaily_(body)` — a read handler behind the existing role gate (any signed-in role, per Jac's 2026-07-03 call), with an optional `since` floor.
- `installUnitDailyTrigger()` — one-time, self-deduplicating trigger install.

One shared history serves **both** the manager's exact Time Utilization formula (`Δhours ÷ expected × 100` — the front-end swaps off its days-on-rent proxy once ~30 days accumulate) **and** fleet-history #454 (`fleetStatus` rides the same rows).

**Deploy status:** blocked on credentials, not code — the clasp OAuth token is RAPT-blocked (`invalid_grant / invalid_rapt`), so `clasp push` can't run from this session. The assembled `Code.js` (live source + splice) sits ready in the session's clasp working copy and passes the syntax gate. Ships via either a re-minted `CLASPRC_JSON_B64` secret (then the /clasp throwaway-test → STOP-gate flow) or the 3-step editor paste documented in the file header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr

---
_Generated by [Claude Code](https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr)_