### PR TITLE
Invoice Print PDF: grouped "yard log" document

### DIFF
--- a/app.js
+++ b/app.js
@@ -15988,45 +15988,49 @@ function invoicePrintGroups(inv) {
   groups.sort((a, b) => a.isOther ? 1 : b.isOther ? -1 : (a.start < b.start ? 1 : a.start > b.start ? -1 : 0));
   return groups;
 }
-/** One printed line row → { icon, name, cat, meta }, with the provenance tail stripped off
- *  the stored label (it now lives in the group header) and the unit's category surfaced. */
+/** One printed line row → { icon, name, cat, meta }. A unit line shows its glyph + name +
+ *  CATEGORY only (the per-day rate/qty is dropped — the card header now carries the window +
+ *  duration). Transport keeps its leg descriptor; a manual line shows its plain label. */
 function prLineParts(li) {
   let rest = String(li.label || '').replace(/\s*·\s*Ext of\s+\S+\s*$/i, '').replace(/\s*·\s*Extension\s*→.*$/i, '');
   if (li.kind === 'transport') return { icon: I.truck, name: 'Transport', cat: '', meta: rest.replace(/^Transport\s*·\s*/i, '') };
   const u = li.unitId ? IDX.unit.get(li.unitId) : null;
   if (u) {
     const cat = IDX.category.get(u.categoryId);
-    let meta = rest;
-    if (u.name && rest.startsWith(u.name + ' · ')) meta = rest.slice((u.name + ' · ').length);
-    else { const p = rest.split(' · '); if (p.length > 1) { p.shift(); meta = p.join(' · '); } }
-    return { icon: categoryIconFor(cat && cat.name), name: u.name, cat: (cat && cat.name) || '', meta };
+    return { icon: categoryIconFor(cat && cat.name), name: u.name, cat: (cat && cat.name) || '', meta: '' };
   }
   return { icon: '', name: rest, cat: '', meta: '' };
 }
