### PR TITLE
Cache-bust: bump ?v= token so the #483 fold-invoice fix loads immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260704h" />
+  <link rel="stylesheet" href="style.css?v=20260706a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260704h"></script>
-  <script type="module" src="app.js?v=20260704h"></script>
+  <script src="rule-usage.js?v=20260706a"></script>
+  <script type="module" src="app.js?v=20260706a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Context
While triaging #482 (fold-invoice suggestion overflow), I found a parallel session had **already fixed it** in #483 (merged to main as `a20326b`) — same root cause, equivalent fix (`.mergeform`, `width: min(300px, 74vw)`). I stood down my duplicate code change.

## What this PR does
#483's fix is correct but it **didn't bump the shared `?v=` cache-bust token** — main's `index.html` still read `?v=20260704h`. Per CLAUDE.md ("Cache-bust on every deploy"), a release must bump the token so browsers load the new `style.css`/`app.js` immediately instead of waiting out Pages' 10-min `max-age`.

This bumps the shared token **`20260704h → 20260706a`** (the three versioned refs: `style.css`, `rule-usage.js`, `app.js`). No logic or UI change.

Smoke gate passes.

Related to #482 / #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)