### PR TITLE
Wrangler fix: unlink fully detaches rental from invoice (clears stale chip, repairs stuck rentals) (#581)

### DIFF
--- a/app.js
+++ b/app.js
@@ -13949,9 +13949,19 @@ const WR_OPERATIONS = {
     },
   },
   unlinkInvoice: {
-    // Repair a mislinked rental — clear its invoiceId so it can be re-billed fresh (e.g. an invoice-number
-    // collision left it pointing at another customer's bill). Money-safe: mirrors the app's §7.4 inv-remove
-    // guard — refuse while ANY payment is allocated to THIS rental on that invoice (a refund is out of scope).
+    // Repair a mislinked rental — fully detach it from its invoice(s) so it can be re-billed fresh (e.g. an
+    // invoice-number collision left it pointing at another customer's bill). A rental links to an invoice TWO
+    // ways — the legacy r.invoiceId pointer AND the invoice's rentalIds series list — and rentalInvoices()
+    // (what the detail chip + +Invoice affordance read) keys off rentalIds. So we must clear BOTH sides, or
+    // clearing invoiceId alone leaves the chip lingering and blocks re-invoicing (#581). Mirrors the full
+    // detach in inv-remove / voidInvoice. Money-safe: mirrors the app's §7.4 inv-remove guard — refuse while
+    // ANY payment is allocated to THIS rental on a linked invoice (a refund is out of scope).
+    _linked(r) {   // every invoice this rental is on, via either linkage mechanism
+      const invs = rentalInvoices(r).slice();
+      const legacy = r.invoiceId ? IDX.invoice.get(r.invoiceId) : null;
+      if (legacy && !invs.includes(legacy)) invs.push(legacy);
+      return invs;
+    },
     _pick(p) {
       if (p && p.rentalId) { const r = IDX.rental.get(p.rentalId); return r ? { rental: r } : { issue: `no rental “${p.rentalId}”` }; }
       const custRef = (p && (p.customer != null ? p.customer : p.customerId)) || '';
@@ -13959,7 +13969,7 @@ const WR_OPERATIONS = {
       const cres = wrResolveCustomer(custRef);
       if (cres.many) return { issue: `more than one customer matches “${custRef}” — which one?` };
       if (!cres.rec) return { issue: `no customer matching “${custRef}”` };
-      const linked = (DATA.rentals || []).filter((r) => r.customerId === cres.rec.customerId && r.invoiceId);
+      const linked = (DATA.rentals || []).filter((r) => r.customerId === cres.rec.customerId && this._linked(r).length);
       if (!linked.length) return { issue: `no invoice-linked rental for ${cres.rec.name}` };
       if (linked.length > 1) return { issue: `${cres.rec.name} has ${linked.length} invoice-linked rentals — say which rental id` };
       return { rental: linked[0] };
@@ -13968,16 +13978,21 @@ const WR_OPERATIONS = {
       const pick = this._pick(p);
       if (pick.issue) return { issue: pick.issue };
       const r = pick.rental;
-      if (!r.invoiceId) return { issue: `rental ${r.rentalId} isn’t linked to an invoice` };
-      const inv = IDX.invoice.get(r.invoiceId);
-      if (inv && rentalAllocated(inv, r.rentalId) > 0.005) return { issue: `a payment is assigned to this rental on ${invoiceShort(r.invoiceId)} — that has to be refunded first, which I can’t do` };
-      return { summary: `unlink invoice ${invoiceShort(r.invoiceId)} from ${rentalUnitsLabel(r) || `rental ${r.rentalId}`} (frees it to re-bill)` };
+      const invs = this._linked(r);
+      if (!invs.length) return { issue: `rental ${r.rentalId} isn’t linked to an invoice` };
+      const paid = invs.find((inv) => rentalAllocated(inv, r.rentalId) > 0.005);
+      if (paid) return { issue: `a payment is assigned to this rental on ${invoiceShort(paid.invoiceId)} — that has to be refunded first, which I can’t do` };
+      return { summary: `unlink invoice ${invs.map((iv) => invoiceShort(iv.invoiceId)).join(', ')} from ${rentalUnitsLabel(r) || `rental ${r.rentalId}`} (frees it to re-bill)` };
     },
     apply(p) {
       const pick = this._pick(p); if (pick.issue || !pick.rental) return null;
-      const r = pick.rental; const old = r.invoiceId;
+      const r = pick.rental; const invs = this._linked(r);
+      const label = invs.map((iv) => invoiceShort(iv.invoiceId)).join(', ') || invoiceShort(r.invoiceId);
+      // FULL detach — drop the rental from every invoice's rentalIds series list AND clear the legacy
+      // pointer, so rentalInvoices() (the chip / +Invoice source) stops returning it (#581).
+      invs.forEach((inv) => { inv.rentalIds = (inv.rentalIds || []).filter((id) => id !== r.rentalId); reindex('invoices', inv); });
       r.invoiceId = null; reindex('rentals', r);
-      logAction(r, `Invoice ${invoiceShort(old)} unlinked — repair mislinked invoice (Mr. Wrangler)`);
+      logAction(r, `Invoice ${label} unlinked — repair mislinked invoice (Mr. Wrangler)`);
       return { entity: 'rentals', id: r.rentalId };
     },
   },
@@ -17021,9 +17036,15 @@ function handlePillX(xEl) {
   } else if (kind === 'cust-swap') {
     rec.customerId = null; toast('Customer removed — drag a replacement on (or quick-add one).'); return render();
   } else if (kind === 'inv-remove') {
-    const inv = IDX.invoice.get(rec.invoiceId);
-    if (inv && rentalAllocated(inv, rec.rentalId) > 0) { toast('Blocked: a payment is assigned to this rental — refund it first to unlink (§7.4).'); return; }
-    rec.invoiceId = null; toast('Invoice unlinked.'); render();
+    // Full detach of this rental from its invoice(s). A rental links TWO ways — the legacy r.invoiceId
+    // pointer AND the invoice's rentalIds series list (what rentalInvoices() / this chip read) — so clear
+    // BOTH, or the chip lingers and +Invoice stays blocked after a "clean" unlink (#581). Money-safe:
+    // refuse while a payment is allocated to this rental on any linked invoice (§7.4).
+    const linkedInvs = rentalInvoices(rec).slice(); const legacyInv = rec.invoiceId ? IDX.invoice.get(rec.invoiceId) : null;
+    if (legacyInv && !linkedInvs.includes(legacyInv)) linkedInvs.push(legacyInv);
+    if (linkedInvs.some((inv) => rentalAllocated(inv, rec.rentalId) > 0)) { toast('Blocked: a payment is assigned to this rental — refund it first to unlink (§7.4).'); return; }
+    linkedInvs.forEach((inv) => { inv.rentalIds = (inv.rentalIds || []).filter((id) => id !== rec.rentalId); reindex('invoices', inv); });
+    rec.invoiceId = null; reindex('rentals', rec); toast('Invoice unlinked.'); render();
   } else if (kind === 'inv-cust-remove') {
     if (invoiceTotals(rec).paid > 0) { toast('Blocked: invoice has a payment — customer locked (§7.5).'); return; }
     rec.customerId = null; toast('Customer removed — drag a replacement onto the invoice (or quick-add one).'); return render();

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -1976,8 +1976,23 @@ try {
       T.DATA.rentals.push(r2); T.IDX.rental.set('DIAG-UR2', r2); T.DATA.invoices.push(i2); T.IDX.invoice.set('DIAG-UI2', i2); T.reindex('rentals', r2); T.reindex('invoices', i2);
       const v2 = T.WR_OPERATIONS.unlinkInvoice.validate({ rentalId: 'DIAG-UR2' });
       ok(!!v2.issue && /payment|refund/i.test(v2.issue), 'unlinkInvoice: refuses while a payment is allocated to the rental (money-safe)');
-      T.DATA.rentals = T.DATA.rentals.filter((x) => x !== r1 && x !== r2); T.DATA.invoices = T.DATA.invoices.filter((x) => x !== i1 && x !== i2);
-      T.IDX.rental.delete('DIAG-UR1'); T.IDX.rental.delete('DIAG-UR2'); T.IDX.invoice.delete('DIAG-UI1'); T.IDX.invoice.delete('DIAG-UI2');
+      // (d) #581 regression — the rental is linked via the invoice's rentalIds SERIES list (what rentalInvoices()
+      // + the detail chip read), which is the real linkage. Unlink must clear BOTH sides so rentalInvoices()
+      // stops returning it (else the chip lingers and +Invoice stays blocked after a "clean" unlink).
+      const r3 = { rentalId: 'DIAG-UR3', customerId: cust.customerId, invoiceId: 'DIAG-UI3', status: 'Reserved', mock: true };
+      const i3 = { invoiceId: 'DIAG-UI3', customerId: cust.customerId, rentalIds: ['DIAG-UR3'], date: T.TODAY_ISO, amountPaid: 0, lineItems: [{ kind: 'rental', ref: 'DIAG-UR3', lid: 'UL3', amount: 89 }], mock: true };
+      T.DATA.rentals.push(r3); T.IDX.rental.set('DIAG-UR3', r3); T.DATA.invoices.push(i3); T.IDX.invoice.set('DIAG-UI3', i3); T.reindex('rentals', r3); T.reindex('invoices', i3);
+      T.WR_OPERATIONS.unlinkInvoice.apply({ rentalId: 'DIAG-UR3' });
+      ok(!r3.invoiceId && !i3.rentalIds.includes('DIAG-UR3') && T.rentalInvoices(r3).length === 0, 'unlinkInvoice: full detach — clears BOTH the invoiceId pointer AND the rentalIds series link (#581)');
+      // (e) #581 — a rental left linked ONLY via rentalIds (invoiceId already null, the stuck state) can still be repaired
+      const r4 = { rentalId: 'DIAG-UR4', customerId: cust.customerId, invoiceId: null, status: 'Reserved', mock: true };
+      const i4 = { invoiceId: 'DIAG-UI4', customerId: cust.customerId, rentalIds: ['DIAG-UR4'], date: T.TODAY_ISO, amountPaid: 0, lineItems: [{ kind: 'rental', ref: 'DIAG-UR4', lid: 'UL4', amount: 89 }], mock: true };
+      T.DATA.rentals.push(r4); T.IDX.rental.set('DIAG-UR4', r4); T.DATA.invoices.push(i4); T.IDX.invoice.set('DIAG-UI4', i4); T.reindex('rentals', r4); T.reindex('invoices', i4);
+      ok(!T.WR_OPERATIONS.unlinkInvoice.validate({ rentalId: 'DIAG-UR4' }).issue, 'unlinkInvoice: a rentalIds-only link (invoiceId already null) still validates for repair (#581)');
+      T.WR_OPERATIONS.unlinkInvoice.apply({ rentalId: 'DIAG-UR4' });
+      ok(T.rentalInvoices(r4).length === 0, 'unlinkInvoice: repairs a rentalIds-only stuck rental (#581)');
+      T.DATA.rentals = T.DATA.rentals.filter((x) => x !== r1 && x !== r2 && x !== r3 && x !== r4); T.DATA.invoices = T.DATA.invoices.filter((x) => x !== i1 && x !== i2 && x !== i3 && x !== i4);
+      T.IDX.rental.delete('DIAG-UR1'); T.IDX.rental.delete('DIAG-UR2'); T.IDX.rental.delete('DIAG-UR3'); T.IDX.rental.delete('DIAG-UR4'); T.IDX.invoice.delete('DIAG-UI1'); T.IDX.invoice.delete('DIAG-UI2'); T.IDX.invoice.delete('DIAG-UI3'); T.IDX.invoice.delete('DIAG-UI4');
     }
 
     // §inv-id-format (Jac 2026-07-08) — new ##MMDDYY id (no 'i', month up front, counter PER MONTH);

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 23307 lines, 38 chapters
+## app.js — 23328 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -35,17 +35,17 @@
 | APP-25 | 11344–12959 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
 | APP-26 | 12960–13069 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
 | APP-27 | 13070–13554 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 13555–14700 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
-| APP-29 | 14701–14986 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-30 | 14987–15182 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, toast |
-| APP-31 | 15183–15186 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 15187–17348 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+55) |
-| APP-33 | 17349–18452 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
-| APP-34 | 18453–19755 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
-| APP-35 | 19756–20238 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 20239–20241 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 20242–22756 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+158) |
-| APP-38 | 22757–23307 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
+| APP-28 | 13555–14715 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
+| APP-29 | 14716–15001 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-30 | 15002–15197 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, toast |
+| APP-31 | 15198–15201 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 15202–17369 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+55) |
+| APP-33 | 17370–18473 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
+| APP-34 | 18474–19776 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
+| APP-35 | 19777–20259 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 20260–20262 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 20263–22777 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+158) |
+| APP-38 | 22778–23328 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
 
 ## config.js — 605 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260710p" />
