### PR TITLE
Pre-promotion audit: remaining 11 findings + backend snippet fixes

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -55,8 +55,11 @@ jobs:
       - name: Prune merged task branches (never main/staging/area/*)
         run: |
           set -euo pipefail
-          gh pr list -R "$REPO" --state merged --limit 1000 --json headRefName -q '.[].headRefName' | sort -u > merged.txt
-          gh pr list -R "$REPO" --state open   --limit 1000 --json headRefName -q '.[].headRefName' | sort -u > open.txt
+          # #552 audit item 18: --paginate (not a --limit cap) so the "never delete a branch
+          # with an open PR" guard can't be defeated by a stale/reused branch name falling
+          # outside a fixed-size window once the repo passes 1000 PRs.
+          gh pr list -R "$REPO" --state merged --paginate --json headRefName -q '.[].headRefName' | sort -u > merged.txt
+          gh pr list -R "$REPO" --state open   --paginate --json headRefName -q '.[].headRefName' | sort -u > open.txt
           gh api "repos/$REPO/branches?per_page=100" --paginate -q '.[].name' | sort -u > live.txt
           echo "live=$(wc -l < live.txt) merged-PRs=$(wc -l < merged.txt) open-PRs=$(wc -l < open.txt)"
           deleted=0
@@ -138,7 +141,7 @@ jobs:
             wrangler/card-error-surfacing
           "
           # runtime safety nets, independent of the embedded list
-          gh pr list -R "$REPO" --state open --limit 1000 --json headRefName -q '.[].headRefName' | sort -u > open.txt
+          gh pr list -R "$REPO" --state open --paginate --json headRefName -q '.[].headRefName' | sort -u > open.txt
           gh api "repos/$REPO/branches?per_page=100" --paginate -q '.[].name' | sort -u > live.txt
           mode="DRY-RUN"; [ "${EXECUTE:-false}" = "true" ] && mode="DELETE"
           echo "mode=$mode  (open-PRs=$(wc -l < open.txt), live branches=$(wc -l < live.txt))"

--- a/app.js
+++ b/app.js
@@ -5826,7 +5826,11 @@ const CARD_COLUMNS = {
     C('price', 'Price', 'money', (r) => rentalPrice(r)?.price ?? null),
     C('status', 'Status', 'badge', (r) => rentalDisplayStatus(r), { set: 'rentalStatus' }),
     C('window', 'Window', 'date', (r) => r.startDate || '', { cell: (r) => (r.startDate || r.endDate) ? esc(fmtWindow(r.startDate, r.endDate)) : '—' }),
-    C('invoice', 'Invoice', 'badge', (r) => { const inv = r.invoiceId && IDX.invoice.get(r.invoiceId); return inv ? invoiceTotals(inv).status : ''; }, { set: 'invoiceStatus' }),
+    // #552 audit item 8: rentalActiveInvoice() reads the LATEST §28cap chunk (same
+    // convention billWOToInvoice/extension-billing already use), not just r.invoiceId
+    // (the first chunk) — a long rental's badge no longer goes stale once a
+    // continuation invoice is created.
+    C('invoice', 'Invoice', 'badge', (r) => { const inv = rentalActiveInvoice(r); return inv ? invoiceTotals(inv).status : ''; }, { set: 'invoiceStatus' }),
   ],
   customers: [
     C('name', 'Customer', 'text', (c) => c.name),
@@ -6466,12 +6470,21 @@ function refundLines(inv) {
 /* Does this rental's invoice line(s) for a unit carry a refund? Drives the cross-card
    strikethrough on the rental (Jac 2026-06-23) — a refunded unit/transport shows on
    the rental itself, not only inside the invoice. unitId null = the whole rental. */
+// #552 audit item 8: walks the WHOLE §28cap chunk series (rentalInvoices), not just
+// r.invoiceId (the first chunk) — a refund on a continuation invoice was previously
+// invisible here. Falls back to r.invoiceId directly if the series lookup comes up
+// empty, mirroring rentalActiveInvoice()'s same safety net.
 function rentalLineRefund(r, unitId) {
-  if (!r || !r.invoiceId) return { refunded: false, fully: false };
-  const inv = IDX.invoice.get(r.invoiceId); if (!inv) return { refunded: false, fully: false };
-  const mine = (inv.lineItems || []).filter((li) => li.ref === r.rentalId && (unitId == null || li.unitId === unitId) && (li.kind === 'rental' || li.kind === 'transport'));
+  if (!r) return { refunded: false, fully: false };
+  const invs = rentalInvoices(r);
+  const list = invs.length ? invs : (r.invoiceId ? [IDX.invoice.get(r.invoiceId)].filter(Boolean) : []);
+  if (!list.length) return { refunded: false, fully: false };
+  const mine = [];
+  list.forEach((inv) => (inv.lineItems || []).forEach((li) => {
+    if (li.ref === r.rentalId && (unitId == null || li.unitId === unitId) && (li.kind === 'rental' || li.kind === 'transport')) mine.push([inv, li]);
+  }));
   if (!mine.length) return { refunded: false, fully: false };
-  return { refunded: mine.some((li) => lineRefunded(inv, li)), fully: mine.every((li) => lineFullyRefunded(inv, li)) };
+  return { refunded: mine.some(([inv, li]) => lineRefunded(inv, li)), fully: mine.every(([inv, li]) => lineFullyRefunded(inv, li)) };
 }
 /* Jac ─ Site ─ Jac transport journey under an invoice rental line. +Log Delivery /
    +Log Recovery ARE the same captures as the yard tool's +Start/+End (one event,
@@ -8212,7 +8225,14 @@ function legacyKpiRaw(roleId) {
   const f = fleetInsp();
   const c = (v) => ({ v, unit: '' }), usd = (v) => ({ v, unit: '$' });
   if (roleId === 'mechanic') return [c(f.Ready + f['Not Ready']), c(W.filter((w) => w.phase === 'Complete').length), c(W.filter((w) => (w.lineItems || []).some((li) => (li.cost || 0) > 0 || (li.hours || 0) > 0) && w.billCustomer === 'Yes').length)];
-  if (roleId === 'mtech') return [c(R.length - R.filter((r) => r.fieldCall).length), c(f.Ready), c(N.filter((n) => !n.woId).length)];
+  if (roleId === 'mtech') {
+    // #552 audit item 9: WO Rate ring's raw value now mirrors kpiPct's exact numerator
+    // (30-day window, inspections WITH a woId) — was counting all-time inspections
+    // WITHOUT one, moving opposite the percentage and popping the celebration on the
+    // wrong events.
+    const cutoff = new Date(TODAY.getTime() - 30 * 86400000).toISOString().slice(0, 10);
+    return [c(R.length - R.filter((r) => r.fieldCall).length), c(f.Ready), c(N.filter((n) => (n.date || '') >= cutoff && n.woId).length)];
+  }
   if (roleId === 'driver') return [c(R.filter((r) => ['On Rent', 'End Rent', 'Off Rent', 'Returned'].includes(r.status)).length), c(N.filter((n) => n.wash === 'Yes').length), c(drivingScoreValue() || 0)];
   if (roleId === 'office') return [usd(INV.reduce((a, i) => a + invoiceTotals(i).paid - (Number(i.refundedAmount) || 0), 0)), c(R.filter((r) => ['On Rent', 'End Rent', 'Off Rent', 'Returned'].includes(r.status)).length), c(0)];
   if (roleId === 'sales') {
@@ -8315,13 +8335,11 @@ function headerEl() {
 }
 /* Theme cycle: dark → yard → light → dark. The bottom-bar button shows the icon
    + tooltip of the theme you'll switch TO next (matching the old sun/moon convention). */
+// #552 audit follow-up (2026-07-09): dark/ranch/light removed — dormant, unreachable
+// via the live toggle (Jac: "we only have one theme... the others can be removed").
 const THEME_NEXT = {
   yard:       { next: 'bluedsteel', icon: I.bluesteel, tip: 'Blued Steel' },
   bluedsteel: { next: 'yard',       icon: I.hardhat,   tip: 'Yard mode' },
-  // dormant fallbacks — the live toggle is the Yard ⇄ Blued Steel flip; any stale stored theme recovers to Yard
-  dark:  { next: 'yard', icon: I.hardhat, tip: 'Yard mode' },
-  ranch: { next: 'yard', icon: I.hardhat, tip: 'Yard mode' },
-  light: { next: 'yard', icon: I.hardhat, tip: 'Yard mode' },
 };
 /** The action toolbar — pinned to the LEFT of the bottom comms band (the
  *  conversation rail fills the middle, bell + inbox sit at the right). On phones
@@ -14233,11 +14251,14 @@ let dragLayer = null, dragArc = null, chatDropPad = null, zipZones = null, zipDw
    hard money/safety gates live in the §16 mutations and re-fire on drop. */
 const DROP_MATRIX = {
   units: {
-    rentals: (u, r) => u.fleetStatus === 'Active' && r.unitId !== u.unitId,                       // §9 — non-Active units aren't rentable
+    // #552 audit item 11: rentalHasUnit() scans the WHOLE r.units[] (not just the
+    // legacy-primary r.unitId), so a non-primary unit already linked to a multi-unit
+    // rental no longer visually lights up as a valid drop target.
+    rentals: (u, r) => u.fleetStatus === 'Active' && !rentalHasUnit(r, u.unitId),                 // §9 — non-Active units aren't rentable
     invoices: (u, i) => !i.locked && !!unbilledOpenWOForUnit(u.unitId),                           // §7.6 — needs a billable open WO
   },
   rentals: {
-    units: (r, u) => u.fleetStatus === 'Active' && r.unitId !== u.unitId,
+    units: (r, u) => u.fleetStatus === 'Active' && !rentalHasUnit(r, u.unitId),
     invoices: (r, i) => !i.locked && !r.invoiceId && (!i.customerId || !r.customerId || i.customerId === r.customerId),   // §7.5 — one invoice per rental + customer scoping
     customers: (r, c) => r.customerId !== c.customerId && !/Blacklist/i.test(c.accountType || ''),                        // §9 blacklist
   },
@@ -15119,7 +15140,7 @@ function onClick(e) {
   if (closest('.js-ring')) return openOverlay({ kind: 'role', role: closest('.js-ring').dataset.role });
   if (closest('.js-roadmap')) return openOverlay({ kind: 'roadmap' });
   if (closest('.js-close')) return closeOverlay();
-  if (closest('.js-theme')) { state.theme = (THEME_NEXT[state.theme] || THEME_NEXT.dark).next; try { localStorage.setItem('jactec.theme', state.theme); } catch (e) {} if (state.overlay && state.overlay.kind !== 'addCard') renderOverlay(); render(); return; }
+  if (closest('.js-theme')) { state.theme = (THEME_NEXT[state.theme] || THEME_NEXT.yard).next; try { localStorage.setItem('jactec.theme', state.theme); } catch (e) {} if (state.overlay && state.overlay.kind !== 'addCard') renderOverlay(); render(); return; }
   if (closest('.js-qr')) return shareSession();
   if (closest('.js-previews') || closest('.js-roweye')) { e.stopPropagation(); state.previewsOn = !state.previewsOn; if (!state.previewsOn) hideHoverPreview(); try { localStorage.setItem('jactec.previewsOff', state.previewsOn ? '0' : '1'); } catch (e) {} toast(state.previewsOn ? 'Hover previews on.' : 'Hover previews off — every eye runs red.'); return render(); }
   if (closest('.js-hotkeys')) return openOverlay({ kind: 'hotkeys' });

--- a/backlog.md
+++ b/backlog.md
@@ -26,6 +26,13 @@ the task. To work one: `git checkout <branch>`, refresh it from its area
 ## Notes
 - **#4 Memberships** is parked but unspecified — needs a concrete task (state
   machine? member pricing gating? renewals / Paid-Until? unlimited transport?).
+- **Timeline Selector** (app.js §13.4, `graphViewsFor`/`openGvWinMenu`) — a per-
+  chart time-window filter (7/30/90/180/360 days, or All time) that's fully
+  built but never wired to any graph view (`v.timed` is never set `true`).
+  Kept in the code intentionally (Jac, 2026-07-09 pre-promotion audit follow-
+  up: "I have a lot in mind for this. Leave it in the UI but add a task for
+  later completion.") — needs a concrete spec for which graph(s) should get
+  it before it's wired up.
 - **`area/comms-notifications`** is a new area created off `staging` for #9 + #11
   (they share send plumbing — templates, triggers, delivery status).
 - Safety backup of the pre-reset `staging` tip lives at branch

--- a/ci/check-design-md.mjs
+++ b/ci/check-design-md.mjs
@@ -136,7 +136,9 @@ const norm = (v) => v.toLowerCase().replace(/\s+/g, '')
 let mapped = 0;
 for (const [cv, dk] of Object.entries(MAP)) {
   const want = cssVar[cv], got = colors[dk];
-  if (want == null) { WARN(`drift map: style.css ${cv} (→ ${dk}) not found in :root — update the map`); continue; }
+  // #552 audit item 14: a mapped var vanishing from :root (renamed/removed) is real
+  // drift, arguably the most common kind — this must fail the build, not just warn.
+  if (want == null) { ERR(`drift: style.css ${cv} (→ colors.${dk}) not found in :root — update the map or restore the token`); continue; }
   if (got == null) { ERR(`drift: DESIGN.md colors.${dk} missing — style.css ${cv} = ${want}`); continue; }
   if (norm(want) !== norm(got)) ERR(`drift: colors.${dk} = "${got}" ≠ style.css ${cv} = "${want}"`);
   else mapped++;

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -649,9 +649,17 @@ try {
       const s1 = T.salePriceSuggest(cat);
       ok(!!s1 && s1.basis === 'msrp' && s1.bottom === Math.round(cat.msrp * 0.5 / 25) * 25 && s1.ask === Math.round(cat.msrp * 0.8 / 25) * 25, 'SPE: MSRP basis scales bottom/ask on $25 steps');
       T.__state.settings.company = { ...(co0 || {}), salePriceBasis: 'cost', saleBottomPct: 55, salePriceMode: 'approve' };
+      // #552 audit item 15b: `cat` above was picked for MSRP > 0 (the previous assertion's
+      // criterion), unrelated to categoryCostBasis's need for a unit with trueCost/
+      // purchasePrice set — base was usually 0, so this never ran. Build a synthetic
+      // unit with trueCost set so it always does.
+      const costUnit = { unitId: 'T12J9-COSTU', categoryId: cat.categoryId, name: 'Cost Basis Test Unit', fleetStatus: 'Active', trueCost: 12000, mock: true };
+      T.DATA.units.push(costUnit); T.IDX.unit.set(costUnit.unitId, costUnit);
       const s2 = T.salePriceSuggest(cat);
       const base = T.categoryCostBasis(cat);
-      if (base) ok(s2.base === base && s2.bottom === Math.round(base * 0.55 / 25) * 25 && s2.ask == null, 'SPE: cost basis uses avg unit cost; unset ask % stays null');
+      ok(base > 0, 'SPE: categoryCostBasis picks up a unit with trueCost set');
+      ok(!!s2 && s2.base === base && s2.bottom === Math.round(base * 0.55 / 25) * 25 && s2.ask == null, 'SPE: cost basis uses avg unit cost; unset ask % stays null');
+      T.DATA.units = T.DATA.units.filter((u) => u !== costUnit); T.IDX.unit.delete(costUnit.unitId);
       T.__state.settings.company = co0;
       ok(T.salePriceSuggest(cat) === null || !T.salePricingCfg().on, 'SPE: engine is OFF when no percents are configured');
       const ld0 = (cat.lostDemand || []).length;
@@ -1129,8 +1137,15 @@ try {
     ok(/card/i.test(T.rentalRuleBlock({}, { name: 'X' }, 'On Rent') || ''), 'card Required + no card → On Rent blocked (true hard stop)');
     st.settings.rentalRules = { po: 'required' };
     ok(/PO/.test(T.rentalRuleBlock({ invoiceId: null }, { name: 'X' }, 'On Rent') || ''), 'PO Required + no invoice/PO → On Rent blocked');
-    const poInv = T.DATA.invoices.find((i) => i.po);
-    if (poInv) ok(T.rentalRuleBlock({ invoiceId: poInv.invoiceId }, { name: 'X' }, 'On Rent') === null, 'PO Required + invoice carries a PO → allowed');
+    // #552 audit item 15a: was `T.DATA.invoices.find((i) => i.po)` — every seeded invoice
+    // has po:'', so this never found one and the assertion silently never ran. Build a
+    // synthetic PO'd invoice so this branch actually executes every run.
+    {
+      const poInv = { invoiceId: 'T22-PO', po: 'PO-12345', mock: true };
+      T.DATA.invoices.push(poInv); T.IDX.invoice.set(poInv.invoiceId, poInv);
+      ok(T.rentalRuleBlock({ invoiceId: poInv.invoiceId }, { name: 'X' }, 'On Rent') === null, 'PO Required + invoice carries a PO → allowed');
+      T.DATA.invoices = T.DATA.invoices.filter((i) => i !== poInv); T.IDX.invoice.delete(poInv.invoiceId);
+    }
     st.settings.rentalRules = { id: 'required' };
     ok(/ID/i.test(T.rentalRuleBlock({}, { name: 'X' }, 'On Rent') || '') && T.rentalRuleBlock({}, { name: 'X', idNumber: 'LA-12345' }, 'On Rent') === null, 'ID Required: blocks without an ID #, allows with one');
     st.settings.rentalRules = { terms: 'required' };

--- a/config.js
+++ b/config.js
@@ -292,19 +292,6 @@ export const FLAG_META = {
 /** Severity rank for sorting/highest-wins. Higher = more severe. */
 export const FLAG_SEVERITY_RANK = { red: 3, yellow: 2, green: 1 };
 
-/* ── Legacy → canonical import map (SPEC §8 / §13; used by the import layer) ─ */
-export const LEGACY_MAP = {
-  rentalStatus: { 'Quoting': 'Quote', 'Return': 'Returned', 'End': 'End Rent', 'Refunded': 'Cancelled' },
-  transportType: { '🚚🔄': 'Round-Trip', '🚚🔻': 'Delivery', '🚚🔼': 'Recovery' },
-  woPhase: {
-    'NEW': 'Part Needed?', 'Done!!': 'Complete', '🙏🔩': 'Part Needed', '🚫🔩': 'No Part Needed',
-    '🔩✅📬': 'Part is Local', '🔩🔄📬': 'Part Ordered', '@Retailer': 'Part is Local', '@Dealer': 'Part is Local',
-    'Hrs': 'Complete',
-  },
-  marker: { 'NCP': 'Ready', '?': 'Not Ready', '❌': 'Failed', '': 'Ready' },
-  store: { 'SUL': 'Sulphur', 'BMT': 'Sulphur', 'Pick One': 'Sulphur' },
-};
-
 /* ── Transport-on-status: when does the truck icon show? (SPEC §8) ────────── */
 const TRUCK_STATUSES = new Set(['Tomorrow', 'Today', 'Reserved', 'On Rent']);
 export function showsTruck(rentalStatus, transportType) {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 21806 lines, 38 chapters
+## app.js — 21827 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -22,32 +22,32 @@
 | APP-12 | 5081–5248 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
 | APP-13 | 5249–5479 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, cardWindow, …(+6) |
 | APP-14 | 5480–5794 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 5795–5990 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 5991–7466 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+40) |
-| APP-17 | 7467–7684 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupCollapsed, toggleGroupCollapsed, …(+7) |
-| APP-18 | 7685–7952 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
-| APP-19 | 7953–8077 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 8078–8242 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 8243–8464 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, wrChatResolved, activeMobileCard, currentMobileMember, MOBILE_TOGGLE_GROUPS, …(+4) |
-| APP-22 | 8465–9528 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+99) |
-| APP-23 | 9529–9571 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 9572–10414 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 10415–12009 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-26 | 12010–12118 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-27 | 12119–12602 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 12603–13748 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
-| APP-29 | 13749–14014 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+16) |
-| APP-30 | 14015–14210 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, toast |
-| APP-31 | 14211–14214 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 14215–16199 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-33 | 16200–17294 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
-| APP-34 | 17295–18572 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+83) |
-| APP-35 | 18573–19029 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-36 | 19030–19032 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 19033–21255 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+137) |
-| APP-38 | 21256–21806 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
+| APP-15 | 5795–5994 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 5995–7479 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+40) |
+| APP-17 | 7480–7697 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupCollapsed, toggleGroupCollapsed, …(+7) |
+| APP-18 | 7698–7965 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
+| APP-19 | 7966–8090 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 8091–8262 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 8263–8482 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, wrChatResolved, activeMobileCard, currentMobileMember, MOBILE_TOGGLE_GROUPS, …(+4) |
+| APP-22 | 8483–9546 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+99) |
+| APP-23 | 9547–9589 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 9590–10432 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 10433–12027 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-26 | 12028–12136 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-27 | 12137–12620 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 12621–13766 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
+| APP-29 | 13767–14032 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+16) |
+| APP-30 | 14033–14228 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, toast |
+| APP-31 | 14229–14232 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 14233–16220 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-33 | 16221–17315 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
+| APP-34 | 17316–18593 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+83) |
+| APP-35 | 18594–19050 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-36 | 19051–19053 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 19054–21276 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+137) |
+| APP-38 | 21277–21827 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
 
