### PR TITLE
Stage inbound SMS keyword auto-reply (STOP/START/HELP) — A2P/10DLC compliance

### DIFF
--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -1,5 +1,29 @@
 # Backend deploy queue — ready the moment auth is unblocked (2026-07-06)
 
+## ⛔ STAGED, NOT DEPLOYED — SMS keyword auto-reply (2026-07-08, A2P/10DLC compliance)
+- **What:** inbound Twilio webhook handler (`smsInbound_`) so a real customer STOP/START/HELP
+  text actually flips `commsConsent.sms` on the customer record (the campaign registration
+  *declares* these keywords; this is what *handles* them). STOP/STOPALL/UNSUBSCRIBE/CANCEL/
+  END/QUIT → `commsConsent.sms = 'opted-out'`; START/YES/UNSTOP/SUBSCRIBE/JOIN/BEGIN/RESUME/
+  OPTIN → `'opted-in'`; HELP/INFO → info reply only. Any other inbound text is logged to the
+  customer's thread, not auto-replied to. Replies to the keyword itself go out via a direct
+  Twilio call (intentionally bypassing `sendCustomerMessage_`'s opt-out hard-block — the STOP/
+  START confirmation IS the compliance mechanism, not a message subject to consent).
+- **Source:** `docs/handoffs/sms-keyword-autoreply-backend.gs`. Depends on the already-live
+  Phase-1 SMS pipe (`customer-sms-backend.gs`, shipped 2026-07-06) for `smsNormalizePhone_` /
+  `messagesSheet_`.
+- **Wire-up:** `// Router: if (action === 'inboundSms' || e.parameter.MessageSid) return smsInbound_(e);`
+  (placed ahead of the JSON-body action switch — Twilio POSTs form-urlencoded). Needs a NEW
+  Script Property `TWILIO_INBOUND_TOKEN` (shared-secret webhook token — GAS can't read the
+  `X-Twilio-Signature` header, see the file's assumption #2) and the Twilio number's "A message
+  comes in" webhook pointed at the exec URL with that token in the query string. Also flip on
+  Twilio's "send opt-out keywords to my application" (Advanced Opt-Out) setting, or Twilio
+  intercepts STOP/START at the carrier level and this handler never fires.
+- **Consent field written:** `customer.commsConsent.sms` (shallow-merged; `email`/other keys
+  untouched) — matches the exact shape `sendCustomerMessage_` already reads for its hard-block.
+  See the file header for the full assumption if the live shape has drifted since 2026-07-06.
+- **Status:** staged, not deployed — **STOP-gated** (Jac's explicit go before any `/clasp` deploy).
+
 ## ✅ DEPLOYED — team-chat privacy (2026-07-08, Jac editor deploy)
 - **What:** `getChats_` / `setChats_` replaced with scoped + authorized versions (+ helpers
   `chatCanSee_` / `chatMergeMsgs_` / `chatMergeSeen_` / `chatAuthorizeWrite_`). Team-chat
@@ -84,6 +108,7 @@ https://script.google.com/d/1hw9A7Id3YIoiSCBkNFeDaKGRv-VtljFFIuBdQG5QULrgS0DjQhQ
 |---|---|---|---|---|
 | 1 | **perfReport** — Web-Vitals sink → `_perf` tab (5k-row FIFO, metrics-only by construction) | `perf-report-backend.gs` | `if (action === 'perfReport') return json(perfReport_(body));` (wrap in `json()` — `handle()` must return a ContentService output, not the bare `{ok:true}` the source's comment shows) | ✅ DEPLOYED @62 (2026-07-06) |
 | 2 | **unitDaily snapshots (M4)** — daily unit hours/fleet-status history | `unit-daily-snapshots.gs` | router line per that file + run `installUnitDailyTrigger()` ONCE | ✅ Already live @57 (2026-07-03) |
+| 3 | **SMS keyword auto-reply** — inbound Twilio STOP/START/HELP webhook (A2P/10DLC compliance) | `sms-keyword-autoreply-backend.gs` | `if (action === 'inboundSms' \|\| e.parameter.MessageSid) return smsInbound_(e);` (before the JSON-body switch — Twilio posts form fields) + new Script Property `TWILIO_INBOUND_TOKEN` + Twilio console webhook config | ⛔ staged, not deployed — STOP-gated |
 
 Deploy flow (same deployment id, same exec URL). **`push` via the API, then deploy from the
 EDITOR** — the API `deploy` breaks anonymous access (see the ⛔ section above):

--- a/docs/handoffs/sms-keyword-autoreply-backend.gs
+++ b/docs/handoffs/sms-keyword-autoreply-backend.gs
@@ -1,0 +1,261 @@
+/* SMS keyword auto-reply — inbound Twilio webhook handler
+ * (comms-notifications Phase 2/3, A2P/10DLC compliance: STOP/START/HELP)
+ *
+ * ADDITIVE splice for Code.gs (gitignored; pushed via the service-account path —
+ * see docs/handoffs/BACKEND-DEPLOY-QUEUE.md; go-live is Jac's editor deploy).
+ * The A2P 10DLC campaign registration DECLARES opt-in/opt-out/help keywords;
+ * this is the handler that actually HONORS a real inbound STOP/START/HELP from
+ * a customer instead of only registering the intent.
+ *
+ * DEPENDS ON helpers already LIVE in Code.gs from the Phase-1 SMS pipe
+ * (docs/handoffs/customer-sms-backend.gs, shipped 2026-07-06 per the comms
+ * spec's D5 addendum) — do not splice this file into a Code.gs that predates
+ * that phase:
+ *   smsNormalizePhone_(p)   — digits-only E.164-ish normalizer (also used to
+ *                             match the inbound `From` against a customer's
+ *                             stored `phone`)
+ *   messagesSheet_()        — the shared `messages` log tab ([id, json] rows)
+ *   readRecord_ / writeRecord_ / tryLock_ / todayIso_ / ss() — base Code.gs helpers
+ *
+ * ============================================================================
+ * ASSUMPTIONS / OPEN ITEMS — read before splicing or deploying
+ * ============================================================================
+ * 1. CONSENT FIELD (the compliance-critical one). This handler reads/writes
+ *    the customer record's:
+ *        customer.commsConsent = { sms: 'opted-in'|'opted-out'|'unknown',
+ *                                   email: 'opted-in'|'opted-out'|'unknown',
+ *                                   updatedAt: <epoch ms>, source: '...' }
+ *    per docs/specs/comms-notifications.md §4.2, and it is EXACTLY the shape
+ *    `sendCustomerMessage_`'s hard-block reads today:
+ *        var consent = (cust.commsConsent && cust.commsConsent[channel]) || 'unknown';
+ *        if (consent === 'opted-out') return { ok:false, reason:'opted-out' };
+ *    (see customer-sms-backend.gs line ~119-120). This handler only ever
+ *    touches the `sms` key — `email` and any other existing keys on the
+ *    object are read back and preserved verbatim (a shallow merge, not a
+ *    replace) so it can never accidentally clear email consent.
+ *    IF THE LIVE Code.gs's commsConsent SHAPE HAS DRIFTED from this since
+ *    2026-07-06, reconcile before splicing — a mismatch here means the STOP
+ *    handler silently writes a field the hard-block never reads, which is a
+ *    live compliance bug (customer thinks they opted out; sends continue).
+ * 2. WEBHOOK AUTHENTICITY / ANTI-SPOOF. The spec (§5.3) asks for the Twilio
+ *    `X-Twilio-Signature` HMAC to be verified before any state change. GAS
+ *    web-app doPost(e) does NOT expose incoming HTTP headers at all (a known
+ *    Apps Script limitation — `e` only has parameter/parameters/postData/
+ *    contentLength/queryString), so the header-based signature check as
+ *    literally specced CANNOT be implemented here. Workaround used (the
+ *    common pattern for GAS + Twilio): a shared-secret token embedded in the
+ *    webhook URL query string itself, e.g. `.../exec?wh=<TOKEN>&...`, read
+ *    back as `e.parameter.wh` and compared to a new Script Property
+ *    `TWILIO_INBOUND_TOKEN`. Configure the SAME token in both places. This is
+ *    weaker than a signed request (a leaked URL is a leaked secret) but is a
+ *    real bar against blind/opportunistic POSTs to the guessed exec URL.
+ *    Flag for Jac: confirm this substitution is acceptable, or front the
+ *    webhook with something that CAN read the header (e.g. a tiny Cloud
+ *    Function / Cloudflare Worker relay) if stricter verification is needed.
+ * 3. PROVIDER SHAPE. Written for TWILIO's inbound webhook fields (`From`,
+ *    `Body`, `To`, `MessageSid`, form-urlencoded) and replies via the Twilio
+ *    REST send path (TWILIO_SID/TWILIO_TOKEN/TWILIO_FROM — the same Script
+ *    Properties customer-sms-backend.gs already reads), per this task's
+ *    explicit brief ("Twilio posts inbound messages"). NOTE: the spec's D5
+ *    addendum (2026-07-06) instead names "the Mocean inbound webhook" as the
+ *    two-way channel. If Mocean ends up the primary inbound provider, this
+ *    parser needs a Mocean-shaped sibling (different field names and a
+ *    different signature/verification scheme) — don't assume this file
+ *    covers both.
+ * 4. UNKNOWN SENDER. An inbound from a phone number that matches no customer
+ *    record is NEVER auto-attached to any customer (anti-spoof, spec §10) —
+ *    keyword replies (STOP/START/HELP) still fire (they're generic, no PII),
+ *    but nothing is written to any customer record and non-keyword replies
+ *    from an unknown number are simply dropped (not logged), since there is
+ *    no customer thread to attach them to.
+ * 5. FIRST-WORD MATCHING. Per this task's brief, the body is trimmed,
+ *    uppercased, and only the FIRST WORD is matched against the keyword
+ *    sets (e.g. "Stop please" still matches). This is more lenient than
+ *    Twilio/CTIA's own default carrier-level matching (typically the ENTIRE
+ *    trimmed message must equal one keyword) — intentional per spec, but
+ *    worth knowing since it means a message that merely *starts* with STOP
+ *    text will opt someone out.
+ * 6. REPLIES BYPASS THE OPT-OUT HARD-BLOCK — ON PURPOSE. The STOP
+ *    confirmation, the START confirmation, and HELP are sent via a direct
+ *    Twilio call (`smsInboundReply_`), NOT through `sendCustomerMessage_`,
+ *    because that function would immediately re-block a STOP confirmation to
+ *    a number it just marked opted-out. This is not a violation of the
+ *    "hard-block opted-out, no override" rule (spec Q-16) — the opt-out/
+ *    opt-in/HELP confirmations are the compliance mechanism ITSELF (CTIA/
+ *    TCPA require exactly these system replies regardless of opt state);
+ *    they are not a marketing/transactional message riding the customer's
+ *    consent. No other message type gets this bypass.
+ *
+ * ============================================================================
+ * WIRE-UP
+ * ============================================================================
+ * Router (Twilio POSTs application/x-www-form-urlencoded — not the app's own
+ * JSON `{action:...}` body — so route on MessageSid ahead of the normal
+ * action switch, before the JSON body is parsed/required):
+ *     // Router: if (action === 'inboundSms' || e.parameter.MessageSid) return smsInbound_(e);
+ * `smsInbound_` returns a raw TwiML `ContentService` XML output (empty
+ * `<Response></Response>`), NOT `json(...)` — Twilio's webhook expects a
+ * TwiML body (or empty 200), not the app's `{ok:...}` envelope. The actual
+ * reply text goes out via a separate outbound Twilio API call, not inline
+ * TwiML, so it lands in the `messages` log like every other send.
+ *
+ * Twilio console config:
+ *  - Phone number → Messaging → "A message comes in" → Webhook, POST, pointed
+ *    at the exec URL with the shared-secret query param from assumption #2
+ *    appended, e.g. `https://script.google.com/macros/s/AKfycb.../exec?wh=...`.
+ *  - Advanced Opt-Out: Twilio can intercept STOP/START at the carrier level
+ *    and auto-reply WITHOUT ever forwarding the message to our webhook. If
+ *    that's on, our own `commsConsent` never learns about the opt-out. Enable
+ *    "Send inbound messages for opt-out keywords to my application" (the
+ *    Messaging Service / Advanced Opt-Out setting) so this handler still
+ *    fires and records the opt-out in our data — this is *why* the handler
+ *    must be idempotent (task brief): Twilio may ALSO auto-reply on its own,
+ *    and our handler may fire on top of that.
+ *
+ * Script Properties (names only, set in the editor — never in this repo):
+ *   TWILIO_SID / TWILIO_TOKEN / TWILIO_FROM   — already required by
+ *                                                customer-sms-backend.gs
+ *   TWILIO_INBOUND_TOKEN                      — NEW (assumption #2), the
+ *                                                shared-secret webhook token
+ */
+
+var SMS_STOP_WORDS_ = { STOP: 1, STOPALL: 1, UNSUBSCRIBE: 1, CANCEL: 1, END: 1, QUIT: 1 };
+var SMS_START_WORDS_ = { START: 1, YES: 1, UNSTOP: 1, SUBSCRIBE: 1, JOIN: 1, BEGIN: 1, RESUME: 1, OPTIN: 1 };
+var SMS_HELP_WORDS_ = { HELP: 1, INFO: 1 };
+
+var SMS_STOP_CONFIRM_ = "JacRentals: You're unsubscribed and will receive no more texts. Reply START to opt back in.";
+var SMS_START_CONFIRM_ = "JacRentals: You're opted in to service texts. Msg frequency varies. Msg & data rates may apply. Reply HELP for help, STOP to opt out.";
+var SMS_HELP_TEXT_ = 'JacRentals service texts. Msg frequency varies. Msg & data rates may apply. Reply STOP to opt out. Help: operations@jacrentals.com.';
+
+// Entry point — see WIRE-UP above. Always returns a fast TwiML 200; never
+// lets an exception propagate back to Twilio (a 5xx there triggers retries).
+function smsInbound_(e) {
+  try {
+    var p = (e && e.parameter) || {};
+    var wh = PropertiesService.getScriptProperties().getProperty('TWILIO_INBOUND_TOKEN');
+    if (wh && String(p.wh || '') !== wh) return smsTwiml_();   // unverified (assumption #2): drop, no state change, still 200
+
+    var from = smsNormalizePhone_(p.From || '');
+    var raw = String(p.Body || '');
+    var word = raw.trim().toUpperCase().split(/\s+/)[0] || '';
+    if (!from) return smsTwiml_();                              // nothing to act on
+
+    var cust = smsFindCustomerByPhone_(from);                    // null = unknown sender; NEVER auto-attach (spec §10)
+
+    if (SMS_STOP_WORDS_[word]) {
+      if (cust) smsSetConsent_(cust, 'sms', 'opted-out', 'reply-stop');
+      smsInboundReply_(cust, from, SMS_STOP_CONFIRM_, 'keyword-stop');
+      return smsTwiml_();
+    }
+    if (SMS_START_WORDS_[word]) {
+      if (cust) smsSetConsent_(cust, 'sms', 'opted-in', 'reply-start');
+      smsInboundReply_(cust, from, SMS_START_CONFIRM_, 'keyword-start');
+      return smsTwiml_();
+    }
+    if (SMS_HELP_WORDS_[word]) {
+      smsInboundReply_(cust, from, SMS_HELP_TEXT_, 'keyword-help');   // HELP always answers, regardless of opt state
+      return smsTwiml_();
+    }
+
+    // A genuine customer reply, not a keyword — do NOT auto-reply (spec:
+    // only append to the log so it can surface in the customer's thread).
+    // Unattached (unknown-sender) replies are dropped, not logged — no
+    // customer record exists to attach the thread to (assumption #4).
+    if (cust) smsLogInbound_(cust, from, raw.slice(0, 600), String(p.MessageSid || ''));
+    return smsTwiml_();
+  } catch (err) {
+    return smsTwiml_();   // Twilio needs a fast 200 regardless — never surface an error to the provider
+  }
+}
+
+// Scan `customers` for a phone match (mirrors the [id, json] row shape used
+// by membershipBillingCron's customer scan). Returns the parsed record or
+// null — callers must never create/attach a record on a null result.
+function smsFindCustomerByPhone_(normPhone) {
+  if (!normPhone) return null;
+  var s = ss().getSheetByName('customers'); if (!s) return null;
+  var last = s.getLastRow(); if (last < 2) return null;
+  var vals = s.getRange(2, 2, last - 1, 1).getValues();   // json column
+  for (var i = 0; i < vals.length; i++) {
+    var c; try { c = JSON.parse(vals[i][0]); } catch (e2) { continue; }
+    if (c && smsNormalizePhone_(c.phone) === normPhone) return c;
+  }
+  return null;
+}
+
+// Shallow-merges ONE channel's consent state into the existing commsConsent
+// object (never replaces the whole object — email/other keys survive).
+// Idempotent: re-setting the same value is a harmless no-op write.
+function smsSetConsent_(cust, channel, value, source) {
+  var lock = tryLock_(20000); if (!lock) return false;
+  try {
+    var c = readRecord_('customers', cust.customerId); if (!c) return false;
+    var consent = (c.commsConsent && typeof c.commsConsent === 'object') ? c.commsConsent : {};
+    consent[channel] = value;          // spec §4.2 shape: { sms, email, updatedAt, source }
+    consent.updatedAt = Date.now();
+    consent.source = source;
+    c.commsConsent = consent;
+    writeRecord_('customers', c);
+    return true;
+  } finally { lock.releaseLock(); }
+}
+
+// Sends a system reply directly via Twilio (bypassing sendCustomerMessage_'s
+// consent gate on purpose — see assumption #6) and logs it to `messages`.
+function smsInboundReply_(cust, to, text, kind) {
+  var status = 'failed', providerId = '', providerErr = '', fromUsed = '';
+  var props = PropertiesService.getScriptProperties();
+  var sid = props.getProperty('TWILIO_SID'), tok = props.getProperty('TWILIO_TOKEN'), from = props.getProperty('TWILIO_FROM');
+  if (sid && tok && from) {
+    fromUsed = from;
+    try {
+      var res = UrlFetchApp.fetch('https://api.twilio.com/2010-04-01/Accounts/' + encodeURIComponent(sid) + '/Messages.json', {
+        method: 'post', muteHttpExceptions: true,
+        headers: { Authorization: 'Basic ' + Utilities.base64Encode(sid + ':' + tok) },
+        payload: { From: from, To: '+' + to, Body: text },
+      });
+      var out = JSON.parse(res.getContentText() || '{}');
+      if (res.getResponseCode() < 300 && out.sid) { status = 'sent'; providerId = out.sid; }
+      else providerErr = String(out.message || out.error_message || res.getResponseCode()).slice(0, 80);
+    } catch (e) { providerErr = 'fetch-error'; }
+  } else {
+    providerErr = 'not-configured';   // no Twilio creds in Script Properties — logged, not thrown
+  }
+  smsLogOutbound_(cust, to, fromUsed, text, kind, status, providerId, providerErr);
+}
+
+function smsLogOutbound_(cust, to, fromUsed, text, template, status, providerId, providerErr) {
+  try {
+    var msgId = 'MSG-' + Utilities.getUuid().slice(0, 8);
+    var row = {
+      msgId: msgId, channel: 'sms', provider: 'twilio', direction: 'outbound', entity: 'customer',
+      recId: cust ? String(cust.customerId) : '', customerId: cust ? String(cust.customerId) : '',
+      template: template, to: to, from: fromUsed, subject: '', body: text, status: status,
+      providerId: providerId || '', providerErr: providerErr || '', by: 'system', auto: true,
+      quiet: false, dedupKey: '', when: new Date().toISOString(),
+    };
+    messagesSheet_().appendRow([msgId, JSON.stringify(row)]);
+  } catch (e) { /* logging must never block the reply path */ }
+}
+
+// A non-keyword inbound reply — logged only (no auto-reply), so it can
+// surface in the customer's thread (commsThreads_/messagesFor_ already skip
+// any row without a customerId, so unattached inbound never leaks in there).
+function smsLogInbound_(cust, from, text, inboundSid) {
+  try {
+    var msgId = 'MSG-' + Utilities.getUuid().slice(0, 8);
+    var row = {
+      msgId: msgId, channel: 'sms', provider: 'twilio', direction: 'inbound', entity: 'customer',
+      recId: String(cust.customerId), customerId: String(cust.customerId), template: '', to: from, from: from,
+      subject: '', body: text, status: 'replied', providerId: inboundSid || '', providerErr: '', by: '',
+      auto: false, quiet: false, dedupKey: '', when: new Date().toISOString(),
+    };
+    messagesSheet_().appendRow([msgId, JSON.stringify(row)]);
+  } catch (e) {}
+}
+
+// Twilio expects a fast 200 with an empty (or TwiML) body; we already send
+// any reply asynchronously via the REST API above, so this is always empty.
+function smsTwiml_() {
+  return ContentService.createTextOutput('<Response></Response>').setMimeType(ContentService.MimeType.XML);
+}


### PR DESCRIPTION
## Summary
- Adds `docs/handoffs/sms-keyword-autoreply-backend.gs` — a **staged, additive GAS handler** (not deployed) for the Twilio inbound-SMS webhook that actually handles a real customer `STOP`/`START`/`HELP` reply. The A2P/10DLC campaign registration *declares* these keywords; this is the handler that *honors* them.
- Updates `docs/handoffs/BACKEND-DEPLOY-QUEUE.md` with a new queue entry (item #3), status "staged, not deployed — STOP-gated."

## What the handler does
- Parses Twilio's inbound `From`/`Body`/`MessageSid` (form-urlencoded webhook POST).
- Normalizes the body (trim, uppercase) and matches the **first word** against:
  - **Opt-out** (`STOP`/`STOPALL`/`UNSUBSCRIBE`/`CANCEL`/`END`/`QUIT`) → sets `commsConsent.sms = 'opted-out'`, replies with the opt-out confirmation.
  - **Opt-in** (`START`/`YES`/`UNSTOP`/`SUBSCRIBE`/`JOIN`/`BEGIN`/`RESUME`/`OPTIN`) → sets `commsConsent.sms = 'opted-in'`, replies with the opt-in confirmation.
  - **Help** (`HELP`/`INFO`) → replies with help text; always answers regardless of opt state.
  - Anything else → no auto-reply; logged to the customer's `messages` thread if the sender matches a known customer, otherwise dropped (never auto-attached to an arbitrary customer — anti-spoof).
- Idempotent by design (Twilio may also auto-handle STOP at the carrier level; our own record still gets updated when the webhook fires).

## Consent field written
`customer.commsConsent.sms` — a **shallow merge** (email/other keys on the object are preserved), matching exactly the shape `sendCustomerMessage_` already reads for its opt-out hard-block:
```js
var consent = (cust.commsConsent && cust.commsConsent[channel]) || 'unknown';
if (consent === 'opted-out') return { ok:false, reason:'opted-out' };
```
Full detail + drift-check note is in the file header (assumption #1).

## Ambiguity flagged for review (documented at the top of the .gs file)
1. **Webhook signature verification.** The spec (`docs/specs/comms-notifications.md` §5.3) calls for verifying Twilio's `X-Twilio-Signature` HMAC before any state change. GAS web-app `doPost(e)` does **not** expose incoming HTTP headers at all, so that literal approach is impossible here. Workaround: a shared-secret token in the webhook URL query string (`?wh=<TWILIO_INBOUND_TOKEN>`, a new Script Property), compared server-side. Flagged for Jac's explicit sign-off, or swap to a header-capable relay later if stricter verification is required.
2. **Provider/channel note.** Written for Twilio's inbound shape per this task's brief; the spec's 2026-07-06 D5 addendum instead names "the Mocean inbound webhook" for two-way SMS. If Mocean becomes the primary inbound provider, this needs a Mocean-shaped sibling parser.
3. **Reply bypasses the opt-out hard-block on purpose** — the STOP/START/HELP confirmations are sent via a direct Twilio call, not `sendCustomerMessage_`, because that function would otherwise re-block the STOP confirmation it just triggered. This is intentional (the confirmation IS the compliance mechanism), not a loosening of the "hard-block, no override" rule — flagged in the file for visibility.

## Deploy status
**STOP-gated — staged only, NOT deployed.** No secrets/keys in this file; only Script Property *names* are referenced (`TWILIO_SID`/`TWILIO_TOKEN`/`TWILIO_FROM` — already required by the live Phase-1 SMS pipe — plus a new `TWILIO_INBOUND_TOKEN`). Deploy requires Jac's explicit `/clasp` go per the queue doc's standing rule.

## Test plan
- [x] `node --check` on the file (via a temp `.js` copy, since the repo's `"type": "module"` in `package.json` makes node treat `.gs` as an unknown extension directly) — syntax OK.
- [x] `git status` confirms only `docs/handoffs/sms-keyword-autoreply-backend.gs` and `docs/handoffs/BACKEND-DEPLOY-QUEUE.md` changed.
- [ ] Manual re-review of the exact `commsConsent` shape against the live `Code.gs` before splicing (per assumption #1) — Code.gs is gitignored and not visible from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtNtp5ApjnkrT4XUvDvdaQ)_