### PR TITLE
Category glyphs: no hover tint, animations paused until hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260703v" />
+  <link rel="stylesheet" href="style.css?v=20260703w" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260703v"></script>
-  <script type="module" src="app.js?v=20260703v"></script>
+  <script src="rule-usage.js?v=20260703w"></script>
+  <script type="module" src="app.js?v=20260703w"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -3058,7 +3058,6 @@ body { font-variant-numeric: tabular-nums; }
    move (one crisp beat, no bounce/loop — same .12s control timing as the rest of the
    system). `mo-none` (the box/unmatched fallback) is deliberately inert. ── */
 .cat-glyph { display: inline-flex; transition: transform .12s cubic-bezier(.2,.7,.2,1), color .12s ease; }
-.ur:hover .cat-glyph, .catr:hover .cat-glyph { color: var(--accent); }
 .ur:hover .mo-dig,     .catr:hover .mo-dig     { transform: translateY(1.5px) rotate(-8deg); }
 .ur:hover .mo-chop,    .catr:hover .mo-chop    { transform: rotate(-14deg); }
 .ur:hover .mo-spin,    .catr:hover .mo-spin    { transform: rotate(80deg); }
@@ -3080,15 +3079,19 @@ body { font-variant-numeric: tabular-nums; }
 
 /* ── ANIMATED CATEGORY GLYPHS (Jac, 2026-07-03) — the excavator / boom-lift / skid-steer
    families render CATEGORY_ANIM loops (icons-anim.js, converted from Jac's supplied
-   Lottie artwork). Ambient 3s loops, currentColor strokes (.k2 = dimmed secondary);
-   pivots work because the SVG nests translate(p) › animated group › translate(-a) at
-   each Lottie anchor. Jac explicitly opted into ambient icon motion here (overrides the
-   one-orchestrated-moment default); reduced-motion freezes every loop to the rest pose. ── */
+   Lottie artwork). PAUSED at the rest pose until the parent row/card (.ur/.catr) is
+   hovered (Jac, 2026-07-03: icons should NOT move until hovered, and never tint orange);
+   currentColor strokes (.k2 = dimmed secondary); pivots work because the SVG nests
+   translate(p) › animated group › translate(-a) at each Lottie anchor.
+   Reduced-motion keeps them frozen entirely. ── */
 .catanim { width: 1em; height: 1em; display: inline-block; overflow: visible; }
 .catanim .k2 { opacity: .55; }
 .catanim g { transform-box: view-box; transform-origin: 0 0; }
 /* travel groups animate via translate; rotate groups pivot at their Lottie anchor
    because the markup nests translate(p) > [anim] > translate(-a). */
+.catanim [class*="xc-"], .catanim [class*="bl-"], .catanim [class*="sk-"] { animation-play-state: paused; }
+.ur:hover .catanim [class*="xc-"], .ur:hover .catanim [class*="bl-"], .ur:hover .catanim [class*="sk-"],
+.catr:hover .catanim [class*="xc-"], .catr:hover .catanim [class*="bl-"], .catr:hover .catanim [class*="sk-"] { animation-play-state: running; }
 .catanim .xc-run { animation: caXcRun 3s ease-in-out infinite; }
 .catanim .xc-bob { animation: caXcBob 1.5s ease-in-out infinite; }
 .catanim .xc-dig { animation: caXcDig 3s ease-in-out infinite; }


### PR DESCRIPTION
## Summary

Two corrections from Jac on the category icons:

- **No orange tint on hover** — removed the `.ur:hover/.catr:hover` rule that recolored the category glyph to the accent; icons keep their normal color.
- **Animated glyphs hold still until hovered** — the excavator / boom-lift / skid-steer loops are `animation-play-state: paused` at their rest pose and only run while the parent unit row (`.ur`) or category card (`.catr`) is hovered. Reduced-motion keeps them frozen entirely (unchanged).

Cache token bumped to `20260703w`.

## Test plan

- [x] `node ci/gen-rule-usage.mjs --check` / `check-window-catalog` / `gen-code-map --check` green
- [ ] `ci/smoke.mjs` / `ci/logic-test.mjs` via CI (kicked manually — pull_request events don't fire on this branch)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6UMERhaADAj4upCCS1r5p)_