### PR TITLE
Printable invoice: full-bleed kraft page (no white borders)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7253,7 +7253,7 @@ const DETAIL = {
           ${ledgerRow(`Due${i.dueDate ? ' · ' + fmtShortDate(i.dueDate) : ''}`, money2(t.balance), 'due')}
           ${!locked ? `<div class="kv" style="justify-content:flex-end;align-items:center;gap:7px;margin-top:2px"><span class="derived" style="font-size:11px">Set due date</span><input type="date" class="js-due-date" data-rec="${esc(i.invoiceId)}" value="${esc(i.dueDate || '')}" style="font-size:11px;color:var(--txt);background:var(--panel-2);border:1px solid var(--line);border-radius:6px;padding:3px 7px;color-scheme:dark"></div>` : ''}
           ${payCell ? `<div class="pillrow" style="justify-content:flex-end;margin-top:9px">${payCell}</div>` : ''}
-          <div class="pillrow" style="justify-content:flex-end;margin-top:9px">${ghostPill('🖨 Print', { js: 'js-print-invoice', data: { rec: i.invoiceId } })}${ghostPill('✉ Send Email', { js: 'js-send-email', data: { rec: i.invoiceId }, disabled: !cust || !cust.email, tip: !cust ? 'No customer on file' : !cust.email ? 'No email on file' : '' })}${ghostPill('💬 Send Text', { js: 'js-send-text', data: { rec: i.invoiceId }, disabled: !cust || !cust.phone, tip: !cust ? 'No customer on file' : !cust.phone ? 'No phone on file' : '' })}</div>
+          <div class="pillrow" style="justify-content:flex-end;margin-top:9px">${ghostPill('🖨 Print', { js: 'js-print-invoice', data: { rec: i.invoiceId }, tip: 'Edge-to-edge already. For a fully clean page, turn off “Headers & footers” in the print dialog (Chrome remembers it).' })}${ghostPill('✉ Send Email', { js: 'js-send-email', data: { rec: i.invoiceId }, disabled: !cust || !cust.email, tip: !cust ? 'No customer on file' : !cust.email ? 'No email on file' : '' })}${ghostPill('💬 Send Text', { js: 'js-send-text', data: { rec: i.invoiceId }, disabled: !cust || !cust.phone, tip: !cust ? 'No customer on file' : !cust.phone ? 'No phone on file' : '' })}</div>
         </div>
       </div></div>`;
     const notes = notesSection('invoices', i, 'invoiceId');
@@ -17797,8 +17797,9 @@ function printInvoice(invoiceId) {
         ${logCol('Rental Log', rentalLog, true)}
       </div>
     </div>`;
+  document.documentElement.classList.add('printing');   // full-bleed: kraft rides the root canvas so it fills every sheet edge
   document.body.classList.add('printing');
-  const cleanup = () => { document.body.classList.remove('printing'); window.removeEventListener('afterprint', cleanup); };
+  const cleanup = () => { document.documentElement.classList.remove('printing'); document.body.classList.remove('printing'); window.removeEventListener('afterprint', cleanup); };
   window.addEventListener('afterprint', cleanup);
   window.print();
 }

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 21365 lines, 38 chapters
+## app.js — 21366 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -41,11 +41,11 @@
 | APP-31 | 14016–14019 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-32 | 14020–15982 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
 | APP-33 | 15983–17077 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
-| APP-34 | 17078–18337 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+83) |
-| APP-35 | 18338–18790 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-36 | 18791–18793 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 18794–20814 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+129) |
-| APP-38 | 20815–21365 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
+| APP-34 | 17078–18338 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+83) |
+| APP-35 | 18339–18791 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-36 | 18792–18794 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 18795–20815 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+129) |
+| APP-38 | 20816–21366 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
 
 ## config.js — 578 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260708m" />
