### PR TITLE
Split mobile card-toggle rail into 3 main-card toggles; role-based landing

### DIFF
--- a/app.js
+++ b/app.js
@@ -8087,9 +8087,22 @@ function currentMobileMember() {
   const m = (s.cols && s.cols[colObj.id]) || colObj.default;
   return SHOP_TYPES.includes(m) ? 'shop' : m;
 }
-// §M1 — the flat card list the phone toggle bar offers. The 3 shop sub-types fold into one
-// 'shop' entry (the wrench), matching desktop; it opens the 3-bar shop graph.
-const MOBILE_CARDS = ['units', 'categories', 'shop', 'rentals', 'calendar', 'customers', 'invoices'];
+// §M1 — the phone footer is 3 independent 2-way toggles, one per desktop column (left:
+// Units/Categories · middle: Rentals/Calendar · right: Customers/Invoices). Shop (Work
+// Orders/Service/Inspections) is being retired on mobile — reachable by search/link pill,
+// not from this rail.
+const MOBILE_TOGGLE_GROUPS = [
+  { col: 'left',   members: ['units', 'categories'] },
+  { col: 'middle', members: ['rentals', 'calendar'] },
+  { col: 'right',  members: ['customers', 'invoices'] },
+];
+// The 3 MAIN cards, left→right — what the footer swipe steps between (never a sub-card).
+const MAIN_CARDS = ['units', 'rentals', 'customers'];
+// Which main card a member (incl. a sub-card or a folded shop type) belongs to.
+function mainCardOfMember(m) {
+  const col = COLUMN_OF[SHOP_TYPES.includes(m) ? 'shop' : m];
+  return col === 'middle' ? 'rentals' : col === 'right' ? 'customers' : 'units';
+}
 // §M1 — jump straight to a card (flattens the 3-column model on phones): set the column +
 // member, flip the visible column, and show that card's LIST (or, for Shop, its graph).
 function goToCard(member) {
@@ -8100,18 +8113,25 @@ function goToCard(member) {
   else { const mc = s.cards[member]; if (mc) { mc.mode = 'list'; mc.recId = null; mc.recType = null; } }
   render();
 }
-// §M1 phone footer — ONE card-toggle bar: every card collapsed to its icon, the SELECTED
-// card expands to icon + stamped label. Tap an icon to jump to that card's list. The card's
-// search/sort row is moved DOWN into the .mdock-searchslot by render(). Swipe the dock
-// left/right to step through cards; the grid swipe is Back/Forward.
+// §M1 phone footer — THREE card-toggle bars (Units/Categories · Rentals/Calendar ·
+// Customers/Invoices), one per desktop column. Every member is an icon; ONLY the single
+// card the user is currently ON expands to icon + stamped label — every other icon, in
+// every group, stays icon-only (keeps 3 narrow toggles from fighting each other for label
+// width). Tap an icon to jump straight to that card's list. The card's search/sort row is
+// moved DOWN into .mdock-searchslot by render(). Swipe the dock left/right to step through
+// the 3 MAIN cards; the grid swipe is Back/Forward.
 function mobileDockEl() {
   const cur = currentMobileMember();
-  const togs = MOBILE_CARDS.map((m) => {
-    const on = m === cur;
-    return `<button class="mcard-tog${on ? ' on' : ''}" data-gocard="${m}" data-tip="${esc(MEMBER_TITLE[m] || m)}"><span class="mct-ico">${memberIcon(m)}</span>${on ? `<span class="mct-lbl">${esc(MEMBER_TITLE[m] || m)}</span>` : ''}</button>`;
-  }).join('');
+  const barHtml = (members) => {
+    const btns = members.map((m) => {
+      const on = m === cur;
+      return `<button class="mcard-tog${on ? ' on' : ''}" data-gocard="${m}" data-tip="${esc(MEMBER_TITLE[m] || m)}"><span class="mct-ico">${memberIcon(m)}</span>${on ? `<span class="mct-lbl">${esc(MEMBER_TITLE[m] || m)}</span>` : ''}</button>`;
+    }).join('');
+    return `<div class="mcard-bar">${btns}</div>`;
+  };
+  const groups = MOBILE_TOGGLE_GROUPS.map((g) => barHtml(g.members)).join('');
   const d = el('div', 'mobile-dock');
-  d.innerHTML = `<div class="mdock-searchslot"></div><div class="mdock-row"><div class="mcard-bar">${togs}</div></div>`;
+  d.innerHTML = `<div class="mdock-searchslot"></div><div class="mdock-row">${groups}</div>`;
   return d;
 }
 /* ════════════════════════════════════════════════════════════════════════
@@ -17476,14 +17496,25 @@ async function shareSession() {
     caption: tabs.length ? `Scan to open your ${tabs.length} open tab${tabs.length === 1 ? '' : 's'} on another device — sign in with the shared password.`
       : 'Scan to open Rental Wrangler on another device — sign in with the shared password.' });
 }
-// Shop roles (Mechanic / M.Tech) get the Shop card + its 3-bar graph as the landing view
-// — quick access to the crew's worklist. A default only; they can navigate anywhere after.
-function applyShopRoleLanding() {
-  if (currentRole !== 'mechanic' && currentRole !== 'mtech') return;
+// §M1 role landing — each role lands on the card they work from most, both as the desktop
+// column reveal and (since phones show one column at a time) the active phone column. A
+// default only — every role can navigate anywhere after. Driver's landing member is a
+// SUB-card (Calendar, the day's driver schedule) even though the footer swipe only steps
+// between the 3 MAIN cards — the middle toggle is how a driver gets back to it.
+const ROLE_LANDING = {
+  mechanic: { col: 'left' },                        // Units
+  mtech:    { col: 'left' },                         // Units
+  office:   { col: 'middle' },                       // Rentals
+  sales:    { col: 'right' },                        // Customers
+  driver:   { col: 'middle', member: 'calendar' },   // Calendar — the driver's day
+};
+function applyRoleLanding() {
+  const land = ROLE_LANDING[currentRole]; if (!land) return;
   const s = activeSession(); if (!s) return;
-  if (s.cols) s.cols.left = 'shop';
-  const sc = s.cards.shop; if (sc) { sc.segment = 'all'; sc.graphView = true; sc.mode = 'list'; sc.recId = null; sc.recType = null; }
-  const li = COLUMNS.findIndex((c) => c.id === 'left'); if (li >= 0) state.mobileCol = li;   // phone: make the Shop column the active one
+  const member = land.member || COLUMNS.find((c) => c.id === land.col).default;
+  if (s.cols) s.cols[land.col] = member;
+  const mc = s.cards[member]; if (mc) { mc.mode = 'list'; mc.recId = null; mc.recType = null; }
+  const idx = COLUMNS.findIndex((c) => c.id === land.col); if (idx >= 0) state.mobileCol = idx;   // phone: make that column the active one
   render();
 }
 async function attemptLogin() {
@@ -17515,7 +17546,7 @@ async function attemptLogin() {
     sessionStorage.setItem('jactec.pw', pw);
     await loadFromBackend();
     finishLoad();
-    applyShopRoleLanding();   // shop roles (Mechanic / M.Tech) land on the Shop graph
+    applyRoleLanding();   // each role lands on its default main/sub-card
   } catch (e) {
     backendPassword = ''; sessionStorage.removeItem('jactec.pw'); sessionStorage.removeItem('jactec.role');
     renderLogin(/unauthorized/i.test(String(e && e.message)) ? 'That password wasn’t recognized.' : "Couldn't reach the database. Check your connection and try again.");
@@ -17572,9 +17603,9 @@ function boot() {
     if (Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy) * 1.3) return;            // not a clean horizontal swipe
     swipeFired = true;                                                             // swallow the trailing click (row/toggle)
     if (s.footer) {
-      const cur = currentMobileMember(); let i = MOBILE_CARDS.indexOf(cur); if (i < 0) i = 0;   // left → next card, right → previous
-      const next = Math.max(0, Math.min(MOBILE_CARDS.length - 1, i + (dx < 0 ? 1 : -1)));
-      if (next !== i) { goToCard(MOBILE_CARDS[next]); haptic(8); }
+      const cur = mainCardOfMember(currentMobileMember()); let i = MAIN_CARDS.indexOf(cur); if (i < 0) i = 0;   // fold a sub-card to its main card first; left → next, right → previous
+      const next = Math.max(0, Math.min(MAIN_CARDS.length - 1, i + (dx < 0 ? 1 : -1)));
+      if (next !== i) { goToCard(MAIN_CARDS[next]); haptic(8); }
     } else {
       const card = activeMobileCard();
       if (dx > 0) cardBack(card); else cardFwd(card);                              // swipe right → Back, left → Forward

--- a/config.js
+++ b/config.js
@@ -388,7 +388,7 @@ export const COLUMNS = [
 ];
 export const COLUMN_OF = {
   units: 'left', categories: 'left', inspections: 'left', serviceOrders: 'left', workOrders: 'left', shop: 'left',
-  rentals: 'middle', invoices: 'right', customers: 'right',
+  rentals: 'middle', calendar: 'middle', invoices: 'right', customers: 'right',
 };
 
 /* ── In-card sort fields (SPEC §12 locked table) ─────────────────────────── */

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 18024 lines, 38 chapters
+## app.js — 18055 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -29,23 +29,23 @@
 | APP-19 | 7405–7599 | §10 | §10 SHOP CARD — merged Work Orders + Service Orders + Inspections | shopItemMode, shopItemsByType, shopUrgency, shopSort, shopCardEl, shopItemMatches, shopListView, shopRowColor, shopRowEl |
 | APP-20 | 7600–7724 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
 | APP-21 | 7725–7889 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-22 | 7890–8116 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_CARDS, goToCard, …(+1) |
-| APP-23 | 8117–8963 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+75) |
-| APP-24 | 8964–9006 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-25 | 9007–9849 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-26 | 9850–10828 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-27 | 10829–10926 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-28 | 10927–11406 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-29 | 11407–12516 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
-| APP-30 | 12517–12786 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-31 | 12787–12925 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
-| APP-32 | 12926–12929 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-33 | 12930–14535 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-34 | 14536–15464 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
-| APP-35 | 15465–16505 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
-| APP-36 | 16506–16952 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-37 | 16953–16955 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-38 | 16956–18024 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+51) |
+| APP-22 | 7890–8136 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, activeMobileCard, currentMobileMember, MOBILE_TOGGLE_GROUPS, MAIN_CARDS, …(+3) |
+| APP-23 | 8137–8983 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatRoleOn, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, openChat, chatFeed, CHAT_AV, …(+75) |
+| APP-24 | 8984–9026 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-25 | 9027–9869 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-26 | 9870–10848 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-27 | 10849–10946 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-28 | 10947–11426 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-29 | 11427–12536 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
+| APP-30 | 12537–12806 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-31 | 12807–12945 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, toast |
+| APP-32 | 12946–12949 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-33 | 12950–14555 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-34 | 14556–15484 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, offloadPhoto, …(+39) |
+| APP-35 | 15485–16525 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+73) |
+| APP-36 | 16526–16972 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-37 | 16973–16975 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-38 | 16976–18055 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, dataSnapshot, loadFromBackend, PERSIST_ID, lastSaved, snapshotSaved, …(+52) |
 
 ## config.js — 594 lines, 0 chapters
 


