### PR TITLE
Wrangler fix: cache-bust for the transport-due tool (#510)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260707e" />
+  <link rel="stylesheet" href="style.css?v=20260707f" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260707e"></script>
-  <script type="module" src="app.js?v=20260707e"></script>
+  <script src="rule-usage.js?v=20260707f"></script>
+  <script type="module" src="app.js?v=20260707f"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
The transport-due tool (`find_transports`) merged in #511 landed in `app.js` but the shared `?v=` cache token in `index.html` was never bumped. GitHub Pages serves `max-age=600` with no per-file hashing, so a phone/desktop keeps loading the **stale** cached `app.js` and never picks up the new tool — exactly the gap CLAUDE.md → *Cache-bust on every deploy* warns about.

**Change:** bump the shared token `20260707e → 20260707f` on `style.css`, `rule-usage.js`, and `app.js`. One-line deploy hygiene, no code change.

Follows up #511 · Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)