### PR TITLE
Docs: sync backend-data spec to 2026-07-09 shipped reality

### DIFF
--- a/docs/specs/backend-data.md
+++ b/docs/specs/backend-data.md
@@ -20,6 +20,58 @@ These resolve the §11 Open Questions and the §3 central gate question (D3).
 
 ---
 
+## Shipped status (2026-07-09)
+
+> Reconciliation pass against `docs/handoffs/BACKEND-DEPLOY-QUEUE.md` (the authoritative deploy
+> tracker), `docs/handoffs/audit-2026-07-09-parked-findings.md`, and
+> `docs/handoffs/membership-billing-additions.gs`. This section doesn't rewrite anything below —
+> it's a status check. Look for inline **[SHIPPED 2026-07-09]** / **[DEVIATED]** /
+> **[STILL PLANNED]** markers at the specific §s this pass touched.
+
+- **Backend security audit — CLOSED.** A dedicated 8-agent adversarial backend security audit
+  found 32 findings (4 critical, 7 high, 16 medium, 5 low), on top of the earlier 19-agent
+  pre-promotion audit of PR #552 (54 findings, tracked in `audit-2026-07-09-parked-findings.md`;
+  51/54 resolved as of that doc, and most of what remained there is superseded by the fixes
+  below). **All but ONE finding from the backend security audit are now fixed and deployed live**
+  (backend versions **v83–v88** per `BACKEND-DEPLOY-QUEUE.md`'s deploy recipe). The one parked
+  item: **`saveSession_`'s missing Script Properties expiry** (§2.7 auth/session actions) — stored
+  sessions don't auto-expire; parked pending a design decision, not yet fixed.
+- **OQ-1 (§3.2, §11) — the spec's central open question — is SHIPPED, not merely decided.**
+  Per-role passwords + server-side tier enforcement are **live** (`role-tiers-backend.gs`,
+  deployed 2026-06-26 era, reconfirmed live during the 2026-07-09 audit pass). **§3.2's
+  "authorization is CLIENT-SIDE today" framing and the §2.9 D3 drift row are now OUTDATED** — see
+  the inline markers. What's left of OQ-1 is narrower than originally scoped: per-ACTION tier maps
+  for future Phase-2 actions as they land, not the keystone gate itself.
+- **Production incident — membership billing backend, root-caused and fixed 2026-07-09.** The
+  app-driven membership functions (`membershipEnroll_`/`membershipCancel_`/`membershipReactivate_`/
+  `membershipBillingCron`, §2.7) were **silently deleted from the live backend 11 minutes after
+  they first shipped on 2026-06-25** — a v46→v48 regression where a same-night redeploy was built
+  from a stale pre-merge `Code.js` snapshot. `membership-billing-additions.gs`'s own header claim
+  of "DEPLOYED LIVE 2026-06-25 (v46)" was true for only ~11 minutes; confirmed via the Apps Script
+  REST API's version history. Zero organic usage in that live window (zero `MINV-` invoices, zero
+  `membership:true` invoices) so no revenue/data impact. Re-spliced and redeployed; the daily
+  billing trigger is installed. The frontend call sites (`app.js` ~3762/3780/3813) were live the
+  whole time and now hit working handlers again. **This is the sharpest real-world illustration of
+  drift risk D2 (§2.9) to date** — no backend version/schema stamp meant the regression was
+  invisible for weeks.
+- **Team-chat privacy (§2.7 `getChats`/`setChats`, §12.2) — two-stage, only stage 1 is live.**
+  Stage 1 (scoped reads + authorized writes) shipped live 2026-07-08. The backend audit then found
+  stage 1's old-client back-compat fallback (unscoped when `body.me` is absent) is a **universal
+  bypass**, not just a compat shim — any caller could omit `me` and read/tamper with every chat.
+  The fix (dropping the unscoped fallback) is **prepared in
+  `docs/handoffs/team-chat-privacy-backend.gs` but NOT yet deployed** — gated on the frontend
+  branch that sends `me`/`rosterId` on every call landing first. **[STILL PLANNED]**
+- **`seed` action hardening (§3.1, §7.4, R1) — SHIPPED.** The audit found the backend `seed`
+  action had no server-side role check — any signed-in role (not just admin) could invoke the
+  whole-DB-replace action directly, even though the frontend `#reseed` entry point was already
+  admin-gated. Now requires Admin+ server-side, closing that client/server gap.
+- **`recordCharge_` dedup (§5.4, R12, OQ-14) — SHIPPED, narrower than OQ-14 as scoped.** A repeat
+  call for an already-recorded Stripe PaymentIntent now no-ops instead of re-inflating
+  `amountPaid` — real double-charge/double-count hardening, but not the proposed per-charge
+  idempotency-key scheme. OQ-14 as originally written is still open.
+
+---
+
 ## 1. Goal & Problem
 
 ### What this area is for
