### PR TITLE
History/audit log: gate $ amounts behind canMoney() for non-money roles

### DIFF
--- a/app.js
+++ b/app.js
@@ -6950,7 +6950,7 @@ const DETAIL = {
     const actEntry = state.actOpen === c.customerId
       ? `<div class="act-entry"><input class="act-in js-act-in" data-rec="${c.customerId}" placeholder="${state.actMode === 'schedule' ? 'Schedule an action…' : 'Log an action…'}" /></div>`
       : '';
-    const hit = (a, strip) => `<div class="hitem"><span class="htime">${esc(fmtShortDate(a.when))}</span><span>${esc(strip ? a.text.replace(/^Scheduled:\s*/, '') : a.text)}</span></div>`;
+    const hit = (a, strip) => `<div class="hitem"><span class="htime">${esc(fmtShortDate(a.when))}</span><span>${esc(histText(strip ? a.text.replace(/^Scheduled:\s*/, '') : a.text))}</span></div>`;
     const acts = (c.activityLog || []).filter((a) => !/^Scheduled:/.test(a.text)).map((a) => hit(a)).join('');
     const scheds = (c.activityLog || []).filter((a) => /^Scheduled:/.test(a.text)).map((a) => hit(a, true)).join('');
     const activity = acts || scheds ? `<div class="act-cols"><div class="act-col">${acts}</div><div class="act-col">${scheds}</div></div>` : '';
@@ -7271,7 +7271,7 @@ function historySection(card, rec, cs, chips) {
   const q = (cs?.historySearch || '').trim().toLowerCase();
   const items = q ? base.filter((h) => (h.search || `${h.when} ${h.text}`).toLowerCase().includes(q)) : base;
   const log = items.length
-    ? items.map((h) => `<div class="hitem"><span class="htime">${esc(h.when)}</span>${h.pill || ''}<span>${esc(h.text)}</span>${h.by ? `<span class="hby">${esc(h.by)}</span>` : ''}</div>`).join('')
+    ? items.map((h) => `<div class="hitem"><span class="htime">${esc(h.when)}</span>${h.pill || ''}<span>${esc(histText(h.text))}</span>${h.by ? `<span class="hby">${esc(h.by)}</span>` : ''}</div>`).join('')
     : `<div class="muted" style="font-size:12px">${q || chip ? 'No matching history.' : 'No history yet.'}</div>`;
   const chipBar = chips?.length
     ? `<div class="hvals">${chips.map((c) => `<button class="hv ${c.cls || ''} ${cs?.histKind === c.kind ? 'on' : ''} js-hchip" data-card="${esc(card)}" data-kind="${esc(c.kind)}">${esc(c.label)}</button>`).join('')}</div>` : '';
@@ -16697,6 +16697,10 @@ function logAction(rec, text) { if (!rec) return; rec.actions = rec.actions || [
 // Humanize a field key + format a value for an audit line ("Phone: (337)… → (337)…").
 const humanizeField = (f) => ({ po: 'PO', eta: 'ETA', 'insurance.policyRef': 'Policy #', 'insurance.effective': 'Coverage effective', 'insurance.expires': 'Coverage expires', 'insurance.insuredValue': 'Insured value', 'insurance.premium': 'Premium', accountNotes: 'Notes', assignedMechanic: 'Mechanic', gpsType: 'GPS type', gpsPlacement: 'GPS placement', purchasePrice: 'Purchase price', purchaseDate: 'Purchase date', trueCost: 'True cost', purchaseHours: 'Hours at purchase', currentHours: 'Hours', startHours: 'Start hours', returnHours: 'Return hours', rentalName: 'Name', woReport: 'Report', firstName: 'First name', lastName: 'Last name' }[f] || (f.charAt(0).toUpperCase() + f.slice(1).replace(/([A-Z])/g, ' $1')));
 const auditVal = (v) => { const s = String(v ?? '').trim(); return s ? (s.length > 28 ? s.slice(0, 28) + '…' : s) : '(empty)'; };
+/* Margin gate (units-fleet, Jac 2026-07-08): non-money roles never see dollar
+   amounts in the History/audit log — a client-side DISPLAY redaction only (the raw
+   action text still stores & syncs), same philosophy as the D1 bottomDollar gate. */
+function histText(t) { return canMoney() ? String(t) : String(t).replace(/\$\d[\d,]*(?:\.\d{1,2})?/g, '$•••'); }
 
 /* §12.6 — WO phase changes (header pill + per-line journey pills) via a woPhase
    dropdown; reaching Complete reverts a Failed unit to Not Ready (§9). */
@@ -18272,7 +18276,7 @@ function exposeTestApi() {
       latestCustomerSelfie, woBackdrop, offloadPhotoNow, base64PhotoTargets, wrStore, wranglerRailLoad, wrOffloadChatImages, wrEvictChatBlobs, driveViewUrl, mergeWranglerRails,
       recordDateMatch, dateTermHits, rowMatches,
       kpiFor, kpiRaw, kpiEval, legacyKpiPct, legacyKpiRaw, KPI_DEFAULTS, wrValidateKpi, roleRings,
-      companyRevenueGoal, companyName, companyTagline, membershipPricing, membershipFee, membershipStatus, isActiveMember, rentalPrice, setFunnelStage, markMembershipSigned, rentalProtectionRate, rentalProtectionAmount, protectionLineItems, syncProtectionLine, membershipEconomics, membershipFeeRevenue, membershipSectionHtml, membershipCancel, membershipReactivate, membershipCancellationInvoice, addMonthsISO, openMembershipEnroll, membershipEnrollCommit, rentalRuleBlock, dueForCustomer, customFieldsFor, checklistFor, checklistRequired, inspFamilyKey, inspKeyOfCat, inspItemFails, inspItemUnanswered, inspItemType, inspEvidenceMissing, applySettings, getStatus, pageDefaultSlice, previewOverlayFor, WINDOW_CATALOG, unitCoverage, fleetInsuredValue, fleetPremiumMonthly, insuranceTypeCatalog, invoiceCollectionsActive, getEntityColor, getEntityFlags, isEmptyMockDraft, sweepEmptyDrafts, createInvoiceForRental, syncRentalLines, rentalLineItems, salePriceSuggest, salePricingCfg, categoryCostBasis, driverRoster, driverName, legDriverField, dispatchEvents, applyShopRoleLanding, topServiceForUnit, snoozeService, svcSnoozedUntil, unitServiceRows, recordServiceCompletion, setRole: (r) => { currentRole = r || ''; render(); },
+      companyRevenueGoal, companyName, companyTagline, membershipPricing, membershipFee, membershipStatus, isActiveMember, rentalPrice, setFunnelStage, markMembershipSigned, rentalProtectionRate, rentalProtectionAmount, protectionLineItems, syncProtectionLine, membershipEconomics, membershipFeeRevenue, membershipSectionHtml, membershipCancel, membershipReactivate, membershipCancellationInvoice, addMonthsISO, openMembershipEnroll, membershipEnrollCommit, rentalRuleBlock, dueForCustomer, customFieldsFor, checklistFor, checklistRequired, inspFamilyKey, inspKeyOfCat, inspItemFails, inspItemUnanswered, inspItemType, inspEvidenceMissing, applySettings, getStatus, pageDefaultSlice, previewOverlayFor, WINDOW_CATALOG, unitCoverage, fleetInsuredValue, fleetPremiumMonthly, insuranceTypeCatalog, invoiceCollectionsActive, getEntityColor, getEntityFlags, isEmptyMockDraft, sweepEmptyDrafts, createInvoiceForRental, syncRentalLines, rentalLineItems, salePriceSuggest, salePricingCfg, categoryCostBasis, driverRoster, driverName, legDriverField, dispatchEvents, applyShopRoleLanding, topServiceForUnit, snoozeService, svcSnoozedUntil, unitServiceRows, recordServiceCompletion, setRole: (r) => { currentRole = r || ''; render(); }, histText, canMoney,
       openCustomerForm, renderOverlay, render, cardComplete, cardCaptureState, cardHasSelfie, cardHasSignature, captureSelfie, captureSignature, __state: state };   // UI drivers for headless screenshot/e2e tests
 
   } catch (e) { /* no window (non-browser) */ }

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -1613,6 +1613,19 @@ try {
       T.__state.overlay = null;
     }
 
+    // === History money gate (units-fleet, Jac 2026-07-08) — histText() masks $ amounts
+    // in the History/audit log for non-money roles (client-side DISPLAY redaction only,
+    // same D1 bottomDollar philosophy); money-tier roles see amounts untouched. ===
+    {
+      T.setRole('driver');   // staff tier (1) — below money (2)
+      const masked = T.histText('Sold for $12,500 on Jul 1');
+      ok(/\$•••/.test(masked) && !/\$12,500/.test(masked), 'histText: non-money role masks a dollar amount in a History line');
+      ok(T.histText('Hours 1,265.9 HRS') === 'Hours 1,265.9 HRS', 'histText: non-$ numbers (hours, PO #s) are left untouched — no false-positive masking');
+      T.setRole('office');   // money tier (2) — amounts show normally
+      ok(T.histText('Sold for $12,500 on Jul 1') === 'Sold for $12,500 on Jul 1', 'histText: money-tier role sees the dollar amount unmasked');
+      T.setRole('');          // restore demo/no-role
+    }
+
     return out;
   });
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 18404 lines, 37 chapters
+## app.js — 18408 lines, 37 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -41,10 +41,10 @@
 | APP-31 | 13165–13168 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-32 | 13169–14892 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
 | APP-33 | 14893–15917 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+43) |