-/** Customer-safe amendment log — the invoice's + its rentals' actions, scrubbed of internal
- *  ops detail (staff names via `by`, pricing locks, Mr. Wrangler, card/ACH, mechanic/GPS),
- *  internal-but-relevant wording translated to plain language, oldest→newest so the ticket
- *  reads like a running log. */
+/** Customer-safe amendment logs — SEPARATED: { invoiceLog, rentalLog }. Each is the record's
+ *  actions scrubbed of internal ops detail (staff names via `by`, pricing locks, Mr. Wrangler,
+ *  card/ACH, mechanic/GPS), internal-but-relevant wording translated to plain language, sorted
+ *  MOST RECENT → oldest. rentalLog entries carry the rental name (which unit(s)). */
 function invoiceAmendments(inv) {
   const DENY = /pricing (un)?locked|mr\.?\s*wrangler|added by|••|\bach\b|\bcard\b|mechanic|assigned|\bgps\b|\bhours\b/i;
-  const raw = [];
-  (inv.actions || []).forEach((a) => raw.push(a));
-  (inv.rentalIds || []).map((id) => IDX.rental.get(id)).filter(Boolean).forEach((r) => {
-    const rname = rentalUnitsLabel(r) || r.rentalName || '';
-    (r.actions || []).forEach((a) => raw.push(Object.assign({}, a, { rname })));
-  });
-  const out = [];
-  raw.forEach((a) => {
+  const scrub = (a, rname) => {
     let text = String(a.text || '');
-    if (!text || DENY.test(text)) return;
+    if (!text || DENY.test(text)) return null;
     text = text
       .replace(/Merged in invoice\s+\S+.*$/i, 'Combined with a prior ticket')
       .replace(/Continuation (of|invoice)\b.*$/i, 'Continued on a new ticket (28-day billing)')
       .replace(/Transport type →/i, 'Transport set to');
-    out.push({ when: a.when, clock: a.clock || '', seq: a.seq || 0, text, rname: a.rname || '' });
+    return { when: a.when, clock: a.clock || '', seq: a.seq || 0, text, rname: rname || '' };
+  };
+  const recent = (x, y) => (x.when < y.when ? 1 : x.when > y.when ? -1 : (y.seq - x.seq));   // most recent → oldest
+  const invoiceLog = (inv.actions || []).map((a) => scrub(a)).filter(Boolean).sort(recent);
+  const rentalLog = [];
+  (inv.rentalIds || []).map((id) => IDX.rental.get(id)).filter(Boolean).forEach((r) => {
+    const rname = rentalUnitsLabel(r) || r.rentalName || '';
+    (r.actions || []).forEach((a) => { const s = scrub(a, rname); if (s) rentalLog.push(s); });
   });
-  out.sort((x, y) => (x.when < y.when ? -1 : x.when > y.when ? 1 : x.seq - y.seq));
-  return out;
+  rentalLog.sort(recent);
+  return { invoiceLog, rentalLog };
+}
+/** Invoice status → the print doc's accent state: green (paid), yellow (open / not yet due),
+ *  red (past due). Drives the date stamp, hazard stripe, Balance Due and the Paid stamp. */
+function prInvoiceInk(inv, t) {
+  if ((t || invoiceTotals(inv)).balance <= 0.005) return 'is-paid';
+  return /^(Late|Collections)/.test((t || invoiceTotals(inv)).status) ? 'is-due' : 'is-open';
 }
 function printInvoice(invoiceId) {
   const inv = IDX.invoice.get(invoiceId); if (!inv) return;
@@ -16034,14 +16038,23 @@ function printInvoice(invoiceId) {
   const cust = inv.customerId ? IDX.customer.get(inv.customerId) : null;
   const groups = invoicePrintGroups(inv);
   const paid = t.balance <= 0.005 && t.total > 0;
+  const ink = prInvoiceInk(inv, t);   // is-paid (green) / is-open (yellow) / is-due (red)
   const bigDate = (fmtShortDate(inv.date) || '').toUpperCase();
 
-  const lineRows = (g) => g.lines.map((li) => {
-    const p = prLineParts(li);
-    return `<tr class="pr-line"><td class="pr-desc">${p.icon ? `<span class="pr-ic">${p.icon}</span>` : '<span class="pr-ic"></span>'}<span class="pr-txt"><span class="pr-nm">${esc(p.name)}</span>${p.cat ? `<span class="pr-cat">${esc(p.cat)}</span>` : ''}${p.meta ? `<span class="pr-mt">${esc(p.meta)}</span>` : ''}</span></td><td class="pr-amt r">${money2(Number(li.amount) || 0)}</td></tr>`;
-  }).join('');
-  const bodyRows = groups.length ? groups.map((g) => `<tr class="pr-grp"><td class="pr-grp-h"><span class="pr-grp-t">${esc(g.title)}</span>${g.window ? `<span class="pr-grp-win">${esc(g.window)}</span>` : ''}${g.dur ? `<span class="pr-grp-dur">${esc(g.dur)}</span>` : ''}${g.prov ? `<span class="pr-grp-prov">${esc(g.prov)}</span>` : ''}</td><td class="pr-grp-sub r">${money2(g.subtotal)}</td></tr>${lineRows(g)}`).join('')
-    : '<tr><td colspan="2" class="pr-empty">No line items.</td></tr>';
+  // Each rental → a soft card with a CENTERED header (title · window · duration · provenance)
+  // and its per-rental subtotal pinned right; the unit lines sit inside on ledger rules.
+  const cardHtml = (g) => {
+    const lines = g.lines.map((li) => {
+      const p = prLineParts(li);
+      return `<div class="pr-line"><span class="pr-desc">${p.icon ? `<span class="pr-ic">${p.icon}</span>` : '<span class="pr-ic"></span>'}<span class="pr-txt"><span class="pr-nm">${esc(p.name)}</span>${p.cat ? `<span class="pr-cat">${esc(p.cat)}</span>` : ''}${p.meta ? `<span class="pr-mt">${esc(p.meta)}</span>` : ''}</span></span><span class="pr-amt">${money2(Number(li.amount) || 0)}</span></div>`;
+    }).join('');
+    const meta = `${g.window ? `<span>${esc(g.window)}</span>` : ''}${g.dur ? `<span>${esc(g.dur)}</span>` : ''}${g.prov ? `<span class="pr-prov">${esc(g.prov)}</span>` : ''}`;
+    return `<section class="pr-card">
+      <header class="pr-card-h"><span class="pr-card-sub">${money2(g.subtotal)}</span><div class="pr-card-t">${esc(g.title)}</div>${meta ? `<div class="pr-card-m">${meta}</div>` : ''}</header>
+      <div class="pr-card-lines">${lines}</div>
+    </section>`;
+  };
+  const groupsHtml = groups.length ? groups.map(cardHtml).join('') : '<div class="pr-empty">No line items.</div>';
 
   const paymentRows = (inv.payments || []).length
     ? (inv.payments || []).map((pmt) => {
@@ -16055,48 +16068,43 @@ function printInvoice(invoiceId) {
       }).join('')
     : (t.paid ? `<div><span>Paid${inv.paymentMethod ? ' · ' + esc(inv.paymentMethod) : ''}</span><span>${money2(t.paid)}</span></div>` : '');
 
-  const amend = invoiceAmendments(inv);
-  const amendRows = amend.length
-    ? amend.map((a) => `<div class="pr-am-row"><span class="pr-am-when">${esc(fmtShortDate(a.when))}${a.clock ? ' · ' + esc(a.clock) : ''}</span><span class="pr-am-tx">${esc(a.text)}${a.rname ? ` <em>· ${esc(a.rname)}</em>` : ''}</span></div>`).join('')
-    : '<div class="pr-am-empty">No amendments — original ticket as written.</div>';
+  const { invoiceLog, rentalLog } = invoiceAmendments(inv);
+  const logRow = (a, withName) => `<div class="pr-am-row"><span class="pr-am-when">${esc(fmtShortDate(a.when))}${a.clock ? ' · ' + esc(a.clock) : ''}</span><span class="pr-am-tx">${esc(a.text)}${withName && a.rname ? ` <em>· ${esc(a.rname)}</em>` : ''}</span></div>`;
+  const logCol = (title, items, withName) => `<div class="pr-log"><div class="pr-log-h">${title}</div>${items.length ? items.map((a) => logRow(a, withName)).join('') : '<div class="pr-am-empty">No entries.</div>'}</div>`;
 
   let host = document.getElementById('print-root');
   if (!host) { host = document.createElement('div'); host.id = 'print-root'; document.body.appendChild(host); }
   host.innerHTML = `
-    <div class="pr-doc">
+    <div class="pr-doc ${ink}">
       <div class="pr-head">
-        <div class="pr-brandwrap"><span class="pr-mark">${I.bluesteel}</span><div><div class="pr-brand">${esc(companyName())}</div><div class="pr-sub">${esc(companyTagline())} · Yard Log</div></div></div>
+        <div class="pr-brandwrap"><img class="pr-logo" src="assets/jac-rentals-logo.jpg" alt="${esc(companyName())}" /><div><div class="pr-brand">${esc(companyName())}</div><div class="pr-sub">${esc(companyTagline())} · Yard Log</div></div></div>
         <div class="pr-datestamp">${esc(bigDate)}</div>
       </div>
       <div class="pr-hazard" aria-hidden="true"></div>
       <div class="pr-meta">
         <div><span class="pr-k">Invoice</span><span class="pr-v">${esc(inv.invoiceId)}</span></div>
         <div><span class="pr-k">Bill to</span><span class="pr-v">${esc(cust ? cust.name : '—')}</span></div>
-        <div><span class="pr-k">Date</span><span class="pr-v">${esc(fmtShortDate(inv.date) || '—')}</span></div>
+        <div><span class="pr-k">Created</span><span class="pr-v">${esc(fmtShortDate(inv.date) || '—')}</span></div>
         <div><span class="pr-k">Due</span><span class="pr-v">${esc(inv.dueDate ? fmtShortDate(inv.dueDate) : '—')}</span></div>
         ${inv.po ? `<div><span class="pr-k">PO</span><span class="pr-v">${esc(inv.po)}</span></div>` : ''}
-        ${inv.covStart && inv.covEnd ? `<div><span class="pr-k">Rental period</span><span class="pr-v">${esc(fmtShortDate(inv.covStart))} – ${esc(fmtShortDate(inv.covEnd))}</span></div>` : ''}
         ${inv.contOf ? `<div><span class="pr-k">Continuation of</span><span class="pr-v">${esc(invoiceShort(inv.contOf))} (28-day billing split)</span></div>` : ''}
       </div>
-      <table class="pr-lines"><thead><tr><th>Description</th><th class="r">Amount</th></tr></thead><tbody>${bodyRows}</tbody></table>
-      <div class="pr-tot">
-        <div><span>Grand Subtotal</span><span>${money2(t.subtotal)}</span></div>
-        <div><span>Tax${t.exempt ? ' (exempt)' : ` (${(TAX_RATE * 100).toFixed(2)}%)`}</span><span>${t.exempt ? '—' : money2(t.tax)}</span></div>
-        <div class="pr-big"><span>Total</span><span>${money2(t.total)}</span></div>
-        ${paymentRows}
-        <div class="pr-due"><span>Balance Due</span><span>${money2(t.balance)}</span></div>
+      <div class="pr-groups">${groupsHtml}</div>
+      <div class="pr-summary">
+        ${paid ? '<div class="pr-stamp" aria-hidden="true">Paid in Full</div>' : ''}
+        <div class="pr-tot">
+          <div><span>Grand Subtotal</span><span>${money2(t.subtotal)}</span></div>
+          <div><span>Tax${t.exempt ? ' (exempt)' : ` (${(TAX_RATE * 100).toFixed(2)}%)`}</span><span>${t.exempt ? '—' : money2(t.tax)}</span></div>
+          <div class="pr-big"><span>Total</span><span>${money2(t.total)}</span></div>
+          ${paymentRows}
+          <div class="pr-due"><span>Balance Due</span><span>${money2(t.balance)}</span></div>
+        </div>
       </div>
-      ${paid ? '<div class="pr-stamp" aria-hidden="true">Paid in Full</div>' : ''}
-      <div class="pr-sign">
-        <div class="pr-sig"><span class="pr-sig-r"></span><span class="pr-sig-l">Customer Signature</span></div>
-        <div class="pr-sig"><span class="pr-sig-r"></span><span class="pr-sig-l">Authorized By</span></div>
-        <div class="pr-sig"><span class="pr-sig-r"></span><span class="pr-sig-l">Date</span></div>
+      <div class="pr-logs">
+        ${logCol('Invoice Log', invoiceLog, false)}
+        ${logCol('Rental Log', rentalLog, true)}
       </div>
-      <div class="pr-amend">
-        <div class="pr-amend-h">Yard Log — Amendments</div>
-        ${amendRows}
-      </div>
-      <div class="pr-foot"><span class="pr-foot-thx">Thank you for your business — much obliged. Questions on this ticket? Give the yard a holler${companyPhone() ? ` — ${esc(companyPhone())}` : ''}.</span><span class="pr-foot-mark">A JacTec Service</span></div>
+      <div class="pr-foot">Thank you for your business — much obliged. Questions on this ticket? Give the yard a holler${companyPhone() ? ` — ${esc(companyPhone())}` : ''}.</div>
     </div>`;
   document.body.classList.add('printing');
   const cleanup = () => { document.body.classList.remove('printing'); window.removeEventListener('afterprint', cleanup); };

--- a/app.js
+++ b/app.js
@@ -15936,20 +15936,139 @@ async function recordManualPayment(invoiceId) {
     if (live()) { o.busy = false; o.error = (e && e.rwTimeout) ? 'Timed out — try again.' : ((e && e.message) || 'Network error — try again.'); renderOverlay(); }
   }
 }
-// Print / PDF a customer-facing invoice (#109) — a clean white document (not the dark
-// yard UI) rendered into #print-root; the @media print rules hide everything else and
-// the browser's print dialog handles paper or "Save as PDF".
+// ── Invoice "Yard Log" PRINT / PDF (#109; reshaped to a kraft yard-log page 2026-07-08).
+// A customer-facing document rendered into #print-root: line items GROUPED by rental
+// (recent→oldest window), each group stamped with its window · duration · merge/extension
+// provenance · per-rental subtotal; a grand subtotal; a machine glyph per unit line; a red
+// BALANCE DUE + PAID stamp; a signature block; and a customer-safe Amendments log. The
+// @media print rules swap the dark yard UI out and the browser dialog handles "Save as PDF".
+
+/** "2 Days" · "2 Weeks" · "1 Month" from a day count (28d = 1 Month, matching the 4-Week
+ *  rate; falls back to whole weeks then days). */
+function prDuration(days) {
+  if (days % 28 === 0) { const m = days / 28; return `${m} Month${m === 1 ? '' : 's'}`; }
+  if (days % 7 === 0)  { const w = days / 7;  return `${w} Week${w === 1 ? '' : 's'}`; }
+  return `${days} Day${days === 1 ? '' : 's'}`;
+}
+/** Provenance stamp for a rental group: "Merged from 216i" (lines carry a `fromInv` tag
+ *  stamped at merge time) · "Extension of 216i" (a line's "Ext of NNN" tail, or the invoice's
+ *  contOf when this is the covered rental) · "Extension" (a grow-in-place extension line). */
+function prGroupProvenance(inv, r, gl) {
+  const merged = gl.find((li) => li.fromInv);
+  if (merged) return `Merged from ${invoiceShort(merged.fromInv)}`;
+  for (const li of gl) { const m = /·\s*Ext of\s+(\S+)\s*$/i.exec(li.label || ''); if (m) return `Extension of ${m[1]}`; }
+  if (inv.contOf && r && inv.covOf === r.rentalId) return `Extension of ${invoiceShort(inv.contOf)}`;
+  if (gl.some((li) => li.kind === 'extension')) return 'Extension';
+  return '';
+}
+/** Group an invoice's line items by rental, newest window first (manual / unlinked lines
+ *  fall to a trailing "Additional charges" group). */
+function invoicePrintGroups(inv) {
+  const map = new Map(), order = [];
+  (inv.lineItems || []).forEach((li) => {
+    const r = li.ref ? IDX.rental.get(li.ref) : null;
+    const key = r ? r.rentalId : '__other';
+    if (!map.has(key)) { map.set(key, { r, key, lines: [] }); order.push(key); }
+    map.get(key).lines.push(li);
+  });
+  const groups = order.map((key) => {
+    const g = map.get(key), r = g.r;
+    const start = r ? r.startDate : '', end = r ? r.endDate : '';   // unlinked "Additional charges" get no window/duration
+    const days = (parseISO(start) && parseISO(end)) ? Math.max(1, dayDiff(parseISO(start), parseISO(end))) : 0;
+    return {
+      key, r, isOther: key === '__other', start,
+      title: (key === '__other') ? 'Additional charges' : 'Rental',
+      window: (start && end) ? `${fmtShortDate(start)} – ${fmtShortDate(end)}` : '',
+      dur: days ? prDuration(days) : '',
+      prov: (key === '__other') ? '' : prGroupProvenance(inv, r, g.lines),
+      subtotal: g.lines.reduce((a, li) => a + (Number(li.amount) || 0), 0),
+      lines: g.lines,
+    };
+  });
+  groups.sort((a, b) => a.isOther ? 1 : b.isOther ? -1 : (a.start < b.start ? 1 : a.start > b.start ? -1 : 0));
+  return groups;
+}
+/** One printed line row → { icon, name, cat, meta }, with the provenance tail stripped off
+ *  the stored label (it now lives in the group header) and the unit's category surfaced. */
+function prLineParts(li) {
+  let rest = String(li.label || '').replace(/\s*·\s*Ext of\s+\S+\s*$/i, '').replace(/\s*·\s*Extension\s*→.*$/i, '');
+  if (li.kind === 'transport') return { icon: I.truck, name: 'Transport', cat: '', meta: rest.replace(/^Transport\s*·\s*/i, '') };
+  const u = li.unitId ? IDX.unit.get(li.unitId) : null;
+  if (u) {
+    const cat = IDX.category.get(u.categoryId);
+    let meta = rest;
+    if (u.name && rest.startsWith(u.name + ' · ')) meta = rest.slice((u.name + ' · ').length);
+    else { const p = rest.split(' · '); if (p.length > 1) { p.shift(); meta = p.join(' · '); } }
+    return { icon: categoryIconFor(cat && cat.name), name: u.name, cat: (cat && cat.name) || '', meta };
+  }
+  return { icon: '', name: rest, cat: '', meta: '' };
+}
+/** Customer-safe amendment log — the invoice's + its rentals' actions, scrubbed of internal
+ *  ops detail (staff names via `by`, pricing locks, Mr. Wrangler, card/ACH, mechanic/GPS),
+ *  internal-but-relevant wording translated to plain language, oldest→newest so the ticket
+ *  reads like a running log. */
+function invoiceAmendments(inv) {
+  const DENY = /pricing (un)?locked|mr\.?\s*wrangler|added by|••|\bach\b|\bcard\b|mechanic|assigned|\bgps\b|\bhours\b/i;
+  const raw = [];
+  (inv.actions || []).forEach((a) => raw.push(a));
+  (inv.rentalIds || []).map((id) => IDX.rental.get(id)).filter(Boolean).forEach((r) => {
+    const rname = rentalUnitsLabel(r) || r.rentalName || '';
+    (r.actions || []).forEach((a) => raw.push(Object.assign({}, a, { rname })));
+  });
+  const out = [];
+  raw.forEach((a) => {
+    let text = String(a.text || '');
+    if (!text || DENY.test(text)) return;
+    text = text
+      .replace(/Merged in invoice\s+\S+.*$/i, 'Combined with a prior ticket')
+      .replace(/Continuation (of|invoice)\b.*$/i, 'Continued on a new ticket (28-day billing)')
+      .replace(/Transport type →/i, 'Transport set to');
+    out.push({ when: a.when, clock: a.clock || '', seq: a.seq || 0, text, rname: a.rname || '' });
+  });
+  out.sort((x, y) => (x.when < y.when ? -1 : x.when > y.when ? 1 : x.seq - y.seq));
+  return out;
+}
 function printInvoice(invoiceId) {
   const inv = IDX.invoice.get(invoiceId); if (!inv) return;
   const t = invoiceTotals(inv);
   const cust = inv.customerId ? IDX.customer.get(inv.customerId) : null;
-  const rows = (inv.lineItems || []).map((li) => `<tr><td>${esc(li.label)}</td><td class="r">${money2(Number(li.amount) || 0)}</td></tr>`).join('')
-    || '<tr><td colspan="2" class="pr-empty">No line items.</td></tr>';
+  const groups = invoicePrintGroups(inv);
+  const paid = t.balance <= 0.005 && t.total > 0;
+  const bigDate = (fmtShortDate(inv.date) || '').toUpperCase();
+
+  const lineRows = (g) => g.lines.map((li) => {
+    const p = prLineParts(li);
+    return `<tr class="pr-line"><td class="pr-desc">${p.icon ? `<span class="pr-ic">${p.icon}</span>` : '<span class="pr-ic"></span>'}<span class="pr-txt"><span class="pr-nm">${esc(p.name)}</span>${p.cat ? `<span class="pr-cat">${esc(p.cat)}</span>` : ''}${p.meta ? `<span class="pr-mt">${esc(p.meta)}</span>` : ''}</span></td><td class="pr-amt r">${money2(Number(li.amount) || 0)}</td></tr>`;
+  }).join('');
+  const bodyRows = groups.length ? groups.map((g) => `<tr class="pr-grp"><td class="pr-grp-h"><span class="pr-grp-t">${esc(g.title)}</span>${g.window ? `<span class="pr-grp-win">${esc(g.window)}</span>` : ''}${g.dur ? `<span class="pr-grp-dur">${esc(g.dur)}</span>` : ''}${g.prov ? `<span class="pr-grp-prov">${esc(g.prov)}</span>` : ''}</td><td class="pr-grp-sub r">${money2(g.subtotal)}</td></tr>${lineRows(g)}`).join('')
+    : '<tr><td colspan="2" class="pr-empty">No line items.</td></tr>';
+
+  const paymentRows = (inv.payments || []).length
+    ? (inv.payments || []).map((pmt) => {
+        const when = pmt.at ? esc(fmtShortDate(pmt.at)) : '';
+        const method = pmt.type === 'cash' ? 'Cash'
+          : pmt.type === 'check' ? ('Check' + (pmt.checkNum ? ' #' + esc(String(pmt.checkNum)) : ''))
+          : pmt.type === 'ach-pending' ? 'ACH (pending)'
+          : pmt.type === 'charge' ? 'Card'
+          : esc(String(pmt.type || 'Payment'));
+        return `<div><span>Paid${when ? ' · ' + when : ''} · ${method}</span><span>${money2((Number(pmt.amountCents) || 0) / 100)}</span></div>`;
+      }).join('')
+    : (t.paid ? `<div><span>Paid${inv.paymentMethod ? ' · ' + esc(inv.paymentMethod) : ''}</span><span>${money2(t.paid)}</span></div>` : '');
+
+  const amend = invoiceAmendments(inv);
+  const amendRows = amend.length
+    ? amend.map((a) => `<div class="pr-am-row"><span class="pr-am-when">${esc(fmtShortDate(a.when))}${a.clock ? ' · ' + esc(a.clock) : ''}</span><span class="pr-am-tx">${esc(a.text)}${a.rname ? ` <em>· ${esc(a.rname)}</em>` : ''}</span></div>`).join('')
+    : '<div class="pr-am-empty">No amendments — original ticket as written.</div>';
+
   let host = document.getElementById('print-root');
   if (!host) { host = document.createElement('div'); host.id = 'print-root'; document.body.appendChild(host); }
   host.innerHTML = `
     <div class="pr-doc">
-      <div class="pr-head"><div class="pr-brand">${esc(companyName())}</div><div class="pr-sub">${esc(companyTagline())}</div></div>
+      <div class="pr-head">
+        <div class="pr-brandwrap"><span class="pr-mark">${I.bluesteel}</span><div><div class="pr-brand">${esc(companyName())}</div><div class="pr-sub">${esc(companyTagline())} · Yard Log</div></div></div>
+        <div class="pr-datestamp">${esc(bigDate)}</div>
+      </div>
+      <div class="pr-hazard" aria-hidden="true"></div>
       <div class="pr-meta">
         <div><span class="pr-k">Invoice</span><span class="pr-v">${esc(inv.invoiceId)}</span></div>
         <div><span class="pr-k">Bill to</span><span class="pr-v">${esc(cust ? cust.name : '—')}</span></div>
@@ -15959,25 +16078,25 @@ function printInvoice(invoiceId) {
         ${inv.covStart && inv.covEnd ? `<div><span class="pr-k">Rental period</span><span class="pr-v">${esc(fmtShortDate(inv.covStart))} – ${esc(fmtShortDate(inv.covEnd))}</span></div>` : ''}
         ${inv.contOf ? `<div><span class="pr-k">Continuation of</span><span class="pr-v">${esc(invoiceShort(inv.contOf))} (28-day billing split)</span></div>` : ''}
       </div>
-      <table class="pr-lines"><thead><tr><th>Description</th><th class="r">Amount</th></tr></thead><tbody>${rows}</tbody></table>
+      <table class="pr-lines"><thead><tr><th>Description</th><th class="r">Amount</th></tr></thead><tbody>${bodyRows}</tbody></table>
       <div class="pr-tot">
-        <div><span>Subtotal</span><span>${money2(t.subtotal)}</span></div>
+        <div><span>Grand Subtotal</span><span>${money2(t.subtotal)}</span></div>
         <div><span>Tax${t.exempt ? ' (exempt)' : ` (${(TAX_RATE * 100).toFixed(2)}%)`}</span><span>${t.exempt ? '—' : money2(t.tax)}</span></div>
         <div class="pr-big"><span>Total</span><span>${money2(t.total)}</span></div>
-        ${(inv.payments || []).length
-          ? (inv.payments || []).map((p) => {
-              const when = p.at ? esc(fmtShortDate(p.at)) : '';
-              const method = p.type === 'cash' ? 'Cash'
-                : p.type === 'check' ? ('Check' + (p.checkNum ? ' #' + esc(String(p.checkNum)) : ''))
-                : p.type === 'ach-pending' ? 'ACH (pending)'
-                : p.type === 'charge' ? 'Card'
-                : esc(String(p.type || 'Payment'));
-              return `<div><span>Paid${when ? ' · ' + when : ''} · ${method}</span><span>${money2((Number(p.amountCents) || 0) / 100)}</span></div>`;
-            }).join('')
-          : (t.paid ? `<div><span>Paid${inv.paymentMethod ? ' · ' + esc(inv.paymentMethod) : ''}</span><span>${money2(t.paid)}</span></div>` : '')}
-        <div class="pr-due"><span>Balance due</span><span>${money2(t.balance)}</span></div>
+        ${paymentRows}
+        <div class="pr-due"><span>Balance Due</span><span>${money2(t.balance)}</span></div>
       </div>
-      <div class="pr-foot">Thank you for your business — much obliged. Questions on this ticket? Give the yard a holler.</div>
+      ${paid ? '<div class="pr-stamp" aria-hidden="true">Paid in Full</div>' : ''}
+      <div class="pr-sign">
+        <div class="pr-sig"><span class="pr-sig-r"></span><span class="pr-sig-l">Customer Signature</span></div>
+        <div class="pr-sig"><span class="pr-sig-r"></span><span class="pr-sig-l">Authorized By</span></div>
+        <div class="pr-sig"><span class="pr-sig-r"></span><span class="pr-sig-l">Date</span></div>
+      </div>
+      <div class="pr-amend">
+        <div class="pr-amend-h">Yard Log — Amendments</div>
+        ${amendRows}
+      </div>
+      <div class="pr-foot"><span class="pr-foot-thx">Thank you for your business — much obliged. Questions on this ticket? Give the yard a holler${companyPhone() ? ` — ${esc(companyPhone())}` : ''}.</span><span class="pr-foot-mark">A JacTec Service</span></div>
     </div>`;
   document.body.classList.add('printing');
   const cleanup = () => { document.body.classList.remove('printing'); window.removeEventListener('afterprint', cleanup); };
@@ -16861,8 +16980,10 @@ function mergeInvoiceInto(keepId, absorbId) {
   if (!invoiceMergeable(keep)) { toast(`Blocked: invoice ${invoiceShort(keepId)} has a payment or lock — can't merge into it (refund/unlock first).`); return; }
   if (!invoiceMergeable(src)) { toast(`Blocked: invoice ${invoiceShort(absorbId)} has a payment or lock — refund/unlock it before merging.`); return; }
   if (keep.customerId !== src.customerId) { toast('Blocked: those invoices belong to different customers.'); return; }
-  // move every line over, re-minting lids so allocations can never collide on the keeper
-  const moved = (src.lineItems || []).map((li) => Object.assign({}, li, { lid: lineLid() }));
+  // move every line over, re-minting lids so allocations can never collide on the keeper.
+  // Stamp the absorbed invoice id as `fromInv` (kept if a line was already merged once, so
+  // the earliest source sticks) — the print doc reads it for the "Merged from" group stamp.
+  const moved = (src.lineItems || []).map((li) => Object.assign({}, li, { lid: lineLid(), fromInv: li.fromInv || absorbId }));
   moved.forEach((li) => keep.lineItems.push(li));
   // union rentalIds + relink the absorbed invoice's rentals to the keeper (§7.5: one invoice per rental)
   (src.rentalIds || []).forEach((rid) => {
@@ -17792,7 +17913,7 @@ function exposeTestApi() {
       recordDateMatch, dateTermHits, rowMatches,
       kpiFor, kpiRaw, kpiEval, legacyKpiPct, legacyKpiRaw, KPI_DEFAULTS, wrValidateKpi, roleRings,
       companyRevenueGoal, companyName, companyTagline, membershipPricing, membershipFee, membershipStatus, isActiveMember, rentalPrice, setFunnelStage, markMembershipSigned, rentalProtectionRate, rentalProtectionAmount, protectionLineItems, syncProtectionLine, membershipEconomics, membershipFeeRevenue, membershipSectionHtml, membershipCancel, membershipReactivate, membershipCancellationInvoice, addMonthsISO, openMembershipEnroll, membershipEnrollCommit, rentalRuleBlock, dueForCustomer, customFieldsFor, checklistFor, checklistRequired, inspFamilyKey, inspKeyOfCat, inspItemFails, inspItemUnanswered, inspItemType, inspEvidenceMissing, applySettings, getStatus, pageDefaultSlice, previewOverlayFor, WINDOW_CATALOG, setRole: (r) => { currentRole = r || ''; render(); },
-      openCustomerForm, renderOverlay, render, cardComplete, cardCaptureState, cardHasSelfie, cardHasSignature, captureSelfie, captureSignature, __state: state };   // UI drivers for headless screenshot/e2e tests
+      openCustomerForm, renderOverlay, render, printInvoice, invoicePrintGroups, invoiceAmendments, cardComplete, cardCaptureState, cardHasSelfie, cardHasSignature, captureSelfie, captureSignature, __state: state };   // UI drivers for headless screenshot/e2e tests
 
   } catch (e) { /* no window (non-browser) */ }
 }

--- a/app.js
+++ b/app.js
@@ -15977,7 +15977,7 @@ function invoicePrintGroups(inv) {
     const days = (parseISO(start) && parseISO(end)) ? Math.max(1, dayDiff(parseISO(start), parseISO(end))) : 0;
     return {
       key, r, isOther: key === '__other', start,
-      title: (key === '__other') ? 'Additional charges' : 'Rental',
+      title: (key === '__other') ? 'Other' : 'Rental',
       window: (start && end) ? `${fmtShortDate(start)} – ${fmtShortDate(end)}` : '',
       dur: days ? prDuration(days) : '',
       prov: (key === '__other') ? '' : prGroupProvenance(inv, r, g.lines),
@@ -15993,7 +15993,14 @@ function invoicePrintGroups(inv) {
  *  duration). Transport keeps its leg descriptor; a manual line shows its plain label. */
 function prLineParts(li) {
   let rest = String(li.label || '').replace(/\s*·\s*Ext of\s+\S+\s*$/i, '').replace(/\s*·\s*Extension\s*→.*$/i, '');
-  if (li.kind === 'transport') return { icon: I.truck, name: 'Transport', cat: '', meta: rest.replace(/^Transport\s*·\s*/i, '') };
+  if (li.kind === 'transport') {
+    const r = li.ref ? IDX.rental.get(li.ref) : null;
+    const eu = (r && li.unitId) ? unitEntry(r, li.unitId) : null;
+    const type = (eu && eu.transportType) || (r && r.transportType) || rest.replace(/^Transport\s*·\s*/i, '');
+    const addr = (eu && eu.deliveryAddress) || (r && r.deliveryAddress) || '';
+    const miles = Number((eu && eu.transportMiles) || (r && r.transportMiles) || 0);
+    return { icon: I.truck, name: 'Transport', cat: '', meta: [type, addr, miles ? `${miles} mi` : ''].filter(Boolean).join(' · ') };
+  }
   const u = li.unitId ? IDX.unit.get(li.unitId) : null;
   if (u) {
     const cat = IDX.category.get(u.categoryId);
@@ -16040,9 +16047,11 @@ function printInvoice(invoiceId) {
   const paid = t.balance <= 0.005 && t.total > 0;
   const ink = prInvoiceInk(inv, t);   // is-paid (green) / is-open (yellow) / is-due (red)
   const bigDate = (fmtShortDate(inv.date) || '').toUpperCase();
+  const brandName = companyName().replace(/([a-z])([A-Z])/g, '$1 $2');   // "JacRentals" → "Jac Rentals" (proper case, spaced)
+  const custPhoto = cust ? latestCustomerSelfie(cust) : '';
 
-  // Each rental → a soft card with a CENTERED header (title · window · duration · provenance)
-  // and its per-rental subtotal pinned right; the unit lines sit inside on ledger rules.
+  // Each rental → a soft card with a single-line header: the bold title FIRST, then its window ·
+  // duration · provenance, and the per-rental subtotal pinned right; the unit lines sit inside.
   const cardHtml = (g) => {
     const lines = g.lines.map((li) => {
       const p = prLineParts(li);
@@ -16050,7 +16059,7 @@ function printInvoice(invoiceId) {
     }).join('');
     const meta = `${g.window ? `<span>${esc(g.window)}</span>` : ''}${g.dur ? `<span>${esc(g.dur)}</span>` : ''}${g.prov ? `<span class="pr-prov">${esc(g.prov)}</span>` : ''}`;
     return `<section class="pr-card">
-      <header class="pr-card-h"><span class="pr-card-sub">${money2(g.subtotal)}</span><div class="pr-card-t">${esc(g.title)}</div>${meta ? `<div class="pr-card-m">${meta}</div>` : ''}</header>
+      <header class="pr-card-h"><span class="pr-card-t">${esc(g.title)}</span>${meta ? `<span class="pr-card-m">${meta}</span>` : ''}<span class="pr-card-sub">${money2(g.subtotal)}</span></header>
       <div class="pr-card-lines">${lines}</div>
     </section>`;
   };
@@ -16077,7 +16086,7 @@ function printInvoice(invoiceId) {
   host.innerHTML = `
     <div class="pr-doc ${ink}">
       <div class="pr-head">
-        <div class="pr-brandwrap"><img class="pr-logo" src="assets/jac-rentals-logo.jpg" alt="${esc(companyName())}" /><div><div class="pr-brand">${esc(companyName())}</div><div class="pr-sub">${esc(companyTagline())} · Yard Log</div></div></div>
+        <div class="pr-brandwrap"><img class="pr-logo" src="assets/jac-rentals-logo.jpg" alt="${esc(brandName)}" /><div><div class="pr-brand">${esc(brandName)}</div><div class="pr-sub">${esc(companyTagline())}</div></div></div>
         <div class="pr-datestamp">${esc(bigDate)}</div>
       </div>
       <div class="pr-hazard" aria-hidden="true"></div>
@@ -16091,7 +16100,10 @@ function printInvoice(invoiceId) {
       </div>
       <div class="pr-groups">${groupsHtml}</div>
       <div class="pr-summary">
-        ${paid ? '<div class="pr-stamp" aria-hidden="true">Paid in Full</div>' : ''}
+        <div class="pr-cust">
+          ${custPhoto ? `<img class="pr-cust-photo" src="${esc(custPhoto)}" alt="" />` : ''}
+          ${paid ? `<div class="pr-stamp${custPhoto ? ' on-photo' : ''}" aria-hidden="true">Paid in Full</div>` : ''}
+        </div>
         <div class="pr-tot">
           <div><span>Grand Subtotal</span><span>${money2(t.subtotal)}</span></div>
           <div><span>Tax${t.exempt ? ' (exempt)' : ` (${(TAX_RATE * 100).toFixed(2)}%)`}</span><span>${t.exempt ? '—' : money2(t.tax)}</span></div>
@@ -16104,7 +16116,6 @@ function printInvoice(invoiceId) {
         ${logCol('Invoice Log', invoiceLog, false)}
         ${logCol('Rental Log', rentalLog, true)}
       </div>
-      <div class="pr-foot">Thank you for your business — much obliged. Questions on this ticket? Give the yard a holler${companyPhone() ? ` — ${esc(companyPhone())}` : ''}.</div>
     </div>`;
   document.body.classList.add('printing');
   const cleanup = () => { document.body.classList.remove('printing'); window.removeEventListener('afterprint', cleanup); };

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 18052 lines, 38 chapters
+## app.js — 18063 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -42,10 +42,10 @@
 | APP-32 | 12861–12864 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-33 | 12865–14470 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
 | APP-34 | 14471–15399 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15400–16567 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+79) |
-| APP-36 | 16568–17016 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 17017–17019 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 17020–18052 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+49) |
+| APP-35 | 15400–16578 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+79) |
+| APP-36 | 16579–17027 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 17028–17030 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 17031–18063 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+49) |
 
 ## config.js — 558 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 17923 lines, 38 chapters
+## app.js — 18044 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -42,10 +42,10 @@
 | APP-32 | 12861–12864 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-33 | 12865–14470 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
 | APP-34 | 14471–15399 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15400–16440 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 16441–16887 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16888–16890 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16891–17923 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+49) |
+| APP-35 | 15400–16559 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+78) |
+| APP-36 | 16560–17008 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 17009–17011 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 17012–18044 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+49) |
 
 ## config.js — 558 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 18044 lines, 38 chapters
+## app.js — 18052 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -42,10 +42,10 @@
 | APP-32 | 12861–12864 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-33 | 12865–14470 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
 | APP-34 | 14471–15399 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15400–16559 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+78) |
-| APP-36 | 16560–17008 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 17009–17011 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 17012–18044 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+49) |
+| APP-35 | 15400–16567 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+79) |
+| APP-36 | 16568–17016 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 17017–17019 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 17020–18052 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+49) |
 
 ## config.js — 558 lines, 0 chapters
 

--- a/style.css
+++ b/style.css
@@ -3775,13 +3775,15 @@ body.dragging .row.drop-ok { opacity: 1; }
   border-image: repeating-linear-gradient(90deg, var(--tan) 0 7px, transparent 7px 13px) 1;
 }
 