@@ -103,6 +155,13 @@ A Google Sheets cell is hard-capped at **50 000 chars** and the backend writes e
 ### 2.7 The action catalog (shipped — full list in CODE-MAP Part III)
 `backendCall` makes ~40 distinct actions today, grouped: **auth/session** (`auth, saveSession, getSession`), **data sync** (`load, seed, sync`), **config/views** (`getConfig, setConfig, getViews, setViews`), **team chat** (`getChats, setChats`), **wrangler rail** (`getWranglerRail, setWranglerRail`), **Wrangler AI** (`wrangler`), **wrangler inbox** (`wranglerRequests, wranglerThread, wranglerComment, wranglerApprove, wranglerDismiss, wranglerFile, wranglerNotifications`), **files/media** (`uploadFile, uploadCapture, archiveAgreementMedia`), **Stripe cards/bank** (`stripePubKey, stripeSetupIntent, stripeSaveCard, stripeSetDefault, stripeRemoveCard, stripeBankSetupIntent, stripeSaveBank, stripeVerifyBank`), **Stripe charging** (`stripeChargeInvoice, stripeFinalizeInvoice, recordManualPayment`), **membership** (`membershipEnroll, membershipCancel, membershipReactivate`), **misc** (`mapsKey, feedback`).
 
+**[DEVIATED — incident, now re-SHIPPED 2026-07-09]** The **membership** actions above were
+silently absent from the live backend from ~11 minutes after their 2026-06-25 ship until
+2026-07-09 (v46→v48 regression — see "Shipped status" above); this catalog entry describes the
+now-restored contract, not a continuously-live one. **`saveSession`/`getSession` — [STILL
+PLANNED]:** `saveSession_` has no Script Properties expiry on stored sessions — the one open
+finding from the 2026-07-09 backend security audit, parked pending a design decision.
+
 ### 2.8 Deploy & source (shipped)
 - `Code.gs` is **gitignored** (the public repo is served by Pages and the source holds passwords / `DEFAULT_CONFIG`). It ships via **`/clasp`** (additive, STOP-gated) from a private mirror repo, never git. See `docs/backend-clasp-setup.md`.
 - The frontend↔backend boundary is documented in **CODE-MAP.md Part III** (the authoritative contract).
@@ -112,7 +171,7 @@ A Google Sheets cell is hard-capped at **50 000 chars** and the backend writes e
 |---|---|---|---|
 | D1 | `wranglerComment` resume path ADDs `wrangler-fix` but does **not** remove `wrangler-needs-jac` → answered cards stay stuck "Needs your answer". Frontend `wranglerClearNeedsAnswer` is a local-only stopgap; a hard refresh re-surfaces it. | Open (needs `Code.gs` redeploy) | `docs/wrangler-inbox-backend.md:176` |
 | D2 | Backend has no schema/version stamp — the frontend can't detect "this backend predates action X" except by probing for an "unknown action" reply (see `attemptLogin` `auth` fallback, `app.js:16076`). | Open | §5.6 |
-| D3 | No server-side enforcement of role tiers — the password is a **single team password**; the `auth` action *returns* a role but no action is gated on it server-side. All authorization is client-side today. | Open / by-design? | §3 |
+| D3 | No server-side enforcement of role tiers — the password is a **single team password**; the `auth` action *returns* a role but no action is gated on it server-side. All authorization is client-side today. | **[DEVIATED — SHIPPED 2026-07-09]** Was Open/by-design; now resolved — per-role passwords + server-side tier enforcement are live (`role-tiers-backend.gs`). See "Shipped status" above and §3.2. | §3 |
 
 ---
 
