### PR TITLE
Wrangler fix: history timestamps drift a day behind (#541)

### DIFF
--- a/app.js
+++ b/app.js
@@ -16229,7 +16229,12 @@ let actionSeq = 0;
 let currentUser = (() => { try { return localStorage.getItem('jactec.user') || ''; } catch { return ''; } })();
 let currentRole = (() => { try { return sessionStorage.getItem('jactec.role') || ''; } catch { return ''; } })();
 function nowClock() { const d = new Date(); let h = d.getHours(); const ap = h < 12 ? 'AM' : 'PM'; h = h % 12 || 12; return `${h}:${String(d.getMinutes()).padStart(2, '0')} ${ap}`; }
-function logAction(rec, text) { if (!rec) return; rec.actions = rec.actions || []; rec.actions.push({ when: TODAY_ISO, clock: nowClock(), text, by: currentUser || '', seq: actionSeq++ }); saveSoon(); }
+// Live local date, computed fresh at call time. TODAY_ISO is a module-load CONSTANT, so a
+// long-lived session (tab left open across midnight) freezes it a day (or more) behind —
+// pairing a stale `when` with a live `nowClock()` produced "Jul 07 · 11:59 AM" for a Jul 08
+// event. Stamp new log entries with the actual current date instead.
+function nowISO() { const d = new Date(), p = (n) => String(n).padStart(2, '0'); return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`; }
+function logAction(rec, text) { if (!rec) return; rec.actions = rec.actions || []; rec.actions.push({ when: nowISO(), clock: nowClock(), text, by: currentUser || '', seq: actionSeq++ }); saveSoon(); }
 // Humanize a field key + format a value for an audit line ("Phone: (337)… → (337)…").
 const humanizeField = (f) => ({ po: 'PO', eta: 'ETA', accountNotes: 'Notes', assignedMechanic: 'Mechanic', gpsType: 'GPS type', gpsPlacement: 'GPS placement', purchasePrice: 'Purchase price', purchaseDate: 'Purchase date', trueCost: 'True cost', purchaseHours: 'Hours at purchase', currentHours: 'Hours', startHours: 'Start hours', returnHours: 'Return hours', rentalName: 'Name', woReport: 'Report', firstName: 'First name', lastName: 'Last name' }[f] || (f.charAt(0).toUpperCase() + f.slice(1).replace(/([A-Z])/g, ' $1')));
 const auditVal = (v) => { const s = String(v ?? '').trim(); return s ? (s.length > 28 ? s.slice(0, 28) + '…' : s) : '(empty)'; };

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260710b" />
+  <link rel="stylesheet" href="style.css?v=20260710c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260710b"></script>
-  <script type="module" src="app.js?v=20260710b"></script>
+  <script src="rule-usage.js?v=20260710c"></script>
+  <script type="module" src="app.js?v=20260710c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Report
[#541](https://github.com/operations-jacrentals/rental-wrangler/issues/541) — a unit's HISTORY row read **Jul 07 · 11:59 AM** for an event that actually happened **Jul 08** (off by one day).

## Root cause
`logAction` (app.js) stamped each action's date with **`TODAY_ISO`** — an `export const` in `config.js` computed **once at module load** — while pairing it with a **live `nowClock()`** for the time. When the SPA is left open across midnight (a shop tablet/desktop that never reloads), `TODAY_ISO` freezes a day behind the real date, so a Jul 08 11:59 AM action logs **`when` = Jul 07** (stale) + **`clock` = 11:59 AM** (live) → the exact "Jul 07 · 11:59 AM" symptom. Date-derived history rows (inspection/WO `.date`) use real record dates and are unaffected — only `logAction` rows drift, matching the report.

## Fix
Stamp new log entries with a **fresh local date** (`nowISO()`, computed live like `nowClock()` already is) instead of the frozen constant. `rec.actions[].when` is used only for display/search text and is never compared against `TODAY_ISO`, so the change is side-effect-free. Comments/messages were checked and are safe — they display the live `at` epoch, not `when`.

## Gates
- ✅ `node ci/smoke.mjs`
- ✅ `node ci/logic-test.mjs` (431/431)
- ✅ `node ci/gen-rule-usage.mjs --check`
- Bumped shared `?v=` cache-bust token.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)