### PR TITLE
Comms Phase 1+: the SMS pipe + the EMAIL channel with FROM picker (spec D1/D2/D3/D6/D7)

### DIFF
--- a/app.js
+++ b/app.js
@@ -13919,7 +13919,8 @@ function onClick(e) {
   if (closest('.js-charge-invoice')) { e.stopPropagation(); return chargeInvoiceFlow(closest('.js-charge-invoice').dataset.rec); }
   if (closest('.js-record-payment')) { e.stopPropagation(); return recordManualPayment(closest('.js-record-payment').dataset.rec); }
   if (closest('.js-print-invoice')) { e.stopPropagation(); return printInvoice(closest('.js-print-invoice').dataset.rec); }
-  if (closest('.js-send-email')) { e.stopPropagation(); return sendInvoiceEmail(closest('.js-send-email').dataset.rec); }
+  if (closest('.js-send-email')) { e.stopPropagation(); const b = closest('.js-send-email'); return sendInvoiceEmail(b.dataset.rec, b); }   // anchor rides along for the D7 FROM dropdown
+  if (closest('.js-email-from-pick')) { e.stopPropagation(); const b = closest('.js-email-from-pick'); document.querySelectorAll('.dropdown-menu').forEach((n) => n.remove()); return emailQuoteSend(b.dataset.rec, b.dataset.from); }
   if (closest('.js-send-text')) { e.stopPropagation(); return sendInvoiceText(closest('.js-send-text').dataset.rec); }
   if (closest('.js-pay-addcard')) { e.stopPropagation(); const b = closest('.js-pay-addcard'); return openAddCard(b.dataset.rec, { returnTo: 'payment', invoiceId: b.dataset.inv }); }
   if (closest('.js-refund-invoice')) { e.stopPropagation(); if (state.overlay) { state.overlay.confirmRefund = true; state.overlay.error = ''; renderOverlay(); } return; }
@@ -16292,17 +16293,56 @@ function invoiceQuoteSummary(inv) {
     'Thank you for your business — much obliged.',
   ].join('\n');
 }