@@ -131,6 +190,11 @@ A Google Sheets cell is hard-capped at **50 000 chars** and the backend writes e
 Tiers come from the role-system redesign (`ROLE_TIERS`, `config.js:326`): `staff < money < manager < admin < developer`, compared by `tierRank`.
 
 ### 3.2 The central gate question — authorization is CLIENT-SIDE today (D3)
+> **[DEVIATED — SHIPPED 2026-07-09]** This section describes the pre-2026-06-26 state. Per-role
+> passwords + server-side tier enforcement (`role-tiers-backend.gs`) are now **live** — see
+> "Shipped status" above. The description below is kept as the historical rationale for D1;
+> its "authorization is client-side today" framing is superseded.
+
 **This is the single most important open decision in this spec.** Today:
 - A **single shared team password** gates *all* `backendCall`s. Anyone with it can call any action.
 - The `auth` action *returns* the caller's role (`attemptLogin`, `app.js:16076`) but the server does **not** refuse a `sync`/`stripeChargeInvoice`/`setConfig` based on tier — the *frontend* hides the affordance (`canMoney`, `adminUnlocked()`).
@@ -151,6 +215,10 @@ This is acceptable for a small trusted team behind one password, but it means **
 - There is **no customer self-service / row-isolated tenant build today** — the whole DB loads for every signed-in operator. A customer portal (out of scope here; `mobile-remote` area) would need true row-level isolation, which the current "load everything" model does not provide.
 
 ### 3.4 Money / pricing-floor gating at the data layer
+> **[DEVIATED — partial]** Money-*action* gating is now server-enforced (§3.2, OQ-1 shipped
+> 2026-07-09). The field-level `load`-payload redaction question below (OQ-6) is a separate,
+> narrower question and is **not** confirmed shipped — this table still describes the current
+> (client-hide-only) exposure for the fields themselves.
 - `bottomDollar` and `msrp`/`askPrice` (category pricing floors, `data.js:25`) ride in the `categories` entity and are **loaded for every role** — visibility is gated *only* client-side (the margin/floor display gate lives in the rendering areas, not here). The backend ships them to everyone. **OQ-6:** should the floor fields be stripped from the `load` payload for sub-`money` tiers (server-side redaction), or is client-side hide sufficient given §3.2?
 - Money-moving actions (`stripeChargeInvoice`, `recordManualPayment`, …) are gated by `canMoney` client-side. Per §3.2, server-side enforcement is OQ-1.
 