+  <link rel="stylesheet" href="style.css?v=20260710q" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260710p"></script>
-  <script type="module" src="app.js?v=20260710p"></script>
+  <script src="rule-usage.js?v=20260710q"></script>
+  <script type="module" src="app.js?v=20260710q"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Root cause (#581)

A rental links to an invoice **two ways** — the legacy `r.invoiceId` pointer **and** the invoice's `rentalIds` series list. `rentalInvoices()` — which drives the rental-detail invoice chip **and** the `+Invoice` affordance — keys off `rentalIds`, not `r.invoiceId`.

Both unlink paths cleared only `r.invoiceId` and left the rental in `inv.rentalIds`. So after a "clean" unlink:
- the chip kept rendering (`274JY  $0 / $730.95`) and re-invoicing stayed blocked (`rentalInvoices()` still returned the invoice), while
- `find_rentals` reported `invoiced:false` (it reads `r.invoiceId`), and
- a retry of Mr. Wrangler's `unlinkInvoice` said *"isn't linked to an invoice"* (it only checked `r.invoiceId`) — leaving the rental **permanently stuck**, no hard-refresh fixes it (the stale link is in persisted data).

## Fix — full detach on BOTH unlink paths (mirrors the known-good `inv-line-remove` / `voidInvoice`)

- **`WR_OPERATIONS.unlinkInvoice`**: new `_linked(r)` helper recognizes **either** linkage; `apply` drops the rental from every linked invoice's `rentalIds` **and** clears `r.invoiceId`; `validate` no longer rejects a `rentalIds`-only link — so it can **repair a rental that's already stuck** (`r.invoiceId` null, series link lingering).
- **`inv-remove`** (the ✕ on the rental-detail chip): same full detach, resolving linked invoices via `rentalInvoices()` so it works even when `r.invoiceId` is already null.

## Money-safety
Payment guards preserved and **broadened** — unlink is refused while a payment is allocated to the rental on **any** linked invoice (§7.4). Nothing else in money/allocation/lock/refund touched.

## Gates
smoke ✓ · logic-test **662/662** ✓ (3 new #581 regression checks — fail before / pass after, incl. the `rentalIds`-only stuck-state repair) · gen-rule-usage --check ✓ · window-catalog ✓ · gen-code-map --check ✓.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)