+  <link rel="stylesheet" href="style.css?v=20260708n" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260708m"></script>
-  <script type="module" src="app.js?v=20260708m"></script>
+  <script src="rule-usage.js?v=20260708n"></script>
+  <script type="module" src="app.js?v=20260708n"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -4223,7 +4223,18 @@ body.dragging .row.drop-ok { opacity: 1; }
 @media print {
   body.printing > *:not(#print-root) { display: none !important; }
   body.printing #print-root { display: block; }
-  @page { margin: 12mm; }
+  /* FULL-BLEED (2026-07-08): kill the white paper frame so the kraft reaches every sheet
+     edge. @page margin 0 drops the browser's paper margin; the kraft color rides on the
+     root canvas (html.printing) so it also paints BELOW a short invoice and on every page
+     of a multi-page one; and the doc trades its old page margin for its own inner padding
+     so text still sits a clean, even inset from the edge instead of jamming the paper edge.
+     (The browser's own header/footer — date/title/URL/page# — is a print-dialog setting we
+     can't remove from CSS; the Print button's tip points users to turn it off once.) */
+  @page { margin: 0; }
+  /* Both the root canvas AND the body carry the kraft (body's own dark app bg would otherwise
+     paint below a short invoice if the user enables "Background graphics"). exact = print it. */
+  html.printing, body.printing { background: #f7f2ea !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  body.printing #print-root .pr-doc { max-width: none; margin: 0; padding: 16mm 18mm 16mm; }
 }
 .pr-doc {
   --pr-ink: #14181d; --pr-mut: #6f6656; --pr-tan: #8a5a2b;


### PR DESCRIPTION
## What & why

Jac didn't like the white borders framing the printed invoice. The customer print/PDF doc (the kraft "YARD LOG" page) sat inside a **12mm white paper frame** from `@page { margin: 12mm }`. This makes the kraft paper bleed to **every sheet edge** instead.

## Changes

- **`@page { margin: 0 }`** — drops the browser's paper margin so nothing frames the doc.
- **Kraft on the root canvas + body** (`html.printing, body.printing { background: #f7f2ea }`, `print-color-adjust: exact`) — so the paper color also fills **below a short invoice** and on **every page** of a multi-page one. Carrying it on `body` too prevents the app's dark background from painting through if the user enables *Background graphics* in the print dialog.
- **Doc inner padding** replaces the old page margin (`.pr-doc` → `max-width: none; padding: 16mm 18mm 16mm`) so text still sits a clean, even inset from the edge rather than jamming the paper edge.
- **`printing` class on `<html>`** in `printInvoice()` (alongside the existing `body` class) so the canvas rule scopes to the invoice print only — the two other `window.print()` flows (signed agreement / membership) write their own documents and are untouched.
- **Print button tip** — the browser's own header/footer (date · title · URL · page #) is a *print-dialog* setting CSS can't remove, so the 🖨 Print button now carries a one-line hover tip pointing users to turn off **"Headers & footers"** once (Chrome remembers it).
- **Cache token** bumped `l → m` on the shared `?v=` in `index.html`.

## Base

Cut from **`staging`**, not `main` — the kraft print doc lives on staging (redesigned 2026-07-08) and this rides along with it. `main` still has the older, plainer invoice.

## Verification

- Rendered the real `.pr-doc` markup against the actual `style.css` under **print media** at Letter size (headless Chromium). Confirmed: kraft fills all four edges, content inset by its padding, no white frame and **no dark band below the content**; PDF is a clean 1-page Letter sheet; no console errors.
- Gates: `gen-rule-usage --check`, `check-window-catalog`, `gen-code-map --check` ✓ ; boot **smoke** ✓ ; `node --check app.js` ✓. (Browser `logic-test` — money/multi-unit — is untouched by a print-CSS change; CI runs it.)

### Before → After
Before: kraft doc inside a white margin frame. After: kraft to every sheet edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011smrKobswx8xENw7uNAVUc

---
_Generated by [Claude Code](https://claude.ai/code/session_011smrKobswx8xENw7uNAVUc)_