### PR TITLE
Add A2P-compliant Privacy Policy + SMS Terms pages (Twilio 10DLC)

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Privacy Policy — JacRentals</title>
+<style>
+  :root{
+    --bg:#f7f6f3; --panel:#ffffff; --ink:#1c2126; --ink2:#4c555f; --line:#e3e0d9;
+    --accent:#c25a2b; --accent-ink:#7a3a1a;
+    --serif:'Iowan Old Style','Palatino Linotype',Georgia,'Times New Roman',serif;
+    --sans:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#14171b; --panel:#1b1f24; --ink:#e7ebf0; --ink2:#a3acb6; --line:#2b3138; --accent:#e08a52; --accent-ink:#e08a52; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;font-size:17px}
+  .wrap{max-width:720px;margin:0 auto;padding:0 22px 80px}
+  header{border-bottom:3px solid var(--accent);margin-bottom:34px;padding:34px 0 18px}
+  .mark{font-family:var(--sans);font-weight:800;letter-spacing:.5px;font-size:15px;text-transform:uppercase;color:var(--accent-ink)}
+  h1{font-family:var(--serif);font-weight:600;font-size:38px;line-height:1.1;margin:10px 0 6px;text-wrap:balance}
+  .eff{color:var(--ink2);font-size:14px;margin:0}
+  h2{font-family:var(--serif);font-weight:600;font-size:23px;margin:38px 0 8px}
+  p{margin:0 0 14px;color:var(--ink)} p.lead{color:var(--ink2)}
+  ul{margin:0 0 14px;padding-left:22px} li{margin:0 0 8px}
+  .callout{background:var(--panel);border:1px solid var(--line);border-left:4px solid var(--accent);border-radius:8px;padding:14px 18px;margin:18px 0}
+  a{color:var(--accent-ink);text-decoration:underline}
+  strong{font-weight:700}
+  footer{margin-top:46px;padding-top:18px;border-top:1px solid var(--line);color:var(--ink2);font-size:14px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="mark">JacRentals</div>
+    <h1>Privacy Policy</h1>
+    <p class="eff">Heavy-equipment rental · Sulphur, Louisiana · Effective July 7, 2026</p>
+  </header>
+
+  <p class="lead">JacRentals ("we," "us," "our") respects your privacy. This policy explains what information we collect from our rental customers, how we use it, and the choices you have — including how we handle the mobile phone number you give us for text messaging.</p>
+
+  <h2>Information we collect</h2>
+  <p>When you rent equipment from us or open an account, we collect the information you provide directly: your name, mailing and job-site addresses, phone number, email address, rental history, and billing details. We collect this only to operate your rentals and your account.</p>
+
+  <h2>How we use your information</h2>
+  <ul>
+    <li>To quote, reserve, deliver, service, and return the equipment you rent.</li>
+    <li>To send you account, invoice, reminder, delivery, and pickup notifications by phone call, text message, or email.</li>
+    <li>To respond to your questions and provide customer support.</li>
+    <li>To meet our legal, tax, and safety obligations.</li>
+  </ul>
+
+  <h2>Text messaging &amp; your mobile number</h2>
+  <div class="callout">
+    <p style="margin:0"><strong>We do not sell, rent, or share your mobile phone number or your text-messaging consent with any third parties or affiliates for their marketing or promotional purposes.</strong> No mobile information is shared with third parties for marketing. Any sharing described below is strictly limited to what is needed to deliver our own service to you.</p>
+  </div>
+  <p>If you provide your mobile number and opt in, we use it to send you service text messages about your rentals — quotes, reservation and return reminders, delivery and pickup alerts, invoice and balance notices, and replies to your questions. <strong>Message frequency varies</strong> based on your rental activity. <strong>Message and data rates may apply.</strong> You can opt out at any time by replying <strong>STOP</strong>, or reply <strong>HELP</strong> for assistance. See our <a href="./sms-terms.html">SMS Terms &amp; Conditions</a> for the full program details.</p>
+
+  <h2>When we share information</h2>
+  <p>We share your information only with service providers who help us run our business — for example, our payment processor to charge an invoice, our mapping provider to route a delivery, or our SMS provider to deliver a text you asked to receive. These providers may use your information only to perform that service for us. We may also disclose information when required by law. We never sell your personal information.</p>
+
+  <h2>Data retention &amp; security</h2>
+  <p>We keep your information for as long as your account is active and as needed for our legitimate business and legal obligations. We use reasonable administrative and technical safeguards to protect it.</p>
+
+  <h2>Your choices</h2>
+  <p>You may update your contact details or ask us about the information we hold by contacting us below. You can stop service texts any time by replying STOP.</p>
+
+  <h2>Contact us</h2>
+  <p>JacRentals — Sulphur, Louisiana<br>
+  Email: <a href="mailto:operations@jacrentals.com">operations@jacrentals.com</a><br>
+  Web: <a href="https://www.jacrentals.com/">www.jacrentals.com</a></p>
+
+  <footer>© 2026 JacRentals. This policy may be updated; the effective date above reflects the latest version.</footer>
+</div>
+</body>
+</html>

--- a/sms-terms.html
+++ b/sms-terms.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SMS Terms &amp; Conditions — JacRentals</title>
+<style>
+  :root{
+    --bg:#f7f6f3; --panel:#ffffff; --ink:#1c2126; --ink2:#4c555f; --line:#e3e0d9;
+    --accent:#c25a2b; --accent-ink:#7a3a1a;
+    --serif:'Iowan Old Style','Palatino Linotype',Georgia,'Times New Roman',serif;
+    --sans:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#14171b; --panel:#1b1f24; --ink:#e7ebf0; --ink2:#a3acb6; --line:#2b3138; --accent:#e08a52; --accent-ink:#e08a52; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;font-size:17px}
+  .wrap{max-width:720px;margin:0 auto;padding:0 22px 80px}
+  header{border-bottom:3px solid var(--accent);margin-bottom:34px;padding:34px 0 18px}
+  .mark{font-family:var(--sans);font-weight:800;letter-spacing:.5px;font-size:15px;text-transform:uppercase;color:var(--accent-ink)}
+  h1{font-family:var(--serif);font-weight:600;font-size:38px;line-height:1.1;margin:10px 0 6px;text-wrap:balance}
+  .eff{color:var(--ink2);font-size:14px;margin:0}
+  h2{font-family:var(--serif);font-weight:600;font-size:23px;margin:38px 0 8px}
+  p{margin:0 0 14px} p.lead{color:var(--ink2)}
+  ul{margin:0 0 14px;padding-left:22px} li{margin:0 0 8px}
+  .callout{background:var(--panel);border:1px solid var(--line);border-left:4px solid var(--accent);border-radius:8px;padding:14px 18px;margin:18px 0}
+  a{color:var(--accent-ink);text-decoration:underline}
+  strong{font-weight:700}
+  footer{margin-top:46px;padding-top:18px;border-top:1px solid var(--line);color:var(--ink2);font-size:14px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="mark">JacRentals</div>
+    <h1>SMS Terms &amp; Conditions</h1>
+    <p class="eff">Heavy-equipment rental · Sulphur, Louisiana · Effective July 7, 2026</p>
+  </header>
+
+  <p class="lead">These terms govern the text-message program operated by JacRentals. By providing your mobile number and opting in, you agree to the terms below.</p>
+
+  <h2>The program</h2>
+  <p>JacRentals sends service (transactional) text messages to rental customers who have provided their mobile number and agreed to receive texts. Messages relate to your own rentals and account and may include equipment quotes and totals, reservation and return-date reminders, delivery and pickup alerts, invoice and balance notices, and replies to your questions.</p>
+
+  <h2>How you opt in</h2>
+  <p>You opt in by giving us your mobile number and agreeing to receive text messages when you rent equipment or open an account with us, in person or over the phone. We send texts only to customers who have opted in.</p>
+
+  <h2>Message frequency &amp; cost</h2>
+  <div class="callout">
+    <p style="margin:0"><strong>Message frequency varies</strong> depending on your rental activity. <strong>Message and data rates may apply</strong> according to the plan you have with your wireless carrier — these charges are billed by and payable to your carrier.</p>
+  </div>
+
+  <h2>Opt out — reply STOP</h2>
+  <p>You can cancel the text-message program at any time by replying <strong>STOP</strong> to any message. After you send STOP, we will send one confirmation message and then stop sending texts. If you want to rejoin later, sign up again as you did the first time.</p>
+
+  <h2>Help — reply HELP</h2>
+  <p>For help, reply <strong>HELP</strong> to any message, or contact us at <a href="mailto:operations@jacrentals.com">operations@jacrentals.com</a>.</p>
+
+  <h2>Carriers &amp; delivery</h2>
+  <p>Carriers are not liable for delayed or undelivered messages. Message delivery is subject to the effective transmission from your wireless service provider and is outside our control.</p>
+
+  <h2>Privacy</h2>
+  <p>Your mobile number and messaging consent are handled under our <a href="./privacy.html">Privacy Policy</a>. <strong>We do not sell or share your mobile number or messaging consent with third parties or affiliates for their marketing purposes.</strong></p>
+
+  <h2>Contact us</h2>
+  <p>JacRentals — Sulphur, Louisiana<br>
+  Email: <a href="mailto:operations@jacrentals.com">operations@jacrentals.com</a><br>
+  Web: <a href="https://www.jacrentals.com/">www.jacrentals.com</a></p>
+
+  <footer>© 2026 JacRentals. These terms may be updated; the effective date above reflects the latest version.</footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What

Two standalone static legal pages, served by GitHub Pages once merged:
- **`privacy.html`** → https://app.jacrentals.com/privacy.html
- **`sms-terms.html`** → https://app.jacrentals.com/sms-terms.html

These are the two required URLs for the **Twilio A2P/10DLC campaign registration** (the SMS-sender approval that gates the customer-text channel). Reviewers open them and check for specific language, so both pages carry the three carrier-mandated disclosures verbatim:
1. Mobile phone numbers and messaging consent are **never sold or shared with third parties/affiliates for marketing**.
2. **Message frequency varies.**
3. **Message and data rates may apply.**

Plus **STOP** (opt-out) / **HELP** instructions and the carrier-liability disclaimer. Contact is `operations@jacrentals.com` + Sulphur, LA — no invented phone number.

## Why merge to `main`

`main` is the branch GitHub Pages deploys (`app.jacrentals.com`), so these have to land here to go live. They are **standalone files** — `index.html` (the app) and every module are untouched, so the `smoke` CI check passes unchanged and there's no `?v=` cache-bust to bump. This does not go through the staging flow because it's a static-page add, not an app feature.

## After merge

The URLs resolve within ~1 min of the Pages build. Paste them into the two A2P campaign fields (privacy policy + terms & conditions), finish the campaign, buy the 337 number, and the SMS channel is fully wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtNtp5ApjnkrT4XUvDvdaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtNtp5ApjnkrT4XUvDvdaQ)_