-| APP-34 | 15918–16970 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-35 | 16971–17422 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-36 | 17423–17425 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 17426–18404 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
+| APP-34 | 15918–16974 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+74) |
+| APP-35 | 16975–17426 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-36 | 17427–17429 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 17430–18408 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+43) |
 
 ## config.js — 569 lines, 0 chapters
 


### PR DESCRIPTION
## Why
Jac popup-confirmed decision: non-money roles must never see dollar amounts in the History / audit log. This is a **client-side DISPLAY redaction only** — the raw action text still stores and syncs untouched — same philosophy as the units-fleet D1 `bottomDollar` display gate. Money-tier roles (office/sales/manager/admin/owner/developer) see amounts normally.

Pairs with #530 (whose "Sold for $X" unit-sale History line is one of the things now masked for non-money roles).

## What changed
Exactly three surgical touches, no scope creep:

1. **Helper** (`app.js`, next to `auditVal`/`humanizeField`, near `logAction`):
   ```js
   function histText(t) { return canMoney() ? String(t) : String(t).replace(/\$\d[\d,]*(?:\.\d{1,2})?/g, '$•••'); }
   ```
   Masks `$12,500` / `$210` / `$1,240.00` → `$•••`; leaves non-$ numbers (`1,265.9 HRS`, `PO #123`) untouched.