@@ -334,7 +402,7 @@ All money (tax 10.75%, aging tiers, 28-day series, allocations) is derived in `A
 - Optional ambient sync pulse (OQ-9) and/or admin Health plate (OQ-10).
 
 ### Phase 3 — Hardening (only if Jac wants the trust boundary tightened)
-- Server-side tier enforcement and/or per-role passwords (OQ-1).
+- Server-side tier enforcement and/or per-role passwords (OQ-1). **[SHIPPED 2026-07-09]** — live via `role-tiers-backend.gs`; see "Shipped status" above.
 - Server-side floor-field redaction for sub-`money` tiers (OQ-6).
 - Append-only server audit log (OQ-8).
 - Signed/expiring Drive media URLs (OQ-7).
@@ -382,13 +450,13 @@ Concrete, testable. CI-gate impact noted; recall port 8000 → **9147** before r
 | R4 | **Lost concurrent edit** — last-clean-writer-wins drops a field another user set on the same record. | High | record-level clean-check; OQ-11 (field-level merge for money) |
 | R5 | **50k cell jam** — one bloated record aborts the all-or-nothing `sync`. | High | offload-to-Drive + `holdOversized` (§2.6) |
 | R6 | **Id collision** across devices (two offline quotes minting the same id). | Medium | time-salted ids (`R-NEW…`, `app.js:14826`); reindex by id |
-| R7 | **Authorization bypass** — a password-holder POSTs a money/admin action their UI hides. | Medium (by-design today) | client gates are UX; OQ-1 for server enforcement |
+| R7 | **Authorization bypass** — a password-holder POSTs a money/admin action their UI hides. | **[DEVIATED — SHIPPED 2026-07-09]** Lower than before (was Medium/by-design) | server-side tier enforcement is now live (`role-tiers-backend.gs`, OQ-1 shipped — see "Shipped status" above); residual: per-ACTION tier maps still need adding for new Phase-2 actions as they land |
 | R8 | **GAS quota / cold-start latency** stalls login or sync. | Medium | defensive parse; backoff; `health` probe (OQ-4) |
 | R9 | **Backend/frontend version skew** after a partial deploy. | Medium | probe fallback today; `backendVersion` (OQ-2) |
 | R10 | **Audit trail loss** — a record's `actions[]` is overwritten by a sync, losing who-did-what. | Low/Medium | append-only server audit (OQ-8) |
 | R11 | **Refresh disrupts active work** (mid-drag/mid-type adoption). | Low | extensive guards in `refreshFromBackend` (§2.4) — keep them |
 | R12 | **Double-charge** — a money action returns an *ambiguous* failure (`http-500` mid-charge) and the client re-fires it. | Critical | money actions are NEVER on the sync-backoff retry path (§5.4); an ambiguous charge result surfaces to the operator, who confirms before re-charging; Stripe idempotency keys (OQ-14) would harden this |
-| R13 | **Password compromise** — the single shared password leaks; the only revocation is rotating it for the whole team. | High | rotate-and-redeploy (OQ-13); no per-device revocation today |
+| R13 | **Password compromise** — the single shared password leaks; the only revocation is rotating it for the whole team. | **[PARTIALLY DEVIATED 2026-07-09]** Lower than before (was High) | per-role passwords are now live — a compromised role's password can be rotated without disrupting the others (partial OQ-13 fix); still no per-device session revocation, and `saveSession_` has no Script Properties expiry (parked finding from the 2026-07-09 audit) |
 | R14 | **Offline write queue is in-memory only** — un-flushed dirty edits live in JS memory; a tab crash (not a clean close) before `beforeunload` fires loses them. | Medium | `beforeunload` flush + unsaved-changes prompt (§2.5) covers clean close; a true offline-durable queue (IndexedDB) is `frontend-performance` scope, OQ-15 |
 | R15 | **`migrateCustomers` boot-storm** — a legacy DB dirties many records on first load, triggering one large `sync` that could brush the 50k/batch limits. | Low | one-shot `saveSoon` (§4.3) + `holdOversized` isolation; warned-once oversize tracking |
 
@@ -400,7 +468,7 @@ Concrete, testable. CI-gate impact noted; recall port 8000 → **9147** before r
 
 > Seed list: none captured in the code-grounding map — all questions below were generated from the live code. Each is a real fork with trade-offs for Jac to settle.
 
-**OQ-1 — Authorization: keep the single team password (client-side gates only), or enforce tiers server-side?**
+**OQ-1 — Authorization: keep the single team password (client-side gates only), or enforce tiers server-side? [SHIPPED 2026-07-09]** Resolved to option (b)/(c) and deployed — per-role passwords + server-side tier enforcement are live (`role-tiers-backend.gs`). See "Shipped status" above. What remains open is narrower: per-ACTION tier maps for new Phase-2 actions as they land.
 Today one password gates everything and the server trusts the client to hide money/admin actions (§3.2, D3). Options: (a) **keep as-is** — simplest, fine for a small trusted team, but client gates are UX not security; (b) **per-role passwords** — the `auth` action returns a tier, each action checks it server-side; (c) **a single password + server-side tier check on sensitive actions only** (`stripe*`, `setConfig`, `seed`). Trade-off: (b)/(c) are real security but add `Code.gs` complexity and a credential-management burden. *Recommend surfacing before any "wants" area assumes the gate.*
 
 **OQ-2 — Add an explicit `backendVersion`/capability action, or keep probing "unknown action"?**
@@ -436,10 +504,10 @@ Record-level last-writer-wins (§7.2) is fine for most entities but two operator
 **OQ-12 — Fix D1 (the `wranglerComment` label drift) in this area's spec, or defer to `wrangler-ai`?**
 It's a backend `Code.gs` fix (remove `wrangler-needs-jac` on answer) that lives at this seam but belongs conceptually to `wrangler-ai`. Recommend fixing here (it's small, additive, and this area owns `Code.gs` deploy) but tracking it under both.
 
-**OQ-13 — Password lifecycle: is rotate-and-redeploy an acceptable revocation story, or do we need per-device/per-role credentials?**
+**OQ-13 — Password lifecycle: is rotate-and-redeploy an acceptable revocation story, or do we need per-device/per-role credentials? [PARTIALLY SHIPPED 2026-07-09]** Option (b), per-role passwords, is live (ties to OQ-1, shipped) — a compromised/departed role's password can now be rotated without disrupting the other roles. Option (c), a device-session registry with server-side revoke, is not confirmed built; the 2026-07-09 backend audit's one remaining open finding (`saveSession_` has no Script Properties expiry) is directly related — see "Shipped status" above.
 Today the only way to revoke access (a lost phone, a departed hand) is to change the single team password and have everyone re-enter it. There is no per-device session kill. Options: (a) **keep rotate-only** — dead simple, fine until headcount/turnover grows; (b) **per-role passwords** (ties OQ-1) — lets you revoke a role without disrupting others; (c) a **device-session registry** (`saveSession`/`getSession` already exist) with a server-side revoke list. Trade-off: (b)/(c) are real `Code.gs` work and a credential-management burden for a 1-admin shop. *Surface before any field-device rollout.*
 
-**OQ-14 — Should money actions carry a Stripe idempotency key to make a retry safe?**
+**OQ-14 — Should money actions carry a Stripe idempotency key to make a retry safe? [PARTIALLY ADDRESSED 2026-07-09]** The 2026-07-09 backend audit shipped a narrower, related fix: `recordCharge_` now no-ops on a repeat call for an already-recorded PaymentIntent instead of re-inflating `amountPaid`. The full per-charge idempotency-key scheme described below is still open.
 Today money actions are simply kept off the auto-retry path (R12) and an ambiguous result surfaces to the operator. A Stripe **idempotency key** (a per-charge nonce the backend forwards to Stripe) would make even an accidental re-fire a no-op, hardening against double-charge at the source. Cost: the frontend mints a nonce per charge attempt and the `Code.gs` charge handler forwards it; small, additive, and strictly safer. *Recommend yes for `stripeChargeInvoice` / `recordManualPayment` if/when the charge path is next touched.*
 
 **OQ-15 — Do we want a durable (IndexedDB) offline write queue, or is the in-memory queue + `beforeunload` prompt enough?**
@@ -454,8 +522,8 @@ Un-flushed dirty edits live only in JS memory; a clean close is covered by the `
 
 ### 12.2 What this area depends on
 - **`wrangler-ai`** — shares the `Code.gs` deploy surface and owns the inbox actions (D1/OQ-12); the `wrangler` proxy action lives here but is authored there.
