### PR TITLE
M4 handoff — deployed @57; document the editor-run trigger install

### DIFF
--- a/docs/handoffs/unit-daily-snapshots.gs
+++ b/docs/handoffs/unit-daily-snapshots.gs
@@ -23,7 +23,11 @@
  *      gate (so any signed-in role can read — Jac's 2026-07-03 call):
  *        if (action === 'unitDaily') return json(unitDaily_(body));
  *   3. Run installUnitDailyTrigger() ONCE from the Apps Script editor
- *      (or transiently via a temp menu) — it self-deduplicates.
+ *      (Run button) — the editor will prompt to authorize the new
+ *      trigger permission (script.scriptapp) on first run; approve it.
+ *      This CANNOT be automated: web-app executions lack that scope,
+ *      and adding a scope requires owner re-consent — which IS the
+ *      editor run. Deployed to prod @57, 2026-07-03.
  */
 
 var UNITDAILY_TAB = 'unitDaily';


### PR DESCRIPTION
Docs-only follow-up to #473: the M4 backend is now **deployed to production** (version @57, same `/exec` URL) via the freshly re-minted clasp credential — throwaway-tested first (auth regression clean, `unitDaily` handler live, bad passwords rejected), then promoted after Jac's explicit OK, then re-verified on the prod URL.

This updates the tracked copy (`docs/handoffs/unit-daily-snapshots.gs`) to mirror prod exactly: the experimental self-healing trigger install is removed — web-app executions lack the `script.scriptapp` scope, and granting a new scope requires owner re-consent, which *is* the editor run. The header now documents the one remaining step: run `installUnitDailyTrigger()` once from the Apps Script editor and approve the permissions prompt; snapshots then run daily ~5am.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr

---
_Generated by [Claude Code](https://claude.ai/code/session_012XnmdpxBAMhKbYthHwNGfr)_