### PR TITLE
Phase 6 design-system sweep: colored-dot toggles -> background tints

### DIFF
--- a/app.js
+++ b/app.js
@@ -3826,8 +3826,8 @@ function custMetaField(c, field, label, ph) {
 function funnelSectionHtml(c) {
   const tab = (state.funnelTab && state.funnelTab[c.customerId]) || 'rental';
   const seg = segCtl([
-    { label: `Rental <span class="seg-dot ${naDotClass(c, 'rental')}"></span>`, js: 'js-funnel-tab', data: { rec: c.customerId, tab: 'rental' }, on: tab === 'rental' ? 'accent' : null },
-    { label: `Equipment Sales <span class="seg-dot ${naDotClass(c, 'usedSales')}"></span>`, js: 'js-funnel-tab', data: { rec: c.customerId, tab: 'usedSales' }, on: tab === 'usedSales' ? 'accent' : null },
+    { label: 'Rental', js: `js-funnel-tab ${naDotClass(c, 'rental')}`, data: { rec: c.customerId, tab: 'rental' }, on: tab === 'rental' ? 'accent' : null },
+    { label: 'Equipment Sales', js: `js-funnel-tab ${naDotClass(c, 'usedSales')}`, data: { rec: c.customerId, tab: 'usedSales' }, on: tab === 'usedSales' ? 'accent' : null },
   ]);
   let body;
   if (tab === 'rental') {
@@ -12592,7 +12592,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     // The card rail IS the header (no title). Account tab + a tab per card (signed dot) + a +Card add.
     const railTabs = `<div class="ag-tabs" role="tablist">
       <button type="button" class="ag-tab js-nc-tab${tab === 'account' ? ' on' : ''}" data-tab="account">Account</button>
-      ${cards.map((k) => `<button type="button" class="ag-tab js-nc-tab${tab === k.id ? ' on' : ''}" data-tab="${esc(k.id)}"><span class="ag-dot ${{ complete: 'ok', 'in-progress': 'mid', stale: 'bad' }[cardCaptureState(custRec, k)]}"></span>${esc(brandName(k.brand))} ••${esc(k.last4)}</button>`).join('')}
+      ${cards.map((k) => `<button type="button" class="ag-tab js-nc-tab${tab === k.id ? ' on' : ''} ${{ complete: 'ok', 'in-progress': 'mid', stale: 'bad' }[cardCaptureState(custRec, k)]}" data-tab="${esc(k.id)}">${esc(brandName(k.brand))} ••${esc(k.last4)}</button>`).join('')}
       ${canMoney() ? addBtn('Card', { link: true, js: 'js-add-card', data: { rec: o.editId || '' } }) : ''}
     </div>`;
     const headRail = `${railTabs}<span class="spacer"></span>${isEdit ? `<button class="iconbtn iconbtn-bare js-nc-qr" data-tip="Open on phone">${I.qr}</button>` : ''}`;

--- a/style.css
+++ b/style.css
@@ -2626,8 +2626,14 @@ select.nc-in { cursor: pointer; }
 .ag-tabs .add-field { align-self: center; margin-bottom: 2px; }
 .ag-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
 .ag-dot.ok { background: var(--green); }
-.ag-dot.mid { background: var(--yellow); box-shadow: 0 0 0 3px var(--yellow-bg); }   /* §7.1c in-progress */
+.ag-dot.mid { background: var(--yellow); box-shadow: 0 0 0 3px var(--yellow-bg); }   /* wrops-row live indicator */
 .ag-dot.bad { background: var(--red); box-shadow: 0 0 0 3px var(--red-bg), 0 0 6px color-mix(in srgb, var(--red) 40%, transparent); }
+/* §7.1c / Phase 6 (2026-07-10 dot->background sweep) — card capture status reads via the TAB's
+   own background tint (not a corner dot), same soft-bg + solid-ink treatment as .c-green/.c-yellow/.c-red. */
+.ag-tab.ok { background: var(--green-bg); color: var(--green); }
+.ag-tab.mid { background: var(--yellow-bg); color: var(--yellow); }   /* in-progress */
+.ag-tab.bad { background: var(--red-bg); color: var(--red); box-shadow: 0 0 6px color-mix(in srgb, var(--red) 25%, transparent); }
+.ag-tab.on.ok, .ag-tab.on.mid, .ag-tab.on.bad { color: var(--txt); }   /* selected: the underline already marks "active" — status still reads via background alone */
 /* short status banner — a thin red hazard rail, calm body */
 .ag-banner { position: relative; padding: 9px 13px 9px 20px; border-radius: 10px; margin: 2px 0 16px; font-size: 12.5px; font-weight: 600; }
 .ag-banner.bad { background: var(--red-bg); border: 1px solid var(--accent-line); border-color: var(--red); color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); box-shadow: 0 0 6px color-mix(in srgb, var(--red) 25%, transparent); }
@@ -3374,12 +3380,15 @@ body { font-variant-numeric: tabular-nums; }
 .funnel-hd { display: flex; align-items: center; justify-content: center; gap: 10px; margin-bottom: 13px; }
 .funnel-hd .fh-rule { flex: 1; border-top: 1.5px dashed var(--tan, #c2925a); opacity: .4; }   /* saddle-stitch flanks (ranch seasoning) */
 .funnel-sec .seg button.on-accent { background: var(--accent); color: var(--on-orange); }     /* selected tab = the ONE orange (rule #3) */
-.seg .seg-dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; }
-.seg .seg-dot.due { background: var(--red); box-shadow: 0 0 0 2px color-mix(in srgb, var(--red) 30%, transparent); }
-.seg .seg-dot.soon { background: var(--yellow); }
-.seg .seg-dot.ok { background: var(--green); }
-.seg button.on-accent .seg-dot.soon { background: #1a1205; }   /* keep the dot legible on the orange selected tab */
-.seg button.on-accent .seg-dot.ok { background: #04150d; }
+/* Phase 6 (2026-07-10 dot->background sweep) — next-action urgency reads via the segment's own
+   background tint (not a corner dot), same soft-bg + solid-ink treatment as .c-green/.c-yellow/.c-red. */
+.funnel-sec .seg button.due { background: var(--red-bg); color: var(--red); }
+.funnel-sec .seg button.soon { background: var(--yellow-bg); color: var(--yellow); }
+.funnel-sec .seg button.ok { background: var(--green-bg); color: var(--green); }
+.funnel-sec .seg button.on-accent.due,
+.funnel-sec .seg button.on-accent.soon,
+.funnel-sec .seg button.on-accent.ok { background: var(--accent); color: var(--on-orange); }   /* selected always wins the fill — orange stays the ONE selection signal */
+.funnel-sec .seg button.on-accent.due { box-shadow: inset 0 0 0 2px var(--red); }   /* due still surfaces even on the active tab, matching the prior un-muted red dot */
 
 .fb-toprow { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
 /* R28 — the account button: a neutral steel chip, stamped label = the account type */


### PR DESCRIPTION
## Summary
Phase 6 of the 2026-07-10 account-agreements-membership-redesign plan/spec (§7c): "every toggle currently using a colored status dot gets the dot replaced by a red/green/yellow background color on the toggle itself." Per the plan's own scoping note, this ships as its own PR against `area/design-system` rather than folding into the customers-crm PR.

Scope was narrowed with Jac before implementation: of 6 dot-bearing interactive families found in the codebase, only the 2 that are genuine 3-state red/yellow/green **status** toggles were converted. The other 4 (chat-rail tabs, chat-member toggle buttons, the note color-tag picker, the comment-flag picker) use dots for 6-color **category** coding, not status, and were left untouched.

- **Customer funnel toggle** (`funnelSectionHtml`, `.funnel-sec .seg`): the Rental/Equipment-Sales segmented control's next-action urgency (due/soon/ok) now reads via a background tint on the segment itself, replacing a small `seg-dot`. Uses the existing soft-bg + solid-ink convention (`--red-bg`/`--yellow-bg`/`--green-bg` + matching text color), same as `.c-green`/`.c-yellow`/`.c-red` elsewhere. The selected segment stays solid orange (rule #3, one orange = one meaning); a `due` status still surfaces via a thin inset ring so it isn't lost when that segment is also the active one (mirrors the prior dot's un-muted red-on-orange behavior). `soon`/`ok` don't get a ring when selected, matching how those dots were previously muted to near-invisible on the orange tab.
- **Card-capture tabs** (`.ag-tab`, account/agreements popup): signing progress (stale/in-progress/complete) now reads via the same background-tint treatment on the tab itself, replacing a corner `ag-dot`.
- Left `.ag-dot`'s base rules in place — the unrelated Wrangler-ops chat list "live" indicator (`wranglerOpsRow`) reuses that class and is out of this sweep's scope.

## Test plan
- [x] `node --check app.js`
- [x] `node ci/gen-rule-usage.mjs --check`
- [x] `node ci/check-window-catalog.mjs`
- [x] `node tools/gen-code-map.mjs --check`
- [x] Browser self-critique screenshots (dark theme, the app's only theme) across all reachable states for both components: funnel toggle (due/soon/ok, selected and unselected) and card-capture tabs (complete/in-progress/stale) — all legible, no clipping, no color mismatches, selection state stays unambiguous.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GCh6icZT743uADb1M9dM51)_