### PR TITLE
Revert 3-frame glyph motion + extend hover nudge to unit mini-cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260707d" />
+  <link rel="stylesheet" href="style.css?v=20260707e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260707d"></script>
-  <script type="module" src="app.js?v=20260707d"></script>
+  <script src="rule-usage.js?v=20260707e"></script>
+  <script type="module" src="app.js?v=20260707e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -3229,61 +3229,28 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
 .catr-head { display: flex; align-items: center; gap: 6px; min-width: 0; }
 .catr-cat { flex: 0 0 auto; width: 18px; height: 18px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
 .catr-cat svg { width: 17px; height: 17px; display: block; }
-/* ── CATEGORY GLYPH HOVER MOTION (Jac, 2026-07-03; converted to a 3-frame stepped loop
-   2026-07-07 — Jac: "three frames... a motion picture, simpler than full JS") — hovering
-   the unit row (.ur) or the category mini-card (.catr) cycles its category icon through
-   three discrete transform poses (a CSS `steps()` loop, not a smooth tween — a hard-cut
-   flipbook using the SAME static glyph 3 times, no new artwork per family). Paused at
-   rest; runs only while hovered. `mo-none` (the box/unmatched fallback) stays inert.
-   IMPORTANT: the `animation-play-state: running` hover overrides must stay AFTER the
-   base `animation:` shorthands below — same-specificity rules apply in source order,
-   so if the shorthand came second it would silently reset play-state back to running
-   (this bit us once already on the lift/skidsteer loops). ── */
-.cat-glyph { display: inline-flex; transition: color .12s ease; }
-@keyframes mo-dig-cy     { 0%, 100% { transform: none; } 33% { transform: translateY(1.5px) rotate(-8deg); } 66% { transform: translateY(-1px) rotate(3deg); } }
-@keyframes mo-chop-cy    { 0%, 100% { transform: none; } 33% { transform: rotate(-14deg); } 66% { transform: rotate(6deg); } }
-@keyframes mo-spin-cy    { 0%, 100% { transform: rotate(0deg); } 33% { transform: rotate(120deg); } 66% { transform: rotate(240deg); } }
-@keyframes mo-raise-cy   { 0%, 100% { transform: none; } 33% { transform: translateY(-1.5px) rotate(7deg); } 66% { transform: translateY(-.5px) rotate(3deg); } }
-@keyframes mo-snap-cy    { 0%, 100% { transform: scale(1); } 33% { transform: scale(1.14); } 66% { transform: scale(1.05); } }
-@keyframes mo-press-cy   { 0%, 100% { transform: none; } 33% { transform: translateY(2px) scale(.94); } 66% { transform: translateY(-1px) scale(1.03); } }
-@keyframes mo-roll-cy    { 0%, 100% { transform: rotate(0deg); } 33% { transform: translateX(1px) rotate(14deg); } 66% { transform: translateX(2px) rotate(28deg); } }
-@keyframes mo-spark-cy   { 0%, 100% { transform: scale(1); } 33% { transform: scale(1.16); } 66% { transform: scale(1.06); } }
-@keyframes mo-puff-cy    { 0%, 100% { transform: none; } 33% { transform: translateX(2px) scale(1.06); } 66% { transform: translateX(1px) scale(1.02); } }
-@keyframes mo-drip-cy    { 0%, 100% { transform: none; } 33% { transform: translateY(2px) scale(.92); } 66% { transform: translateY(3.5px) scale(.88); } }
-@keyframes mo-slosh-cy   { 0%, 100% { transform: rotate(0deg); } 33% { transform: rotate(-9deg); } 66% { transform: rotate(7deg); } }
-@keyframes mo-flicker-cy { 0%, 100% { transform: none; } 33% { transform: scale(1.1) rotate(-5deg); } 66% { transform: scale(.95) rotate(4deg); } }
-@keyframes mo-pulse-cy   { 0%, 100% { transform: scale(1); } 33% { transform: scale(1.12); } 66% { transform: scale(1.05); } }
-.mo-dig     { animation: mo-dig-cy     .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-chop    { animation: mo-chop-cy    .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-spin    { animation: mo-spin-cy    .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-raise   { animation: mo-raise-cy   .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-snap    { animation: mo-snap-cy    .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-press   { animation: mo-press-cy   .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-roll    { animation: mo-roll-cy    .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-spark   { animation: mo-spark-cy   .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-puff    { animation: mo-puff-cy    .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-drip    { animation: mo-drip-cy    .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-slosh   { animation: mo-slosh-cy   .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-flicker { animation: mo-flicker-cy .9s steps(1,end) infinite; animation-play-state: paused; }
-.mo-pulse   { animation: mo-pulse-cy   .9s steps(1,end) infinite; animation-play-state: paused; }
-.ur:hover .mo-dig,     .catr:hover .mo-dig,
-.ur:hover .mo-chop,    .catr:hover .mo-chop,
-.ur:hover .mo-spin,    .catr:hover .mo-spin,
-.ur:hover .mo-raise,   .catr:hover .mo-raise,
-.ur:hover .mo-snap,    .catr:hover .mo-snap,
-.ur:hover .mo-press,   .catr:hover .mo-press,
-.ur:hover .mo-roll,    .catr:hover .mo-roll,
-.ur:hover .mo-spark,   .catr:hover .mo-spark,
-.ur:hover .mo-puff,    .catr:hover .mo-puff,
-.ur:hover .mo-drip,    .catr:hover .mo-drip,
-.ur:hover .mo-slosh,   .catr:hover .mo-slosh,
-.ur:hover .mo-flicker, .catr:hover .mo-flicker,
-.ur:hover .mo-pulse,   .catr:hover .mo-pulse   { animation-play-state: running; }
+/* ── CATEGORY GLYPH HOVER MOTION (Jac, 2026-07-03) — hovering the unit row (.ur) or the
+   category mini-card (.catr) nudges its category icon with a short, per-family CSS-only
+   move (one crisp beat, no bounce/loop — same .12s control timing as the rest of the
+   system). `mo-none` (the box/unmatched fallback) is deliberately inert. ── */
+.cat-glyph { display: inline-flex; transition: transform .12s cubic-bezier(.2,.7,.2,1), color .12s ease; }
+.ur:hover .mo-dig,     .catr:hover .mo-dig     { transform: translateY(1.5px) rotate(-8deg); }
+.ur:hover .mo-chop,    .catr:hover .mo-chop    { transform: rotate(-14deg); }
+.ur:hover .mo-spin,    .catr:hover .mo-spin    { transform: rotate(80deg); }
+.ur:hover .mo-raise,   .catr:hover .mo-raise   { transform: translateY(-1.5px) rotate(7deg); }
+.ur:hover .mo-snap,    .catr:hover .mo-snap    { transform: scale(1.14); }
+.ur:hover .mo-press,   .catr:hover .mo-press   { transform: translateY(2px) scale(.94); }
+.ur:hover .mo-roll,    .catr:hover .mo-roll    { transform: translateX(2px) rotate(14deg); }
+.ur:hover .mo-spark,   .catr:hover .mo-spark   { transform: scale(1.16); }
+.ur:hover .mo-puff,    .catr:hover .mo-puff    { transform: translateX(2px) scale(1.06); }
+.ur:hover .mo-drip,    .catr:hover .mo-drip    { transform: translateY(2px) scale(.92); }
+.ur:hover .mo-slosh,   .catr:hover .mo-slosh   { transform: rotate(-9deg); }
+.ur:hover .mo-flicker, .catr:hover .mo-flicker { transform: scale(1.1) rotate(-5deg); }
+.ur:hover .mo-pulse,   .catr:hover .mo-pulse   { transform: scale(1.12); }
 .ur:hover .mo-none,    .catr:hover .mo-none    { transform: none; }
 @media (prefers-reduced-motion: reduce) {
   .cat-glyph { transition: color .12s ease; }
-  .mo-dig, .mo-chop, .mo-spin, .mo-raise, .mo-snap, .mo-press, .mo-roll, .mo-spark,
-  .mo-puff, .mo-drip, .mo-slosh, .mo-flicker, .mo-pulse { animation: none !important; transform: none !important; }
+  .ur:hover .cat-glyph, .catr:hover .cat-glyph { transform: none !important; }
 }
 
 /* ── ANIMATED CATEGORY GLYPHS (Jac, 2026-07-03) — the excavator / boom-lift / skid-steer

--- a/style.css
+++ b/style.css
@@ -3229,34 +3229,35 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
 .catr-head { display: flex; align-items: center; gap: 6px; min-width: 0; }
 .catr-cat { flex: 0 0 auto; width: 18px; height: 18px; color: var(--txt-2); display: flex; align-items: center; justify-content: center; }
 .catr-cat svg { width: 17px; height: 17px; display: block; }
-/* ── CATEGORY GLYPH HOVER MOTION (Jac, 2026-07-03) — hovering the unit row (.ur) or the
+/* ── CATEGORY GLYPH HOVER MOTION (Jac, 2026-07-03; extended to unit mini-cards
+   2026-07-07) — hovering the unit row (.ur), the unit mini-card (.ucard), or the
    category mini-card (.catr) nudges its category icon with a short, per-family CSS-only
    move (one crisp beat, no bounce/loop — same .12s control timing as the rest of the
    system). `mo-none` (the box/unmatched fallback) is deliberately inert. ── */
 .cat-glyph { display: inline-flex; transition: transform .12s cubic-bezier(.2,.7,.2,1), color .12s ease; }
-.ur:hover .mo-dig,     .catr:hover .mo-dig     { transform: translateY(1.5px) rotate(-8deg); }
-.ur:hover .mo-chop,    .catr:hover .mo-chop    { transform: rotate(-14deg); }
-.ur:hover .mo-spin,    .catr:hover .mo-spin    { transform: rotate(80deg); }
-.ur:hover .mo-raise,   .catr:hover .mo-raise   { transform: translateY(-1.5px) rotate(7deg); }
-.ur:hover .mo-snap,    .catr:hover .mo-snap    { transform: scale(1.14); }
-.ur:hover .mo-press,   .catr:hover .mo-press   { transform: translateY(2px) scale(.94); }
-.ur:hover .mo-roll,    .catr:hover .mo-roll    { transform: translateX(2px) rotate(14deg); }
-.ur:hover .mo-spark,   .catr:hover .mo-spark   { transform: scale(1.16); }
-.ur:hover .mo-puff,    .catr:hover .mo-puff    { transform: translateX(2px) scale(1.06); }
-.ur:hover .mo-drip,    .catr:hover .mo-drip    { transform: translateY(2px) scale(.92); }
-.ur:hover .mo-slosh,   .catr:hover .mo-slosh   { transform: rotate(-9deg); }
-.ur:hover .mo-flicker, .catr:hover .mo-flicker { transform: scale(1.1) rotate(-5deg); }
-.ur:hover .mo-pulse,   .catr:hover .mo-pulse   { transform: scale(1.12); }
-.ur:hover .mo-none,    .catr:hover .mo-none    { transform: none; }
+.ur:hover .mo-dig,     .ucard:hover .mo-dig,     .catr:hover .mo-dig     { transform: translateY(1.5px) rotate(-8deg); }
+.ur:hover .mo-chop,    .ucard:hover .mo-chop,    .catr:hover .mo-chop    { transform: rotate(-14deg); }
+.ur:hover .mo-spin,    .ucard:hover .mo-spin,    .catr:hover .mo-spin    { transform: rotate(80deg); }
+.ur:hover .mo-raise,   .ucard:hover .mo-raise,   .catr:hover .mo-raise   { transform: translateY(-1.5px) rotate(7deg); }
+.ur:hover .mo-snap,    .ucard:hover .mo-snap,    .catr:hover .mo-snap    { transform: scale(1.14); }
+.ur:hover .mo-press,   .ucard:hover .mo-press,   .catr:hover .mo-press   { transform: translateY(2px) scale(.94); }
+.ur:hover .mo-roll,    .ucard:hover .mo-roll,    .catr:hover .mo-roll    { transform: translateX(2px) rotate(14deg); }
+.ur:hover .mo-spark,   .ucard:hover .mo-spark,   .catr:hover .mo-spark   { transform: scale(1.16); }
+.ur:hover .mo-puff,    .ucard:hover .mo-puff,    .catr:hover .mo-puff    { transform: translateX(2px) scale(1.06); }
+.ur:hover .mo-drip,    .ucard:hover .mo-drip,    .catr:hover .mo-drip    { transform: translateY(2px) scale(.92); }
+.ur:hover .mo-slosh,   .ucard:hover .mo-slosh,   .catr:hover .mo-slosh   { transform: rotate(-9deg); }
+.ur:hover .mo-flicker, .ucard:hover .mo-flicker, .catr:hover .mo-flicker { transform: scale(1.1) rotate(-5deg); }
+.ur:hover .mo-pulse,   .ucard:hover .mo-pulse,   .catr:hover .mo-pulse   { transform: scale(1.12); }
+.ur:hover .mo-none,    .ucard:hover .mo-none,    .catr:hover .mo-none    { transform: none; }
 @media (prefers-reduced-motion: reduce) {
   .cat-glyph { transition: color .12s ease; }
-  .ur:hover .cat-glyph, .catr:hover .cat-glyph { transform: none !important; }
+  .ur:hover .cat-glyph, .ucard:hover .cat-glyph, .catr:hover .cat-glyph { transform: none !important; }
 }
 
 /* ── ANIMATED CATEGORY GLYPHS (Jac, 2026-07-03) — the excavator / boom-lift / skid-steer
    families render CATEGORY_ANIM loops (icons-anim.js, converted from Jac's supplied
-   Lottie artwork). PAUSED at the rest pose until the parent row/card (.ur/.catr) is
-   hovered (Jac, 2026-07-03: icons should NOT move until hovered, and never tint orange);
+   Lottie artwork). PAUSED at the rest pose until the parent row/card (.ur/.ucard/.catr)
+   is hovered (Jac, 2026-07-03: icons should NOT move until hovered, and never tint orange);
    currentColor strokes (.k2 = dimmed secondary); pivots work because the SVG nests
    translate(p) › animated group › translate(-a) at each Lottie anchor.
    Reduced-motion keeps them frozen entirely. ── */
@@ -3286,6 +3287,7 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
    shorthand resets play-state to running, so declaration order is load-bearing. */
 .catanim [class*="bl-"], .catanim [class*="sk-"] { animation-play-state: paused; }
 .ur:hover .catanim [class*="bl-"], .ur:hover .catanim [class*="sk-"],
+.ucard:hover .catanim [class*="bl-"], .ucard:hover .catanim [class*="sk-"],
 .catr:hover .catanim [class*="bl-"], .catr:hover .catanim [class*="sk-"] { animation-play-state: running; }
 @media (prefers-reduced-motion: reduce) {
   .catanim *, .catanim { animation: none !important; }


### PR DESCRIPTION
## Summary
Two related changes to the category-glyph hover motion system (both touch the same CSS block, so they ship together):

1. **Revert the 3-frame stepped motion (#502).** Back to the prior **single-beat hover nudge** — each family's icon does one crisp transform on hover, no loop. Jac didn't like the stepped/flipbook feel and will hand-draw real frames to hand off later. All the delivery plumbing is kept intact (the `CATEGORY_MOTION` mapping, the `.cat-glyph` wrapper, and the `CATEGORY_ANIM` sprite path that drives the real boom-lift / skid-steer loops) so a hand-drawn family drops straight in as a `CATEGORY_ANIM[key]` entry.
2. **Extend the hover nudge to unit mini-cards.** The motion previously only fired on the unit row (`.ur`) and category mini-card (`.catr`). Added `.ucard:hover` (the unit mini-card) to every `mo-*` trigger, the reduced-motion override, and the `CATEGORY_ANIM` play-state gate — so a unit mini-card's category glyph now animates on hover too.

- Bumped the `?v=` cache-bust token.

## Test plan
- [x] `node --check app.js`
- [x] `node ci/smoke.mjs` (port swapped to 9147 locally, reverted after)
- [x] `node ci/logic-test.mjs` (404/404 checks passed)
- [x] `node ci/gen-rule-usage.mjs --check`
- [x] `node ci/check-window-catalog.mjs`
- [x] `node tools/gen-code-map.mjs --check`
- [x] `node tools/gen-icons.mjs --check`
- [x] Verified via a Playwright harness using the real `style.css` + generated glyphs: a `.ucard`'s glyph transform is `none` at rest and applies the correct `mo-*` nudge on hover
