### PR TITLE
Spec sync: Shop-card retirement + A2P/SMS compliance (2026-07-08)

### DIFF
--- a/docs/specs/comms-notifications.md
+++ b/docs/specs/comms-notifications.md
@@ -20,6 +20,18 @@ These resolve the §11 Open Questions. **Priority note:** Jac wants this built *
 
 **Defaults adopted:** Q-2 → consent `unknown` = implied for **transactional** (quotes/reminders; quick legal check, marketing needs express opt-in) · Q-16 → **hard-block opted-out**, no override · Q-7 → **record-only** recipients (no ad-hoc numbers) · Q-9/Q-17 → `messages` log is **server-only** (on-demand fetch; PII never synced) · Q-8b → history phone lines **masked** · Q-13/Q-14 → templates in a **server-side registry**, hardcoded v1 · Q-11 → channel **stop-on-fail** for automated · Q-15 → daily send-cap as an admin setting · Q-10 → quiet hours **America/Chicago**, server-computed.
 
+## ✅ Decisions / status — 2026-07-07/08 (Jac) — A2P/10DLC compliance + Comms Rail
+
+- **D5 · Comms Rail shipped & merged (#501).** The four-category bottom rail — single-open law (open one, previous closes), Team chat + Mr. Wrangler migrated onto the rail engine. Canon: the D8/D9 addendum later in this doc.
+- **⚠️ D6 · A2P/10DLC registration runs on TWILIO — appears to SUPERSEDE D1's Mocean choice for the registered outbound SMS (CONFIRM).** This session's carrier registration, brand (approved), 10DLC campaign, and the sending number (`+1 337 607 1352`) are all **Twilio**. Either the provider decision changed from Mocean → Twilio, or both are in play — **flag for Jac to reconcile D1.** The `sendCustomerMessage` server contract stays provider-agnostic regardless.
+- **D7 · Public compliance pages are LIVE (Pages, alongside the app).** `privacy.html` + `sms-terms.html` (#497, merged) carry the carrier-mandated language: transactional-only purpose, **message frequency varies**, **msg & data rates may apply**, **STOP**/**HELP**, and the explicit **"we do not sell/share your mobile number or messaging consent with third parties/affiliates for marketing"** clause. `sample-quote.html` (#523, → `main`) is a **public, no-login** sample of what a quote/invoice text-link opens — added because the A2P reviewer must be able to open message links (real per-customer quote/invoice links are login-gated).
+- **D8 · A2P campaign CTA-verification saga (root cause on record).** The 10DLC campaign was **rejected twice** for "issues verifying the Call to Action." Root cause: message links pointed to **login-gated** pages the reviewer couldn't open. Fix = the public `sample-quote.html` + a resubmission packet (opt-in/message-flow text pointing at the three public URLs, cleaned sample messages, keep "Embedded links" checked). Resubmitted; **approval outcome pending.**
+- **D9 · Opt-in/out/help keywords (for the registration + future inbound handling).** Opt-in: `START,YES,UNSTOP,SUBSCRIBE,JOIN,BEGIN,RESUME,OPTIN`. Opt-out: `STOP,STOPALL,UNSUBSCRIBE,CANCEL,END,QUIT`. Help: `HELP,INFO`. Each paired with a compliant confirmation message (brand · frequency · rates · STOP/HELP). Primary opt-in is **offline** (in person / by phone at rental or account signup) — described in the campaign message-flow field; no public web opt-in form.
+
+**🔴 Known open blockers (see the session Parked list):**
+- The Twilio number `+1 337 607 1352` is **not attached to a Messaging Service** (`messaging_service_sid: null`) → sends fail **error 30034** until Jac attaches it (Console → Messaging → Services). Independent of campaign approval.
+- **Inbound keyword auto-reply handlers** (a real `START`/`HELP`/`STOP` from a customer triggering the right reply in the GAS SMS pipe) are **declared in the registration but not yet built** in the backend — offered, parked.
+
 ---
 
 ## 1. Goal & Problem

--- a/docs/specs/maintenance-shop.md
+++ b/docs/specs/maintenance-shop.md
@@ -1,11 +1,13 @@
 # Maintenance / Shop — SPEC v1 (DRAFT)
 
-**Date:** 2026-06-28
+**Date:** 2026-06-28 (updated 2026-07-08)
 **Status:** DRAFT — for critique
 **Area branch:** `area/maintenance-shop`
 **Task branch:** `maintenance-shop/spec` (proposed)
 **Maturity:** shipped
-**Scope:** The merged Shop card (Work Orders, Service Orders, Inspections), the recurring-service countdown engine, WO lifecycle/parts/billing, the inspection → auto-WO cascade, and the parts/vendor back-office boards.
+**Scope:** ~~The merged Shop card~~ (RETIRED 2026-07-07 — see the D5 note below; WO/Service/Inspections now render inside a Unit's detail, owned by `units-fleet`), the recurring-service countdown engine, WO lifecycle/parts/billing, the inspection → auto-WO cascade, and the parts/vendor back-office boards.
+
+> ⚠️ **2026-07-07 canon shift:** §2.1 below still describes the standalone **Shop card** as live — that card was **retired** on `area/units-fleet` (units-fleet §2.7 / D5). The engine described in this spec (WO lifecycle, service countdown, parts/vendor boards, inspection cascade) is unchanged and still canon; only the **front-end surface moved** — Work Orders, the per-unit Services list, and Inspections now render inside a **Unit's own detail**, and the Units card carries the cross-fleet worklist. Read §2.1's "merged Shop card" as historical; the boards + engine remain here.
 
 ---
 
@@ -19,6 +21,15 @@ These resolve the §11 Open Questions and **supersede the §3 target-state money
 - **D4 · Field Call billing defaults to No (resolves OQ-6).** A field-call WO defaults `billCustomer:'No'` — the shop eats it unless someone explicitly decides to bill (customer-relations-conservative).
 
 **Defaults adopted:** OQ-7 → manager can override the photo-proof service completion · OQ-9 → confirm on a **backwards** hour-meter entry · OQ-10 → a cancelled WO with real work must be **reopened before billing** (no stranded cost) · OQ-8 → drivers can request a wash · OQ-4 → keep explicit Complete-WO (no auto-complete) · OQ-3 → 3-bar front page defaults for mechanic/M.Tech · OQ-5 → parts `partId` FK in Phase 3.
+
+## ✅ Decisions — 2026-07-07/08 (Jac) — SHIPPED on `area/units-fleet`
+
+The Shop-side render surface and the D3 service-schedule blocker were resolved this session; the canonical spec for the shipped detail is **units-fleet §2.7 / D4–D8** (the Model entity lives in `units-fleet`). Cross-referenced here because it lands on this area's engine:
+
+- **D5 · Shop card RETIRED (units-fleet D5).** The standalone merged Shop card (§2.1) is gone. WO sections, the per-unit **Services** list, and the inspection segctl render inside a **Unit's detail**; the **Units** card carries the cross-fleet worklist (service-urgency sort + `__svcstat` filter + the stackbars graph via `graphViewsFor('units')`); mechanics land on Units at clock-in (`applyShopRoleLanding`); every WO/inspection/service ref resolves to the owning unit (`unitOfShopRec`). The **3-bar wrench graph** (§6.1, previously "approved-unbuilt") shipped in this new Units home.
+- **D3 RESOLVED → per-MODEL schedules.** OQ-2/D3 asked for per-category maker schedules + per-unit overrides. Shipped as a **per-Model** schedule (a new category-scoped **Model** entity — a category can standardize on one or a few real make/models), which is the better join point: `unitServiceRows(u)` prefers `IDX.model.get(u.modelId).tasks`, falling back honestly to the generic list. **Real production data is LIVE:** 63 models, 869 sourced tasks, 34 Drive-hosted OEM manuals, 233 fluid/part `detail` entries (double-extracted + capacity-verified; blanks left honest where a manual is silent).
+- **Service snooze (backlog #43)** and the **"hold their hands" mechanic surface** (fluid capacity/type + parts, per-task manual deep-links, editable parts reusing the WO `partform`, a side-by-side vendor/cost panel, and browse-the-parts-catalog attach) shipped — full canon in units-fleet §2.7 / D6–D7.
+- **Parts board reuse (ties OQ-5).** The parts catalog board (`DATA.parts`) gained a **pick mode** (`pickTarget`) so a service task can attach an existing catalog part (vendor/cost/OEM prefilled). The `partId` FK deepening from OQ-5 remains Phase 3; today a service task's `partRefs` carry `oem`/`vendorId` loosely, matched to the catalog by `productNumber`.
 
 ---
 


### PR DESCRIPTION
Cross-area spec updates from the 2026-07-07/08 session. Docs-only. (The code + the `units-fleet` spec itself live on `area/units-fleet`; this PR carries only the two **neighbor-area** specs so they don't ride inside the units-fleet area branch.)

## `docs/specs/maintenance-shop.md`
- Flags the **Shop card as RETIRED** (units-fleet D5): the merged Shop card described in §2.1 is gone; WO sections, the per-unit Services list, and the inspection segctl now render inside a **Unit's detail**, and the Units card carries the cross-fleet worklist. The engine (WO lifecycle, service countdown, parts/vendor boards, inspection cascade) is unchanged and still canon here.
- Records **D3 resolved** → the per-schedule "production blocker" shipped as **per-MODEL schedules** (new category-scoped Model entity), with real production data live (63 models / 869 tasks / 34 OEM manuals / 233 fluid+part detail entries).
- Notes the parts-board **pick mode** (ties OQ-5) and the mechanic "hold their hands" surface.

## `docs/specs/comms-notifications.md`
- Records the **Comms Rail** merge (#501).
- **⚠️ Flags a provider discrepancy for Jac:** D1 says SMS provider = **Mocean**, but this session's A2P/10DLC registration, brand, campaign, and number (`+1 337 607 1352`) are all **Twilio** — appears to supersede D1; needs reconciliation.
- Records the live public compliance pages (`privacy.html` / `sms-terms.html` / `sample-quote.html`), the **CTA-verification** rejection root cause + fix, and the opt-in/out/help **keyword sets**.
- Lists the open blockers: the number isn't attached to a Messaging Service (error 30034), and inbound keyword auto-reply handlers are declared-but-unbuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtNtp5ApjnkrT4XUvDvdaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtNtp5ApjnkrT4XUvDvdaQ)_