2. **The two render sites that show an audit line's `.text`** (verified via grep — these are the only two):
   - `historySection` (app.js ~7274) — the main entity History renderer.
   - The customer `activityLog` `hit()` renderer (app.js ~6953).

   Team-chat bubbles (~app.js:8358) are explicitly **out of scope** — internal comms, not the audit log.

3. **`ci/logic-test.mjs`** — `histText` exposed via the `window.__rw` test API, plus a new assertion block: a `driver` (staff-tier) session masks `$12,500` but leaves `1,265.9 HRS` alone; an `office` (money-tier) session sees `$12,500` unmasked.

No new UI element, no `data-r` rule, no WINDOW_CATALOG change — this only touches existing render output.

## Gate results (port-swapped to 9147 per repo convention, then reverted)
- `node ci/smoke.mjs` — pass
- `node ci/logic-test.mjs` — 448/448 pass, including the 3 new histText assertions
- `node ci/gen-rule-usage.mjs --check` — pass (no rule usage changed)
- `node ci/check-window-catalog.mjs` — pass (36 popup kinds, no popup added/removed)
- `node tools/gen-code-map.mjs --check` — pass (regenerated `docs/code-map.generated.md` for the line-number drift the new helper introduced inside §17 STRIPE/PAYMENTS; no chapter added/moved/retitled)
- `node --check app.js` — pass

## Playwright verification (chromium headless, served on 9147, `#local`)
Seeded a unit's History with a `Sold for $12,500 on Jul 1` action line via `window.__rw`, then rendered its inline detail (Units card, standard view):
- **Money role (`office`)**: History shows `Sold for $12,500 on Jul 1` unmasked.
- **Driver role (`driver`, staff-tier)**: same line renders as `Sold for $••• on Jul 1`.
- Zero app-code console errors (only the sandbox-blocked external Google Fonts/Stripe CDN calls and the expected `dev-version.txt` 404, same as `ci/smoke.mjs` already allow-lists).
- 2 screenshots captured (money vs. non-money History) confirming the masked/unmasked rendering.

## Scope confirmation
`git diff origin/area/units-fleet..HEAD -- app.js` touches exactly: the `histText` helper, the two render-site one-line wraps, and the `histText`/`canMoney` additions to the `exposeTestApi` test surface. Nothing else in app.js changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MtNtp5ApjnkrT4XUvDvdaQ)_