### PR TITLE
GPS: bump ?v= cache-bust token (20260708p)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260708o" />
+  <link rel="stylesheet" href="style.css?v=20260708p" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260708o"></script>
-  <script type="module" src="app.js?v=20260708o"></script>
+  <script src="rule-usage.js?v=20260708p"></script>
+  <script type="module" src="app.js?v=20260708p"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
app.js changed in the last merge (GPS Fleet Utilization) but the `?v=` cache-bust token wasn't bumped along with it — fixes that gap. Text-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7qc8fHnQzauK2XzXa1dT6

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7qc8fHnQzauK2XzXa1dT6)_