-## config.js — 615 lines, 0 chapters
+## config.js — 602 lines, 0 chapters
 
 Chapter **CFG** — no internal banners, the whole file is one chapter.
 

--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -91,6 +91,7 @@ https://script.google.com/d/1hw9A7Id3YIoiSCBkNFeDaKGRv-VtljFFIuBdQG5QULrgS0DjQhQ
 |---|---|---|---|---|
 | 1 | **perfReport** — Web-Vitals sink → `_perf` tab (5k-row FIFO, metrics-only by construction) | `perf-report-backend.gs` | `if (action === 'perfReport') return json(perfReport_(body));` (wrap in `json()` — `handle()` must return a ContentService output, not the bare `{ok:true}` the source's comment shows) | ✅ DEPLOYED @62 (2026-07-06) |
 | 2 | **unitDaily snapshots (M4)** — daily unit hours/fleet-status history | `unit-daily-snapshots.gs` | router line per that file + run `installUnitDailyTrigger()` ONCE | ✅ Already live @57 (2026-07-03) |
+| 3 | **perfReport formula-injection guard** — `t1()` gets a leading-apostrophe guard so a client-supplied `build`/`device`/`role` starting with `=/+/-/@` can't be evaluated as a formula if the `_perf` tab is ever opened/exported (#552 audit, low severity — metrics tab, no money/PII) | `perf-report-backend.gs` (updated in place — same file as #1, now with the fix) | Replace the live `t1()` function body with the one in the source file (same signature, one added guard line) | ⏳ QUEUED (2026-07-09) — not yet deployed, needs the usual STOP-gate |
 
 Deploy flow (same deployment id, same exec URL). **`push` via the API, then deploy from the
 EDITOR** — the API `deploy` breaks anonymous access (see the ⛔ section above):

--- a/docs/handoffs/audit-2026-07-09-parked-findings.md
+++ b/docs/handoffs/audit-2026-07-09-parked-findings.md
@@ -1,184 +1,115 @@
-# Pre-promotion audit — parked findings (2026-07-09)
+# Pre-promotion audit — findings tracker (2026-07-09)
 
-Source: 19-agent adversarial line-by-line audit of `staging` (branch `wrangler-fix/pr552-batch`,
-content-identical to `origin/staging`), run before PR #552's staging→main promotion per Jac's
-explicit "before, not after" instruction. 54 findings confirmed after verification (0 critical /
-7 high / 20 medium / 27 low). 23 were mechanical/zero-risk and fixed in PR #554.
+Source: 19-agent adversarial line-by-line audit of `staging` before PR #552's promotion to
+`main`. 54 findings confirmed after verification (0 critical / 7 high / 20 medium / 27 low).
 
-**UPDATE (same day):** all 7 HIGH items below were then also resolved — Jac chose to work
-through them one at a time via popup rather than leave them parked — and shipped in PR #556.
-Item 17 (branch-janitor's `backup/*` guard) was actually part of the #554 batch, cross-referenced
-here only because item 23 is related. Both are left in place below, marked done, for the record.
-**21 MEDIUM/LOW items remain genuinely parked** — those still need a judgment call, touch
-money/auth semantics lightly enough not to be urgent, or need more investigation than a
-pre-promotion pass should absorb.
+**Status as of end-of-day 2026-07-09: 51 of 54 resolved.** 23 mechanical/zero-risk fixes shipped
+in PR #554. The 7 HIGH items shipped in PR #556 (Jac worked through each via popup rather than
+leave them parked). The remaining 21 MEDIUM/LOW items were then *also* worked through
+("let's fix all of them, go!") — all but 3 are now resolved too. Items 16, 20, and 21 below
+remain genuinely open (16 was attempted and reverted — see its entry for why).
 
-Legend: **file:line** — one-line verdict. Full evidence trail is in the audit transcript if needed.
+Legend: **file:line** — one-line verdict.
 
 ---
 
-## HIGH — money / auth / security (7) — ✅ ALL FIXED, shipped in PR #556
+## ✅ RESOLVED — HIGH (7, shipped PR #556)
 
-1. **app.js:1662, 1673 (`setTransportType`, `armTransportNode`)** — Transport-type changes reprice
-   an invoice's transport line (via `syncTransportLine`), and the dedicated editor (`openTransportEdit`)
-   explicitly gates this behind `canMoney()` ("a site/leg edit reprices transport — money tier, whole
-   edit"). But the segmented-control (`.js-ttype`) and route-rail (`.js-tnode`) controls call
-   `setTransportType`/`armTransportNode` directly with **no** role check — a mechanic/driver-tier
-   login (both legitimately view the rental detail for dispatch) can reprice transport. Needs a call:
-   add `canMoney()` to these two paths, or decide the money-repricing action itself should be
-   restricted differently (e.g. require confirmation, or split "which stops" from "what it costs").
-
-2. **app.js:12817 (`wrValidatePlan`)** — The `update` branch enforces the Office/Admin money-tier gate
-   for any `WR_MONEY_FIELDS` field; the `create` branch has no equivalent check. Mr. Wrangler (the AI)
-   could create a category or expense with attacker-influenced rate/amount fields regardless of the
-   requesting role. Needs the same gate added to `create`, but worth a careful pass over the whole
-   Acts chapter (APP-28) in case other actions have the same update-gated/create-ungated asymmetry.
-
-3. **app.js:18304 (WO header phase-pill dropdown)** — Can jump a work order straight to `Complete`
-   with no confirmation, which directly violates the CLAUDE.md rule "changing a WO part/task line to
-   Complete must NOT complete the work order — only the blue Complete WO button does." This is a
-   documented invariant being broken in a live control; recommend prioritizing this one first among
-   the parked items even though it needs UI/flow judgment (block the dropdown from offering
-   `Complete`, or intercept and redirect to the real Complete-WO flow).
-
-4. **app.js:17359 (`openPayInvoice`/`chargeInvoiceFlow`/`refundInvoiceFlow`/`recordManualPayment`)** —
-   Missing the defense-in-depth `canMoney()` check that every sibling money action in the same click
-   dispatcher has inline. Likely low exploitability if the entry points are themselves gated elsewhere,
-   but worth confirming and closing the gap explicitly rather than relying on gating upstream.
-
-5. **app.js:18918 (`billWOToInvoice`)** — The quick "Bill" button on a WO card can add a line to a
-   pricing-locked invoice, bypassing the §7.5 lock gate enforced everywhere else. Money-integrity bug;
-   needs the same lock check every other billing path uses.
-
-6. **ci/check-design-md.mjs:71** — The `components:` block parser only recognizes a single-line
-   component definition; a multi-line entry is silently dropped from validation with no error/warning.
-   This is a CI-gate correctness bug (the gate whose job is to keep `DESIGN.md` honest can silently
-   skip real content) rather than a live-app risk — still worth a fix, lower urgency than 1-5.
-
-7. **`.github/workflows/wrangler-fix.yml:67`** — The autonomous Wrangler-fix agent's prompt embeds
-   `github.event.issue.title`/`.body` verbatim (confirmed: only in the `prompt:` string, never in a
-   `run:` shell step — no direct shell-injection path, see item 48 below). But the audit flagged a
-   concrete secret-exfiltration consequence worth your read: with `--allowedTools Bash` and a PAT in
-   `GH_TOKEN`, a maliciously crafted issue body could attempt to instruct the agent to read/leak the
-   PAT or API key via a crafted PR/comment. The existing mitigations (CI-gated auto-merge, "never
-   weaken money/card/auth" instruction, STOP-and-ask-Jac on ambiguity) are real but don't specifically
-   address prompt-injection-driven secret exfiltration. Worth a design pass if/when this workflow is
-   switched on for real (currently inert pending secrets).
+1. **Transport-type money gate** (app.js `setTransportType`/`armTransportNode`) — now requires
+   `canMoney()`, matching the address editor's existing gate.
+2. **Wrangler create-gate** (`wrValidatePlan`) — `create` ops now strip money fields below money
+   tier, same as `update` already did.
+3. **WO Complete/Cancel redesign** — the header status pill is now a read-only derived display
+   (`woBottleneck`), not a dropdown; a Cancel gate was added to line items (blocked if the line
+   still carries cost).
+4. **Payment-flow defense-in-depth** — `openPayInvoice`/`chargeInvoiceFlow`/`refundInvoiceFlow`/
+   `recordManualPayment`(`postManualPayment`) all now re-check `canMoney()` internally.
+5. **`billWOToInvoice` rewrite** — bills to the invoice carrying the rental that needed the WO
+   specifically, falls through to a fresh invoice if that one's locked/paid.
+6. **`check-design-md.mjs` fail-loud fix** — a wrapped component spec now hard-errors instead of
+   silently escaping validation.
+7. **`wrangler-fix.yml` prompt-hardening** — untrusted-data framing + standing no-secrets
+   instruction added. Exploitability checked: repo is public, but the trigger label can only be
+   attached by an existing collaborator; the in-app reporter requires a human "Submit new issue"
+   click, never auto-files.
 
 ---
 
-## MEDIUM (13)
+## ✅ RESOLVED — MEDIUM/LOW (shipped same day, 2026-07-09, no PR # yet at time of writing)
 
-8. **app.js:6472 (`rentalLineRefund`)** + **app.js:5830 (rentals card "Invoice" column)** — Same root
-   cause, bundle together: both only look at `r.invoiceId` (the rental's *first* §28-cap chunk
-   invoice), so a refund or status change on a continuation invoice (chunk #2+) is invisible to the
-   refund UI and the Invoice column/footer counts. The fix shape already exists in the codebase
-   (`rentalInvoices(r)` walks the whole series, already used a few lines away in the same renderer) —
-   this is a real gap in the r4 chunk-billing area, worth doing as one focused fix.
-
-9. **app.js:8217 (`legacyKpiRaw`, mtech "WO Rate" ring)** — The raw/gamification value moves opposite
-   to the percentage it's supposed to mirror (counts all-time inspections *without* a WO instead of
-   30-day inspections *with* one), so the score-pop celebration fires on the wrong events. Cosmetic/
-   gamification only, but a real inversion bug — needs the raw computation's windowing to match the
-   percentage computation's windowing.
-
-10. **app.js:9688 (§13.4 Timeline Selector)** — Confirmed permanently unreachable: `v.timed` is never
-    set `true` anywhere, so this whole window-picker feature (button, menu, handlers, ~160 lines) can
-    never render. Product decision, not a bug fix: either finish wiring it or delete it as dead UI.
-
-11. **app.js:14230 (`DROP_MATRIX` units↔rentals validators)** — Uses the legacy single-unit `r.unitId`
-    instead of checking all of `r.units[]`, so a non-primary unit already linked to a multi-unit rental
-    still visually lights up as a valid drag-drop target (the real link function still blocks the actual
-    drop with a toast, so no data corruption — just a misleading visual).
-
-12. **app.js:18321 (`setWoLinePhase`)** — Derives the WO's displayed phase from whichever open line
-    happens to be *last* in array order, not the worst-severity bottleneck (`woBottleneck()` elsewhere
-    does this correctly via `WO_SEV` sort). Can show a misleadingly mild status on the WO header. Same
-    subsystem as item 3 (WO phase) — consider fixing together.
-
-13. **config.js:295 (`LEGACY_MAP`)** — Confirmed zero consumers anywhere in the frontend. Per the
-    project's own dead-code-report caveat, string-dispatch/import-script usage can hide a real
-    reference — cross-check against `tools/import-real-data.ps1` before deleting; this is exactly the
-    class of "looks dead statically, might be load-bearing for CSV import" case that needs a human
-    check rather than an automated one.
-
-14. **ci/check-design-md.mjs:130** — The drift guard downgrades to an advisory `WARN` (not a build-
-    failing `ERR`) when a mapped `style.css :root` variable can't be found at all — arguably the most
-    common real-world drift case (a renamed/removed token) escapes the gate whose entire job is to
-    catch exactly that. All 24 currently-mapped vars happen to still resolve, so this hasn't bitten yet.
-
-15. **ci/logic-test.mjs:1132 and :654** — Two dead assertions (never execute due to fixture state):
-    the "PO on file unblocks On Rent" rental-rule check, and the sale-price engine's "cost basis"
-    regression check. Both were empirically confirmed dead (instrumented + run through the real
-    Playwright harness). This means two money/pricing code paths have zero regression coverage despite
-    a passing-green test file — worth fixing the fixtures so these actually exercise the intended path.
-
-16. **tools/gen-code-map.mjs:88 and tools/dead-code-scan.mjs:59** — Both banner-parsers pair up
-    chapter-boundary rule-lines by flat array position with no proximity/validity check, contradicting
-    `gen-code-map.mjs`'s own docstring ("a banner is a cluster of rule lines within 3 lines of each
-    other"). A stray 6+-`═` line anywhere in the codebase would silently desync chapter titles/ranges
-    in the generated docs, with `--check` unable to catch it (it only checks the desynced *output* is
-    self-consistent, not that the desync happened). Tooling-only, no live-app impact, but worth
-    hardening since these generators are trusted for navigation.
-
-17. **`.github/workflows/branch-janitor.yml:66`** — ✅ *fixed in PR #554* — listed here only because
-    the sibling item below (23) is related and still parked.
-
-18. **docs/handoffs/perf-report-backend.gs:31** — Writes client-controlled strings (build/device/role)
-    straight into Sheet cells with no formula-injection sanitization (no leading-apostrophe guard
-    against a value starting with `=`/`+`/`-`/`@`). This is a *reference snippet*, not live code — only
-    matters if/when re-pasted to the real backend — but worth fixing the tracked snippet so the next
-    paste-deploy doesn't carry the gap forward.
-
-19. **docs/handoffs/membership-billing-additions.gs:14** — Still shows the dispatch snippet gating on
-    the superseded name-keyed `MONEY_ROLES` map rather than the tier-based `roleMoneyOk_` that
-    `role-tiers-backend.gs` says replaced it. Same class as item 26 below (cash-payment snippet). Both
-    are reference-doc staleness, not live-backend bugs (assuming the live migration already happened),
-    but risk being pasted back verbatim by a future session that pattern-matches on the wrong file.
+8. **`rentalLineRefund` + rentals "Invoice" column** (app.js) — both now walk the whole §28cap
+   chunk series (`rentalInvoices`/`rentalActiveInvoice`) instead of only the first chunk.
+9. **mtech "WO Rate" gamification ring** (`legacyKpiRaw`) — raw value now uses the same 30-day
+   window + same-direction count as the percentage it's supposed to mirror.
+11. **`DROP_MATRIX` units↔rentals validators** — now use `rentalHasUnit()` (checks the whole
+    `r.units[]`) instead of the legacy single-unit `r.unitId`.
+12. **`setWoLinePhase`'s phase derivation** — resolved as a side effect of item 3: the function no
+    longer writes `w.phase` at all (that's now purely a derived display), so the wrong-derivation
+    bug has no code path left to occur on.
+13. **`LEGACY_MAP`** (config.js) — deleted. Verified zero references anywhere in the frontend
+    *and* in `tools/import-real-data.ps1` (the one plausible "import layer" in the repo) before
+    removing.
+14. **`check-design-md.mjs` drift guard** — a missing mapped `:root` var now hard-errors instead
+    of just warning.
+15. **2 dead test assertions** (`ci/logic-test.mjs`) — both fixture bugs fixed (synthetic PO'd
+    invoice; synthetic unit with `trueCost` set) so both now actually execute every run.
+16. **`gen-code-map.mjs` + `dead-code-scan.mjs` banner-pairing** — ⚠ **attempted, reverted.** Tried
+    a max-gap validity check between a banner's open/close rule lines, but real banners in this
+    file routinely carry 10-30+ lines of descriptive prose (the deleted ranch-theme banner alone
+    spanned 13), so any gap threshold tight enough to catch a genuinely stray line also rejects
+    the vast majority of real banners — confirmed by running it against the actual file (`--check`
+    started failing with 20+ banner-id mismatches). Reverted to the original pairing logic rather
+    than ship something broken. The underlying finding is still real (no proximity/validity check
+    at all) but a line-count heuristic isn't the right fix for this codebase's banner-size
+    distribution — would need a smarter check (e.g. comparing against the previous known-good
+    banner count) or just isn't worth hardening against a failure mode with zero real occurrences.
+17. **`branch-janitor.yml`'s `backup/*` guard** — fixed earlier, in PR #554.
+18. **`perf-report-backend.gs` formula-injection guard** — fixed in the tracked snippet (leading-
+    apostrophe guard on `t1()`) and **queued** in `BACKEND-DEPLOY-QUEUE.md` (#3) — **not yet
+    deployed live**, needs the usual `/clasp` STOP-gate before it ships.
+19. **`membership-billing-additions.gs` stale gate** — corrected `MONEY_ROLES[role]` →
+    `roleMoneyOk_(role)` in the snippet. **⚠ New finding while fixing this**: a live Code.gs read
+    (via the Drive connector) found **none** of `membershipEnroll_`/`membershipCancel_`/
+    `membershipReactivate_`/`membershipBillingCron` actually exist in the bound script, despite
+    this file's header claiming "DEPLOYED LIVE 2026-06-25 (version 46)." Flagged at the top of
+    that file — needs Jac to confirm whether this is a versioning mismatch (deployed web-app
+    version vs. bound-script content) or the app-driven membership system genuinely isn't live.
+22. **`--good` CSS token / light theme** — resolved differently than originally scoped: Jac opted
+    to delete the light theme entirely (confirmed dormant/unreachable) rather than define
+    `--good` for it. Also deleted the `ranch` theme (same dormant class, ~25 rule-blocks) per
+    Jac's "the others can be removed." **⚠ New finding**: the whole theme-TOGGLE mechanism turned
+    out to be unreachable too — no `.js-theme` button ever renders in the UI (only its click-
+    handler exists), so even the documented Yard⇄Blued-Steel cycle can never fire; the app is
+    permanently on `bluedsteel`. Not touched — Jac may want to revisit whether to finish wiring a
+    real toggle button or clean up `THEME_NEXT`/`yard` CSS too.
+23. **`branch-janitor.yml` pagination** — both `gh pr list` calls (the daily prune job AND the
+    one-time stranded-branch cleanup job) now use `--paginate` instead of `--limit 1000`.
+24. **`cash-payment-backend.gs` stale gate** — corrected to `roleMoneyOk_(role)`; confirmed this
+    one **is** live and matches (unlike item 19's discrepancy).
+25. **Missing Stripe/gpsToken backend snippets** — written from a live Code.gs read via the Drive
+    connector: `docs/handoffs/stripe-actions-backend.gs` (dispatch table + 2 representative
+    handlers) and `docs/handoffs/gps-token-proxy-backend.gs`. **⚠ New finding while writing the
+    gpsToken snippet**: the live `gpsToken_` has a hardcoded plaintext password fallback baked
+    into the source (justified in-line as "server-side + gitignored, never served publicly," which
+    is true for the public-repo vector but means the credential can't be fully rotated without an
+    editor edit). Flagged in the new snippet file, not fixed (would need a live backend deploy).
 
 ---
 
-## LOW (8)
+## ⏳ STILL OPEN (2)
 
-20. **config.js:26 (`colorVar`/`colorBgVar`)** — Documented as the mandatory color-resolution API in
-    the file's own header comment, but zero call sites; app.js reimplements the same template-literal
-    pattern inline dozens of times instead. Not necessarily "delete" — could also mean "go retrofit the
-    inline call sites to use the documented helper," which is a bigger, deliberate cleanup, not a
-    park-and-forget deletion.
+20. **`colorVar()`/`colorBgVar()`** (config.js) — documented as the mandatory color-resolution
+    API but zero call sites. **Parked at Jac's explicit direction** ("park this as a design thing
+    to look at later") — not touched.
 
-21. **style.css:1944 (`!important` on `.set-planned-sub`)** — Papers over a specificity conflict that
-    scoping the selector (`.set-planned p.set-planned-sub`) would resolve cleanly. Low risk but touches
-    live rendering, so flagged rather than auto-fixed.
-
-22. **style.css:2753 (`--good` token)** — Referenced with a hardcoded fallback in 5 places but never
-    defined in `:root`/`[data-theme="light"]`, so it always renders the literal fallback and never
-    themes per-mode like its sibling status colors do. Fixing means choosing dark/light values — a
-    design-token decision, not a mechanical one.
-
-23. **`.github/workflows/branch-janitor.yml:58`** — `gh pr list --limit 1000` on both merged/open
-    queries isn't paginated (unlike the `gh api .../branches --paginate` call in the same file); at
-    >1000 PRs a stale/reused branch name could theoretically slip past the "never delete a branch with
-    an open PR" guard. Not urgent at current repo scale, but a real latent gap in an unattended daily
-    job — worth switching to `--paginate` when convenient.
-
-24. **docs/handoffs/cash-payment-backend.gs:17** — Same staleness class as item 19: dispatch snippet
-    still shows the pre-tier-redesign `MONEY_ROLES[role]` gate rather than `roleMoneyOk_(role)`.
-
-25. **Backend contract coverage gaps (informational, no file to edit)** — Two backend action families
-    the frontend calls have **no** tracked reference snippet at all in `docs/handoffs/`: all 10 Stripe
-    actions (`stripePubKey` through `stripeFinalizeInvoice` — the single largest unverifiable,
-    money-critical backend surface in this whole review) and the `gpsToken` GAS-side proxy action. This
-    isn't a bug — the live `Code.gs` may implement these correctly — but there's no way to verify from
-    this repo, and no snippet to hand a future session. Worth writing reference snippets for both next
-    time you're in the Apps Script editor.
+21. **`style.css:1944` `!important` on `.set-planned-sub`** — papers over a specificity conflict
+    that scoping the selector would resolve cleanly. Not part of today's fix pass; low risk but
+    touches live rendering, so still flagged rather than auto-fixed.
 
 ---
 
 ## Dropped (not real findings — kept for completeness)
 
-- `.github/workflows/branch-janitor.yml:55` and `wrangler-fix.yml:79` — the audit's F17 pass explicitly
-  went looking for GitHub Actions script-injection (untrusted `${{ github.event.* }}` interpolated into
-  a `run:` shell step) and came back clean on both files: neither ever puts issue/PR title, body, or
-  labels into a `run:` step — `wrangler-fix.yml` only interpolates them into the Claude action's
-  `prompt:` string (a different, already-acknowledged risk — see HIGH item 7). Recorded here so the
-  question doesn't get re-asked, not because either needs action.
+- `.github/workflows/branch-janitor.yml:55` and `wrangler-fix.yml:79` — the audit's F17 pass
+  explicitly went looking for GitHub Actions script-injection and came back clean on both files.
+  Recorded here so the question doesn't get re-asked.

--- a/docs/handoffs/cash-payment-backend.gs
+++ b/docs/handoffs/cash-payment-backend.gs
@@ -14,8 +14,12 @@
  * This file is the tracked source of truth — NO secrets. Two edits to Code.gs:
  *
  * EDIT 1 — dispatch (in handle(), right after the membershipActivate line):
- *   if (action === 'recordManualPayment') return json(MONEY_ROLES[role] ? recordManualPayment_(body, role) : { ok: false, error: 'forbidden' });
- *   if (action === 'recordManualRefund')  return json(MONEY_ROLES[role] ? recordManualRefund_(body, role) : { ok: false, error: 'forbidden' });
+ *   if (action === 'recordManualPayment') return json(roleMoneyOk_(role) ? recordManualPayment_(body, role) : { ok: false, error: 'forbidden' });
+ *   if (action === 'recordManualRefund')  return json(roleMoneyOk_(role) ? recordManualRefund_(body, role) : { ok: false, error: 'forbidden' });
+ *
+ * CONFIRMED against the live Code.gs (Drive read, 2026-07-09): both dispatch
+ * lines already use roleMoneyOk_ in production — this file was stale (still
+ * showed the pre-migration MONEY_ROLES[role] form), now corrected to match.
  *
  * EDIT 2 — paste the two functions below (anywhere top-level; e.g. after the
  * Stripe section). They reuse existing helpers: readRecord_, writeRecord_,

--- a/docs/handoffs/gps-token-proxy-backend.gs
+++ b/docs/handoffs/gps-token-proxy-backend.gs
@@ -1,0 +1,54 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * gpsToken — WranglerGPS auth proxy (AS-BUILT REFERENCE, read from live
+ * Code.gs via the Drive connector 2026-07-09, for the #552 pre-promotion
+ * audit's "no snippet exists for this action" gap). NO secrets below.
+ * -------------------------------------------------------------------------
+ * The forked WranglerGPS telematics service (Railway) authenticates with a
+ * SINGLE team password that mints an x-auth-token good for both reads and
+ * remote engine shutdown — so that password must never reach the public
+ * Pages client. app.js calls backendCall('gpsToken') instead; the backend
+ * logs in server-side and hands back ONLY the derived token.
+ *
+ * Dispatch (in handle(), after the role/password gate):
+ *   if (action === 'gpsToken') return json(gpsToken_(role));
+ * gpsToken is also listed in WRITE_ACTIONS (POST-only) — the derived token
+ * is itself shutdown-capable, so it must never ride in a GET URL that could
+ * get logged/prefetched (§256 in the live source).
+ * ════════════════════════════════════════════════════════════════════════ */
+
+function gpsToken_(role) {
+  var props = PropertiesService.getScriptProperties();
+  // Script Property WINS. Live source ALSO carries a hardcoded fallback
+  // password here (a real string, not a placeholder) for "no Script-Property
+  // step needed to go live" — see the audit finding below before ever
+  // re-pasting this function verbatim.
+  var pw = props.getProperty('GPS_DASHBOARD_PASSWORD') || '<REDACTED — see finding below, do not restore a hardcoded fallback>';
+  if (!pw) return { ok: false, error: 'gps-not-configured' };
+  var base = (props.getProperty('GPS_BACKEND_URL') || 'https://wranglergps-production-c2ad.up.railway.app').replace(/\/+$/, '');
+  var resp;
+  try {
+    resp = UrlFetchApp.fetch(base + '/auth/login', {
+      method: 'post', contentType: 'application/json',
+      payload: JSON.stringify({ password: pw }), muteHttpExceptions: true
+    });
+  } catch (e) { return { ok: false, error: 'gps-unreachable' }; }
+  var code = resp.getResponseCode();
+  var out; try { out = JSON.parse(resp.getContentText()); } catch (e) { out = null; }
+  if (code >= 200 && code < 300 && out && out.token) return { ok: true, token: out.token };
+  return { ok: false, error: 'gps-auth-' + code };   // never echo the upstream body — may leak internals
+}
+
+/* ── AUDIT FINDING (2026-07-09) — flagged to Jac in chat, not fixed here ──
+ * The live gpsToken_ has a HARDCODED plaintext fallback password baked into
+ * the source (`props.getProperty('GPS_DASHBOARD_PASSWORD') || '<a real
+ * password string>'`), justified in the live comment as "minimal steps,
+ * secrets-exposure OK — Code.js is server-side + gitignored, never served
+ * publicly." That's true for the PUBLIC-repo exposure vector, but it still
+ * means the credential can never be fully rotated without an editor edit
+ * (clearing the Script Property alone doesn't remove it — the fallback just
+ * silently takes back over), and it sits in plaintext for anyone with edit
+ * access to the Apps Script project, not just Script Properties access.
+ * Recommend: set GPS_DASHBOARD_PASSWORD as a real Script Property (it may
+ * already be set — Script Property still wins today) and remove the
+ * hardcoded fallback string entirely on the next backend deploy.
+ * ── */

--- a/docs/handoffs/membership-billing-additions.gs
+++ b/docs/handoffs/membership-billing-additions.gs
@@ -1,9 +1,24 @@
 /* ════════════════════════════════════════════════════════════════════════
+ * ⚠ UNVERIFIED AS OF 2026-07-09 — this file's header claims "DEPLOYED LIVE
+ * 2026-06-25 (version 46)", but a live Code.gs read via the Drive connector
+ * that day found ZERO occurrences of membershipEnroll_, membershipCancel_,
+ * membershipReactivate_, membershipBillingCron, or MEM_TERM_MONTHS anywhere
+ * in the bound script — only the older Stripe-Subscription membershipActivate_
+ * path exists live. Either the deployed web-app version differs from the
+ * bound-script content this read saw (Apps Script versioning — a deploy can
+ * be pinned to an older version than the editor's current content), or the
+ * app-driven membership system documented below is NOT actually live despite
+ * this header. Flagged to Jac (#552 audit follow-up, 2026-07-09) — do not
+ * trust the "DEPLOYED LIVE" claim below until that's confirmed one way or
+ * the other. The gate-name correction (MONEY_ROLES → roleMoneyOk_) below is
+ * still applied for whenever this does get deployed for real.
+ * ════════════════════════════════════════════════════════════════════════ */
+/* ════════════════════════════════════════════════════════════════════════
  * MEMBERSHIP — app-driven billing backend. DEPLOYED LIVE 2026-06-25 (version 46)
  * to the prod deployment via clasp. This file is the tracked, secret-free record of
  * the code that is live in Code.gs (which is gitignored). Reconciled against the real
  * backend helpers (readRecord_/writeRecord_/computeInvoiceCents_/stripeChargeInvoice_/
- * appendLedger_/getConfigObj/ss()/tryLock_/todayIso_/TAX_RATE_SERVER/MONEY_ROLES).
+ * appendLedger_/getConfigObj/ss()/tryLock_/todayIso_/TAX_RATE_SERVER/roleMoneyOk_).
  *
  * NOTE: the backend ALSO has a separate, dormant Stripe-SUBSCRIPTION membership system
  * (membershipActivate_ / membershipDailySweep / stripeWebhook_). Per Jac (2026-06-25) we
@@ -11,9 +26,9 @@
  * the two never overlap.
  *
  * ── DISPATCH (spliced into handle(), right after the membershipActivate line ~184) ──
- *   if (action === 'membershipEnroll')     return json(MONEY_ROLES[role] ? membershipEnroll_(body, role)     : { ok:false, error:'forbidden' });
- *   if (action === 'membershipCancel')     return json(MONEY_ROLES[role] ? membershipCancel_(body, role)     : { ok:false, error:'forbidden' });
- *   if (action === 'membershipReactivate') return json(MONEY_ROLES[role] ? membershipReactivate_(body, role) : { ok:false, error:'forbidden' });
+ *   if (action === 'membershipEnroll')     return json(roleMoneyOk_(role) ? membershipEnroll_(body, role)     : { ok:false, error:'forbidden' });
+ *   if (action === 'membershipCancel')     return json(roleMoneyOk_(role) ? membershipCancel_(body, role)     : { ok:false, error:'forbidden' });
+ *   if (action === 'membershipReactivate') return json(roleMoneyOk_(role) ? membershipReactivate_(body, role) : { ok:false, error:'forbidden' });
  *
  * ── REMAINING MANUAL STEP: install the daily trigger (clasp run can't — no API-exec deploy).
  *   In the Apps Script editor: Run → installMembershipBillingCron_   (creates a daily 3am trigger)

--- a/docs/handoffs/perf-report-backend.gs
+++ b/docs/handoffs/perf-report-backend.gs
@@ -16,6 +16,15 @@
  *
  * WIRE-UP: add to handle()'s router:
  *     if (action === 'perfReport') return perfReport_(body);
+ *
+ * ⚠ FIX PENDING DEPLOY (#552 audit, 2026-07-09) — CONFIRMED live via Drive read:
+ * `t1()` truncates `build`/`device`/`role` to a length cap but never neutralizes
+ * a leading =/+/-/@, so a crafted client value opens the door to Sheets/Excel
+ * formula injection for anyone who later opens/exports the `_perf` tab. Low
+ * severity (metrics tab, no money/PII), but free to close. `t1()` below is
+ * the FIXED version — one line added, everything else unchanged from live.
+ * NOT deployed by this session — queued in BACKEND-DEPLOY-QUEUE.md, needs the
+ * usual /clasp STOP-gate before it goes live.
  */
 var PERF_TAB = '_perf';
 var PERF_MAX_ROWS = 5000;   // rolling window — the sink can never bloat the file
@@ -27,7 +36,11 @@ function perfReport_(body) {
     var v = (body && body.vitals) || {};
     var r = (body && body.renders) || {};
     var n1 = function (x) { x = Number(x); return isFinite(x) ? x : ''; };
-    var t1 = function (x, cap) { return String(x == null ? '' : x).slice(0, cap || 40); };
+    var t1 = function (x, cap) {
+      var s2 = String(x == null ? '' : x).slice(0, cap || 40);
+      if (/^[=+\-@]/.test(s2)) s2 = "'" + s2;   // formula-injection guard: force plain text, don't let a leading =/+/-/@ get evaluated
+      return s2;
+    };
     s.appendRow([
       new Date(), t1(body && body.build), t1(body && body.device, 10), t1(body && body.role, 24),
       n1(v.lcp), n1(v.inp), n1(v.cls), n1(r.p50), n1(r.p95), n1(r.over), n1(r.n),

--- a/docs/handoffs/stripe-actions-backend.gs
+++ b/docs/handoffs/stripe-actions-backend.gs
@@ -1,0 +1,144 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * Stripe money actions — AS-BUILT REFERENCE (read from live Code.gs via the
+ * Drive connector 2026-07-09, for the #552 pre-promotion audit's "no
+ * snippet exists for the largest money-critical backend surface" gap).
+ * NO secrets below — STRIPE_SECRET / STRIPE_PUBLISHABLE_KEY are read from
+ * PropertiesService only, never hardcoded, never echoed (stripeDiag reports
+ * only whether it's configured + its key-mode prefix, never the value).
+ * -------------------------------------------------------------------------
+ * Central gate (handle(), after the role/password auth check): every
+ * action name prefixed "stripe" (except stripePubKey, public-by-design, and
+ * stripeDiag) goes through ONE money-tier check before any handler runs —
+ * confirms the r5/r9-class frontend gap audit found does NOT exist on the
+ * backend; this is exactly the "check centrally, not per-handler" pattern
+ * the frontend audit (item 4) was retrofitted to match:
+ *
+ *   if (action && action.indexOf('stripe') === 0) {
+ *     if (!roleMoneyOk_(role)) return json({ ok: false, error: 'forbidden' });
+ *     if (action === 'stripeDiag') { ... reports configured + key-mode only ... }
+ *     if (action === 'stripeSetupIntent')     return json(stripeSetupIntent_(body, role));
+ *     if (action === 'stripeSaveCard')        return json(stripeSaveCard_(body, role));
+ *     if (action === 'stripeBankSetupIntent') return json(stripeBankSetupIntent_(body, role));   // §14b ACH
+ *     if (action === 'stripeSaveBank')        return json(stripeSaveBank_(body, role));          // §14b ACH
+ *     if (action === 'stripeVerifyBank')      return json(stripeVerifyBank_(body, role));        // §14b ACH
+ *     if (action === 'stripeSetDefault')      return json(stripeSetDefault_(body, role));
+ *     if (action === 'stripeRemoveCard')      return json(stripeRemoveCard_(body, role));
+ *     if (action === 'stripeListCards')       return json(stripeListCards_(body, role));
+ *     if (action === 'stripeChargeInvoice')   return json(stripeChargeInvoice_(body, role));
+ *     if (action === 'stripeFinalizeInvoice') return json(stripeFinalizeInvoice_(body, role));
+ *     if (action === 'stripeRefundInvoice')   return json(stripeRefundInvoice_(body, role));
+ *     if (action === 'stripeLockInvoice')     return json(stripeLockInvoice_(body, role));
+ *     if (action === 'stripeUnlockInvoice')   return json(stripeUnlockInvoice_(body, role));
+ *     return json({ ok: false, error: 'unknown action' });
+ *   }
+ *
+ * stripePubKey is handled separately, above the role gate — public by design
+ * (any signed-in role reads it so the client runs Stripe in the same
+ * test↔live mode as the secret key, no code change needed on rotation).
+ * ════════════════════════════════════════════════════════════════════════ */
+
+// Bootstraps a Stripe Customer for this app-customer on first use, then opens
+// a SetupIntent (off_session, card-only) for the browser to confirm. The
+// resulting clientSecret never touches this backend again until confirmed.
+function stripeSetupIntent_(body, role) {
+  var customerId = String(body.customerId || '');
+  var lock = tryLock_(15000); if (!lock) return { ok: false, error: 'busy' };
+  try {
+    var rec = readRecord_('customers', customerId);
+    if (!rec) return { ok: false, error: 'customer-not-found' };
+    if (!rec.stripeId) {
+      var cr = stripeApi_('post', 'customers', {
+        name: rec.name || ((rec.firstName || '') + ' ' + (rec.lastName || '')).trim(),
+        email: rec.email || '', phone: rec.phone || '', 'metadata[customerId]': customerId
+      });
+      if (!cr.ok || !cr.body.id) return { ok: false, error: 'stripe-customer-failed' };
+      rec.stripeId = cr.body.id; writeRecord_('customers', rec);
+    }
+    var si = stripeApi_('post', 'setup_intents', {
+      customer: rec.stripeId, usage: 'off_session', 'payment_method_types[]': 'card',
+      'metadata[customerId]': customerId, 'metadata[role]': role
+    });
+    if (!si.ok || !si.body.client_secret) return { ok: false, error: 'stripe-setupintent-failed' };
+    return { ok: true, clientSecret: si.body.client_secret, setupIntentId: si.body.id, stripeId: rec.stripeId };
+  } finally { lock.releaseLock(); }
+}
+
+// Charges an invoice's live balance (or a capped partial). Re-uses an
+// in-flight PaymentIntent instead of ever opening a second one (guards
+// double-charge), enforces MAX_CHARGE_CENTS, handles 3DS (requires_action)
+// and ACH (processing) as distinct outcomes, and idempotency-keys every
+// Stripe call on (invoiceId, amount, attempt) so a network retry can never
+// double-charge. invoiceSealOk_() re-verifies a LOCKED invoice wasn't
+// altered since sealing before charging it — the server-side half of the
+// same §7.5 lock the frontend enforces (see #552 audit item 5's
+// billWOToInvoice fix for the frontend-side analog of this kind of check).
+function stripeChargeInvoice_(body, role) {
+  var invoiceId = String(body.invoiceId || '');
+  var reqCents = body.amountCents != null ? Math.round(Number(body.amountCents)) : null;   // optional partial request
+  var lock = tryLock_(20000); if (!lock) return { ok: false, error: 'busy' };
+  try {
+    var inv = readRecord_('invoices', invoiceId);
+    if (!inv) return { ok: false, error: 'invoice-not-found' };
+    if (!invoiceSealOk_(inv)) return { ok: false, error: 'invoice-integrity' };       // locked invoice was altered since sealing
+    var amt = computeInvoiceCents_(inv), balance = amt.balanceCents;
+    if (balance <= 0) return { ok: true, status: 'succeeded', alreadyPaid: true, amountPaid: Number(inv.amountPaid) || 0 };
+    var cust = inv.customerId ? readRecord_('customers', inv.customerId) : null;
+    if (!cust || !cust.stripeId) return { ok: false, error: 'no-stripe-customer' };  // resolved server-side (IDOR-safe)
+    if (!cust.defaultPmId && !body.paymentMethodId) return { ok: false, error: 'no-card-on-file' };
+    if (inv.pendingPaymentIntentId) {
+      var ex = stripeApi_('get', 'payment_intents/' + encodeURIComponent(inv.pendingPaymentIntentId), null);
+      var eb = ex.body || {};
+      if (ex.ok && eb.status === 'succeeded') return recordCharge_(inv, cust, eb, Number(eb.amount), role);
+      if (ex.ok && eb.status === 'requires_action') return { ok: false, requiresAction: true, error: 'authentication_required', paymentIntentId: eb.id, clientSecret: eb.client_secret };
+      if (ex.ok && eb.status === 'processing') return { ok: true, processing: true, status: 'processing', paymentIntentId: eb.id };   // §14b ACH still settling
+      delete inv.pendingPaymentIntentId;   // previous attempt is dead → start fresh
+    }
+    var cents = (reqCents && reqCents > 0) ? Math.min(reqCents, balance) : balance;
+    if (!(cents > 0)) return { ok: false, error: 'bad-invoice-amount' };
+    if (cents > MAX_CHARGE_CENTS) return { ok: false, error: 'over-ceiling' };
+    var attempt = (Number(inv.chargeAttempts) || 0) + 1;
+    var chosenPm = cust.defaultPmId, passedAch = false;
+    if (body.paymentMethodId) {   // §253 — re-fetch picked PM from Stripe + IDOR-check
+      var pmFetch = stripeApi_('get', 'payment_methods/' + encodeURIComponent(String(body.paymentMethodId)), null);
+      if (pmFetch.ok && pmFetch.body.customer === cust.stripeId) {
+        chosenPm = String(body.paymentMethodId);
+        passedAch = ((pmFetch.body.type || '') === 'us_bank_account');
+      }
+    }
+    var pi = stripeApi_('post', 'payment_intents', {
+      amount: cents, currency: 'usd', customer: cust.stripeId, payment_method: chosenPm,
+      off_session: 'true', confirm: 'true', description: 'Invoice ' + invoiceId,
+      'metadata[invoiceId]': invoiceId, 'metadata[customerId]': inv.customerId || '', 'metadata[role]': role
+    }, 'inv_' + invoiceId + '_' + cents + '_' + attempt);   // idempotency key — never replays a cached decline
+    var b = pi.body || {};
+    if (pi.ok && b.status === 'succeeded') return recordCharge_(inv, cust, b, cents, role);
+    if (pi.ok && b.status === 'processing') {
+      inv.pendingPaymentIntentId = b.id; inv.achProcessing = true; inv.chargeAttempts = attempt;
+      inv.payments = inv.payments || [];
+      inv.payments.push({ type: 'ach-pending', paymentIntentId: b.id, amountCents: cents, at: new Date().toISOString(), role: role });
+      writeRecord_('invoices', inv);
+      return { ok: true, processing: true, status: 'processing', paymentIntentId: b.id, chargedCents: cents };
+    }
+    var perr = b.error || {};
+    var piObj = perr.payment_intent || (b.status === 'requires_action' ? b : null);
+    if ((perr.code === 'authentication_required' || (piObj && piObj.status === 'requires_action')) && piObj) {
+      inv.pendingPaymentIntentId = piObj.id; inv.chargeAttempts = attempt; writeRecord_('invoices', inv);
+      return { ok: false, requiresAction: true, error: 'authentication_required', paymentIntentId: piObj.id, clientSecret: piObj.client_secret };
+    }
+    inv.chargeAttempts = attempt; writeRecord_('invoices', inv);
+    return { ok: false, error: (perr.code || 'charge-failed'), declineCode: perr.decline_code || '' };
+  } finally { lock.releaseLock(); }
+}
+
+/* The remaining 8 actions (stripeSaveCard_, stripeBankSetupIntent_,
+ * stripeSaveBank_, stripeVerifyBank_, stripeSetDefault_, stripeRemoveCard_,
+ * stripeListCards_, stripeFinalizeInvoice_, stripeRefundInvoice_,
+ * stripeLockInvoice_/stripeUnlockInvoice_) follow the same shape as the two
+ * above: readRecord_/writeRecord_ against the Sheets-backed store, a
+ * tryLock_ around any write, IDOR checks (re-fetching Stripe objects and
+ * confirming they belong to the resolved customerId rather than trusting
+ * client-supplied IDs), and money fields treated as server-owned. Not
+ * reproduced verbatim here — this snippet exists to close the "totally
+ * unverifiable" gap the audit flagged, not to be a paste-target; the
+ * central money-tier gate above is the one invariant worth re-verifying on
+ * every deploy. */

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260710h" />
+  <link rel="stylesheet" href="style.css?v=20260710i" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260710h"></script>
-  <script type="module" src="app.js?v=20260710h"></script>
+  <script src="rule-usage.js?v=20260710i"></script>
+  <script type="module" src="app.js?v=20260710i"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
    style.css — Rental Wrangler design system (SPEC v6 §6)
    Locked card ruleset: color tokens, the fixed single-page frame, rows-as-chips,
    the universal pill system, label-free 2-column sections, row-background
-   visualizations. Dark is default; [data-theme="light"] overrides the same tokens.
+   visualizations. Dark (:root) is the only live theme — see THEME_NEXT in app.js.
    ============================================================================ */
 
 /* ── §6.1 Color tokens ───────────────────────────────────────────────────── */
@@ -43,29 +43,6 @@
   --shadow: 0 18px 50px -24px rgba(0,0,0,.75);
   --chip-shadow: 0 6px 16px -10px rgba(0,0,0,.7);
   --font: "Geist", -apple-system, "Segoe UI", sans-serif;
-}
-[data-theme="light"] {
-  --bg:#eef1f6; --bg-2:#e6eaf1; --panel:#ffffff; --panel-2:#eef1f6;
-  --card:#ffffff; --card-head:#eef1f6;
-  --line:#cfd6e1; --line-soft:#e1e6ee;
-  --txt:#141821; --txt-2:#414b5a; --txt-3:#69727f; --track:#d3d9e3; --on-orange:#2a1400;
-  --shadow: 0 18px 40px -26px rgba(20,30,60,.35);
-  /* darker, saturated status colors so pill TEXT reads on the light -bg fills */
-  --green:#0c8f5f; --yellow:#956f00; --red:#d52a2a; --blue:#1864d6; --navy:#2f4496;
-  --purple:#7a37c9; --pink:#c5337c; --brown:#855526; --gray:#566072; --orange:#cf6000;
-  --green-bg:rgba(12,143,95,.16); --yellow-bg:rgba(149,111,0,.18);
-  --red-bg:rgba(213,42,42,.15); --blue-bg:rgba(24,100,214,.15);
-  --navy-bg:rgba(47,68,150,.15); --purple-bg:rgba(122,55,201,.15);
-  --pink-bg:rgba(197,51,124,.15); --brown-bg:rgba(133,85,38,.16);
-  --gray-bg:rgba(86,96,114,.15); --orange-bg:rgba(207,96,0,.15);
-  --mix-green:rgba(12,143,95,.30); --mix-yellow:rgba(200,150,10,.42); --mix-red:rgba(213,42,42,.42);
-  --mix-blue:rgba(24,100,214,.32); --mix-navy:rgba(47,68,150,.32); --mix-purple:rgba(122,55,201,.34);
-  --mix-pink:rgba(197,51,124,.32); --mix-brown:rgba(133,85,38,.34); --mix-gray:rgba(86,96,114,.30); --mix-orange:rgba(207,96,0,.30);
-  --chip-shadow: 0 6px 16px -12px rgba(20,30,60,.5);
-  --anchor-section:#dde2ea;
-  /* D8 comms bubbles — the iMessage blue holds on light; the customer tint deepens for AA */
-  --bub-me:#0A84FF; --on-bub-me:#f4f8ff;
-  --bub-them:rgba(207,96,0,.13); --bub-them-line:rgba(207,96,0,.30);
 }
 
 /* ── Reset / base ────────────────────────────────────────────────────────── */
@@ -1647,7 +1624,6 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .winpicker .wp-time { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 9px; padding-bottom: 9px; border-bottom: 1px solid var(--line-soft); }
 .winpicker .wp-time label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); }
 .winpicker .wp-time input[type="time"] { height: 30px; border-radius: 8px; border: 1px solid #fff; background: #fff; color: #16181d; font: inherit; font-size: 13px; padding: 0 8px; color-scheme: light; }   /* rule 16: required input = white until entered */
-[data-theme="light"] .winpicker .wp-time input[type="time"] { color-scheme: light; }
 .winpicker .wp-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 7px; }
 .winpicker .wp-month { font-size: 13px; font-weight: 800; }
 .winpicker .wp-nav { display: flex; gap: 4px; }
@@ -2710,7 +2686,6 @@ select.nc-in { cursor: pointer; }
 .insp-desc:focus { outline: none; border-color: var(--accent-line); }
 .svc-field { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 10px; font-size: 12px; font-weight: 700; color: var(--txt-2); }
 .svc-field input { height: 32px; width: 150px; border-radius: 8px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); font: inherit; font-size: 13px; padding: 0 9px; color-scheme: dark; }
-[data-theme="light"] .svc-field input { color-scheme: light; }
 .svc-ref { margin-bottom: 12px; padding: 10px; border-radius: 10px; background: var(--panel-2); border: 1px solid var(--line); }
 .svc-ref-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 5px; }
 .svc-ref-body { font-size: 12px; color: var(--txt-2); line-height: 1.5; }
@@ -4013,113 +3988,6 @@ body.dragging .row.drop-ok { opacity: 1; }
   text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:14.5px;
 }
 [data-theme="bluedsteel"] .bottombar { margin-top: 2px; }
-
-/* ════════════════════════════════════════════════════════════════════════════
-   THEME — "RANCH" (data-theme="ranch")  ·  real-leather western, 2026-06-14
-   ────────────────────────────────────────────────────────────────────────────
-   A PARALLEL, opt-in theme: the app rebuilt in tooled leather on a barn-wood
-   floor. Real CC0 textures (ambientCG: Leather033A oxblood · Leather004 buff ·
-   Leather029 pebble · Planks037A wood), used the way the popup/unit-card mocks
-   locked it: DARK oxblood cards carry LIGHT-buff content (sections/rows/inputs)
-   with dark ink + WHITE stamped labels; muted earthy status; blue = create;
-   Zilla-Slab stamped type. NO rope yet — clean saddle-stitch edges (a better
-   rope asset drops in here later). Textures load ONLY when ranch is active.
-
-   Reversible + additive: everything is scoped under [data-theme="ranch"] and
-   never touches the .anchored ring (background/position only on the card).
-   ════════════════════════════════════════════════════════════════════════════ */
-[data-theme="ranch"] {
-  --tex-card: url('assets/tex-leather-dark.jpg');
-  --tex-light: url('assets/tex-leather-light.jpg');
-  --tex-pebble: url('assets/tex-leather-pebble.jpg');
-  --tex-wood: url('assets/tex-wood.jpg');
-  --tex-rope: url('assets/tex-rope.jpg');
-  --cream: #f3e1b8;
-  /* surfaces — dark oxblood card/chrome, cream chrome text */
-  --bg:#241608; --bg-2:#2e1c0d; --panel:#34210f; --panel-2:#3e2814;
-  --card:#2a1709; --card-head:#321d0d;
-  --line:#6e4a28; --line-soft:#8a6a40;
-  --txt:#f3e1b8; --txt-2:#d3bd92; --txt-3:#ad9266; --track:#3a2614; --on-orange:#2a1606;
-  --accent:#d9772b; --accent-soft:rgba(217,119,43,.18); --accent-line:rgba(217,119,43,.55);
-  --orange:#d9772b; --orange-bg:rgba(217,119,43,.18);
-  --anchor-section:#3a2614;
-  --radius:16px; --chip-radius:11px;
-  --shadow:0 30px 64px -26px rgba(0,0,0,.82); --chip-shadow:0 5px 14px -8px rgba(0,0,0,.7);
-  /* muted, earthy status — still readable on both buff and leather */
-  --green:#6e8b40;  --green-bg:rgba(110,139,64,.22);
-  --yellow:#c79a35; --yellow-bg:rgba(199,154,53,.22);
-  --red:#a8412f;    --red-bg:rgba(168,65,47,.24);
-  --blue:#3f6298;   --blue-bg:rgba(63,98,152,.2);
-  --navy:#4a5f8a;   --navy-bg:rgba(74,95,138,.2);
-  --gray:#8a7a5e;   --gray-bg:rgba(138,122,94,.2);
-  --brown:#9a6a38;  --brown-bg:rgba(154,106,56,.22);
-}
-/* the barn-wood floor (header & bottom bar float transparent over it) */
-[data-theme="ranch"] html { background:#180f06; }
-[data-theme="ranch"] body {
-  background: linear-gradient(180deg, rgba(217,119,43,.05), transparent 30%), var(--tex-wood);
-  background-size: auto, 360px;
-}
-/* DARK oxblood leather column cards + a thin REAL-ROPE frame + dotted saddle-stitch */
-[data-theme="ranch"] .col > .card {
-  position: relative;
-  background: linear-gradient(180deg, rgba(255,228,188,.05), rgba(0,0,0,.3)), var(--tex-card);
-  background-size: auto, 360px; background-blend-mode: soft-light, normal;
-}
-/* ::after = thin rope frame (an OVERLAY, so the .anchored border-color stays intact) */
-[data-theme="ranch"] .col > .card::after {
-  content:''; position:absolute; inset:0; z-index:5; pointer-events:none; border-radius:inherit;
-  border:6px solid transparent; border-image:var(--tex-rope) 46 round;
-}
-/* ::before = the dotted saddle-stitch, riding just inside the rope */
-[data-theme="ranch"] .col > .card::before {
-  content:''; position:absolute; inset:11px; border-radius:9px; z-index:4; pointer-events:none;
-  border:2px dashed rgba(226,194,134,.42);
-}
-/* LIGHT-buff content surfaces — sections, rows, search/inputs — flip the text
-   tokens to dark ink (custom-prop cascade) and lay the buff hide underneath. */
-[data-theme="ranch"] .section,
-[data-theme="ranch"] .row,
-[data-theme="ranch"] .searchwrap,
-[data-theme="ranch"] .mini-searchwrap,
-[data-theme="ranch"] .lf-in,
-[data-theme="ranch"] .insp-desc {
-  --txt:#34251a; --txt-2:#6a533a; --txt-3:#9a7d50;
-  color:#34251a; border-color:#8a6a40;
-  background: linear-gradient(180deg, rgba(255,255,255,.1), rgba(70,45,20,.06)), var(--tex-light);
-  background-size: auto, 230px; background-blend-mode: normal;
-}
-[data-theme="ranch"] .row { box-shadow: 0 3px 9px -5px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.4); }
-[data-theme="ranch"] .row:hover { border-color: var(--accent-line); }
-/* pop-ups = dark leather, fields buff (handled above via .lf-in) */
-[data-theme="ranch"] .popup {
-  background: linear-gradient(180deg, rgba(255,228,188,.05), rgba(0,0,0,.3)), var(--tex-card);
-  background-size: auto, 360px; background-blend-mode: soft-light, normal;
-  border-color:#1f0f08;
-}
-[data-theme="ranch"] .popup-head { border-bottom-color:#6e4a28; }
-[data-theme="ranch"] .ctx-menu, [data-theme="ranch"] .dropdown-menu {
-  background: linear-gradient(180deg, rgba(0,0,0,.2), rgba(0,0,0,.34)), var(--tex-card); background-size:auto,300px;
-}
-/* ── Zilla-Slab stamped type (the western "stamped steel" voice) ── */
-[data-theme="ranch"] .coltab,
-[data-theme="ranch"] .ring-label,
-[data-theme="ranch"] .section > h4,
-[data-theme="ranch"] .popup-head h3 {
-  font-family:'Zilla Slab', system-ui, serif; text-transform:uppercase; letter-spacing:1px; font-weight:700;
-}
-[data-theme="ranch"] .c-titlecard .c-title {
-  font-family:'Zilla Slab', system-ui, serif; text-transform:uppercase; letter-spacing:.6px; font-weight:700;
-}
-[data-theme="ranch"] .coltab.on {
-  background: linear-gradient(180deg, #e58a34, var(--accent)); color: var(--on-orange);
-  box-shadow: inset 0 1px 0 rgba(255,235,200,.34), 0 3px 9px -4px rgba(217,119,43,.6);
-}
-/* the wrangler saddle-stitch under the deck */
-[data-theme="ranch"] .bottombar {
-  border-top: 1.5px dashed var(--tan);
-  border-image: repeating-linear-gradient(90deg, var(--tan) 0 7px, transparent 7px 13px) 1;
-}
 
 /* ── #109 printable invoice → a kraft "YARD LOG" page (2026-07-08): our logo, a stamped
    Saira header with a status-colored date stamp + hazard-stripe signature rule, each rental


### PR DESCRIPTION
## Summary

Follow-up to #554 (23 easy fixes) and #556 (7 HIGH-severity fixes). Jac asked to work through the remaining 21 MEDIUM/LOW findings too ("let's fix all of them, go!") — this PR carries the 18 that could be safely resolved, plus 5 backend reference-snippet corrections/additions and 2 new findings surfaced along the way. 3 items remain intentionally open (see below).

## Frontend fixes (8)

- **`rentalLineRefund` + rentals "Invoice" column** now walk the whole §28cap chunk series (`rentalInvoices`/`rentalActiveInvoice`), not just the first chunk invoice — a refund or status change on a continuation invoice was previously invisible to both.
- **mtech "WO Rate" gamification ring** — the raw/celebration value now uses the same 30-day window and direction as the percentage it mirrors (was counting the opposite thing, all-time).
- **`DROP_MATRIX` drag validators** now use `rentalHasUnit()` (checks the whole `r.units[]`) instead of the legacy single-unit `r.unitId` — a non-primary unit on a multi-unit rental no longer lights up as a valid drop target.
- **`setWoLinePhase`'s array-order phase bug** — resolved as a side effect of #556's WO-Complete redesign; the function no longer writes `w.phase` at all.
- **`LEGACY_MAP` deleted** from config.js — confirmed zero references anywhere in the frontend or in `tools/import-real-data.ps1` before removing.
- **Light + ranch themes deleted** (style.css + `THEME_NEXT`) — both confirmed dormant/unreachable via the live toggle. **New finding along the way**: the whole theme-toggle button never actually renders in the UI at all, so even the documented Yard⇄Blued-Steel cycle is unreachable — the app is permanently on `bluedsteel`. Not touched, noted in the tracker doc for later.
- **`check-design-md.mjs`'s drift guard** now hard-errors (not just warns) when a mapped `:root` token vanishes entirely — the most common real-world drift case.
- **2 dead `logic-test.mjs` assertions fixed** (a synthetic PO'd invoice; a synthetic unit with `trueCost` set) so both now actually execute every run instead of silently skipping.

## Workflow fix (1)

- **`branch-janitor.yml`** — both `gh pr list` calls (daily prune + one-time stranded-branch cleanup) now use `--paginate` instead of `--limit 1000`.

## Reverted (1)

- Attempted a proximity/validity check for `gen-code-map.mjs`'s and `dead-code-scan.mjs`'s banner-pairing logic, but real banners in this file routinely carry 10-30+ lines of prose — any gap threshold tight enough to catch a genuinely stray line also broke real banner detection (confirmed: `--check` started failing with 20+ mismatches). Reverted to the original logic rather than ship something broken.

## Backend reference snippets (docs/handoffs/ — no live deploy from this session, all deploys stay STOP-gated)

- **`cash-payment-backend.gs`, `membership-billing-additions.gs`** — corrected the stale `MONEY_ROLES[role]` gate to `roleMoneyOk_(role)` in both, verified against a live Code.gs read via the Drive connector.
- **New finding**: `membership-billing-additions.gs` claimed "DEPLOYED LIVE 2026-06-25 (version 46)" but the live script has none of `membershipEnroll_`/`membershipCancel_`/`membershipReactivate_`/`membershipBillingCron` — flagged prominently in the file. Needs Jac to confirm whether this is a versioning mismatch or the app-driven membership system genuinely isn't live.
- **`perf-report-backend.gs`** — added a formula-injection guard to `t1()`, queued in `BACKEND-DEPLOY-QUEUE.md` (#3) as not-yet-deployed.
- **New**: `stripe-actions-backend.gs` and `gps-token-proxy-backend.gs` — written from the live source (Drive read) to close the "no snippet exists" gap for the largest previously-unverifiable backend surface. **New finding**: the live `gpsToken_` has a hardcoded plaintext password fallback baked into the source — flagged in the new snippet, not fixed (would need a live backend deploy).

## Other

- **`backlog.md`** — added the §13.4 Timeline Selector as a deferred task (kept in the UI, not wired) per Jac's direction; it's fully built but has no current graph view it fits.
- **`docs/handoffs/audit-2026-07-09-parked-findings.md`** — fully rewritten to reflect final status: 51 of 54 original findings resolved, 3 remain open (the reverted banner-pairing attempt, `colorVar`/`colorBgVar` parked at Jac's explicit direction, and one `!important` CSS item not part of today's pass).

## Gates

- ✅ `node ci/gen-rule-usage.mjs --check`
- ✅ `node ci/check-window-catalog.mjs`
- ✅ `node tools/gen-code-map.mjs --check`
- ✅ `node ci/check-design-md.mjs` (0 errors, 7 pre-existing advisory warnings, unrelated)
- ✅ `node ci/smoke.mjs`
- ✅ `node ci/logic-test.mjs` — **539/539**

Cache-bust token bumped to `20260710i`.

## Not in this PR

PR #552 (staging → main) stays on hold — staging is now as clean as this pass can make it, but the promotion itself still needs Jac's explicit go-ahead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BJs2CSAzAqgMDGtWhr45Xx)_