-- **`comms-notifications`** — the team-chat (`getChats/setChats`) and wrangler-rail sync ride this layer; any new outbound channel (server-side SMS/email) is a new additive action here.
-- **`memberships`** — `membershipEnroll/Cancel/Reactivate` are additive actions on this seam.
+- **`comms-notifications`** — the team-chat (`getChats/setChats`) and wrangler-rail sync ride this layer; any new outbound channel (server-side SMS/email) is a new additive action here. **[DEVIATED — see "Shipped status" above]** stage-1 scoping shipped 2026-07-08; the privacy-hardening fix (closing the unscoped-fallback bypass) is prepared but not deployed, blocked on a frontend branch.
+- **`memberships`** — `membershipEnroll/Cancel/Reactivate` are additive actions on this seam. **[incident, now re-SHIPPED — see "Shipped status" above]** these were live 2026-06-25, silently regressed 11 minutes later, and were root-caused + redeployed 2026-07-09.
 - **`security-cameras`** — if camera stream URLs/credentials are ever stored, they pass through this contract (and raise a fresh secret-handling question).
 - **`design-system`** — the R25 banner and any new plate must run through `/jactec-ui` + the R-rulebook.
 


### PR DESCRIPTION
Docs-only. Reconciles `docs/specs/backend-data.md` against what actually shipped — status/reality-check pass, not a rewrite.

Notable: the 8-agent backend security audit (32 findings) is closed — all but one (`saveSession_`'s missing session expiry, parked pending a design call) fixed and deployed live (v83–v88); OQ-1 (per-role passwords + server-side tier enforcement) is confirmed SHIPPED, not merely decided; documents the membership-billing production incident (functions silently deleted 11 minutes after shipping 2026-06-25, root-caused via Apps Script version history, redeployed 2026-07-09, zero revenue impact confirmed); team-chat privacy stage 2 is prepared but not deployed, gated on a frontend branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJs2CSAzAqgMDGtWhr45Xx)_