### PR DESCRIPTION
## Summary

- Split the phone footer's flat 7-icon card-toggle bar into **3 independent 2-way toggles**, one per desktop column: **Units/Categories** (left) · **Rentals/Calendar** (middle) · **Customers/Invoices** (right). Shop (Work Orders/Service/Inspections) is retired from mobile nav for now — still reachable via search/link pill, not from this rail (per Jac: "the shop was retired in staging but for main right now just hide Shop").
- Only the card the user is currently on shows an icon+label; every other icon, across all 3 toggles, stays icon-only — matches the existing single-bar convention, just split into 3 groups.
- The footer swipe gesture now only steps between the **3 MAIN cards** (Units/Rentals/Customers). If you're on a sub-card (e.g. Categories, Invoices, Calendar), a swipe folds it to its group first, so you always land on a main card, never a sub-card.
- Each role now lands on the card it works from most, both as the desktop column reveal and the active phone column: **Mechanic/M.Tech → Units**, **Office → Rentals**, **Sales → Customers**, **Driver → Calendar** (the day's driver schedule). Replaces the old hardcoded Mechanic/M.Tech → Shop landing.
- Fixes a latent `COLUMN_OF` gap: `'calendar'` had no column mapping, so `goToCard('calendar')` silently no-op'd instead of actually switching to it.

## Test plan

- [x] `node ci/smoke.mjs`
- [x] `node ci/logic-test.mjs` (431/431)
- [x] `node ci/gen-rule-usage.mjs --check`
- [x] `node ci/check-window-catalog.mjs`
- [x] `node tools/gen-code-map.mjs --check`
- [x] Playwright verification at 390×844 and the 320px floor (`#local` offline demo mode): 3 toggle groups render with correct members, tapping each icon switches to the right card and updates the label, footer swipe from every sub-card (Categories/Calendar/Invoices) correctly lands on its main card in the right direction, no page-level horizontal overflow at 320px.
- [ ] Jac: visual pass on a real phone, and confirm the 5 shipped-role landing defaults feel right in practice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VkVCA3sVtDp74ZezAQKbFx)_