### PR TITLE
GPS: bump ?v= cache-bust token (20260708o)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260708m" />
+  <link rel="stylesheet" href="style.css?v=20260708o" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260708m"></script>
-  <script type="module" src="app.js?v=20260708m"></script>
+  <script src="rule-usage.js?v=20260708o"></script>
+  <script type="module" src="app.js?v=20260708o"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
`area/wrangler-gps` had drifted to a stale `?v=` token (`20260708m`) while `staging` advanced past it (`20260708n`, via a direct staging commit outside this branch). This bumps to `20260708o` so the next promotion to staging is guaranteed newer — closes the window where a browser could cache pre-fix `app.js` bytes under an already-used token. Text-only change; no gates affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7qc8fHnQzauK2XzXa1dT6

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7qc8fHnQzauK2XzXa1dT6)_