-/* ── #109 printable invoice → a kraft "YARD LOG" page (2026-07-08): ledger rule-lines,
-   a stamped Saira header with a hazard-stripe signature rule, machine glyphs per unit
-   line, groups per rental, a red BALANCE DUE + PAID stamp, a signature block, and a
-   customer-safe Amendments log. On screen #print-root is hidden; @media print swaps the
-   whole dark app out for it. Colors are a self-contained PAPER palette (deliberately
-   outside the dark-app tokens — this is white-paper output) and forced to render with
-   print-color-adjust so the kraft tint, red, stripe and stamp actually print. ── */
+/* ── #109 printable invoice → a kraft "YARD LOG" page (2026-07-08): our logo, a stamped
+   Saira header with a status-colored date stamp + hazard-stripe signature rule, each rental
+   in a SOFT CARD with a centered header + per-rental subtotal, machine glyphs per unit line,
+   a Grand Subtotal + status-colored BALANCE DUE + PAID stamp, and SEPARATE Invoice / Rental
+   amendment logs. The accent ink follows payment status — green (paid) / yellow (open, not
+   yet due) / red (past due) — via the .is-paid/.is-open/.is-due modifier on .pr-doc. On
+   screen #print-root is hidden; @media print swaps the whole dark app out for it. Colors are
+   a self-contained PAPER palette (deliberately outside the dark-app tokens — white-paper
+   output) forced to render with print-color-adjust. ── */
 #print-root { display: none; }
 @media print {
   body.printing > *:not(#print-root) { display: none !important; }
@@ -3789,74 +3791,67 @@ body.dragging .row.drop-ok { opacity: 1; }
   @page { margin: 12mm; }
 }
 .pr-doc {
-  --pr-ink: #14181d; --pr-mut: #6f6656; --pr-red: #c0271f; --pr-tan: #8a5a2b;
+  --pr-ink: #14181d; --pr-mut: #6f6656; --pr-tan: #8a5a2b;
   --pr-paper: #f7f2ea; --pr-rule: #e4dac6; --pr-line: #cdbfa6;
+  --pr-accent: #9a6b00; --pr-stripe: #f5c542;   /* default = open/caution; overridden per status below */
   position: relative; max-width: 760px; margin: 0 auto; padding: 20px 24px 26px;
   color: var(--pr-ink); background: var(--pr-paper);
   font-family: Geist, system-ui, sans-serif; font-size: 12.5px; line-height: 1.5;
   -webkit-print-color-adjust: exact; print-color-adjust: exact;
 }
-/* Header — stamped wordmark + brand mark, huge red date stamp, hazard-stripe signature */
+.pr-doc.is-paid { --pr-accent: #2e8b3d; --pr-stripe: #37a84a; }   /* paid in full → green */
+.pr-doc.is-open { --pr-accent: #9a6b00; --pr-stripe: #f5c542; }   /* open, not yet due → yellow */
+.pr-doc.is-due  { --pr-accent: #c0271f; --pr-stripe: #d1362a; }   /* past due → red */
+/* Header — our logo + stamped wordmark, status-colored date stamp, hazard-stripe signature */
 .pr-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
 .pr-brandwrap { display: flex; align-items: center; gap: 11px; }
-.pr-mark { display: inline-flex; }
-.pr-mark svg { width: 40px; height: 40px; color: var(--pr-ink); }
+.pr-logo { width: 46px; height: 46px; flex: 0 0 46px; border-radius: 10px; object-fit: cover; }
 .pr-brand { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 30px; letter-spacing: 1.2px; text-transform: uppercase; line-height: .95; }
 .pr-sub { font-family: 'Saira Condensed', sans-serif; font-size: 11px; letter-spacing: 1.4px; color: var(--pr-mut); text-transform: uppercase; margin-top: 2px; }
-.pr-datestamp { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 34px; letter-spacing: 1px; color: var(--pr-red); line-height: .9; text-align: right; white-space: nowrap; }
-.pr-hazard { height: 7px; margin: 10px 0 16px; border-radius: 2px; background: repeating-linear-gradient(135deg, #f5c542 0 11px, #14181d 11px 22px); }
+.pr-datestamp { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 34px; letter-spacing: 1px; color: var(--pr-accent); line-height: .9; text-align: right; white-space: nowrap; }
+.pr-hazard { height: 7px; margin: 10px 0 16px; border-radius: 2px; background: repeating-linear-gradient(135deg, var(--pr-stripe) 0 11px, #14181d 11px 22px); }
 /* Meta grid on saddle-stitch dotted rules */
 .pr-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 3px 26px; margin-bottom: 16px; }
 .pr-meta > div { display: flex; justify-content: space-between; gap: 12px; border-bottom: 1px dotted var(--pr-line); padding: 3px 0; }
 .pr-k { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10.5px; color: var(--pr-mut); }
 .pr-v { font-weight: 600; }
-/* Line table — ledger rule-lines, grouped by rental */
-.pr-lines { width: 100%; border-collapse: collapse; margin-bottom: 12px; }
-.pr-lines thead th { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 10.5px; color: var(--pr-mut); text-align: left; border-bottom: 2px solid var(--pr-ink); padding: 5px 4px; }
-.pr-lines thead th.r, td.pr-amt, td.pr-grp-sub, .pr-tot .r { text-align: right; }
-.pr-empty { color: var(--pr-mut); font-style: italic; padding: 8px 4px; }
-/* Group header row (saddle-stitch top rule) */
-tr.pr-grp > td { padding: 9px 4px 4px; border-top: 2px dashed var(--pr-tan); vertical-align: bottom; break-inside: avoid; break-after: avoid; }
-.pr-lines tbody tr.pr-grp:first-child > td { border-top: none; }
-.pr-grp-h { display: flex; align-items: baseline; flex-wrap: wrap; gap: 8px; }
-.pr-grp-t { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 800; font-size: 12px; }
-.pr-grp-win { font-weight: 600; font-size: 12px; }
-.pr-grp-dur, .pr-grp-prov { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 10.5px; color: var(--pr-mut); }
-.pr-grp-prov { color: var(--pr-tan); }
-.pr-grp-sub { font-weight: 800; font-size: 12.5px; font-variant-numeric: tabular-nums; }
-/* Line rows */
-.pr-line td { padding: 5px 4px; border-bottom: 1px solid var(--pr-rule); }
-.pr-desc { display: flex; align-items: center; }
+/* Rental soft cards — centered header + per-rental subtotal, unit lines inside */
+.pr-groups { display: flex; flex-direction: column; gap: 9px; margin-bottom: 14px; }
+.pr-card { background: #fffdf8; border: 1px solid var(--pr-line); border-radius: 12px; padding: 9px 14px 6px; break-inside: avoid; }
+.pr-card-h { position: relative; text-align: center; padding-bottom: 6px; margin-bottom: 3px; border-bottom: 2px dashed var(--pr-tan); }
+.pr-card-t { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 13px; }
+.pr-card-m { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 10.5px; color: var(--pr-mut); margin-top: 1px; }
+.pr-card-m > span + span::before { content: ' · '; }
+.pr-card-m .pr-prov { color: var(--pr-tan); }
+.pr-card-sub { position: absolute; right: 0; top: 50%; transform: translateY(-50%); font-weight: 800; font-size: 13px; font-variant-numeric: tabular-nums; }
+.pr-line { display: flex; align-items: center; justify-content: space-between; padding: 4px 2px; border-bottom: 1px solid var(--pr-rule); }
+.pr-card-lines .pr-line:last-child { border-bottom: none; }
+.pr-desc { display: flex; align-items: center; min-width: 0; }
 .pr-ic { display: inline-flex; width: 17px; flex: 0 0 17px; margin-right: 9px; }
 .pr-ic svg { width: 17px; height: 17px; color: var(--pr-ink); vertical-align: middle; }
 .pr-ic .cat-glyph, .pr-ic .cat-glyph * { animation: none !important; }
 .pr-nm { font-weight: 600; }
 .pr-cat, .pr-mt { color: var(--pr-mut); }
 .pr-cat::before, .pr-mt::before { content: ' · '; }
-.pr-mt { font-variant-numeric: tabular-nums; }
-.pr-amt { font-variant-numeric: tabular-nums; white-space: nowrap; }
-/* Totals */
-.pr-tot { margin-left: auto; width: 300px; break-inside: avoid; }
+.pr-amt { font-variant-numeric: tabular-nums; white-space: nowrap; padding-left: 12px; font-weight: 600; }
+.pr-empty { color: var(--pr-mut); font-style: italic; padding: 8px 4px; }
+/* Totals — the PAID stamp (when paid) rides the open space to their left */
+.pr-summary { display: flex; align-items: center; break-inside: avoid; }
+.pr-tot { margin-left: auto; flex: 0 0 300px; }
 .pr-tot > div { display: flex; justify-content: space-between; padding: 4px 0; border-bottom: 1px dotted var(--pr-line); }
 .pr-tot .pr-big { font-weight: 800; font-size: 15px; border-bottom: 2px solid var(--pr-ink); }
-.pr-tot .pr-due { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 17px; color: var(--pr-red); border-bottom: none; padding-top: 8px; }
-/* PAID rubber stamp */
-.pr-stamp { position: absolute; right: 34px; bottom: 168px; transform: rotate(-11deg); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 22px; color: var(--pr-red); border: 3px solid var(--pr-red); border-radius: 6px; padding: 5px 14px; opacity: .82; }
-/* Signature block */
-.pr-sign { display: grid; grid-template-columns: 1fr 1fr 150px; gap: 22px; margin: 26px 0 6px; break-inside: avoid; }
-.pr-sig { display: flex; flex-direction: column; gap: 4px; }
-.pr-sig-r { border-bottom: 1.5px solid var(--pr-ink); height: 20px; }
-.pr-sig-l { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 10px; color: var(--pr-mut); }
-/* Amendments log */
-.pr-amend { margin-top: 18px; border-top: 2px dashed var(--pr-tan); padding-top: 10px; break-inside: avoid; }
-.pr-amend-h { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12px; margin-bottom: 6px; }
-.pr-am-row { display: flex; gap: 12px; padding: 3px 0; border-bottom: 1px dotted var(--pr-line); font-size: 11.5px; }
-.pr-am-when { flex: 0 0 100px; font-family: 'Saira Condensed', sans-serif; letter-spacing: .5px; color: var(--pr-mut); text-transform: uppercase; font-size: 10.5px; padding-top: 1px; }
+.pr-tot .pr-due { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 17px; color: var(--pr-accent); border-bottom: none; padding-top: 8px; }
+/* PAID rubber stamp (only shown when paid → inherits the green accent) */
+.pr-stamp { margin-left: 34px; transform: rotate(-8deg); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 23px; color: var(--pr-accent); border: 3px solid var(--pr-accent); border-radius: 6px; padding: 6px 16px; opacity: .85; }
+/* Separated amendment logs — Invoice Log (left) · Rental Log (right) */
+.pr-logs { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; margin-top: 16px; padding-top: 10px; border-top: 2px dashed var(--pr-tan); break-inside: avoid; }
+.pr-log-h { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12px; margin-bottom: 6px; }
+.pr-am-row { display: flex; gap: 10px; padding: 3px 0; border-bottom: 1px dotted var(--pr-line); font-size: 11px; }
+.pr-am-when { flex: 0 0 104px; font-family: 'Saira Condensed', sans-serif; letter-spacing: .3px; color: var(--pr-mut); text-transform: uppercase; font-size: 10px; padding-top: 1px; }
 .pr-am-tx em { color: var(--pr-mut); font-style: italic; }
-.pr-am-empty { color: var(--pr-mut); font-style: italic; font-size: 11.5px; }
+.pr-am-empty { color: var(--pr-mut); font-style: italic; font-size: 11px; }
 /* Footer */
-.pr-foot { margin-top: 22px; padding-top: 10px; border-top: 1px solid var(--pr-rule); display: flex; justify-content: space-between; align-items: baseline; gap: 16px; font-size: 11px; color: var(--pr-mut); }
-.pr-foot-mark { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; white-space: nowrap; }
+.pr-foot { margin-top: 20px; padding-top: 10px; border-top: 1px solid var(--pr-rule); font-size: 11px; color: var(--pr-mut); }
 
 /* ── KPI MASK — remove this block to restore ring visibility (Jac) ── */
 .kpi-ring, .big-ring, .menu-team-ring { filter: blur(12px); pointer-events: none; }

--- a/style.css
+++ b/style.css
@@ -3775,32 +3775,88 @@ body.dragging .row.drop-ok { opacity: 1; }
   border-image: repeating-linear-gradient(90deg, var(--tan) 0 7px, transparent 7px 13px) 1;
 }
 
-/* ── #109 printable invoice — a clean white customer document, not the dark yard UI.
-   On screen it's hidden; @media print swaps the whole app out for #print-root. ── */
+/* ── #109 printable invoice → a kraft "YARD LOG" page (2026-07-08): ledger rule-lines,
+   a stamped Saira header with a hazard-stripe signature rule, machine glyphs per unit
+   line, groups per rental, a red BALANCE DUE + PAID stamp, a signature block, and a
+   customer-safe Amendments log. On screen #print-root is hidden; @media print swaps the
+   whole dark app out for it. Colors are a self-contained PAPER palette (deliberately
+   outside the dark-app tokens — this is white-paper output) and forced to render with
+   print-color-adjust so the kraft tint, red, stripe and stamp actually print. ── */
 #print-root { display: none; }
 @media print {
   body.printing > *:not(#print-root) { display: none !important; }
   body.printing #print-root { display: block; }
-  @page { margin: 18mm; }
+  @page { margin: 12mm; }
 }
-.pr-doc { color: #14181d; background: #fff; font-family: Geist, system-ui, sans-serif; font-size: 13px; line-height: 1.5; max-width: 720px; }
-.pr-head { border-bottom: 2px solid #14181d; padding-bottom: 10px; margin-bottom: 16px; }
-.pr-brand { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 30px; letter-spacing: 1.5px; text-transform: uppercase; }
-.pr-sub { font-size: 11.5px; letter-spacing: .5px; color: #5a626e; text-transform: uppercase; }
-.pr-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 24px; margin-bottom: 18px; }
-.pr-meta > div { display: flex; justify-content: space-between; gap: 12px; border-bottom: 1px dotted #c3c9d2; padding: 3px 0; }
-.pr-k { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 11px; color: #5a626e; }
+.pr-doc {
+  --pr-ink: #14181d; --pr-mut: #6f6656; --pr-red: #c0271f; --pr-tan: #8a5a2b;
+  --pr-paper: #f7f2ea; --pr-rule: #e4dac6; --pr-line: #cdbfa6;
+  position: relative; max-width: 760px; margin: 0 auto; padding: 20px 24px 26px;
+  color: var(--pr-ink); background: var(--pr-paper);
+  font-family: Geist, system-ui, sans-serif; font-size: 12.5px; line-height: 1.5;
+  -webkit-print-color-adjust: exact; print-color-adjust: exact;
+}
+/* Header — stamped wordmark + brand mark, huge red date stamp, hazard-stripe signature */
+.pr-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
+.pr-brandwrap { display: flex; align-items: center; gap: 11px; }
+.pr-mark { display: inline-flex; }
+.pr-mark svg { width: 40px; height: 40px; color: var(--pr-ink); }
+.pr-brand { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 30px; letter-spacing: 1.2px; text-transform: uppercase; line-height: .95; }
+.pr-sub { font-family: 'Saira Condensed', sans-serif; font-size: 11px; letter-spacing: 1.4px; color: var(--pr-mut); text-transform: uppercase; margin-top: 2px; }
+.pr-datestamp { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 34px; letter-spacing: 1px; color: var(--pr-red); line-height: .9; text-align: right; white-space: nowrap; }
+.pr-hazard { height: 7px; margin: 10px 0 16px; border-radius: 2px; background: repeating-linear-gradient(135deg, #f5c542 0 11px, #14181d 11px 22px); }
+/* Meta grid on saddle-stitch dotted rules */
+.pr-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 3px 26px; margin-bottom: 16px; }
+.pr-meta > div { display: flex; justify-content: space-between; gap: 12px; border-bottom: 1px dotted var(--pr-line); padding: 3px 0; }
+.pr-k { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10.5px; color: var(--pr-mut); }
 .pr-v { font-weight: 600; }
-.pr-lines { width: 100%; border-collapse: collapse; margin-bottom: 14px; }
-.pr-lines th { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 11px; color: #5a626e; text-align: left; border-bottom: 1.5px solid #14181d; padding: 5px 4px; }
-.pr-lines td { padding: 6px 4px; border-bottom: 1px solid #e4e8ee; }
-.pr-lines .r, .pr-tot .r { text-align: right; }
-.pr-empty { color: #8a93a6; font-style: italic; }
-.pr-tot { margin-left: auto; width: 280px; }
-.pr-tot > div { display: flex; justify-content: space-between; padding: 4px 0; border-bottom: 1px dotted #c3c9d2; }
-.pr-tot .pr-big { font-weight: 800; font-size: 15px; border-bottom: 2px solid #14181d; }
-.pr-tot .pr-due { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 15px; border-bottom: none; padding-top: 8px; }
-.pr-foot { margin-top: 28px; padding-top: 10px; border-top: 1px solid #e4e8ee; font-size: 11.5px; color: #5a626e; }
+/* Line table — ledger rule-lines, grouped by rental */
+.pr-lines { width: 100%; border-collapse: collapse; margin-bottom: 12px; }
+.pr-lines thead th { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 10.5px; color: var(--pr-mut); text-align: left; border-bottom: 2px solid var(--pr-ink); padding: 5px 4px; }
+.pr-lines thead th.r, td.pr-amt, td.pr-grp-sub, .pr-tot .r { text-align: right; }
+.pr-empty { color: var(--pr-mut); font-style: italic; padding: 8px 4px; }
+/* Group header row (saddle-stitch top rule) */
+tr.pr-grp > td { padding: 9px 4px 4px; border-top: 2px dashed var(--pr-tan); vertical-align: bottom; break-inside: avoid; break-after: avoid; }
+.pr-lines tbody tr.pr-grp:first-child > td { border-top: none; }
+.pr-grp-h { display: flex; align-items: baseline; flex-wrap: wrap; gap: 8px; }
+.pr-grp-t { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 800; font-size: 12px; }
+.pr-grp-win { font-weight: 600; font-size: 12px; }
+.pr-grp-dur, .pr-grp-prov { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 10.5px; color: var(--pr-mut); }
+.pr-grp-prov { color: var(--pr-tan); }
+.pr-grp-sub { font-weight: 800; font-size: 12.5px; font-variant-numeric: tabular-nums; }
+/* Line rows */
+.pr-line td { padding: 5px 4px; border-bottom: 1px solid var(--pr-rule); }
+.pr-desc { display: flex; align-items: center; }
+.pr-ic { display: inline-flex; width: 17px; flex: 0 0 17px; margin-right: 9px; }
+.pr-ic svg { width: 17px; height: 17px; color: var(--pr-ink); vertical-align: middle; }
+.pr-ic .cat-glyph, .pr-ic .cat-glyph * { animation: none !important; }
+.pr-nm { font-weight: 600; }
+.pr-cat, .pr-mt { color: var(--pr-mut); }
+.pr-cat::before, .pr-mt::before { content: ' · '; }
+.pr-mt { font-variant-numeric: tabular-nums; }
+.pr-amt { font-variant-numeric: tabular-nums; white-space: nowrap; }
+/* Totals */
+.pr-tot { margin-left: auto; width: 300px; break-inside: avoid; }
+.pr-tot > div { display: flex; justify-content: space-between; padding: 4px 0; border-bottom: 1px dotted var(--pr-line); }
+.pr-tot .pr-big { font-weight: 800; font-size: 15px; border-bottom: 2px solid var(--pr-ink); }
+.pr-tot .pr-due { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 17px; color: var(--pr-red); border-bottom: none; padding-top: 8px; }
+/* PAID rubber stamp */
+.pr-stamp { position: absolute; right: 34px; bottom: 168px; transform: rotate(-11deg); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 22px; color: var(--pr-red); border: 3px solid var(--pr-red); border-radius: 6px; padding: 5px 14px; opacity: .82; }
+/* Signature block */
+.pr-sign { display: grid; grid-template-columns: 1fr 1fr 150px; gap: 22px; margin: 26px 0 6px; break-inside: avoid; }
+.pr-sig { display: flex; flex-direction: column; gap: 4px; }
+.pr-sig-r { border-bottom: 1.5px solid var(--pr-ink); height: 20px; }
+.pr-sig-l { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 10px; color: var(--pr-mut); }
+/* Amendments log */
+.pr-amend { margin-top: 18px; border-top: 2px dashed var(--pr-tan); padding-top: 10px; break-inside: avoid; }
+.pr-amend-h { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12px; margin-bottom: 6px; }
+.pr-am-row { display: flex; gap: 12px; padding: 3px 0; border-bottom: 1px dotted var(--pr-line); font-size: 11.5px; }
+.pr-am-when { flex: 0 0 100px; font-family: 'Saira Condensed', sans-serif; letter-spacing: .5px; color: var(--pr-mut); text-transform: uppercase; font-size: 10.5px; padding-top: 1px; }
+.pr-am-tx em { color: var(--pr-mut); font-style: italic; }
+.pr-am-empty { color: var(--pr-mut); font-style: italic; font-size: 11.5px; }
+/* Footer */
+.pr-foot { margin-top: 22px; padding-top: 10px; border-top: 1px solid var(--pr-rule); display: flex; justify-content: space-between; align-items: baseline; gap: 16px; font-size: 11px; color: var(--pr-mut); }
+.pr-foot-mark { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; white-space: nowrap; }
 
 /* ── KPI MASK — remove this block to restore ring visibility (Jac) ── */
 .kpi-ring, .big-ring, .menu-team-ring { filter: blur(12px); pointer-events: none; }

--- a/style.css
+++ b/style.css
@@ -3793,20 +3793,20 @@ body.dragging .row.drop-ok { opacity: 1; }
 .pr-doc {
   --pr-ink: #14181d; --pr-mut: #6f6656; --pr-tan: #8a5a2b;
   --pr-paper: #f7f2ea; --pr-rule: #e4dac6; --pr-line: #cdbfa6;
-  --pr-accent: #9a6b00; --pr-stripe: #f5c542;   /* default = open/caution; overridden per status below */
+  --pr-accent: #e08a00; --pr-stripe: #ffc21c;   /* default = open/caution; overridden per status below */
   position: relative; max-width: 760px; margin: 0 auto; padding: 20px 24px 26px;
   color: var(--pr-ink); background: var(--pr-paper);
   font-family: Geist, system-ui, sans-serif; font-size: 12.5px; line-height: 1.5;
   -webkit-print-color-adjust: exact; print-color-adjust: exact;
 }
-.pr-doc.is-paid { --pr-accent: #2e8b3d; --pr-stripe: #37a84a; }   /* paid in full → green */
-.pr-doc.is-open { --pr-accent: #9a6b00; --pr-stripe: #f5c542; }   /* open, not yet due → yellow */
-.pr-doc.is-due  { --pr-accent: #c0271f; --pr-stripe: #d1362a; }   /* past due → red */
+.pr-doc.is-paid { --pr-accent: #2f9e44; --pr-stripe: #37b04d; }   /* paid in full → green */
+.pr-doc.is-open { --pr-accent: #e08a00; --pr-stripe: #ffc21c; }   /* open, not yet due → vibrant amber-gold */
+.pr-doc.is-due  { --pr-accent: #e11507; --pr-stripe: #ff3a20; }   /* past due → vibrant red */
 /* Header — our logo + stamped wordmark, status-colored date stamp, hazard-stripe signature */
 .pr-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
 .pr-brandwrap { display: flex; align-items: center; gap: 11px; }
 .pr-logo { width: 46px; height: 46px; flex: 0 0 46px; border-radius: 10px; object-fit: cover; }
-.pr-brand { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 30px; letter-spacing: 1.2px; text-transform: uppercase; line-height: .95; }
+.pr-brand { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 30px; letter-spacing: .5px; line-height: .95; }
 .pr-sub { font-family: 'Saira Condensed', sans-serif; font-size: 11px; letter-spacing: 1.4px; color: var(--pr-mut); text-transform: uppercase; margin-top: 2px; }
 .pr-datestamp { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 34px; letter-spacing: 1px; color: var(--pr-accent); line-height: .9; text-align: right; white-space: nowrap; }
 .pr-hazard { height: 7px; margin: 10px 0 16px; border-radius: 2px; background: repeating-linear-gradient(135deg, var(--pr-stripe) 0 11px, #14181d 11px 22px); }
@@ -3815,15 +3815,15 @@ body.dragging .row.drop-ok { opacity: 1; }
 .pr-meta > div { display: flex; justify-content: space-between; gap: 12px; border-bottom: 1px dotted var(--pr-line); padding: 3px 0; }
 .pr-k { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10.5px; color: var(--pr-mut); }
 .pr-v { font-weight: 600; }
-/* Rental soft cards — centered header + per-rental subtotal, unit lines inside */
+/* Rental soft cards — single-line header (bold title first, then meta, subtotal right) */
 .pr-groups { display: flex; flex-direction: column; gap: 9px; margin-bottom: 14px; }
 .pr-card { background: #fffdf8; border: 1px solid var(--pr-line); border-radius: 12px; padding: 9px 14px 6px; break-inside: avoid; }
-.pr-card-h { position: relative; text-align: center; padding-bottom: 6px; margin-bottom: 3px; border-bottom: 2px dashed var(--pr-tan); }
-.pr-card-t { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 13px; }
-.pr-card-m { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 10.5px; color: var(--pr-mut); margin-top: 1px; }
+.pr-card-h { display: flex; align-items: baseline; gap: 9px; padding-bottom: 6px; margin-bottom: 3px; border-bottom: 2px dashed var(--pr-tan); }
+.pr-card-t { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 13px; white-space: nowrap; }
+.pr-card-m { flex: 1 1 auto; font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 10.5px; color: var(--pr-mut); }
 .pr-card-m > span + span::before { content: ' · '; }
 .pr-card-m .pr-prov { color: var(--pr-tan); }
-.pr-card-sub { position: absolute; right: 0; top: 50%; transform: translateY(-50%); font-weight: 800; font-size: 13px; font-variant-numeric: tabular-nums; }
+.pr-card-sub { margin-left: auto; font-weight: 800; font-size: 13px; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .pr-line { display: flex; align-items: center; justify-content: space-between; padding: 4px 2px; border-bottom: 1px solid var(--pr-rule); }
 .pr-card-lines .pr-line:last-child { border-bottom: none; }
 .pr-desc { display: flex; align-items: center; min-width: 0; }
@@ -3835,14 +3835,18 @@ body.dragging .row.drop-ok { opacity: 1; }
 .pr-cat::before, .pr-mt::before { content: ' · '; }
 .pr-amt { font-variant-numeric: tabular-nums; white-space: nowrap; padding-left: 12px; font-weight: 600; }
 .pr-empty { color: var(--pr-mut); font-style: italic; padding: 8px 4px; }
-/* Totals — the PAID stamp (when paid) rides the open space to their left */
-.pr-summary { display: flex; align-items: center; break-inside: avoid; }
-.pr-tot { margin-left: auto; flex: 0 0 300px; }
+/* Totals + the customer's account photo on the left (muted to blend); the PAID stamp
+   overlays the photo when present, else stands alone in that space */
+.pr-summary { display: flex; align-items: center; gap: 16px; break-inside: avoid; }
+.pr-cust { position: relative; display: flex; align-items: center; margin-right: auto; }
+.pr-cust-photo { width: 108px; height: 108px; border-radius: 50%; object-fit: cover; border: 2px solid var(--pr-tan); filter: grayscale(.55) sepia(.16) contrast(.96) brightness(1.03); opacity: .9; }
+.pr-tot { flex: 0 0 300px; }
 .pr-tot > div { display: flex; justify-content: space-between; padding: 4px 0; border-bottom: 1px dotted var(--pr-line); }
 .pr-tot .pr-big { font-weight: 800; font-size: 15px; border-bottom: 2px solid var(--pr-ink); }
 .pr-tot .pr-due { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 17px; color: var(--pr-accent); border-bottom: none; padding-top: 8px; }
-/* PAID rubber stamp (only shown when paid → inherits the green accent) */
-.pr-stamp { margin-left: 34px; transform: rotate(-8deg); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 23px; color: var(--pr-accent); border: 3px solid var(--pr-accent); border-radius: 6px; padding: 6px 16px; opacity: .85; }
+/* PAID rubber stamp — inherits the status accent (green when paid) */
+.pr-stamp { transform: rotate(-8deg); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 22px; color: var(--pr-accent); border: 3px solid var(--pr-accent); border-radius: 6px; padding: 6px 15px; opacity: .9; background: rgba(247, 242, 234, .66); }
+.pr-stamp.on-photo { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%) rotate(-8deg); }
 /* Separated amendment logs — Invoice Log (left) · Rental Log (right) */
 .pr-logs { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; margin-top: 16px; padding-top: 10px; border-top: 2px dashed var(--pr-tan); break-inside: avoid; }
 .pr-log-h { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12px; margin-bottom: 6px; }


### PR DESCRIPTION
Reshapes the customer-facing invoice print/PDF into a kraft **"yard log"** page and restructures what it shows. Screenshots posted in the session chat (partial-balance + paid-in-full).

## What changed
- **Grouped by rental**, newest→oldest window. Unlinked manual lines fall to a trailing **"Additional charges"** group (no window/duration).
- **Rich group headers:** rental window · duration (2 Days / 2 Weeks / 1 Month) · provenance (**Merged from 216i** / **Extension of 216i**) · **per-rental subtotal**.
- **Category on each line** — `White · Mini Excavator · 1-Day×2` — with the family machine glyph via `categoryIconFor()`.
- **"Grand Subtotal"** replaces the old "Subtotal" label.
- **Customer-safe Amendments log:** the invoice's + its rentals' actions, timestamped, oldest→newest, with internal ops detail scrubbed (staff names, pricing locks, Mr. Wrangler, card/ACH, mechanic/GPS) and internal-but-relevant wording translated to plain language.
- **Yard-log styling:** stamped Saira header + brand mark, hazard-stripe signature rule, red date + `BALANCE DUE`, PAID-IN-FULL stamp, signature/authorization block, "A JacTec Service" footer. Kraft palette is self-contained (paper output) and forced to print via `print-color-adjust`.

## Supporting changes
- `mergeInvoiceInto` now stamps a `fromInv` tag on moved lines so **"Merged from"** provenance is reliable going forward (additive; does not affect totals).
- Exposed `printInvoice` / `invoicePrintGroups` / `invoiceAmendments` on the `__rw` test seam for headless screenshot/e2e.
- Regenerated the code-map index.

## Design + decisions
- Ran through `/jactec-ui` (yard data-plate language). Jac chose the **yard-log PAGE** direction (keeps the notebook's soul, drops the wood desk / coffee stain so it prints clean and on-brand) over a faithful skeuomorphic repro, and a **customer-safe curated** Actions Log over the full internal log.
- The print doc has no `data-r` stamped elements (it's a print artifact, not interactive app UI), so the R-Rulebook / WINDOW_CATALOG are unaffected.

## Gates
- `node ci/smoke.mjs` ✓
- `node ci/logic-test.mjs` ✓ (408/408)
- `node ci/gen-rule-usage.mjs --check` ✓
- `node ci/check-window-catalog.mjs` ✓
- `node tools/gen-code-map.mjs --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193tZN63kacw2F8oY7D8eCc

---
_Generated by [Claude Code](https://claude.ai/code/session_0193tZN63kacw2F8oY7D8eCc)_