### PR TITLE
Remove dead theme-toggle mechanism + last CSS !important cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -8343,14 +8343,10 @@ function headerEl() {
     </div>`;
   return h;
 }
-/* Theme cycle: dark → yard → light → dark. The bottom-bar button shows the icon
-   + tooltip of the theme you'll switch TO next (matching the old sun/moon convention). */
-// #552 audit follow-up (2026-07-09): dark/ranch/light removed — dormant, unreachable
-// via the live toggle (Jac: "we only have one theme... the others can be removed").
-const THEME_NEXT = {
-  yard:       { next: 'bluedsteel', icon: I.bluesteel, tip: 'Blued Steel' },
-  bluedsteel: { next: 'yard',       icon: I.hardhat,   tip: 'Yard mode' },
-};
+// #552 audit follow-up (2026-07-09): THEME_NEXT + the .js-theme toggle removed
+// entirely — the button that would trigger it never actually rendered anywhere
+// in the UI, so the whole Yard<->Blued-Steel cycle was unreachable dead code.
+// The app is hardcoded to bluedsteel (state.theme below).
 /** The action toolbar — pinned to the LEFT of the bottom comms band (the
  *  conversation rail fills the middle, bell + inbox sit at the right). On phones
  *  this same set opens up across the top header, so the inbox stays here (the
@@ -14889,7 +14885,7 @@ function onClick(e) {
   // ── DESIGN INSPECTOR intercept (SPEC v8): while inspecting, clicking any
   // rule-bearing element COPIES its reference instead of acting — the exact
   // string Jac pastes to debug ("R4 · Derived pill — RENTALS › RENTAL › …").
-  if (state.inspect && !closest('.js-inspect, .js-lint, .js-rulebook, .js-theme, .overlay, #rw-tip')) {
+  if (state.inspect && !closest('.js-inspect, .js-lint, .js-rulebook, .overlay, #rw-tip')) {
     const hit = ruleOf(t);
     if (hit) {
       e.preventDefault(); e.stopPropagation();
@@ -15150,7 +15146,6 @@ function onClick(e) {
   if (closest('.js-ring')) return openOverlay({ kind: 'role', role: closest('.js-ring').dataset.role });
   if (closest('.js-roadmap')) return openOverlay({ kind: 'roadmap' });
   if (closest('.js-close')) return closeOverlay();
-  if (closest('.js-theme')) { state.theme = (THEME_NEXT[state.theme] || THEME_NEXT.yard).next; try { localStorage.setItem('jactec.theme', state.theme); } catch (e) {} if (state.overlay && state.overlay.kind !== 'addCard') renderOverlay(); render(); return; }
   if (closest('.js-qr')) return shareSession();
   if (closest('.js-previews') || closest('.js-roweye')) { e.stopPropagation(); state.previewsOn = !state.previewsOn; if (!state.previewsOn) hideHoverPreview(); try { localStorage.setItem('jactec.previewsOff', state.previewsOn ? '0' : '1'); } catch (e) {} toast(state.previewsOn ? 'Hover previews on.' : 'Hover previews off — every eye runs red.'); return render(); }
   if (closest('.js-hotkeys')) return openOverlay({ kind: 'hotkeys' });

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 21837 lines, 38 chapters
+## app.js — 21832 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -28,24 +28,24 @@
 | APP-18 | 7708–7975 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, calendarCardEl, …(+3) |
 | APP-19 | 7976–8100 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
 | APP-20 | 8101–8272 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 8273–8492 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, THEME_NEXT, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, wrChatResolved, activeMobileCard, currentMobileMember, MOBILE_TOGGLE_GROUPS, …(+4) |
-| APP-22 | 8493–9556 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+99) |
-| APP-23 | 9557–9599 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 9600–10442 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 10443–12037 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-26 | 12038–12146 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-27 | 12147–12630 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 12631–13776 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
-| APP-29 | 13777–14042 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+16) |
-| APP-30 | 14043–14238 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, toast |
-| APP-31 | 14239–14242 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 14243–16230 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
-| APP-33 | 16231–17325 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
-| APP-34 | 17326–18603 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+83) |
-| APP-35 | 18604–19060 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
-| APP-36 | 19061–19063 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 19064–21286 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+137) |
-| APP-38 | 21287–21837 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
+| APP-21 | 8273–8488 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, bottomBarEl, commsUtilsEl, commsRailEl, wrChatResolved, activeMobileCard, currentMobileMember, MOBILE_TOGGLE_GROUPS, MAIN_CARDS, …(+3) |
+| APP-22 | 8489–9552 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+99) |
+| APP-23 | 9553–9595 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 9596–10438 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 10439–12033 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-26 | 12034–12142 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-27 | 12143–12626 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 12627–13772 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
+| APP-29 | 13773–14038 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+16) |
+| APP-30 | 14039–14234 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, toast |
+| APP-31 | 14235–14238 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 14239–16225 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, cancelLinking, …(+51) |
+| APP-33 | 16226–17320 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
+| APP-34 | 17321–18598 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+83) |
+| APP-35 | 18599–19055 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+19) |
+| APP-36 | 19056–19058 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 19059–21281 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+137) |
+| APP-38 | 21282–21832 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
 
 ## config.js — 602 lines, 0 chapters
 

--- a/docs/handoffs/audit-2026-07-09-parked-findings.md
+++ b/docs/handoffs/audit-2026-07-09-parked-findings.md
@@ -96,15 +96,35 @@ Legend: **file:line** — one-line verdict.
 
 ---
 
-## ⏳ STILL OPEN (2)
+## ⏳ STILL OPEN (1)
 
 20. **`colorVar()`/`colorBgVar()`** (config.js) — documented as the mandatory color-resolution
-    API but zero call sites. **Parked at Jac's explicit direction** ("park this as a design thing
-    to look at later") — not touched.
+    API but zero call sites. **Parked at Jac's explicit direction, revisited and re-confirmed
+    parked** ("still park it") — not touched.
 
-21. **`style.css:1944` `!important` on `.set-planned-sub`** — papers over a specificity conflict
-    that scoping the selector would resolve cleanly. Not part of today's fix pass; low risk but
-    touches live rendering, so still flagged rather than auto-fixed.
+## ✅ RESOLVED — second follow-up round (2026-07-09, later same day)
+
+21. **`style.css` `!important` on `.set-planned-sub`** — rescoped to `.set-planned p.set-planned-sub`
+    (beats `.set-planned p`'s specificity naturally), `!important` removed.
+- **Dead theme-toggle mechanism** — removed entirely per Jac's direction ("remove the whole
+  mechanism"): `THEME_NEXT`, the `.js-theme` click handler, and its reference in the design-
+  inspector click-guard are all gone. `state.theme` stays hardcoded to `'bluedsteel'` (unchanged
+  behavior — it was never reachable anyway).
+- **GPS password fallback** — investigated further per Jac's question ("is it there for a
+  reason maybe?"). Confirmed: yes — the live comment cites Jac's own 2026-07-08 decision
+  ("minimal steps, secrets-exposure OK — Code.js is server-side + gitignored, never served
+  publicly"). Left as-is, not changed.
+- **Membership deployment discrepancy — escalated, not yet resolved.** Traced the full git
+  history: PR #344 (2026-06-25) and its handoff doc confidently claim the app-driven membership
+  backend (`membershipEnroll_`/`membershipCancel_`/`membershipReactivate_`/
+  `membershipBillingCron`) was deployed live as v46, and wired the **frontend** to call those
+  actions in prod — that frontend wiring is still live today (app.js:3762/3780/3813). But two
+  independent fresh Drive pulls confirm those functions do NOT exist in the live Code.gs right
+  now. Leading theory: a later backend deploy (there were several after 6/25) used a stale local
+  Code.gs as its splice base and silently reverted this. **This looks like membership
+  enroll/cancel/reactivate may be broken in production right now** — needs Jac's confirmation
+  (checking a later deploy session's transcript, or a live prod test) before anyone tries to
+  "fix" the tracked doc further.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260710j" />
+  <link rel="stylesheet" href="style.css?v=20260710k" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260710j"></script>
-  <script type="module" src="app.js?v=20260710j"></script>
+  <script src="rule-usage.js?v=20260710k"></script>
+  <script type="module" src="app.js?v=20260710k"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1862,7 +1862,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .set-planned h4 { margin: 4px 0 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 16px; color: var(--txt); }
 .set-planned-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 9.5px; font-weight: 700; color: var(--tan, #c2925a); border: 1px dashed var(--tan, #c2925a); border-radius: 999px; padding: 2px 9px; }
 .set-planned p { margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--txt-2); }
-.set-planned-sub { color: var(--txt-3) !important; font-size: 11px !important; }
+.set-planned p.set-planned-sub { color: var(--txt-3); font-size: 11px; }   /* #552 audit item 21: scoped to beat .set-planned p's specificity, no !important needed */
 
 /* KPIs & Rings tab */
 .kpi-board { display: flex; gap: 16px; align-items: flex-start; }


### PR DESCRIPTION
## Summary

Follow-up to #554/#556/#559 — the last 2 items from the pre-promotion audit tracker, plus two investigations Jac asked for directly.

## Changes

- **Dead theme-toggle mechanism removed.** `THEME_NEXT`, the `.js-theme` click handler, and its stale reference in the design-inspector click-guard are all deleted. The button that would trigger it never actually rendered anywhere in the UI, so the whole Yard⇄Blued-Steel cycle was unreachable dead code (confirmed while investigating the earlier light/ranch theme deletion). `state.theme` stays hardcoded to `'bluedsteel'` — unchanged behavior, it was never reachable anyway.
- **Last `!important`** (`style.css` `.set-planned-sub`) — rescoped to `.set-planned p.set-planned-sub`, which naturally beats the sibling rule's specificity, so `!important` is no longer needed.

## Investigations (no code change, findings documented)

- **GPS password fallback** — Jac asked "is it there for a reason maybe?" Yes: the live `gpsToken_` comment cites Jac's own 2026-07-08 decision ("minimal steps, secrets-exposure OK — Code.js is server-side + gitignored, never served publicly"). Left as-is.
- **Membership deployment discrepancy — escalated.** Traced the full git history: PR #344 (2026-06-25) and its handoff doc confidently claim the app-driven membership backend (`membershipEnroll_`/`membershipCancel_`/`membershipReactivate_`/`membershipBillingCron`) was deployed live as v46, and wired the frontend to call those actions in prod — that frontend wiring is still live today. Two independent fresh Drive pulls of the live Code.gs confirm those functions do NOT exist there. This looks like a real production regression (membership enroll/cancel/reactivate likely broken right now for real users), not just a stale doc — flagged prominently for Jac to confirm.

## Note on this PR's history

This branch's rebase onto `staging` hit a **real** conflict this time (previous rebases in this series were trivial) — staging picked up unrelated category-glyph work (#555/#558) plus someone else's own cache-token bump while this branch was in flight. Resolved: `app.js`/`style.css` auto-merged cleanly, `docs/code-map.generated.md` was regenerated fresh (it's a build artifact, never hand-merged), and the cache token was resolved to `20260710k` — newer than both sides.

## Gates

- ✅ All 5 non-Playwright gates green
- ✅ `node ci/smoke.mjs`
- ✅ `node ci/logic-test.mjs` — **539/539**

Cache-bust token: `20260710k`.

## Not in this PR

PR #552 (staging → main) stays on hold. Given the membership regression finding, promoting to main should probably wait until that's resolved one way or another.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BJs2CSAzAqgMDGtWhr45Xx)_