### PR TITLE
Backend deploy: service-account path for clasp-blocked GAS deploys

### DIFF
--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -1,0 +1,34 @@
+# Backend deploy queue — ready the moment clasp is re-armed (2026-07-06)
+
+The cloud clasp credential is RAPT-expired (`invalid_grant / invalid_rapt`). Re-arm
+(2 minutes, Jac's machine):
+
+1. `npx @google/clasp login` (browser OAuth as operations@jacrentals.com)
+2. `base64 -w0 ~/.clasprc.json` (PowerShell: `[Convert]::ToBase64String([IO.File]::ReadAllBytes("$env:USERPROFILE\.clasprc.json"))`)
+3. Paste the output into the **`CLASPRC_JSON_B64`** environment secret (Claude Code env settings — never into chat/repo)
+4. Start a **fresh cloud session** (secrets inject at session start) and say "deploy the backend queue"
+
+## The queue (all ADDITIVE — splice into Code.gs, one push, one redeploy)
+
+| # | Item | Source | Wire-up | Post-deploy |
+|---|---|---|---|---|
+| 1 | **perfReport** — Web-Vitals sink → `_perf` tab (5k-row FIFO, metrics-only by construction) | `perf-report-backend.gs` | `if (action === 'perfReport') return perfReport_(body);` | Nothing — the client already flushes (fire-and-forget); data appears as sessions run |
+| 2 | **unitDaily snapshots (M4)** — daily unit hours/fleet-status history | `unit-daily-snapshots.gs` | router line per that file + run `installUnitDailyTrigger()` ONCE | Unblocks KPI trend sparklines + true hour-based utilization |
+
+Deploy flow (same deployment id — NEVER a bare `clasp deploy`):
+```bash
+cd ~/rw-backend && clasp pull
+#  splice both .gs files' contents into Code.js
+clasp push --force
+clasp deploy -i AKfycbzHahzgJqOYe9o4GKlRVGh-A7USRn1k4Dvyy4ajLh8EYCqVxofouM28qs8trNlObZw -d "perfReport sink + unitDaily snapshots"
+```
+Verify: `curl -s -L -G --data-urlencode "action=load" --data-urlencode "password=<role-pw>" "$EXEC_URL" | head -c 120`
+then run one app session and confirm a `_perf` row lands; run `installUnitDailyTrigger()` in the editor once.
+
+## NOT in the queue (bigger, later)
+- Collections Phase-2 outbound (`collectionsSend` + agency token) — needs the vendor pick first (spec collections OQ-13)
+- Views getViews/setViews — retired client-side; the actions can stay deployed, harmless
+- Per-role passwords / tier gates — **already live** (`role-tiers-backend.gs`, deployed 2026-06-26 era); the specs' "backend-data OQ-1 blocker" is narrower than written: what remains is per-ACTION tier maps for the new Phase-2 actions when they land
+
+## Standing rule
+Every deploy here is `/clasp` STOP-gated — Jac's explicit go before `clasp deploy`, every time.

--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -1,9 +1,30 @@
-# Backend deploy queue — ready the moment clasp is re-armed (2026-07-06)
+# Backend deploy queue — ready the moment auth is unblocked (2026-07-06)
 
-The cloud clasp credential is RAPT-expired (`invalid_grant / invalid_rapt`). Re-arm
-(2 minutes, Jac's machine):
+## Auth status (2026-07-06): clasp's user-OAuth is BLOCKED by Google's RAPT re-auth policy
 
-1. `npx @google/clasp login` (browser OAuth as operations@jacrentals.com)
+Confirmed with a **brand-new** OAuth consent (not a stale token) — it fails
+`invalid_grant / invalid_rapt` on the very first call. This is Google Workspace enforcing
+a re-authentication policy on the `cloud-platform` scope for the `jacrentals.com` domain;
+it's enforced server-side per-call and a CLI's refresh-token flow can never satisfy it.
+**Re-running `clasp login` will not fix this** — don't retry it.
+
+### The real fix — a SERVICE ACCOUNT (JWT auth, not subject to RAPT), Jac in progress
+
+1. GCP project with the **Apps Script API** enabled.
+2. A service account + JSON key in that project.
+3. The Apps Script project's GCP link pointed at that project (script editor → ⚙️ Project Settings → GCP Project → Change project).
+4. The Apps Script file shared with the service account's email as **Editor**.
+5. The key, base64'd (`base64 -w0 keyfile.json`), set as the **`GAS_SA_KEY_B64`** env secret (never in chat/repo).
+6. Start a fresh cloud session and say "deploy the backend queue" — it drives `docs/handoffs/gas-deploy-service-account.mjs` (push + deploy via the Apps Script REST API directly, no clasp involved).
+
+### Fallback if the service-account setup stalls: deploy by paste
+
+The Apps Script web editor always works regardless of any of the above —
+https://script.google.com/d/1hw9A7Id3YIoiSCBkNFeDaKGRv-VtljFFIuBdQG5QULrgS0DjQhQ_2vyZ/edit
+→ paste the spliced `Code.js` → Deploy → Manage deployments → Edit the existing deployment → New version. Slower, zero dependency on OAuth/service-account plumbing.
+
+### (Historical — clasp user-OAuth re-arm, superseded by the service account above)
+1. `npx @google/clasp login` (browser OAuth as operations@jacrentals.com) — **will hit invalid_rapt immediately per the above; kept only for reference if Google's policy ever changes**
 2. `base64 -w0 ~/.clasprc.json` (PowerShell: `[Convert]::ToBase64String([IO.File]::ReadAllBytes("$env:USERPROFILE\.clasprc.json"))`)
 3. Paste the output into the **`CLASPRC_JSON_B64`** environment secret (Claude Code env settings — never into chat/repo)
 4. Start a **fresh cloud session** (secrets inject at session start) and say "deploy the backend queue"
@@ -15,12 +36,14 @@ The cloud clasp credential is RAPT-expired (`invalid_grant / invalid_rapt`). Re-
 | 1 | **perfReport** — Web-Vitals sink → `_perf` tab (5k-row FIFO, metrics-only by construction) | `perf-report-backend.gs` | `if (action === 'perfReport') return perfReport_(body);` | Nothing — the client already flushes (fire-and-forget); data appears as sessions run |
 | 2 | **unitDaily snapshots (M4)** — daily unit hours/fleet-status history | `unit-daily-snapshots.gs` | router line per that file + run `installUnitDailyTrigger()` ONCE | Unblocks KPI trend sparklines + true hour-based utilization |
 
-Deploy flow (same deployment id — NEVER a bare `clasp deploy`):
+Deploy flow via the service account (same deployment id, same exec URL — the script never
+calls a bare "new deployment" path, so the URL the app already calls stays fixed):
 ```bash
-cd ~/rw-backend && clasp pull
-#  splice both .gs files' contents into Code.js
-clasp push --force
-clasp deploy -i AKfycbzHahzgJqOYe9o4GKlRVGh-A7USRn1k4Dvyy4ajLh8EYCqVxofouM28qs8trNlObZw -d "perfReport sink + unitDaily snapshots"
+npm i --no-save googleapis   # ephemeral, not committed
+#  splice both .gs files' contents into ~/rw-backend/Code.js (pull via the web editor's
+#  file view if clasp pull is also blocked, or via the Drive API — Code.js is not in git)
+GAS_SA_KEY_B64=... node docs/handoffs/gas-deploy-service-account.mjs push
+GAS_SA_KEY_B64=... node docs/handoffs/gas-deploy-service-account.mjs deploy "perfReport sink + unitDaily snapshots"
 ```
 Verify: `curl -s -L -G --data-urlencode "action=load" --data-urlencode "password=<role-pw>" "$EXEC_URL" | head -c 120`
 then run one app session and confirm a `_perf` row lands; run `installUnitDailyTrigger()` in the editor once.

--- a/docs/handoffs/gas-deploy-service-account.mjs
+++ b/docs/handoffs/gas-deploy-service-account.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * gas-deploy-service-account.mjs — deploy Code.js to Apps Script via a SERVICE ACCOUNT,
+ * bypassing clasp's user-OAuth login entirely (spec: docs/handoffs/BACKEND-DEPLOY-QUEUE.md,
+ * Jac 2026-07-06 — clasp's refresh-token flow hits Google's RAPT re-auth policy on the
+ * cloud-platform scope for this Workspace; service-account JWT auth isn't subject to it).
+ *
+ * SETUP (one-time, needs Jac's Google Cloud Console access — see BACKEND-DEPLOY-QUEUE.md):
+ *   1. GCP project with the Apps Script API enabled.
+ *   2. A service account + JSON key in that project.
+ *   3. The Apps Script project's GCP link pointed at that project (editor → Project Settings).
+ *   4. The Apps Script file shared with the service account's email as Editor.
+ *   5. The key, base64'd, in the GAS_SA_KEY_B64 env secret.
+ *
+ * USAGE:
+ *   GAS_SA_KEY_B64=... node gas-deploy-service-account.mjs push   # push local Code.js + manifest
+ *   GAS_SA_KEY_B64=... node gas-deploy-service-account.mjs deploy "description"  # new version + update the live deployment
+ *
+ * Requires the `googleapis` npm package (installed ephemerally: `npm i --no-save googleapis`).
+ * Never logs the key or any token.
+ */
+import { google } from 'googleapis';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const SCRIPT_ID = '1hw9A7Id3YIoiSCBkNFeDaKGRv-VtljFFIuBdQG5QULrgS0DjQhQ_2vyZ';
+const DEPLOYMENT_ID = 'AKfycbzHahzgJqOYe9o4GKlRVGh-A7USRn1k4Dvyy4ajLh8EYCqVxofouM28qs8trNlObZw';
+const SCOPES = [
+  'https://www.googleapis.com/auth/script.projects',
+  'https://www.googleapis.com/auth/script.deployments',
+  'https://www.googleapis.com/auth/script.webapp.deploy',
+  'https://www.googleapis.com/auth/drive.file',
+];
+
+function auth() {
+  const b64 = process.env.GAS_SA_KEY_B64;
+  if (!b64) throw new Error('GAS_SA_KEY_B64 is not set — see docs/handoffs/BACKEND-DEPLOY-QUEUE.md setup steps.');
+  const key = JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
+  return new google.auth.GoogleAuth({ credentials: key, scopes: SCOPES });
+}
+
+async function scriptClient() {
+  const authClient = await auth().getClient();
+  return google.script({ version: 'v1', auth: authClient });
+}
+
+// Local project layout mirrors clasp's: a flat dir of .gs/.js files + appsscript.json.
+// This repo doesn't check the backend in (gitignored); point RW_BACKEND_DIR at wherever
+// Code.js + appsscript.json + the spliced-in .gs additions live (default ~/rw-backend).
+function loadLocalFiles(dir) {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.js') || f.endsWith('.gs') || f === 'appsscript.json');
+  return files.map((f) => {
+    const raw = readFileSync(join(dir, f), 'utf8');
+    if (f === 'appsscript.json') return { name: 'appsscript', type: 'JSON', source: raw };
+    return { name: f.replace(/\.(gs|js)$/, ''), type: 'SERVER_JS', source: raw };
+  });
+}
+
+async function push(dir) {
+  const script = await scriptClient();
+  const files = loadLocalFiles(dir || (process.env.RW_BACKEND_DIR || `${process.env.HOME}/rw-backend`));
+  await script.projects.updateContent({ scriptId: SCRIPT_ID, requestBody: { files } });
+  console.log(`Pushed ${files.length} file(s) to script ${SCRIPT_ID}.`);
+}
+
+async function deploy(description) {
+  const script = await scriptClient();
+  const ver = await script.projects.versions.create({ scriptId: SCRIPT_ID, requestBody: { description: description || 'deploy' } });
+  const versionNumber = ver.data.versionNumber;
+  await script.projects.deployments.update({
+    scriptId: SCRIPT_ID,
+    deploymentId: DEPLOYMENT_ID,
+    requestBody: { deploymentConfig: { versionNumber, description: description || 'deploy', manifestFileName: 'appsscript' } },
+  });
+  console.log(`Deployed version ${versionNumber} to deployment ${DEPLOYMENT_ID} (same exec URL).`);
+}
+
+const [, , cmd, arg] = process.argv;
+if (cmd === 'push') await push(arg);
+else if (cmd === 'deploy') await deploy(arg);
+else { console.error('Usage: node gas-deploy-service-account.mjs push|deploy [arg]'); process.exit(1); }

--- a/docs/handoffs/gas-deploy-service-account.mjs
+++ b/docs/handoffs/gas-deploy-service-account.mjs
@@ -13,6 +13,7 @@
  *   5. The key, base64'd, in the GAS_SA_KEY_B64 env secret.
  *
  * USAGE:
+ *   GAS_SA_KEY_B64=... node gas-deploy-service-account.mjs pull   # fetch live Code.js + manifest (authoritative, like clasp pull)
  *   GAS_SA_KEY_B64=... node gas-deploy-service-account.mjs push   # push local Code.js + manifest
  *   GAS_SA_KEY_B64=... node gas-deploy-service-account.mjs deploy "description"  # new version + update the live deployment
  *
@@ -63,6 +64,23 @@ async function push(dir) {
   console.log(`Pushed ${files.length} file(s) to script ${SCRIPT_ID}.`);
 }
 
+// Fetches the authoritative live source so a splice builds on what's actually deployed
+// (mirrors `clasp pull`) — writes each remote file into `dir` (default ~/rw-backend).
+async function pull(dir) {
+  const script = await scriptClient();
+  const target = dir || (process.env.RW_BACKEND_DIR || `${process.env.HOME}/rw-backend`);
+  const { mkdirSync, writeFileSync } = await import('fs');
+  mkdirSync(target, { recursive: true });
+  const res = await script.projects.getContent({ scriptId: SCRIPT_ID });
+  const files = res.data.files || [];
+  for (const f of files) {
+    const ext = f.type === 'JSON' ? '.json' : f.type === 'HTML' ? '.html' : '.js';
+    const name = f.name === 'appsscript' ? 'appsscript.json' : `${f.name}${ext}`;
+    writeFileSync(join(target, name), f.source, 'utf8');
+  }
+  console.log(`Pulled ${files.length} file(s) from script ${SCRIPT_ID} into ${target}.`);
+}
+
 async function deploy(description) {
   const script = await scriptClient();
   const ver = await script.projects.versions.create({ scriptId: SCRIPT_ID, requestBody: { description: description || 'deploy' } });
@@ -77,5 +95,6 @@ async function deploy(description) {
 
 const [, , cmd, arg] = process.argv;
 if (cmd === 'push') await push(arg);
+else if (cmd === 'pull') await pull(arg);
 else if (cmd === 'deploy') await deploy(arg);
-else { console.error('Usage: node gas-deploy-service-account.mjs push|deploy [arg]'); process.exit(1); }
+else { console.error('Usage: node gas-deploy-service-account.mjs push|pull|deploy [arg]'); process.exit(1); }

--- a/docs/handoffs/perf-report-backend.gs
+++ b/docs/handoffs/perf-report-backend.gs
@@ -1,0 +1,39 @@
+/* perfReport — backend addition (prepared 2026-07-06, spec frontend-performance D2)
+ *
+ * ADDITIVE splice for Code.gs (gitignored; deployed via clasp — see
+ * docs/handoffs/backend-deploy-via-clasp.md). Accepts the client's sampled
+ * Web-Vitals flush and appends it to a dedicated `_perf` tab — OUTSIDE
+ * PERSIST_KEYS, so it never rides diff-sync or the cold-load payload.
+ *
+ * SECURITY:
+ *  - Rides handle()'s existing password gate (any signed-in role — rejects
+ *    anonymous, so the sink can't be spammed from outside).
+ *  - METRICS ONLY by construction: the handler writes an explicit column list;
+ *    a crafted client can't smuggle extra fields into the sheet. No PII, no
+ *    dollars, no record ids, never a password (the role ID string only).
+ *  - Fire-and-forget contract: always returns { ok:true } fast; the client
+ *    swallows failures (a broken sink must be indistinguishable from none).
+ *
+ * WIRE-UP: add to handle()'s router:
+ *     if (action === 'perfReport') return perfReport_(body);
+ */
+var PERF_TAB = '_perf';
+var PERF_MAX_ROWS = 5000;   // rolling window — the sink can never bloat the file
+
+function perfReport_(body) {
+  try {
+    var s = ss().getSheetByName(PERF_TAB);
+    if (!s) { s = ss().insertSheet(PERF_TAB); s.appendRow(['ts', 'build', 'device', 'role', 'lcp', 'inp', 'cls', 'renderP50', 'renderP95', 'renderOver', 'renderN']); }
+    var v = (body && body.vitals) || {};
+    var r = (body && body.renders) || {};
+    var n1 = function (x) { x = Number(x); return isFinite(x) ? x : ''; };
+    var t1 = function (x, cap) { return String(x == null ? '' : x).slice(0, cap || 40); };
+    s.appendRow([
+      new Date(), t1(body && body.build), t1(body && body.device, 10), t1(body && body.role, 24),
+      n1(v.lcp), n1(v.inp), n1(v.cls), n1(r.p50), n1(r.p95), n1(r.over), n1(r.n),
+    ]);
+    var extra = s.getLastRow() - 1 - PERF_MAX_ROWS;
+    if (extra > 0) s.deleteRows(2, extra);   // FIFO: oldest samples roll off
+  } catch (e) { /* fire-and-forget — never propagate an error to the client */ }
+  return { ok: true };
+}


### PR DESCRIPTION
## What

Brings the service-account backend-deploy path (originally landed on `staging`) onto this branch, plus one addition:

- **`docs/handoffs/gas-deploy-service-account.mjs`** — deploys `Code.js` to Apps Script via a service-account JWT (bypasses clasp's user-OAuth, which hits Google's RAPT re-auth policy on the `cloud-platform` scope for this Workspace). Added a **`pull`** command (fetches the live `Code.js`/`appsscript.json` via `projects.getContent`, mirroring `clasp pull`) so a splice builds on the authoritative deployed source instead of blind-overwriting it.
- **`docs/handoffs/BACKEND-DEPLOY-QUEUE.md`** — the deploy runbook + queue (cherry-picked from `staging`, unmodified).
- **`docs/handoffs/perf-report-backend.gs`** — Web-Vitals sampled sink source (cherry-picked from `staging`, unmodified).

## Why draft

This is deploy tooling, not an app-code change — no `app.js`/`style.css` touched, so the usual CI gates (smoke, logic-test, rule-usage, window-catalog, code-map) don't apply. Left as draft because the actual backend deploy (pushing `perfReport_` into the live `Code.js` and cutting a new version) is separately STOP-gated on Jac's explicit go-ahead per the `/clasp` rule, and is currently blocked on enabling the Apps Script API for the service account (write calls fail with `User has not enabled the Apps Script API`, though reads succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMzZ9A6hF2QvTgRZLMc9eu)_