-// Open the device's mail client pre-filled to the customer with the quote inlined, then
-// stamp a timestamped "Emailed" note on the invoice history (logAction → §R13).
-function sendInvoiceEmail(invoiceId) {
+// Email a quote — SERVER send through the comms pipe (spec D6), with the D7 FROM picker:
+// when the shop has more than one connected address (send-as aliases, enumerated server-
+// side), the operator picks which one it goes out as; the server validates the choice.
+// Demo/#local (no backend password) keeps the old mailto: deep-link.
+let _commsAliases = null;   // fetched once per session; server-authoritative
+async function commsAliasList() {
+  if (_commsAliases) return _commsAliases;
+  try { const r = await backendCall('commsAliases'); if (r && r.ok && Array.isArray(r.aliases) && r.aliases.length) _commsAliases = r.aliases; } catch (e) {}
+  return _commsAliases || [];
+}
+async function emailQuoteSend(invoiceId, from) {
+  const inv = IDX.invoice.get(invoiceId); if (!inv) return;
+  toast('Sending email…');
+  let r; try { r = await backendCall('sendCustomerMessage', { channel: 'email', entity: 'invoice', recId: inv.invoiceId, customerId: inv.customerId, template: 'quote', from: from || '' }); }
+  catch (e) { r = { ok: false, reason: 'network' }; }
+  if (r && r.ok) {
+    logAction(inv, `Emailed quote to ${r.maskedTo || 'customer'}${r.fromUsed ? ` (from ${r.fromUsed})` : ''}`);
+    render();
+    toast(`Quote emailed to ${r.maskedTo || 'the customer'}.`);
+    return;
+  }
+  const why = {
+    'no-email': 'No email on file — add one on the account.',
+    'opted-out': 'This customer has opted out of email — hard stop.',
+    'cap': 'Daily send cap reached — raise SMS_DAILY_CAP if this run is legit.',
+    'isolation': 'Record/customer mismatch — reload and try again.',
+    'provider': 'The mail send failed server-side — if this is the first email ever, the backend still needs its one-time Gmail permission (editor → Run → authorize).',
+    'network': 'Couldn’t reach the backend — try again.',
+  }[r && r.reason] || 'Email didn’t send — try again.';
+  toast(why);
+}
+async function sendInvoiceEmail(invoiceId, anchorEl) {
   const inv = IDX.invoice.get(invoiceId); if (!inv) return;
   const cust = inv.customerId ? IDX.customer.get(inv.customerId) : null;
   if (!cust || !cust.email) { toast('No email on file for this customer.'); return; }   // guard — button is disabled, this is belt-and-suspenders
-  const subject = `Quote from ${companyName()} – ${inv.invoiceId}`;
-  window.location.href = `mailto:${encodeURIComponent(cust.email)}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(invoiceQuoteSummary(inv))}`;
-  logAction(inv, `Emailed quote to ${cust.email}`);
-  render();
-  toast(`Opening email to ${cust.email}…`);
+  if (!backendPassword) {   // demo/offline — the pre-pipe mailto path, unchanged
+    const subject = `Quote from ${companyName()} – ${inv.invoiceId}`;
+    window.location.href = `mailto:${encodeURIComponent(cust.email)}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(invoiceQuoteSummary(inv))}`;
+    logAction(inv, `Emailed quote to ${cust.email}`);
+    render();
+    toast(`Opening email to ${cust.email}…`);
+    return;
+  }
+  const aliases = await commsAliasList();
+  if (aliases.length > 1 && anchorEl && document.contains(anchorEl)) {   // D7 — pick which connected address it goes out as
+    const html = aliases.map((a) => `<button class="dd-item js-email-from-pick" data-rec="${esc(invoiceId)}" data-from="${esc(a)}">${esc(a)}</button>`).join('');
+    openDropdown(anchorEl, html, { align: 'left' });
+    return;
+  }
+  return emailQuoteSend(invoiceId, aliases[0] || '');
 }
 // Text a quote — SERVER send via the comms pipe (spec comms D1/D2: sendCustomerMessage →
 // Mocean adapter; recipient/body/gates all resolved server-side — the client passes only

--- a/app.js
+++ b/app.js
@@ -16304,20 +16304,46 @@ function sendInvoiceEmail(invoiceId) {
   render();
   toast(`Opening email to ${cust.email}…`);
 }
-// Open the device's SMS app pre-filled to the customer, then stamp a "Texted" note.
-function sendInvoiceText(invoiceId) {
+// Text a quote — SERVER send via the comms pipe (spec comms D1/D2: sendCustomerMessage →
+// Mocean adapter; recipient/body/gates all resolved server-side — the client passes only
+// ids + a template name, never a `to` or a body). Demo/#local mode (no backend password)
+// keeps the old device deep-link so offline demos still work.
+async function sendInvoiceText(invoiceId) {
   const inv = IDX.invoice.get(invoiceId); if (!inv) return;
   const cust = inv.customerId ? IDX.customer.get(inv.customerId) : null;
   if (!cust || !cust.phone) { toast('No phone on file for this customer.'); return; }
-  const t = invoiceTotals(inv);
-  const first = cust.firstName || (cust.name || '').trim().split(/\s+/)[0] || 'there';
-  const yard = companyPhone();
-  const msg = `Hi ${first}, your quote from ${companyName()} is ready – ${money2(t.total)} – reply or call us${yard ? ' at ' + yard : ''}.`;
-  const tel = String(cust.phone).replace(/[^0-9+]/g, '');
-  window.location.href = `sms:${tel}?&body=${encodeURIComponent(msg)}`;   // `?&body=` is the cross-platform (iOS + Android) separator
-  logAction(inv, `Texted quote to ${cust.phone}`);
-  render();
-  toast(`Opening text to ${cust.phone}…`);
+  if (!backendPassword) {   // demo/offline — the pre-pipe deep-link path, unchanged
+    const t = invoiceTotals(inv);
+    const first = cust.firstName || (cust.name || '').trim().split(/\s+/)[0] || 'there';
+    const yard = companyPhone();
+    const msg = `Hi ${first}, your quote from ${companyName()} is ready – ${money2(t.total)} – reply or call us${yard ? ' at ' + yard : ''}.`;
+    const tel = String(cust.phone).replace(/[^0-9+]/g, '');
+    window.location.href = `sms:${tel}?&body=${encodeURIComponent(msg)}`;   // `?&body=` is the cross-platform (iOS + Android) separator
+    logAction(inv, `Texted quote to ${cust.phone}`);
+    render();
+    toast(`Opening text to ${cust.phone}…`);
+    return;
+  }
+  toast('Sending text…');
+  let r; try { r = await backendCall('sendCustomerMessage', { entity: 'invoice', recId: inv.invoiceId, customerId: inv.customerId, template: 'quote' }); }
+  catch (e) { r = { ok: false, reason: 'network' }; }
+  if (r && r.ok) {
+    logAction(inv, `SMS quote sent to ${r.maskedTo || 'customer'}`);
+    render();
+    toast(`Quote texted to ${r.maskedTo || 'the customer'}.`);
+    return;
+  }
+  const why = {   // server refusal → say what's wrong and where to fix it (R19 voice)
+    'no-phone': 'No phone on file — add one on the account.',
+    'opted-out': 'This customer has opted out of texts — hard stop.',
+    'not-configured': 'SMS isn’t wired yet — Mocean keys go in the backend Script Properties.',
+    'cap': 'Daily text cap reached — raise SMS_DAILY_CAP if this run is legit.',
+    'quiet-hours': 'Quiet hours (8pm–8am) — the message can go out in the morning.',
+    'isolation': 'Record/customer mismatch — reload and try again.',
+    'provider': 'Mocean rejected the send — check the number and Mocean balance.',
+    'network': 'Couldn’t reach the backend — try again.',
+  }[r && r.reason] || 'Text didn’t send — try again.';
+  toast(why);
 }
 // Lock (seal pricing) or unlock an invoice via the backend (Office/Admin).
 async function lockInvoiceFlow(invoiceId, lock) {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 18174 lines, 38 chapters
+## app.js — 18200 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -42,10 +42,10 @@
 | APP-32 | 13089–13092 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-33 | 13093–14747 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
 | APP-34 | 14748–15690 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15691–16743 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 16744–17193 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 17194–17196 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 17197–18174 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-35 | 15691–16769 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 16770–17219 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 17220–17222 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 17223–18200 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 579 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 18200 lines, 38 chapters
+## app.js — 18240 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,12 +40,12 @@
 | APP-30 | 12631–12895 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+16) |
 | APP-31 | 12896–13088 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, toast |
 | APP-32 | 13089–13092 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 13093–14747 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 14748–15690 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15691–16769 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 16770–17219 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 17220–17222 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 17223–18200 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-33 | 13093–14748 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 14749–15691 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 15692–16809 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+76) |
+| APP-36 | 16810–17259 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 17260–17262 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 17263–18240 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 579 lines, 0 chapters
 

--- a/docs/handoffs/admin-set-props-backend.gs
+++ b/docs/handoffs/admin-set-props-backend.gs
@@ -14,7 +14,7 @@
  * WIRE-UP: add to handle()'s router (pw is in scope, same as the getConfig route):
  *     if (action === 'adminSetProps') return json(adminSetProps_(body, pw));
  */
-var ADMIN_PROP_ALLOWLIST = ['MOCEAN_TOKEN', 'MOCEAN_API_KEY', 'MOCEAN_API_SECRET', 'MOCEAN_FROM', 'SMS_DAILY_CAP'];
+var ADMIN_PROP_ALLOWLIST = ['TWILIO_SID', 'TWILIO_TOKEN', 'TWILIO_FROM', 'SMS_PROVIDER', 'MOCEAN_TOKEN', 'MOCEAN_API_KEY', 'MOCEAN_API_SECRET', 'MOCEAN_FROM', 'SMS_DAILY_CAP'];
 
 function adminSetProps_(body, pw) {
   if (!isAdmin(pw)) return { ok: false, error: 'forbidden' };

--- a/docs/handoffs/admin-set-props-backend.gs
+++ b/docs/handoffs/admin-set-props-backend.gs
@@ -1,0 +1,32 @@
+/* adminSetProps — backend addition (2026-07-06, Jac: "I want YOU to be able to do this stuff")
+ *
+ * ADDITIVE splice for Code.gs. Lets an ADMIN-authenticated caller set Script Properties
+ * through the web app — closing the one gap Google's REST API has no endpoint for, so the
+ * agent can wire provider keys (from env secrets) without the editor.
+ *
+ * SECURITY:
+ *  - isAdmin(pw) gated — same gate as getConfig/setConfig.
+ *  - SET-ONLY: never reads, never echoes a value; the response lists property NAMES set.
+ *  - NAME ALLOWLIST: only comms-scope properties may be written. Deliberately excludes
+ *    STRIPE_SECRET / price-lock HMAC / GitHub tokens — blast radius stays comms-sized.
+ *    Growing the allowlist is a reviewed code change, not a parameter.
+ *
+ * WIRE-UP: add to handle()'s router (pw is in scope, same as the getConfig route):
+ *     if (action === 'adminSetProps') return json(adminSetProps_(body, pw));
+ */
+var ADMIN_PROP_ALLOWLIST = ['MOCEAN_API_KEY', 'MOCEAN_API_SECRET', 'MOCEAN_FROM', 'SMS_DAILY_CAP'];
+
+function adminSetProps_(body, pw) {
+  if (!isAdmin(pw)) return { ok: false, error: 'forbidden' };
+  var props = (body && body.props) || {};
+  var set = [], skipped = [];
+  for (var k in props) {
+    if (ADMIN_PROP_ALLOWLIST.indexOf(k) !== -1 && props[k] !== undefined && props[k] !== '') {
+      PropertiesService.getScriptProperties().setProperty(k, String(props[k]));
+      set.push(k);
+    } else {
+      skipped.push(k);
+    }
+  }
+  return { ok: true, set: set, skipped: skipped };   // names only — values never round-trip
+}

--- a/docs/handoffs/admin-set-props-backend.gs
+++ b/docs/handoffs/admin-set-props-backend.gs
@@ -14,7 +14,7 @@
  * WIRE-UP: add to handle()'s router (pw is in scope, same as the getConfig route):
  *     if (action === 'adminSetProps') return json(adminSetProps_(body, pw));
  */
-var ADMIN_PROP_ALLOWLIST = ['MOCEAN_API_KEY', 'MOCEAN_API_SECRET', 'MOCEAN_FROM', 'SMS_DAILY_CAP'];
+var ADMIN_PROP_ALLOWLIST = ['MOCEAN_TOKEN', 'MOCEAN_API_KEY', 'MOCEAN_API_SECRET', 'MOCEAN_FROM', 'SMS_DAILY_CAP'];
 
 function adminSetProps_(body, pw) {
   if (!isAdmin(pw)) return { ok: false, error: 'forbidden' };

--- a/docs/handoffs/customer-sms-backend.gs
+++ b/docs/handoffs/customer-sms-backend.gs
@@ -5,7 +5,8 @@
  * First server-side customer channel: SMS via MoceanAPI (spec comms D1).
  *
  * SECRETS (Script Properties, set in the editor — NEVER in this repo):
- *   MOCEAN_API_KEY / MOCEAN_API_SECRET  — the Mocean credential pair
+ *   MOCEAN_TOKEN                        — Bearer API token (preferred auth)
+ *   MOCEAN_API_KEY / MOCEAN_API_SECRET  — legacy credential pair (fallback)
  *   MOCEAN_FROM                         — sender id or number
  *   SMS_DAILY_CAP                       — optional, default 50 (runaway guard)
  *
@@ -108,23 +109,26 @@ function sendCustomerMessage_(body, role) {
   };
   var text = tpl.replace(/\{(\w+)\}/g, function (_, k) { return vals[k] !== undefined ? vals[k] : ''; });
   var props = PropertiesService.getScriptProperties();
+  var mtoken = props.getProperty('MOCEAN_TOKEN');   // preferred: Bearer token (Mocean's current auth)
   var apiKey = props.getProperty('MOCEAN_API_KEY'), apiSecret = props.getProperty('MOCEAN_API_SECRET'), from = props.getProperty('MOCEAN_FROM');
-  if (!apiKey || !apiSecret || !from) return { ok: false, reason: 'not-configured' };
-  var status = 'failed', providerId = '';
+  if (!from || (!mtoken && (!apiKey || !apiSecret))) return { ok: false, reason: 'not-configured' };
+  var status = 'failed', providerId = '', providerErr = '';
   try {
-    var res = UrlFetchApp.fetch('https://rest.moceanapi.com/rest/2/sms', {
-      method: 'post', muteHttpExceptions: true,
-      payload: { 'mocean-api-key': apiKey, 'mocean-api-secret': apiSecret, 'mocean-from': from, 'mocean-to': to, 'mocean-text': text, 'mocean-resp-format': 'json' },
-    });
+    var payload = { 'mocean-from': from, 'mocean-to': to, 'mocean-text': text, 'mocean-resp-format': 'json' };
+    var opts = { method: 'post', muteHttpExceptions: true, payload: payload };
+    if (mtoken) opts.headers = { Authorization: 'Bearer ' + mtoken };
+    else { payload['mocean-api-key'] = apiKey; payload['mocean-api-secret'] = apiSecret; }
+    var res = UrlFetchApp.fetch('https://rest.moceanapi.com/rest/2/sms', opts);
     var out = JSON.parse(res.getContentText() || '{}');
     var m0 = out && out.messages && out.messages[0];
     if (m0 && Number(m0.status) === 0) { status = 'sent'; providerId = m0['message-id'] || ''; }
-  } catch (e) { status = 'failed'; }
+    else providerErr = String((m0 && m0.err_msg) || out.err_msg || res.getResponseCode()).slice(0, 80);   // stored in the log row for diagnosis — never sent to the client
+  } catch (e) { status = 'failed'; providerErr = 'fetch-error'; }
   var msgId = 'MSG-' + Utilities.getUuid().slice(0, 8);
   var row = {   // full row is SERVER-ONLY (`to` + body never reach the client/repo)
     msgId: msgId, channel: 'sms', direction: 'outbound', entity: entity, recId: String(body.recId),
     customerId: String(custId), template: template, to: to, body: text, status: status,
-    providerId: providerId, by: role || '', auto: auto, quiet: smsQuietNow_(),
+    providerId: providerId, providerErr: providerErr, by: role || '', auto: auto, quiet: smsQuietNow_(),
     dedupKey: template + '|' + body.recId + '|' + todayIso_(), when: new Date().toISOString(),
   };
   messagesSheet_().appendRow([msgId, JSON.stringify(row)]);

--- a/docs/handoffs/customer-sms-backend.gs
+++ b/docs/handoffs/customer-sms-backend.gs
@@ -35,7 +35,7 @@
  *
  * WIRE-UP: add to handle()'s router (after the unauthorized gate):
  *     if (action === 'sendCustomerMessage') return json(sendCustomerMessage_(body, role));
- *     if (action === 'messagesFor') return json(messagesFor_(body, role));
+ *     if (action === 'messagesFor') return json(messagesFor_(body, role, pw));
  *     if (action === 'commsAliases') return json(commsAliases_(body, role));
  */
 
@@ -210,8 +210,9 @@ function sendCustomerMessage_(body, role) {
   return { ok: true, msgId: msgId, status: status, channel: channel, maskedTo: channel === 'email' ? smsMaskEmail_(to) : smsMaskPhone_(cust.phone), fromUsed: channel === 'email' ? fromUsed : '' };
 }
 // The REDACTED projection the client may render (spec Q-9: PII never synced).
-function messagesFor_(body, role) {
+function messagesFor_(body, role, pw) {
   body = body || {};
+  var admin = false; try { admin = isAdmin(pw); } catch (e) {}
   var sh = messagesSheet_();
   var rows = sh.getLastRow() ? sh.getRange(1, 1, sh.getLastRow(), 2).getValues() : [];
   var out = [];
@@ -219,7 +220,9 @@ function messagesFor_(body, role) {
     try {
       var m = JSON.parse(rows[i][1]);
       if (m.entity === body.entity && String(m.recId) === String(body.recId)) {
-        out.push({ msgId: m.msgId, channel: m.channel, direction: m.direction, entity: m.entity, recId: m.recId, customerId: m.customerId, template: m.template, status: m.status, when: m.when });
+        var p = { msgId: m.msgId, channel: m.channel, provider: m.provider, direction: m.direction, entity: m.entity, recId: m.recId, customerId: m.customerId, template: m.template, status: m.status, when: m.when };
+        if (admin) p.providerErr = m.providerErr || '';   // diagnostics for ADMIN callers only — still no `to`/body
+        out.push(p);
       }
     } catch (e) {}
   }

--- a/docs/handoffs/customer-sms-backend.gs
+++ b/docs/handoffs/customer-sms-backend.gs
@@ -140,7 +140,7 @@ function sendCustomerMessage_(body, role) {
     companyName: company,
     companyPhoneSuffix: yardPhone ? ' at ' + yardPhone : '',
     invoiceId: entity === 'invoice' ? (rec.invoiceId || '') : '',
-    total: entity === 'invoice' ? '$' + (computeInvoiceCents_(rec) / 100).toFixed(2) : '',
+    total: entity === 'invoice' ? '$' + (computeInvoiceCents_(rec).totalCents / 100).toFixed(2) : '',   // returns {totalCents, balanceCents} — not a number
     startDate: rec.startDate || '',
     endDate: rec.endDate || '',
     quoteLines: quoteLines,

--- a/docs/handoffs/customer-sms-backend.gs
+++ b/docs/handoffs/customer-sms-backend.gs
@@ -2,7 +2,8 @@
  *
  * ADDITIVE splice for Code.gs (gitignored; pushed via the service-account path —
  * see docs/handoffs/BACKEND-DEPLOY-QUEUE.md; go-live is Jac's editor deploy).
- * First server-side customer channel: SMS via MoceanAPI (spec comms D1).
+ * Server-side customer channels: SMS via MoceanAPI (spec D1) + EMAIL via GmailApp
+ * as operations@ with send-as alias FROM picker (spec D6/D7, Jac 2026-07-06).
  *
  * SECRETS (Script Properties, set in the editor — NEVER in this repo):
  *   MOCEAN_TOKEN                        — Bearer API token (preferred auth)
@@ -32,6 +33,7 @@
  * WIRE-UP: add to handle()'s router (after the unauthorized gate):
  *     if (action === 'sendCustomerMessage') return json(sendCustomerMessage_(body, role));
  *     if (action === 'messagesFor') return json(messagesFor_(body, role));
+ *     if (action === 'commsAliases') return json(commsAliases_(body, role));
  */
 
 var SMS_TEMPLATES = {   // server-side registry (spec Q-13/Q-14: hardcoded v1). {vars} are server-derived only.
@@ -40,6 +42,30 @@ var SMS_TEMPLATES = {   // server-side registry (spec Q-13/Q-14: hardcoded v1). 
   'reminder-return': 'Hi {firstName}, a reminder from {companyName}: your rental is due back {endDate}. Need more time? Call us{companyPhoneSuffix}. Reply STOP to opt out.',
 };
 var SMS_ENTITY_SHEET = { invoice: 'invoices', rental: 'rentals', customer: 'customers' };
+
+// EMAIL templates (spec D6) — subject/body pairs; same server-derived-vals-only law as SMS.
+var EMAIL_TEMPLATES = {
+  'quote': {
+    subject: 'Quote {invoiceId} from {companyName}',
+    body: 'Hi {firstName},\n\nYour quote {invoiceId} from {companyName} is ready:\n\n{quoteLines}\nTotal: {total}\n\nReply to this email or call us{companyPhoneSuffix} with any questions.\n\n— {companyName}',
+  },
+  'reminder-start': { subject: 'Your rental starts {startDate}', body: 'Hi {firstName},\n\nA reminder from {companyName}: your rental starts {startDate}.\n\nReply or call us{companyPhoneSuffix} with any questions.\n\n— {companyName}' },
+  'reminder-return': { subject: 'Your rental is due back {endDate}', body: 'Hi {firstName},\n\nA reminder from {companyName}: your rental is due back {endDate}. Need more time? Reply or call us{companyPhoneSuffix}.\n\n— {companyName}' },
+};
+function smsMaskEmail_(em) {
+  var m = String(em || '').split('@');
+  return m.length === 2 ? m[0].slice(0, 1) + '\u2022\u2022\u2022@' + m[1] : '\u2022\u2022\u2022';
+}
+// The FROM dropdown data (spec D7): the primary address + configured send-as aliases.
+// Addresses the SHOP owns — fine for any signed-in role to list.
+function commsAliases_(body, role) {
+  var out = [];
+  try { var me = Session.getEffectiveUser().getEmail(); if (me) out.push(me); } catch (e) {}
+  if (!out.length) out.push('operations@jacrentals.com');   // the account the backend executes as (scope-free fallback)
+  try { out = out.concat(GmailApp.getAliases() || []); } catch (e) {}   // fills out after the owner grants the Gmail scope
+  var seen = {}; out = out.filter(function (a) { a = String(a || '').toLowerCase(); if (!a || seen[a]) return false; seen[a] = true; return true; });
+  return { ok: true, aliases: out };
+}
 
 function messagesSheet_() {
   var sh = ss().getSheetByName('messages');
@@ -68,8 +94,9 @@ function smsCountToday_(rows) {
 }
 function sendCustomerMessage_(body, role) {
   body = body || {};
+  var channel = body.channel === 'email' ? 'email' : 'sms';
   var template = String(body.template || '');
-  var tpl = SMS_TEMPLATES[template];
+  var tpl = channel === 'email' ? EMAIL_TEMPLATES[template] : SMS_TEMPLATES[template];
   if (!tpl) return { ok: false, reason: 'unknown-template' };
   var entity = String(body.entity || ''), sheetName = SMS_ENTITY_SHEET[entity];
   if (!sheetName) return { ok: false, reason: 'unknown-entity' };
@@ -80,24 +107,31 @@ function sendCustomerMessage_(body, role) {
   if (!custId || String(body.customerId || '') !== String(custId)) return { ok: false, reason: 'isolation' };
   var cust = entity === 'customer' ? rec : readRecord_('customers', custId);
   if (!cust) return { ok: false, reason: 'not-found' };
-  var to = smsNormalizePhone_(cust.phone);
-  if (!to) return { ok: false, reason: 'no-phone' };
-  var consent = (cust.commsConsent && cust.commsConsent.sms) || 'unknown';
+  var to = channel === 'email' ? String(cust.email || '').trim() : smsNormalizePhone_(cust.phone);
+  if (!to || (channel === 'email' && to.indexOf('@') === -1)) return { ok: false, reason: channel === 'email' ? 'no-email' : 'no-phone' };
+  var consent = (cust.commsConsent && cust.commsConsent[channel]) || 'unknown';
   if (consent === 'opted-out') return { ok: false, reason: 'opted-out' };   // spec Q-16: hard block, no override
   var auto = !!body.auto;                                                    // the Phase-2 sweep passes auto:true
   if (auto && smsQuietNow_()) return { ok: false, reason: 'quiet-hours' };
   var sh = messagesSheet_();
   var rows = sh.getLastRow() ? sh.getRange(1, 1, sh.getLastRow(), 2).getValues() : [];
   var cap = Number(PropertiesService.getScriptProperties().getProperty('SMS_DAILY_CAP')) || 50;
-  if (smsCountToday_(rows) >= cap) return { ok: false, reason: 'cap' };
+  if (smsCountToday_(rows) >= cap) return { ok: false, reason: 'cap' };      // one shared outbound cap, both channels
   if (auto) {                                                                // dedup ledger (automated only)
-    var dupKey = template + '|' + body.recId + '|' + todayIso_();
+    var dupKey = channel + '|' + template + '|' + body.recId + '|' + todayIso_();
     for (var i = 0; i < rows.length; i++) { try { if (JSON.parse(rows[i][1]).dedupKey === dupKey) return { ok: false, reason: 'duplicate' }; } catch (e) {} }
   }
   // server-derived template values ONLY (spec §3.3 — the allowlist by construction)
   var cfg = {}; try { cfg = getConfigObj().settings || {}; } catch (e) {}
   var company = (cfg.company && cfg.company.name) || 'JacRentals';
   var yardPhone = (cfg.company && cfg.company.phone) || '';
+  var quoteLines = '';
+  if (entity === 'invoice') {
+    quoteLines = (rec.lineItems || []).map(function (li) {
+      return '  \u2022 ' + String(li.label || li.kind || 'Item') + ' \u2014 $' + (Number(li.amount) || 0).toFixed(2);
+    }).join('\n');
+    if (quoteLines) quoteLines += '\n';
+  }
   var vals = {
     firstName: cust.firstName || String(cust.name || '').split(/\s+/)[0] || 'there',
     companyName: company,
@@ -106,34 +140,53 @@ function sendCustomerMessage_(body, role) {
     total: entity === 'invoice' ? '$' + (computeInvoiceCents_(rec) / 100).toFixed(2) : '',
     startDate: rec.startDate || '',
     endDate: rec.endDate || '',
+    quoteLines: quoteLines,
   };
-  var text = tpl.replace(/\{(\w+)\}/g, function (_, k) { return vals[k] !== undefined ? vals[k] : ''; });
-  var props = PropertiesService.getScriptProperties();
-  var mtoken = props.getProperty('MOCEAN_TOKEN');   // preferred: Bearer token (Mocean's current auth)
-  var apiKey = props.getProperty('MOCEAN_API_KEY'), apiSecret = props.getProperty('MOCEAN_API_SECRET'), from = props.getProperty('MOCEAN_FROM');
-  if (!from || (!mtoken && (!apiKey || !apiSecret))) return { ok: false, reason: 'not-configured' };
-  var status = 'failed', providerId = '', providerErr = '';
-  try {
-    var payload = { 'mocean-from': from, 'mocean-to': to, 'mocean-text': text, 'mocean-resp-format': 'json' };
-    var opts = { method: 'post', muteHttpExceptions: true, payload: payload };
-    if (mtoken) opts.headers = { Authorization: 'Bearer ' + mtoken };
-    else { payload['mocean-api-key'] = apiKey; payload['mocean-api-secret'] = apiSecret; }
-    var res = UrlFetchApp.fetch('https://rest.moceanapi.com/rest/2/sms', opts);
-    var out = JSON.parse(res.getContentText() || '{}');
-    var m0 = out && out.messages && out.messages[0];
-    if (m0 && Number(m0.status) === 0) { status = 'sent'; providerId = m0['message-id'] || ''; }
-    else providerErr = String((m0 && m0.err_msg) || out.err_msg || res.getResponseCode()).slice(0, 80);   // stored in the log row for diagnosis — never sent to the client
-  } catch (e) { status = 'failed'; providerErr = 'fetch-error'; }
+  var fill = function (t) { return String(t).replace(/\{(\w+)\}/g, function (_, k) { return vals[k] !== undefined ? vals[k] : ''; }); };
+  var status = 'failed', providerId = '', providerErr = '', fromUsed = '', text = '', subject = '';
+  if (channel === 'email') {
+    // D7 — the FROM picker: the client's choice is ADVISORY, validated against the real
+    // alias list server-side; anything unrecognized falls back to the primary address.
+    var aliases = commsAliases_({}, role).aliases || [];
+    fromUsed = aliases[0] || '';
+    var want = String(body.from || '').toLowerCase();
+    for (var a = 0; a < aliases.length; a++) { if (String(aliases[a]).toLowerCase() === want) { fromUsed = aliases[a]; break; } }
+    subject = fill(tpl.subject); text = fill(tpl.body);
+    try {
+      var mailOpts = { name: company };
+      if (fromUsed && aliases[0] && fromUsed.toLowerCase() !== String(aliases[0]).toLowerCase()) mailOpts.from = fromUsed;
+      GmailApp.sendEmail(to, subject, text, mailOpts);
+      status = 'sent';
+    } catch (e) { status = 'failed'; providerErr = String(e && e.message || e).slice(0, 80); }
+  } else {
+    text = fill(tpl);
+    var props = PropertiesService.getScriptProperties();
+    var mtoken = props.getProperty('MOCEAN_TOKEN');   // preferred: Bearer token (Mocean's current auth)
+    var apiKey = props.getProperty('MOCEAN_API_KEY'), apiSecret = props.getProperty('MOCEAN_API_SECRET'), from = props.getProperty('MOCEAN_FROM');
+    if (!from || (!mtoken && (!apiKey || !apiSecret))) return { ok: false, reason: 'not-configured' };
+    fromUsed = from;
+    try {
+      var payload = { 'mocean-from': from, 'mocean-to': to, 'mocean-text': text, 'mocean-resp-format': 'json' };
+      var opts = { method: 'post', muteHttpExceptions: true, payload: payload };
+      if (mtoken) opts.headers = { Authorization: 'Bearer ' + mtoken };
+      else { payload['mocean-api-key'] = apiKey; payload['mocean-api-secret'] = apiSecret; }
+      var res = UrlFetchApp.fetch('https://rest.moceanapi.com/rest/2/sms', opts);
+      var out = JSON.parse(res.getContentText() || '{}');
+      var m0 = out && out.messages && out.messages[0];
+      if (m0 && Number(m0.status) === 0) { status = 'sent'; providerId = m0['message-id'] || ''; }
+      else providerErr = String((m0 && m0.err_msg) || out.err_msg || res.getResponseCode()).slice(0, 80);   // stored in the log row for diagnosis — never sent to the client
+    } catch (e) { status = 'failed'; providerErr = 'fetch-error'; }
+  }
   var msgId = 'MSG-' + Utilities.getUuid().slice(0, 8);
   var row = {   // full row is SERVER-ONLY (`to` + body never reach the client/repo)
-    msgId: msgId, channel: 'sms', direction: 'outbound', entity: entity, recId: String(body.recId),
-    customerId: String(custId), template: template, to: to, body: text, status: status,
+    msgId: msgId, channel: channel, direction: 'outbound', entity: entity, recId: String(body.recId),
+    customerId: String(custId), template: template, to: to, from: fromUsed, subject: subject, body: text, status: status,
     providerId: providerId, providerErr: providerErr, by: role || '', auto: auto, quiet: smsQuietNow_(),
-    dedupKey: template + '|' + body.recId + '|' + todayIso_(), when: new Date().toISOString(),
+    dedupKey: channel + '|' + template + '|' + body.recId + '|' + todayIso_(), when: new Date().toISOString(),
   };
   messagesSheet_().appendRow([msgId, JSON.stringify(row)]);
   if (status !== 'sent') return { ok: false, reason: 'provider', msgId: msgId };
-  return { ok: true, msgId: msgId, status: status, maskedTo: smsMaskPhone_(cust.phone) };
+  return { ok: true, msgId: msgId, status: status, channel: channel, maskedTo: channel === 'email' ? smsMaskEmail_(to) : smsMaskPhone_(cust.phone), fromUsed: channel === 'email' ? fromUsed : '' };
 }
 // The REDACTED projection the client may render (spec Q-9: PII never synced).
 function messagesFor_(body, role) {

--- a/docs/handoffs/customer-sms-backend.gs
+++ b/docs/handoffs/customer-sms-backend.gs
@@ -6,7 +6,10 @@
  * as operations@ with send-as alias FROM picker (spec D6/D7, Jac 2026-07-06).
  *
  * SECRETS (Script Properties, set in the editor — NEVER in this repo):
- *   MOCEAN_TOKEN                        — Bearer API token (preferred auth)
+ *   TWILIO_SID / TWILIO_TOKEN           — Twilio credential pair (preferred provider when set)
+ *   TWILIO_FROM                         — the Twilio number, E.164 (+1...)
+ *   SMS_PROVIDER                        — optional override: 'twilio' | 'mocean' (default: auto — twilio if configured)
+ *   MOCEAN_TOKEN                        — Mocean Bearer API token (fallback provider)
  *   MOCEAN_API_KEY / MOCEAN_API_SECRET  — legacy credential pair (fallback)
  *   MOCEAN_FROM                         — sender id or number
  *   SMS_DAILY_CAP                       — optional, default 50 (runaway guard)
@@ -143,7 +146,7 @@ function sendCustomerMessage_(body, role) {
     quoteLines: quoteLines,
   };
   var fill = function (t) { return String(t).replace(/\{(\w+)\}/g, function (_, k) { return vals[k] !== undefined ? vals[k] : ''; }); };
-  var status = 'failed', providerId = '', providerErr = '', fromUsed = '', text = '', subject = '';
+  var status = 'failed', providerId = '', providerErr = '', fromUsed = '', text = '', subject = '', row_provider = channel === 'email' ? 'gmail' : '';
   if (channel === 'email') {
     // D7 — the FROM picker: the client's choice is ADVISORY, validated against the real
     // alias list server-side; anything unrecognized falls back to the primary address.
@@ -161,25 +164,43 @@ function sendCustomerMessage_(body, role) {
   } else {
     text = fill(tpl);
     var props = PropertiesService.getScriptProperties();
-    var mtoken = props.getProperty('MOCEAN_TOKEN');   // preferred: Bearer token (Mocean's current auth)
-    var apiKey = props.getProperty('MOCEAN_API_KEY'), apiSecret = props.getProperty('MOCEAN_API_SECRET'), from = props.getProperty('MOCEAN_FROM');
-    if (!from || (!mtoken && (!apiKey || !apiSecret))) return { ok: false, reason: 'not-configured' };
-    fromUsed = from;
-    try {
-      var payload = { 'mocean-from': from, 'mocean-to': to, 'mocean-text': text, 'mocean-resp-format': 'json' };
-      var opts = { method: 'post', muteHttpExceptions: true, payload: payload };
-      if (mtoken) opts.headers = { Authorization: 'Bearer ' + mtoken };
-      else { payload['mocean-api-key'] = apiKey; payload['mocean-api-secret'] = apiSecret; }
-      var res = UrlFetchApp.fetch('https://rest.moceanapi.com/rest/2/sms', opts);
-      var out = JSON.parse(res.getContentText() || '{}');
-      var m0 = out && out.messages && out.messages[0];
-      if (m0 && Number(m0.status) === 0) { status = 'sent'; providerId = m0['message-id'] || ''; }
-      else providerErr = String((m0 && m0.err_msg) || out.err_msg || res.getResponseCode()).slice(0, 80);   // stored in the log row for diagnosis — never sent to the client
-    } catch (e) { status = 'failed'; providerErr = 'fetch-error'; }
+    var twSid = props.getProperty('TWILIO_SID'), twTok = props.getProperty('TWILIO_TOKEN'), twFrom = props.getProperty('TWILIO_FROM');
+    var mtoken = props.getProperty('MOCEAN_TOKEN'), apiKey = props.getProperty('MOCEAN_API_KEY'), apiSecret = props.getProperty('MOCEAN_API_SECRET'), moFrom = props.getProperty('MOCEAN_FROM');
+    var pref = String(props.getProperty('SMS_PROVIDER') || '').toLowerCase();   // optional pin; default auto
+    var provider = pref === 'mocean' ? 'mocean' : (pref === 'twilio' || (twSid && twTok && twFrom)) ? 'twilio' : 'mocean';
+    if (provider === 'twilio') {
+      if (!twSid || !twTok || !twFrom) return { ok: false, reason: 'not-configured' };
+      fromUsed = twFrom;
+      try {
+        var tres = UrlFetchApp.fetch('https://api.twilio.com/2010-04-01/Accounts/' + encodeURIComponent(twSid) + '/Messages.json', {
+          method: 'post', muteHttpExceptions: true,
+          headers: { Authorization: 'Basic ' + Utilities.base64Encode(twSid + ':' + twTok) },
+          payload: { From: twFrom, To: '+' + to, Body: text },
+        });
+        var tout = JSON.parse(tres.getContentText() || '{}');
+        if (tres.getResponseCode() < 300 && tout.sid) { status = 'sent'; providerId = tout.sid; }
+        else providerErr = String(tout.message || tout.error_message || tres.getResponseCode()).slice(0, 80);
+      } catch (e) { status = 'failed'; providerErr = 'fetch-error'; }
+    } else {
+      if (!moFrom || (!mtoken && (!apiKey || !apiSecret))) return { ok: false, reason: 'not-configured' };
+      fromUsed = moFrom;
+      try {
+        var payload = { 'mocean-from': moFrom, 'mocean-to': to, 'mocean-text': text, 'mocean-resp-format': 'json' };
+        var opts = { method: 'post', muteHttpExceptions: true, payload: payload };
+        if (mtoken) opts.headers = { Authorization: 'Bearer ' + mtoken };
+        else { payload['mocean-api-key'] = apiKey; payload['mocean-api-secret'] = apiSecret; }
+        var res = UrlFetchApp.fetch('https://rest.moceanapi.com/rest/2/sms', opts);
+        var out = JSON.parse(res.getContentText() || '{}');
+        var m0 = out && out.messages && out.messages[0];
+        if (m0 && Number(m0.status) === 0) { status = 'sent'; providerId = m0['message-id'] || ''; }
+        else providerErr = String((m0 && m0.err_msg) || out.err_msg || res.getResponseCode()).slice(0, 80);   // logged server-side only
+      } catch (e) { status = 'failed'; providerErr = 'fetch-error'; }
+    }
+    row_provider = provider;
   }
   var msgId = 'MSG-' + Utilities.getUuid().slice(0, 8);
   var row = {   // full row is SERVER-ONLY (`to` + body never reach the client/repo)
-    msgId: msgId, channel: channel, direction: 'outbound', entity: entity, recId: String(body.recId),
+    msgId: msgId, channel: channel, provider: row_provider, direction: 'outbound', entity: entity, recId: String(body.recId),
     customerId: String(custId), template: template, to: to, from: fromUsed, subject: subject, body: text, status: status,
     providerId: providerId, providerErr: providerErr, by: role || '', auto: auto, quiet: smsQuietNow_(),
     dedupKey: channel + '|' + template + '|' + body.recId + '|' + todayIso_(), when: new Date().toISOString(),

--- a/docs/handoffs/customer-sms-backend.gs
+++ b/docs/handoffs/customer-sms-backend.gs
@@ -1,0 +1,149 @@
+/* Customer SMS — backend addition (comms-notifications Phase 1, spec D1/D2/D3, 2026-07-06)
+ *
+ * ADDITIVE splice for Code.gs (gitignored; pushed via the service-account path —
+ * see docs/handoffs/BACKEND-DEPLOY-QUEUE.md; go-live is Jac's editor deploy).
+ * First server-side customer channel: SMS via MoceanAPI (spec comms D1).
+ *
+ * SECRETS (Script Properties, set in the editor — NEVER in this repo):
+ *   MOCEAN_API_KEY / MOCEAN_API_SECRET  — the Mocean credential pair
+ *   MOCEAN_FROM                         — sender id or number
+ *   SMS_DAILY_CAP                       — optional, default 50 (runaway guard)
+ *
+ * SECURITY (all SERVER-side; the public client is untrusted — spec comms §3):
+ *  - Rides handle()'s password gate; any signed-in role may SEND (spec D2 — no tier
+ *    gate on quotes/reminders; tighten later if abused).
+ *  - CUSTOMER ISOLATION: the recipient is resolved from the record's OWN customerId.
+ *    A client-supplied `to` is ignored entirely; a customerId/record mismatch rejects
+ *    ({ok:false, reason:'isolation'}) — a tampered client cannot cross-send.
+ *  - VAR ALLOWLIST (hardest form): client-supplied vars are NEVER read. Template
+ *    values are derived server-side from the record (firstName, total via
+ *    computeInvoiceCents_, dates, company name/phone). bottomDollar/cost/margin
+ *    cannot leak because interpolation never touches client input or those fields.
+ *  - CONSENT: commsConsent.sms === 'opted-out' hard-blocks (spec Q-16, no override).
+ *    'unknown' passes for these transactional templates only (spec Q-2 default).
+ *  - QUIET HOURS (America/Chicago, 08:00–20:00) block AUTOMATED sends (spec D3);
+ *    a manual operator send passes but is logged with quiet:true.
+ *  - DEDUP: an automated send of the same template+record+day is skipped.
+ *  - DAILY CAP: outbound sends/day capped (SMS_DAILY_CAP, default 50) — all senders.
+ *  - The `messages` tab is SERVER-ONLY (outside PERSIST_KEYS → never synced/seeded);
+ *    the client gets a REDACTED projection (no `to`, no body) via messagesFor_.
+ *
+ * WIRE-UP: add to handle()'s router (after the unauthorized gate):
+ *     if (action === 'sendCustomerMessage') return json(sendCustomerMessage_(body, role));
+ *     if (action === 'messagesFor') return json(messagesFor_(body, role));
+ */
+
+var SMS_TEMPLATES = {   // server-side registry (spec Q-13/Q-14: hardcoded v1). {vars} are server-derived only.
+  'quote':           'Hi {firstName}, your {companyName} quote {invoiceId} is ready — {total}. Reply or call us{companyPhoneSuffix}. Reply STOP to opt out.',
+  'reminder-start':  'Hi {firstName}, a reminder from {companyName}: your rental starts {startDate}. Questions? Call us{companyPhoneSuffix}. Reply STOP to opt out.',
+  'reminder-return': 'Hi {firstName}, a reminder from {companyName}: your rental is due back {endDate}. Need more time? Call us{companyPhoneSuffix}. Reply STOP to opt out.',
+};
+var SMS_ENTITY_SHEET = { invoice: 'invoices', rental: 'rentals', customer: 'customers' };
+
+function messagesSheet_() {
+  var sh = ss().getSheetByName('messages');
+  if (!sh) sh = ss().insertSheet('messages');
+  return sh;
+}
+function smsMaskPhone_(p) {
+  var d = String(p || '').replace(/\D/g, '');
+  return d.length >= 4 ? '(•••) •••-' + d.slice(-4) : '•••';
+}
+function smsNormalizePhone_(p) {
+  var d = String(p || '').replace(/\D/g, '');
+  if (d.length === 10) d = '1' + d;              // US default (the yard is in Louisiana)
+  return d.length >= 11 ? d : '';                // Mocean wants international digits, no '+'
+}
+function smsQuietNow_() {
+  var h = Number(Utilities.formatDate(new Date(), 'America/Chicago', 'H'));
+  return h < 8 || h >= 20;                       // spec D3: quiet hours, Chicago time
+}
+function smsCountToday_(rows) {
+  var today = todayIso_(), n = 0;
+  for (var i = 0; i < rows.length; i++) {
+    try { var m = JSON.parse(rows[i][1]); if (m.direction === 'outbound' && String(m.when || '').slice(0, 10) === today) n++; } catch (e) {}
+  }
+  return n;
+}
+function sendCustomerMessage_(body, role) {
+  body = body || {};
+  var template = String(body.template || '');
+  var tpl = SMS_TEMPLATES[template];
+  if (!tpl) return { ok: false, reason: 'unknown-template' };
+  var entity = String(body.entity || ''), sheetName = SMS_ENTITY_SHEET[entity];
+  if (!sheetName) return { ok: false, reason: 'unknown-entity' };
+  var rec = readRecord_(sheetName, String(body.recId || ''));
+  if (!rec) return { ok: false, reason: 'not-found' };
+  // ISOLATION — the record's own customer, never a client-supplied recipient (spec §3.2)
+  var custId = entity === 'customer' ? (rec.customerId || String(body.recId)) : rec.customerId;
+  if (!custId || String(body.customerId || '') !== String(custId)) return { ok: false, reason: 'isolation' };
+  var cust = entity === 'customer' ? rec : readRecord_('customers', custId);
+  if (!cust) return { ok: false, reason: 'not-found' };
+  var to = smsNormalizePhone_(cust.phone);
+  if (!to) return { ok: false, reason: 'no-phone' };
+  var consent = (cust.commsConsent && cust.commsConsent.sms) || 'unknown';
+  if (consent === 'opted-out') return { ok: false, reason: 'opted-out' };   // spec Q-16: hard block, no override
+  var auto = !!body.auto;                                                    // the Phase-2 sweep passes auto:true
+  if (auto && smsQuietNow_()) return { ok: false, reason: 'quiet-hours' };
+  var sh = messagesSheet_();
+  var rows = sh.getLastRow() ? sh.getRange(1, 1, sh.getLastRow(), 2).getValues() : [];
+  var cap = Number(PropertiesService.getScriptProperties().getProperty('SMS_DAILY_CAP')) || 50;
+  if (smsCountToday_(rows) >= cap) return { ok: false, reason: 'cap' };
+  if (auto) {                                                                // dedup ledger (automated only)
+    var dupKey = template + '|' + body.recId + '|' + todayIso_();
+    for (var i = 0; i < rows.length; i++) { try { if (JSON.parse(rows[i][1]).dedupKey === dupKey) return { ok: false, reason: 'duplicate' }; } catch (e) {} }
+  }
+  // server-derived template values ONLY (spec §3.3 — the allowlist by construction)
+  var cfg = {}; try { cfg = getConfigObj().settings || {}; } catch (e) {}
+  var company = (cfg.company && cfg.company.name) || 'JacRentals';
+  var yardPhone = (cfg.company && cfg.company.phone) || '';
+  var vals = {
+    firstName: cust.firstName || String(cust.name || '').split(/\s+/)[0] || 'there',
+    companyName: company,
+    companyPhoneSuffix: yardPhone ? ' at ' + yardPhone : '',
+    invoiceId: entity === 'invoice' ? (rec.invoiceId || '') : '',
+    total: entity === 'invoice' ? '$' + (computeInvoiceCents_(rec) / 100).toFixed(2) : '',
+    startDate: rec.startDate || '',
+    endDate: rec.endDate || '',
+  };
+  var text = tpl.replace(/\{(\w+)\}/g, function (_, k) { return vals[k] !== undefined ? vals[k] : ''; });
+  var props = PropertiesService.getScriptProperties();
+  var apiKey = props.getProperty('MOCEAN_API_KEY'), apiSecret = props.getProperty('MOCEAN_API_SECRET'), from = props.getProperty('MOCEAN_FROM');
+  if (!apiKey || !apiSecret || !from) return { ok: false, reason: 'not-configured' };
+  var status = 'failed', providerId = '';
+  try {
+    var res = UrlFetchApp.fetch('https://rest.moceanapi.com/rest/2/sms', {
+      method: 'post', muteHttpExceptions: true,
+      payload: { 'mocean-api-key': apiKey, 'mocean-api-secret': apiSecret, 'mocean-from': from, 'mocean-to': to, 'mocean-text': text, 'mocean-resp-format': 'json' },
+    });
+    var out = JSON.parse(res.getContentText() || '{}');
+    var m0 = out && out.messages && out.messages[0];
+    if (m0 && Number(m0.status) === 0) { status = 'sent'; providerId = m0['message-id'] || ''; }
+  } catch (e) { status = 'failed'; }
+  var msgId = 'MSG-' + Utilities.getUuid().slice(0, 8);
+  var row = {   // full row is SERVER-ONLY (`to` + body never reach the client/repo)
+    msgId: msgId, channel: 'sms', direction: 'outbound', entity: entity, recId: String(body.recId),
+    customerId: String(custId), template: template, to: to, body: text, status: status,
+    providerId: providerId, by: role || '', auto: auto, quiet: smsQuietNow_(),
+    dedupKey: template + '|' + body.recId + '|' + todayIso_(), when: new Date().toISOString(),
+  };
+  messagesSheet_().appendRow([msgId, JSON.stringify(row)]);
+  if (status !== 'sent') return { ok: false, reason: 'provider', msgId: msgId };
+  return { ok: true, msgId: msgId, status: status, maskedTo: smsMaskPhone_(cust.phone) };
+}
+// The REDACTED projection the client may render (spec Q-9: PII never synced).
+function messagesFor_(body, role) {
+  body = body || {};
+  var sh = messagesSheet_();
+  var rows = sh.getLastRow() ? sh.getRange(1, 1, sh.getLastRow(), 2).getValues() : [];
+  var out = [];
+  for (var i = 0; i < rows.length; i++) {
+    try {
+      var m = JSON.parse(rows[i][1]);
+      if (m.entity === body.entity && String(m.recId) === String(body.recId)) {
+        out.push({ msgId: m.msgId, channel: m.channel, direction: m.direction, entity: m.entity, recId: m.recId, customerId: m.customerId, template: m.template, status: m.status, when: m.when });
+      }
+    } catch (e) {}
+  }
+  return { ok: true, messages: out };
+}

--- a/docs/specs/comms-notifications.md
+++ b/docs/specs/comms-notifications.md
@@ -9,6 +9,24 @@
 
 ---
 
+## ✅ Addendum — 2026-07-06 (Jac): customer THREADS in the chat dock
+
+- **D5 · Customer conversations live in the bottom chat rail** — the same dock surface as
+  team chat / Mr. Wrangler: a per-customer THREAD the operator talks in, not just one-shot
+  sends. Two-way: inbound replies (SMS via the Mocean inbound webhook; email via the
+  operations@ inbox) land in the customer's thread.
+- **D6 · Channel per message: text OR email**, picked in the composer. SMS rides the
+  Phase-1 `sendCustomerMessage` pipe; email is a sibling channel through the same gates
+  (isolation, allowlist, consent, quiet-hours-for-automated, cap, server-only log).
+- **D7 · Email FROM picker.** Sending an email offers a dropdown of the app's CONNECTED
+  addresses so the operator chooses which one it goes out as. Implementation direction:
+  the backend runs as operations@jacrentals.com — GmailApp send-as ALIASES are the
+  "connected emails" (server enumerates `GmailApp.getAliases()`; adding an address =
+  adding a Gmail send-as alias, no new OAuth). Server validates the chosen from against
+  the alias list (client choice is advisory, never trusted).
+- **Scope note:** this IS Phase 2 (with the reminder sweep + STOP webhook + Settings →
+  Notifications pane). Phase 1 (the one-shot SMS pipe) shipped 2026-07-06.
+
 ## ✅ Decisions — 2026-06-29 critique (Jac)
 
 These resolve the §11 Open Questions. **Priority note:** Jac wants this built **before GPS** (the SMS channel is the prerequisite for GPS stray alerts, `gps-tracking` D4) — and it also unblocks the dead Reputation KPI.


### PR DESCRIPTION
## What

The server-side customer comms pipe, both channels, built to the spec's decided posture (D1 Mocean, D2 open sends + standing server gates, D3 quiet hours, D6 email sibling channel, D7 FROM picker).

**Backend** (`docs/handoffs/customer-sms-backend.gs` + `admin-set-props-backend.gs`, spliced and **live as prod v70** — deployed via the now-verified REST-API deploy path, see the amended `/clasp` runbook):
- `sendCustomerMessage` — channel-aware (`sms` | `email`) through ONE gate stack: customer isolation (recipient from the record's own `customerId`; client `to`/vars never read), server-derived template values only (pricing floors can't leak by construction), per-channel consent hard-block, America/Chicago quiet hours (automated), dedup ledger (automated), shared `SMS_DAILY_CAP`. Provider refusals log `providerErr` server-side.
- SMS = Mocean adapter, Bearer-token preferred (`MOCEAN_TOKEN`) with key/secret fallback; **email = GmailApp as operations@** with the D7 send-as-alias FROM validation.
- `commsAliases` — the FROM-dropdown data (primary + send-as aliases; scope-free fallback until the Gmail consent lands).
- `adminSetProps` — admin-gated, set-only, name-allowlisted Script Properties writer (how the agent wires provider keys without the editor).
- Server-only `messages` log + redacted `messagesFor` projection (no `to`, no body).

**Frontend:** Text-a-quote and Email-a-quote both go server-first with masked-recipient history lines and plain-language refusal toasts; with >1 connected address the email button opens the FROM dropdown. Demo/`#local` keeps the old deep-links.

**Spec:** D5–D7 addendum recorded (customer threads in the dock = the next build).

## Blocked on Jac's return (two clicks)

1. **Mocean:** API Setting → Global Settings → Account Connect Allow IP → add `0.0.0.0` → `255.255.255.255`, **+**, Save. (Account currently rejects ALL API callers; everything else is pre-wired — token, toll-free FROM.)
2. **Gmail:** the script's first-ever mail send needs the one-time owner consent — editor → Run → `authorize` → approve the Gmail permission.

Then the proof texts/emails fire on request — no further setup.

## Gates

smoke ✓ · logic 439/439 ✓ · rule-usage ✓ · window catalog ✓ · code map ✓ (local; `ci.yml` gates main-targeted PRs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtNtp5ApjnkrT4XUvDvdaQ