### PR TITLE
Trunk-based dev workflow: design + plan + deploy scaffolding (draft)

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,8 +29,12 @@ import {
   SHOP_TYPES, COLUMNS, COLUMN_OF,
   legacyTransportPrice, computeTransportPrice, isFueledType, legsForType, YARD_ORIGIN, GOOGLE_MAPS_KEY, GPS_BACKEND_URL,
   fmtWindow, fmtShortDate, showsTruck, parseISO, TODAY_ISO, refreshTodayISO, invoiceShort, TRANSPORT_MAP,
-  FLAG_META, FLAG_SEVERITY_RANK, INSURANCE_COVERAGE_TYPES,
+  FLAG_META, FLAG_SEVERITY_RANK, INSURANCE_COVERAGE_TYPES, FEATURES,
 } from './config.js';
+// Feature-flag reader (scaffold only, dev-workflow trunk-based redesign D5): a big
+// replacement's new code path checks flagOn('key') instead of running unconditionally,
+// so the old path stays live until the flag flips. No feature reads this yet.
+const flagOn = (k) => !!(FEATURES && FEATURES[k] === true);
 
 /* ════════════════════════════════════════════════════════════════════════
    APP-01 · §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you

--- a/config.js
+++ b/config.js
@@ -602,3 +602,18 @@ export const REVENUE_GOAL_DEFAULT = 150000; // SPEC §10 Revenue Goal default
 export const PERF_BUDGET_MS = 100;          // SPEC §3 hard interaction budget
 export const PERF_VITALS_ON = true;         // master kill-switch for Web-Vitals/render instrumentation (spec frontend-performance P0)
 export const PERF_SAMPLE_RATE = 1;          // fraction of sessions that flush a perfReport (1 = all, tune down at scale)
+
+/* ── Feature flags (dev-workflow trunk-based redesign D5, spec 2026-07-12) ──
+ * Scaffold ONLY — nothing is wired to a key yet, no behavior changes here.
+ * What it's for: when a big feature REPLACEMENT ships, land the new code path
+ * ALONGSIDE the old one, gated on FEATURES[key]. Default OFF keeps the old
+ * path live in production; flipping the key to true is the rollout switch,
+ * and flipping it back is the instant rollback — no code surgery either way.
+ * Delete the old path only once the new one has proven out. Small/low-risk
+ * changes skip this scaffold entirely and merge plainly.
+ * CAVEAT — this is NOT a secrecy mechanism: on a public Pages site, a flag
+ * disables EXECUTION, not VISIBILITY — flagged code still ships readable in
+ * the public bundle. Never gate a secret or a security/auth check on this. */
+export const FEATURES = {
+  // add keys here as a big replacement starts, e.g. exampleBigReplacement: false
+};

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,50 +4,50 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 23500 lines, 38 chapters
+## app.js — 23504 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
-| APP-01 | 35–67 | §0.7 | §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you | ERR_LOG, logErr, WRANGLER_REPO, wranglerIssueUrl |
-| APP-02 | 68–90 | §1 | §1 UTILITIES & FORMATTING — $, el, esc, money, num, dates | $, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR |
-| APP-03 | 91–851 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, migrationDirty, migrateCustomers, legacyUnitEntry, migrateRentals, rentalUnits, rentalUnitIds, rentalHasUnit, unitEntry, isPrimaryUnit, …(+83) |
-| APP-04 | 852–958 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 959–1379 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
-| APP-06 | 1380–2127 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+61) |
-| APP-07 | 2128–2981 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+81) |
-| APP-08 | 2982–2989 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 2990–4644 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+115) |
-| APP-10 | 4645–4665 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 4666–5365 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+47) |
-| APP-12 | 5366–5533 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 5534–5773 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
-| APP-14 | 5774–6183 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 6184–6383 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 6384–7853 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+40) |
-| APP-17 | 7854–8112 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 8113–8446 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, salesCardEl, …(+4) |
-| APP-19 | 8447–8571 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 8572–8743 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 8744–9003 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+10) |
-| APP-22 | 9004–10510 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+133) |
-| APP-23 | 10511–10553 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 10554–11396 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 11397–13009 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-26 | 13010–13123 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
-| APP-27 | 13124–13608 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 13609–14769 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
-| APP-29 | 14770–15055 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-30 | 15056–15310 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, …(+1) |
-| APP-31 | 15311–15314 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 15315–17500 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+55) |
-| APP-33 | 17501–18610 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
-| APP-34 | 18611–19919 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
-| APP-35 | 19920–20402 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 20403–20405 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 20406–22949 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+159) |
-| APP-38 | 22950–23500 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
+| APP-01 | 39–71 | §0.7 | §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you | ERR_LOG, logErr, WRANGLER_REPO, wranglerIssueUrl |
+| APP-02 | 72–94 | §1 | §1 UTILITIES & FORMATTING — $, el, esc, money, num, dates | $, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR |
+| APP-03 | 95–855 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, migrationDirty, migrateCustomers, legacyUnitEntry, migrateRentals, rentalUnits, rentalUnitIds, rentalHasUnit, unitEntry, isPrimaryUnit, …(+83) |
+| APP-04 | 856–962 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
+| APP-05 | 963–1383 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
+| APP-06 | 1384–2131 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+61) |
+| APP-07 | 2132–2985 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+81) |
+| APP-08 | 2986–2993 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 2994–4648 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+115) |
+| APP-10 | 4649–4669 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 4670–5369 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+47) |
+| APP-12 | 5370–5537 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 5538–5777 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
+| APP-14 | 5778–6187 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 6188–6387 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 6388–7857 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+40) |
+| APP-17 | 7858–8116 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 8117–8450 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, colTabButtonsHtml, colActionsHtml, memberCardEl, salesCardEl, …(+4) |
+| APP-19 | 8451–8575 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 8576–8747 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 8748–9007 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+10) |
+| APP-22 | 9008–10514 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+133) |
+| APP-23 | 10515–10557 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 10558–11400 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 11401–13013 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-26 | 13014–13127 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback |
+| APP-27 | 13128–13612 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 13613–14773 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+111) |
+| APP-29 | 14774–15059 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-30 | 15060–15314 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, swInit, PERF, perfInit, perfRecordRender, …(+1) |
+| APP-31 | 15315–15318 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 15319–17504 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+55) |
+| APP-33 | 17505–18614 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
+| APP-34 | 18615–19923 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
+| APP-35 | 19924–20406 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 20407–20409 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 20410–22953 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+159) |
+| APP-38 | 22954–23504 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
 
-## config.js — 605 lines, 0 chapters
+## config.js — 620 lines, 0 chapters
 
 Chapter **CFG** — no internal banners, the whole file is one chapter.
 

--- a/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
+++ b/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan — Trunk-Based Dev Workflow with Two-Gate Staging→Production
+
+- **Date:** 2026-07-12
+- **Status:** DRAFT plan (authored autonomously while Jac was away). Needs Jac for the Phase 0 items marked ⛔ (repo settings + secrets) before anything goes live.
+- **Design:** `docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md` (approved 2026-07-12).
+- **Guardrail:** Do **not** touch the `frontend-performance` area while Jac's "App performance issues" session is open (§Phase 3).
+- **Nothing in this plan runs on its own** — the deploy scripts are drafted here as code blocks, not installed as live `.github/workflows/*.yml`, so no pipeline fires until we deliberately wire it in Phase 0/1.
+
+## Guiding shape (from the design)
+
+Two environments, two chat-driven gates, one trunk:
+
+```
+feature branch ──deploy──▶ STAGING (2nd repo)  ──"merge it"──▶ TRUNK (main)  ──"promote it"──▶ PRODUCTION
+   (Claude builds)          you review                          integrated,                     app.jacrentals.com
+                                                                not live yet                    (release-pointer branch)
+```
+
+The one mechanical crux: **production must stop auto-tracking `main`**, or merging to the trunk would go live instantly and destroy Gate 2. Chosen mechanism (fits "Claude does it from chat"): the production repo's Pages serves a **`production` release-pointer branch**, and "promote it" fast-forwards `production` to the approved trunk commit. The trunk (`main`) then holds blessed-but-not-live work, exactly as the design intends.
+
+---
+
+## Phase 0 — One-time setup (⛔ = needs Jac: repo admin / secrets)
+
+0.1 **Keep the staging repo.** `operations-jacrentals/rental-wrangler-staging` stays as the staging site's host (Pages is one-site-per-repo). We stop feeding it by cron; Claude pushes to it on "deploy to staging" (Phase 1).
+
+0.2 ⛔ **Create the production release-pointer branch.** From the current live commit: `git branch production origin/main && git push origin production`. This is a *pointer*, not divergent code — same bytes as the trunk at each promote.
+
+0.3 ⛔ **Repoint production Pages to the `production` branch.** Prod repo → Settings → Pages → Build and deployment → Source = *Deploy from a branch* → Branch = `production` `/ (root)`. After this, merging to `main` no longer changes the live site — only a `production` update does. **Verify** app.jacrentals.com is unchanged immediately after (same commit, just a different source branch pointing at it).
+
+0.4 ⛔ **Add a cross-repo deploy credential** so Claude can push the feature build into the staging repo: either an SSH **deploy key** (public half on `rental-wrangler-staging`, private half as a secret) or a fine-scoped **PAT**. Needed because the default token can't push cross-repo. Store as an env secret this session can read (never echoed).
+
+0.5 **Retire the old staging sync.** Delete/disable the 10-min cron + `sync-staging.yml` workflow-dispatch on the staging mirror **only after** Phase 2 proves the push-based deploy works. (Sequenced so we never have zero working staging paths.)
+
+**Phase 0 exit check:** `main` merges do NOT change the live site; `production` updates DO; staging repo is push-writable by this session.
+
+---
+
+## Phase 1 — The three chat-driven actions (drafted; reversible)
+
+Three tiny scripts under `tools/` (or documented command sequences). Build-free posture preserved — they copy the existing files, they don't bundle. Each bumps the shared `?v=` token so caches refresh (until Phase 6 replaces that with content-hashing).
+
+**1.1 `tools/deploy-staging.mjs` — "put my feature on staging."** Pushes the *current working tree's* site files (`index.html`, `app.js`, `style.css`, `config.js`, `data.js`, `icons*.js`, `rule-usage.js`, assets…) into the staging repo's Pages branch, bumping `?v=`. Draft:
+
+```
+# pseudocode / command shape — finalize paths in implementation
+1. sanity: on a feature branch, working tree builds (node ci/smoke.mjs on :9147)
+2. bump the shared ?v= token in index.html (timestamped)
+3. rsync the site files into a checkout of rental-wrangler-staging (Pages branch)
+4. commit + push that repo   ->  staging URL updates within ~1 min
+5. print the staging URL + the new ?v= marker to confirm
+```
+
+**1.2 "merge it" — Gate 1 (feature → trunk).** Claude, on Jac's say-so:
+```
+1. run the full local gate set (smoke, logic-test, gen-rule-usage --check,
+   check-window-catalog, gen-code-map --check)   # port-swap 8000->9147 per CLAUDE.md
+2. merge the feature branch into main (fast-forward or --no-ff PR merge)
+3. delete the feature branch (local + remote)
+# main is now integrated but NOT live (Pages serves `production`)
+```
+
+**1.3 `tools/promote.mjs` — Gate 2 ("promote it", trunk → production).** Claude, on Jac's say-so:
+```
+1. fast-forward `production` to main's approved commit (byte-identical to what
+   was reviewed on staging, since solo/one-feature-at-a-time)
+2. push `production`  ->  app.jacrentals.com goes live
+3. verify the live site serves the new ?v= marker (curl), report done
+```
+
+**1.4 Feature-flag scaffold (`config.js`).** Add a `FEATURES` map (default all-off for in-flight big replacements) plus a one-line reader in `app.js` (`const flagOn = k => (FEATURES||{})[k] === true`). Big replacements gate their new path on a flag; small features skip it. (Public-Pages caveat from the design: flags hide execution, not source.)
+
+---
+
+## Phase 2 — Prove it end-to-end on ONE small feature
+
+Pick a trivial, low-risk change (a copy tweak or a tiny visual fix — **not** in `frontend-performance`). Run the whole loop: feature branch → `deploy-staging` → review URL → "merge it" → `promote.mjs` → verify live. Confirm: staging updated on push (no cron), production only moved on "promote," live bytes match, rollback works (`git revert` on `main`, re-promote). Only after this passes do we retire the old cron sync (0.5).
+
+---
+
+## Phase 3 — Adopt the trunk model per area, incrementally
+
+Not a big-bang. Next time an `area/<domain>` is touched, do the work as a short feature branch off the trunk instead, verify via Phase-1/2 loop, then retire that area branch (delete once its unmerged work is on the trunk).
+
+- **⛔ SKIP `frontend-performance`** and its area branch until Jac's "App performance issues" session is done — do not migrate or delete that area, and don't apply the parked `frontend-performance.md` spec edit.
+- Order the rest by how stale/low-risk they are; the janitor deletes merged branches.
+- Track remaining area branches in a short checklist so "how many areas left" is always visible.
+
+## Phase 4 — Retire spec-sync / master-spec
+
+Once docs are consolidated on the trunk: remove `tools/spec-sync.mjs`, delete the `master-spec` branch, and strip the `spec-sync` obligations from the `start` skill. (The parked "yesterday's specs" edits land here as **plain commits on the trunk**, not a `spec-sync up` — minus `frontend-performance.md` per the guardrail.)
+
+## Phase 5 — Update skills/docs to the trunk model
+
+Concrete edits (staged as their own reviewed change, since they alter how every future session behaves):
+- **`start` skill** + `references/branch-map.md`: replace "route to a task branch off an area" with "cut a short feature branch / worktree off the trunk"; drop the master-spec `down`/`up` steps + the ~2h spec-sync timer; add the two-gate deploy loop + `claude --worktree` for parallel sessions.
+- **`CLAUDE.md`**: rewrite "Deploy & gates" (branch flow + spec-sync) to the trunk + two-gate model; keep the CI-gate list and cache-bust note (until Phase 6).
+- **`tools/branch-preflight.mjs`**: reduce to trunk + worktree hygiene (or retire).
+
+## Phase 6 — Optional hardening (later)
+
+- **Content-hashed asset filenames** via a small CI hashing step (rename `app.<hash>.js` / rewrite `index.html`) to retire the manual `?v=` bump while staying build-free.
+- **Native GitHub approval gate** (Environments → Required reviewers on the public repo, free) if Jac later wants an audited go-live button instead of the chat command.
+
+---
+
+## Risks & rollback
+
+- **0.3 is the sharp edge.** Repointing Pages source is the only step that can affect the live site; do it at a quiet time and verify the live commit is unchanged right after. Fully reversible (point Pages back to `main`).
+- **Cross-repo secret** must never be echoed; scope it to the staging repo only.
+- **One-feature-at-a-time keeps "byte-identical promotion" true.** If Jac ever runs several features to the trunk before promoting, production promotes *all* merged-but-unpromoted work at once — that's when feature flags (D5) do real work; call it out when it first happens.
+- Every gate is reversible before go-live: dislike on staging → branch never merges; dislike after merge → `git revert` on the trunk before promoting.
+
+## Blocked-on-Jac checklist (for when he's back)
+
+1. ⛔ 0.2 create + push the `production` branch.
+2. ⛔ 0.3 repoint prod Pages source to `production` (+ verify live unchanged).
+3. ⛔ 0.4 provide the cross-repo deploy key/PAT secret.
+4. Confirm branch names (`production` release pointer) and that "Claude does it from chat" promotion is the intended mechanism vs. adding the free native gate now.
+5. Green-light Phase 2's throwaway test feature.

--- a/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
+++ b/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
@@ -97,6 +97,22 @@ Concrete edits (staged as their own reviewed change, since they alter how every 
 - **`CLAUDE.md`**: rewrite "Deploy & gates" (branch flow + spec-sync) to the trunk + two-gate model; keep the CI-gate list and cache-bust note (until Phase 6).
 - **`tools/branch-preflight.mjs`**: reduce to trunk + worktree hygiene (or retire).
 
+### §5a Skill rewrites — `start` + the end-of-session skill (Jac, 2026-07-12: "take note on HOW")
+
+The session-lifecycle pair needs a rewrite for the trunk model. Capturing the approach here so it isn't lost:
+
+- **`start` skill** (rewrite, well-scoped against this design):
+  - STRIP: the "route to a task branch off an `area/<domain>`" flow, the `branch-map.md` area catalogue, the `master-spec` `down`-at-start / `up`-every-2h obligations + the ~2h spec-sync self-timer, and the `branch-preflight --ensure` area/master-spec logic.
+  - ADD: "cut a short feature branch (or `claude --worktree <task>`) off the **trunk**"; the two-gate deploy loop (`deploy-staging` → review URL → "merge it" → wait → "promote it"); the `FEATURES` feature-flag note for big replacements; keep the toolchain probe, memory recall, and the working-discipline/model-triage rules.
+
+- **End-of-session skill** — REPLACES `tidy-sessions`, which Jac flags 2026-07-12 as "**has not been very useful**" (it only lists/archives finished chats). Reconceive it from *archive-only* into an active **wrap-up / land-the-work** skill:
+  - Verify the session's work is committed + pushed + has a PR (branch hygiene).
+  - Report state plainly: what's **merged to the trunk** vs **promoted to production** vs **still pending** — so a session never ends in a fuzzy "is this shipped?" state.
+  - Clean up the **worktree** (`git worktree remove`) once the branch is merged.
+  - Write a short **handoff note** into the session folder.
+  - THEN offer to archive the chat (the old tidy-sessions job) as the last step, not the only step.
+  - **Open — needs Jac (see the fork below):** exactly what made `tidy-sessions` unhelpful, and what he most wants an end skill to *do*, drives the rewrite's shape. Recorded pending his answer.
+
 ## Phase 6 — Optional hardening (later)
 
 - **Content-hashed asset filenames** via a small CI hashing step (rename `app.<hash>.js` / rewrite `index.html`) to retire the manual `?v=` bump while staying build-free.

--- a/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
+++ b/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
@@ -105,13 +105,12 @@ The session-lifecycle pair needs a rewrite for the trunk model. Capturing the ap
   - STRIP: the "route to a task branch off an `area/<domain>`" flow, the `branch-map.md` area catalogue, the `master-spec` `down`-at-start / `up`-every-2h obligations + the ~2h spec-sync self-timer, and the `branch-preflight --ensure` area/master-spec logic.
   - ADD: "cut a short feature branch (or `claude --worktree <task>`) off the **trunk**"; the two-gate deploy loop (`deploy-staging` → review URL → "merge it" → wait → "promote it"); the `FEATURES` feature-flag note for big replacements; keep the toolchain probe, memory recall, and the working-discipline/model-triage rules.
 
-- **End-of-session skill** — REPLACES `tidy-sessions`, which Jac flags 2026-07-12 as "**has not been very useful**" (it only lists/archives finished chats). Reconceive it from *archive-only* into an active **wrap-up / land-the-work** skill:
-  - Verify the session's work is committed + pushed + has a PR (branch hygiene).
-  - Report state plainly: what's **merged to the trunk** vs **promoted to production** vs **still pending** — so a session never ends in a fuzzy "is this shipped?" state.
-  - Clean up the **worktree** (`git worktree remove`) once the branch is merged.
-  - Write a short **handoff note** into the session folder.
-  - THEN offer to archive the chat (the old tidy-sessions job) as the last step, not the only step.
-  - **Open — needs Jac (see the fork below):** exactly what made `tidy-sessions` unhelpful, and what he most wants an end skill to *do*, drives the rewrite's shape. Recorded pending his answer.
+- **End-of-session skill** — REPLACES `tidy-sessions`, which Jac flags 2026-07-12 as "**has not been very useful**" (it only lists/archives finished chats). Jac's chosen shape (2026-07-12) is a **capture-and-close-out** skill, NOT a land/promote skill. Four jobs, in order:
+  1. **Report shipped-state** plainly — what's **merged to the trunk** vs **promoted to production** vs **still pending / uncommitted** — so a session never ends in a fuzzy "did this actually ship?" state.
+  2. **Catch loose work before it's lost** — scan the session for ideas, features, or half-done threads that should live on for later, and **move each onto its own branch** (a parked feature branch / follow-up) so closing the chat never drops a good idea or unfinished piece. This is the job Jac most wanted and the one `tidy-sessions` never did.
+  3. **Guard against premature archive** — if anything is pending, parked, or uncommitted, the session should **NOT** be archived; say so and stop, rather than sweeping it away.
+  4. **Archive the chat reliably** — the old `tidy-sessions` job, done well, as the **last** step and only once 1–3 are clean.
+  - De-scoped per Jac's picks: it does **not** drive the two gates / promote, and does not itself "land" the work beyond reporting + parking. Worktree cleanup + a handoff note fold into steps 1/4.
 
 ## Phase 6 — Optional hardening (later)
 

--- a/docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md
@@ -5,6 +5,43 @@
 - **Branch:** `claude/update-specs-yesterday-y8tr3x` (design authored here; the migration itself lands incrementally — see §9).
 - **Scope:** How we develop and ship, end to end. Replaces the `task → area/<domain> → staging → main` branch chain + the `spec-sync`/`master-spec` machinery with mainstream trunk-based development, while **keeping Jac's staging approval gate**.
 
+## 0. Vocabulary + Intentions — READ THIS FIRST
+
+This section exists so a session that never saw the design conversation still ships with our exact language and intent. Read it before touching anything.
+
+### 0.1 Vocabulary (and what each replaces)
+
+| Term | What it means | Maps to / replaces |
+|---|---|---|
+| **Trunk** (`main`) | The one long-lived branch — the single source of truth | Replaces the ~19 `area/*` branches + the `task → area → staging → main` chain |
+| **Feature branch** | A short-lived, throwaway branch for one piece of work; merged back the same day (or dropped) and **deleted** | Replaces the *permanent* `area/*` branches |
+| **Merge / PR** | Folding a feature branch into the trunk; the PR runs the `smoke` gate | How work joins the trunk |
+| **Environment** | A *place* code runs (staging / production) — a **deploy target, NOT a branch** | The staging site + app.jacrentals.com |
+| **Deploy** | Put a build into an environment so it runs there | — |
+| **Promote** | Move the **exact same build** from staging to production — no rebuild, no re-merge | Replaces "merge `staging` → `main`" |
+| **Approval gate** | A human "OK" before something proceeds | The part Jac **keeps** |
+| **Feature flag** | A runtime on/off switch (a `FEATURES` map in `config.js`) so unfinished / replacement code sits in the trunk turned **off** | New tool (see D5) |
+| **Worktree** | A second working folder on the same repo, so a parallel agent works without colliding | Replaces "a long-lived branch per parallel session" |
+
+**Naming note (important):** here `main` **is the trunk** (the integration line), and **`production` is a separate release-pointer branch** that GitHub Pages serves as the live site. "production" is an environment/pointer — you never *merge a branch into* it; the promote step fast-forwards it.
+
+### 0.2 Intentions (the spirit — hold these, don't drift)
+
+- **The entire redesign has ONE goal: cut ceremony.** The area branches, `spec-sync`, `master-spec`, and the cron mirror were all workarounds for long-lived divergent branches. Fix the branching and the machinery dissolves. **Do not re-introduce ceremony** to solve a problem trunk + short branches already solves.
+- **Jac's explicit steer:** *"do exactly what the mainstream industry does, not pretend I'm smarter than them."* When in doubt, take the boring, standard, well-documented path.
+- **Keep the staging approval gate.** Jac reviews the running app and approves before it goes live. That gate is the whole point; only everything *upstream* of it got simplified.
+- **Two gates, both chat-driven:** "merge it" → trunk; "promote it" → production. Between them, work sits **blessed-but-not-live**. **Promote is ALWAYS Jac's explicit call**, never automatic.
+- **Review a feature BEFORE it joins the trunk**, so "I don't like it" means the branch never merges — nothing to undo (D2).
+- **Big replacements ride behind a feature flag** so backing out is a toggle, not code surgery (D5).
+- **Do NOT touch or "improve" the quality infrastructure:** the CI gates, R-rulebook stamping, Code-Atlas, `jactec-ui`, and the skills. Those are real, not ceremony.
+
+### 0.3 Non-obvious constraints (don't rediscover these the hard way)
+
+- **GitHub Pages serves one site per repo** → the staging site stays a **second repo** (`rental-wrangler-staging`), fed by a **push on deploy** (not a cron).
+- **`main` is branch-protected** → Claude can't push straight to it. That is *exactly why* `production` is a separate **unprotected** pointer branch the promote step is allowed to push to.
+- **The repo is PUBLIC** → a feature flag disables **execution, not visibility**; flagged code still ships readable in the bundle. Never gate a secret or an auth/security check on a flag.
+- **Promotion is "build once, deploy the same bytes"** — production runs the exact build reviewed on staging, never a rebuild or a second merge.
+
 ## 1. Problem / motivation
 
 The current workflow is a large, well-built workaround for one root choice: **long-lived branches used as environments.** There are ~19 permanent `area/*` branches, each drifting 500–800 commits from `main`, plus a 4-tier `task → area → staging → main` promotion chain, plus a custom `spec-sync` tool syncing a `docs/specs/` folder across a dedicated spec-only `master-spec` branch, plus a separate staging *mirror repo* synced by a 10-minute cron + a manual `gh workflow run sync-staging.yml` dispatch.

--- a/docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md
@@ -1,0 +1,102 @@
+# Development Workflow Redesign — Trunk-Based + Two-Gate Staging→Production
+
+- **Date:** 2026-07-12
+- **Status:** APPROVED design (Jac signed off 2026-07-12). Next step: implementation plan (`writing-plans`).
+- **Branch:** `claude/update-specs-yesterday-y8tr3x` (design authored here; the migration itself lands incrementally — see §9).
+- **Scope:** How we develop and ship, end to end. Replaces the `task → area/<domain> → staging → main` branch chain + the `spec-sync`/`master-spec` machinery with mainstream trunk-based development, while **keeping Jac's staging approval gate**.
+
+## 1. Problem / motivation
+
+The current workflow is a large, well-built workaround for one root choice: **long-lived branches used as environments.** There are ~19 permanent `area/*` branches, each drifting 500–800 commits from `main`, plus a 4-tier `task → area → staging → main` promotion chain, plus a custom `spec-sync` tool syncing a `docs/specs/` folder across a dedicated spec-only `master-spec` branch, plus a separate staging *mirror repo* synced by a 10-minute cron + a manual `gh workflow run sync-staging.yml` dispatch.
+
+Almost every one of those moving parts exists to manage the divergence that permanent branches create. The symptom that triggered this redesign: `master-spec` silently went stale and started *downgrading* the specs of any session that ran `spec-sync down` — a second copy of the truth drifting from the first. Jac: *"I still feel my workflow is clunky and overcomplicated… I would like to do exactly what the mainstream industry does instead of pretending I'm smarter than them."*
+
+The research (see §10) is unusually unanimous: fix the branching model and most of the machinery has nothing left to do. Jac's one firm constraint: **keep the staging approval gate** — he reviews the running app on a staging URL and approves before it goes live. That gate is 100% mainstream; it is *staging-as-a-long-lived-branch + mirror repo* that is the anti-pattern. The two separate cleanly.
+
+## 2. Goals
+
+- One **trunk** (`main`); short-lived feature branches; retire the `area/*` branches and the 4-tier promotion chain.
+- **Keep** a staging review environment and a manual approval before production.
+- Retire `spec-sync` and the `master-spec` branch (docs-as-code on the trunk).
+- Retire the 10-minute cron mirror + manual `sync-staging.yml` dispatch (staging becomes a direct deploy).
+- Support **parallel Claude sessions** via git **worktrees** off the trunk, not per-domain branches.
+- Preserve every real quality asset: the CI gates, R-rulebook stamping, Code-Atlas, `jactec-ui`, and the skills.
+
+## 3. Non-goals
+
+- **Not** moving off GitHub Pages (evaluated; a commercial app would pay ~\$20/mo for Netlify/Vercel gated publishing, and Cloudflare Pages has no post-merge approval gate — Pages + Actions stays cheapest and most mainstream). Pages' one-site-per-repo limit means the staging site remains a second repo.
+- **Not** adopting a native GitHub audit gate now. Jac chose chat-driven gates (§5); the native "Required reviewers" Approve button is a documented later option, not this design.
+- **Not** a big-bang cutover. The migration is incremental, one area at a time (§9).
+- **Not** re-litigating the kept infrastructure (CI gates, rulebook, atlas, skills).
+
+## 4. The model, in one picture
+
+```
+open a session
+   │
+   ▼
+short feature branch ───────────────▶  STAGING (runs your feature)
+   │  Claude builds it; deploys at a           │
+   │  testable milestone & tells you           │  you review the running app
+   │                                           │
+   │        ◀──── "looks good, merge it" ──────┘
+   ▼
+TRUNK (main) ── feature merged, branch deleted; a big replacement rides in behind a flag
+   │
+   │  wait as long as you like — blessed, integrated, but NOT live
+   │
+   │        ◀──── "promote it" ────────────────
+   ▼
+PRODUCTION ──▶ app.jacrentals.com  (the exact build you approved)
+```
+
+## 5. Decisions (with rationale)
+
+Each row was decided with Jac on 2026-07-12.
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **One trunk (`main`); short-lived feature branches off it, merged/dropped the same day and deleted.** | Trunk-based development; DORA's elite-performer thresholds (≤3 active branches, merge daily, branches live hours not days). Ends the 500–800-commit drift. |
+| D2 | **Review the feature BEFORE it joins the trunk.** The feature branch is deployed to the staging environment; it merges into the trunk only after approval. | Directly answers Jac's *"what if I don't like it, especially a big replacement?"* — a disliked feature simply never merges; nothing to undo. Maps to his current "review staging, then merge" habit. |
+| D3 | **Two chat-driven gates.** Gate 1 = "merge it" (Claude merges the feature into the trunk, deletes the branch). Gate 2 = "promote it" (Claude promotes the exact approved build to production). The wait between them is Jac's. | Keeps the approval gate Jac values, and decouples *integrate* from *go-live* ("release when ready"). Trunk runs a little ahead of production, holding blessed-but-not-live work — a normal continuous-delivery shape. |
+| D4 | **Both gates operated from the chat**, on Jac's say-so; Claude runs the git/deploy commands. | Least friction, never leaves the session. Trade-off accepted: no native audit trail on go-live (fine for a solo operator; the native GitHub "Required reviewers" gate can be added later). |
+| D5 | **Big replacements ship behind a feature flag** (a `FEATURES` map in `config.js`): new code alongside old, toggle to flip, old code deleted only once confident. Small/low-risk features merge plainly. | The mainstream tool for de-risking large swaps; makes "back it out" a runtime toggle, not code surgery. Caveat: on a public Pages site a flag disables *execution*, not *visibility* — flagged code is still readable in the shipped bundle (not a secrecy mechanism). |
+| D6 | **Parallel Claude sessions use git worktrees** off the trunk (`claude --worktree <name>`), not per-domain branches. `.worktreeinclude` carries gitignored backend/config into each worktree; `isolation: worktree` self-isolates subagents. | First-party Anthropic mechanism for the exact problem the `area/*` branches were built to solve. Isolation without divergence. Sweet spot 3–5 concurrent, not 19. |
+| D7 | **Docs-as-code on the trunk.** Specs/decisions live in `/docs` on `main`; retire `spec-sync` and the `master-spec` branch. Settled decisions can be recorded as ADRs. | With one trunk + short branches, every session sees the latest docs by pulling — the cross-branch sync problem (and its silent-staleness failure mode) disappears. |
+| D8 | **Staging stays a second repo, fed by a push on deploy** (not a cron). Retire the 10-min cron mirror + manual `sync-staging.yml` dispatch. | Pages allows one site per repo, so the staging URL needs a second repo — but it updates instantly on deploy instead of polling, killing the documented "mirror serves an old file under a new token" bug. |
+
+## 6. What stays (real quality infrastructure, unchanged)
+
+The `smoke` + `logic-test` + `gen-rule-usage --check` + `check-window-catalog` + `gen-code-map --check` CI gates; the R-rulebook `data-r` stamping + generator; the Code-Atlas (`docs/CODE-MAP.md`); `jactec-ui` and its rulebook; and all skills (`start`, `clasp`, `atlas`, `wrangler-fix`, `tidy-sessions`, `brainstorming`, etc.). None of this was ceremony — it is the quality floor and it carries over. (Skills that reference the old branch flow — notably `start` and its `branch-map.md` — get updated to describe the trunk model; see §8.)
+
+## 7. What gets deleted
+
+- The ~19 long-lived `area/*` branches.
+- The `task → area/<domain> → staging → main` promotion chain.
+- The `spec-sync` tool (`tools/spec-sync.mjs`) and the `master-spec` branch.
+- The 10-minute cron mirror sync + the manual `sync-staging.yml` workflow-dispatch step.
+- `tools/branch-preflight.mjs`'s area/master-spec ensure logic (reduced to trunk + worktree hygiene, or retired).
+
+## 8. Impacted skills / tooling to update (not delete)
+
+- **`start` skill** + `references/branch-map.md`: rewrite the "route to a task branch off an area" flow into "cut a short feature branch / worktree off the trunk"; drop the master-spec `down`/`up` obligations and the ~2h spec-sync timer.
+- **`CLAUDE.md`**: replace the Deploy & gates branch-flow description and the spec-sync references with the trunk model.
+- **`clasp` skill / backend deploy**: unchanged in mechanism (backend still ships out-of-band), but its references to the branch chain get updated.
+
+## 9. Migration approach (incremental — no big bang)
+
+1. Land this workflow's plumbing (the trunk deploy pipeline: feature-branch→staging push, gated production promote) once, and prove it on one small feature end to end.
+2. Adopt the trunk model **one area at a time**: next time an `area/*` is touched, do the work as a short feature branch off the trunk instead, verify, and retire that area branch. The branch empire dissolves gradually rather than in one risky sweep.
+3. Retire `spec-sync`/`master-spec` once docs are consolidated onto the trunk.
+4. Update the impacted skills/docs (§8) alongside step 1 so new sessions start on the new model.
+
+## 10. Grounding / sources
+
+Trunk-based development & branch lifetime: DORA (dora.dev/capabilities/trunk-based-development), Martin Fowler "Patterns for Managing Source Code Branches" (martinfowler.com/articles/branching-patterns.html), trunkbaseddevelopment.com. Branching models: GitHub Flow (docs.github.com/en/get-started/using-github/github-flow), GitLab "Branching strategies". Feature flags: Fowler "Feature Toggles" (martinfowler.com/articles/feature-toggles.html). Docs-as-code / ADRs: writethedocs.org/guide/docs-as-code, adr.github.io, diataxis.fr. Parallel AI agents: Claude Code worktrees (code.claude.com/docs/en/worktrees) + agent teams (code.claude.com/docs/en/agent-teams). Approval gate & hosting: GitHub Actions Environments / required reviewers (docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments), custom Pages workflows (docs.github.com/.../using-custom-workflows-with-github-pages), Netlify locked deploys, Cloudflare Pages preview deployments, Vercel promote.
+
+## 11. Open implementation questions (for the plan, not this design)
+
+- Exact GitHub Pages wiring for two sites, and making **production deploy only on "promote"** (not automatically on merge to trunk) — e.g. a `production` release-pointer branch that Pages serves and that "promote" fast-forwards, or a Pages source of "GitHub Actions" with a promote-triggered deploy.
+- Cross-repo push mechanism for the staging site (deploy key vs PAT).
+- Whether to add **content-hashed asset filenames** to retire the manual `?v=` cache-bust token (a small CI hashing step can do this without adopting a full bundler, preserving the build-free posture).
+- Where feature-flag reads live in `app.js` and how `config.js` `FEATURES` defaults are set per environment.

--- a/docs/superpowers/specs/2026-07-12-end-of-session-skill-draft.md
+++ b/docs/superpowers/specs/2026-07-12-end-of-session-skill-draft.md
@@ -1,13 +1,13 @@
-# DRAFT — Proposed `end-of-session` Skill
+# DRAFT — Proposed `end` Skill
 
-> **DRAFT — proposed end-of-session skill; activates with the trunk-workflow
+> **DRAFT — proposed end skill; activates with the trunk-workflow
 > migration (see the design/plan). Not yet a live skill.**
 
 This is a review draft only. It is **not** installed at `.claude/skills/` and
 nothing in the app invokes it. It becomes a real skill only when the
 trunk-based dev workflow lands (Phase 5, §5a of the plan below) and someone
 copies the proposed `SKILL.md` content into
-`.claude/skills/end-of-session/SKILL.md`, replacing
+`.claude/skills/end/SKILL.md`, replacing
 `.claude/skills/tidy-sessions/SKILL.md`. Nothing in this document touches the
 live skill.
 
@@ -29,11 +29,11 @@ Worktree cleanup and the handoff note aren't a fifth job; they fold into jobs
 
 ```markdown
 ---
-name: end-of-session
-description: Close out a Claude Code session on the trunk workflow — report what's actually shipped (merged to trunk vs promoted to production vs still pending/uncommitted), sweep loose ideas or half-done threads onto their own parked branches so nothing is lost, refuse to archive while anything is pending/parked/uncommitted, then archive the chat. Replaces tidy-sessions, which only archived. Use when a feature is done, a session is winding down, or chats pile up. Invoke with /end-of-session.
+name: end
+description: Close out a Claude Code session on the trunk workflow — report what's actually shipped (merged to trunk vs promoted to production vs still pending/uncommitted), sweep loose ideas or half-done threads onto their own parked branches so nothing is lost, refuse to archive while anything is pending/parked/uncommitted, then archive the chat. Replaces tidy-sessions, which only archived. Use when a feature is done, a session is winding down, or chats pile up. Invoke with /end.
 ---
 
-# /end-of-session — capture, close out, archive
+# /end — capture, close out, archive
 
 Closes a session properly on the trunk model: one `main` trunk, short-lived
 feature branches, a `production` release-pointer branch. Runs FOUR jobs,
@@ -96,7 +96,7 @@ cheap and reversible; dropping needs an explicit yes.
 5. **Note it** — open a draft PR so it's discoverable without merging:
    `gh pr create --draft --title "[parked] <slug>" --body "<what it is, why
    parked, what's left>"`. Draft PRs surface via `gh pr list --draft`, so a
-   later session (or the next `/end-of-session` run) can resurface stale
+   later session (or the next `/end` run) can resurface stale
    parked work instead of it rotting silently.
 6. **Return** to the branch you were on before parking — never leave the
    session sitting on a parked branch.
@@ -146,9 +146,9 @@ The old `tidy-sessions` job, unchanged in spirit:
 
 ## Open questions for Jac
 
-1. **Skill name / invocation** — `end-of-session`, invoked `/end-of-session`?
-   And should `/tidy-sessions` stick around as an alias during migration, or
-   get deleted outright once this lands?
+1. **Skill name — RESOLVED 2026-07-12 (Jac):** the skill is **`/end`**.
+   Open sub-question: keep `/tidy-sessions` as an alias during the migration, or
+   delete it outright once `/end` lands?
 2. **Parked-branch naming** — is `parked/<slug>` the right prefix, or would
    you rather namespace it under your own `claude/parked-<slug>` convention
    (matching how Claude Code already auto-names its own branches, e.g.

--- a/docs/superpowers/specs/2026-07-12-end-of-session-skill-draft.md
+++ b/docs/superpowers/specs/2026-07-12-end-of-session-skill-draft.md
@@ -1,0 +1,166 @@
+# DRAFT — Proposed `end-of-session` Skill
+
+> **DRAFT — proposed end-of-session skill; activates with the trunk-workflow
+> migration (see the design/plan). Not yet a live skill.**
+
+This is a review draft only. It is **not** installed at `.claude/skills/` and
+nothing in the app invokes it. It becomes a real skill only when the
+trunk-based dev workflow lands (Phase 5, §5a of the plan below) and someone
+copies the proposed `SKILL.md` content into
+`.claude/skills/end-of-session/SKILL.md`, replacing
+`.claude/skills/tidy-sessions/SKILL.md`. Nothing in this document touches the
+live skill.
+
+- **Design:** `docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md`
+- **Plan (authoritative contract for this skill):** `docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md` → §5a "Skill rewrites"
+- **Replaces:** `.claude/skills/tidy-sessions/SKILL.md`, which Jac flagged 2026-07-12 as "has not been very useful" — it only listed and archived finished chats, with no capture step, so a session could close with real work quietly lost.
+
+## Why this shape
+
+§5a fixes the scope precisely: four jobs, in order, and Jac explicitly
+de-scoped driving the two deploy gates ("merge it" / "promote it") and
+"landing" the work — this skill reports and captures, it does not promote.
+Worktree cleanup and the handoff note aren't a fifth job; they fold into jobs
+1 and 4 as noted below.
+
+---
+
+## Proposed `SKILL.md`
+
+```markdown
+---
+name: end-of-session
+description: Close out a Claude Code session on the trunk workflow — report what's actually shipped (merged to trunk vs promoted to production vs still pending/uncommitted), sweep loose ideas or half-done threads onto their own parked branches so nothing is lost, refuse to archive while anything is pending/parked/uncommitted, then archive the chat. Replaces tidy-sessions, which only archived. Use when a feature is done, a session is winding down, or chats pile up. Invoke with /end-of-session.
+---
+
+# /end-of-session — capture, close out, archive
+
+Closes a session properly on the trunk model: one `main` trunk, short-lived
+feature branches, a `production` release-pointer branch. Runs FOUR jobs,
+strictly in order — the archive step only fires once the first three are
+clean. Replaces `tidy-sessions`, which only did job 4.
+
+## 1. Report shipped-state plainly
+Don't let the session end on a fuzzy "did this actually ship?". Check and
+state all three, even when a bucket is empty:
+- **PROMOTED (live):** `git log origin/production..origin/main --oneline` —
+  empty means `main` IS what's live; anything listed is on the trunk but
+  **not yet promoted**.
+- **MERGED TO TRUNK, not yet promoted:** the output of the check above.
+- **PENDING / uncommitted:** `git status -sb` on the current branch/worktree,
+  plus any feature branch this session pushed that never merged.
+- **Worktree state**, if this session ran in a `claude --worktree`: name it,
+  say whether its work already landed on `main`. Landed → cleanup candidate
+  for job 4. Not landed → it's PENDING and blocks archive under job 3.
+- Write this into a short handoff note (session-output folder) so the next
+  session — this one resuming, or a fresh one — doesn't have to re-derive it.
+
+## 2. Catch loose work before it's lost
+The job `tidy-sessions` never did, and the one Jac most wanted. Scan for
+anything worth keeping that isn't already cleanly shipped or committed to a
+tracked branch:
+- `git status -sb` / `git diff` for uncommitted or untracked changes not
+  already covered by job 1's shipped report.
+- `git stash list` — anything stashed and forgotten.
+- Skim the session itself for ideas Jac raised or Claude proposed and then
+  deferred — cue phrases like "later," "not now," "someday," "good idea but
+  skip," "table this," "follow-up." A verbal idea with zero code still
+  counts if it's worth keeping.
+- Any half-built function/file left mid-edit in the working tree that isn't
+  part of the shipping diff.
+
+For each candidate, confirm with Jac via `AskUserQuestion` (never inline —
+CLAUDE.md) as a short list: **park it**, **keep working it now instead of
+ending the session**, or **drop it**. Default suggestion is park — it's
+cheap and reversible; dropping needs an explicit yes.
+
+**Mechanics for parking (every confirmed item):**
+1. **Name it** `parked/<short-kebab-slug>` — e.g. `parked/dark-mode-toggle`.
+   Add a date prefix only if the slug could collide or timing matters:
+   `parked/2026-07-12-dark-mode-toggle`.
+2. **Branch it** off the trunk (or off the current feature branch, if the
+   loose work only makes sense on top of it — say which and why):
+   `git checkout main && git pull && git checkout -b parked/<slug>`.
+3. **Commit the loose work** with a message that stands alone months later —
+   what it is, why it was parked, what's left:
+   ```
+   Park: <one-line description>
+
+   Deferred from <origin branch/session> on <date>.
+   Needs: <what's left to finish it>.
+   ```
+   For an idea with no code yet, commit a short markdown note (e.g. under
+   `docs/superpowers/notes/`) instead of an empty branch — the note IS the
+   artifact.
+4. **Push it:** `git push -u origin parked/<slug>`.
+5. **Note it** — open a draft PR so it's discoverable without merging:
+   `gh pr create --draft --title "[parked] <slug>" --body "<what it is, why
+   parked, what's left>"`. Draft PRs surface via `gh pr list --draft`, so a
+   later session (or the next `/end-of-session` run) can resurface stale
+   parked work instead of it rotting silently.
+6. **Return** to the branch you were on before parking — never leave the
+   session sitting on a parked branch.
+7. List every parked branch + its draft-PR link in the job-1 handoff note.
+
+## 3. Guard against premature archive
+If job 1 found anything PENDING/uncommitted, or job 2 found a loose thread
+that's still undecided (or Jac chose to keep working it now) — **do NOT
+archive**. State plainly what's outstanding and what would clear it (e.g.
+"commit `foo.js`," "confirm parking the CSV-export idea"), then stop. Same
+conservative posture `tidy-sessions` already applied to archiving itself,
+just moved one step earlier to cover the whole close-out.
+
+## 4. Archive the chat reliably — last step, only once 1–3 are clean
+The old `tidy-sessions` job, unchanged in spirit:
+1. List sessions with `mcp__ccd_session_mgmt__list_sessions`. If unavailable
+   (e.g. a cloud run), say so and point Jac to archive in the Claude app.
+2. Identify candidates conservatively: no activity in 7+ days, OR the
+   session's branch is merged/gone (cross-check `gh pr list --state merged`
+   / `git ls-remote`). Never flag the current session or one with an open
+   PR, or no PR yet.
+3. **If this session ran in a worktree and job 1 confirmed its work already
+   landed on `main`, clean it up now** — remove the worktree
+   (`ExitWorktree` / `git worktree remove`) so it doesn't linger as a stale
+   checkout.
+4. Present candidates as a short table (title · last activity · branch
+   status) via `AskUserQuestion`; default-select the clearly-done ones, let
+   Jac deselect.
+5. Archive the confirmed ones with `mcp__ccd_session_mgmt__archive_session`.
+   Report what was archived, what was kept, and what was cleaned up.
+
+## Rules
+- **Never skip ahead.** Job 4 cannot run before 1–3 are clean — that
+  ordering is the whole point of replacing `tidy-sessions`.
+- **Never archive or park without confirmation.** Both are reversible, but
+  silent action isn't welcome (mirrors CLAUDE.md's "questions → popups
+  only" rule).
+- **Never archive the active session.**
+- Default conservative throughout: unsure whether something's finished →
+  leave it, ask.
+- **Out of scope, by design:** driving Gate 1 ("merge it") or Gate 2
+  ("promote it"), and "landing" work beyond reporting + parking. That's the
+  `start` skill's two-gate deploy loop, not this one.
+```
+
+---
+
+## Open questions for Jac
+
+1. **Skill name / invocation** — `end-of-session`, invoked `/end-of-session`?
+   And should `/tidy-sessions` stick around as an alias during migration, or
+   get deleted outright once this lands?
+2. **Parked-branch naming** — is `parked/<slug>` the right prefix, or would
+   you rather namespace it under your own `claude/parked-<slug>` convention
+   (matching how Claude Code already auto-names its own branches, e.g.
+   `claude/update-specs-yesterday-y8tr3x` per the design doc's header)?
+3. **"Note it" mechanism** — is a draft PR (`gh pr create --draft`) enough,
+   or do you also want a running tracking doc (e.g. `docs/PARKED-WORK.md`)
+   listing parked branches, so they're visible without `gh pr list --draft`?
+4. **The old tidy-sessions step 5** (closing already-resolved
+   `wrangler-fix`/`wrangler-request` issues) isn't in the four jobs from
+   §5a — intentionally dropped, or should it fold into job 4 as "the
+   archive job, done well"?
+5. **Job 2 trigger sensitivity** — scanning session transcript for deferred
+   ideas is inherently fuzzy (cue-phrase matching). Worth a tighter
+   definition of "worth keeping" so this doesn't either miss real threads or
+   nag Jac with trivial ones?

--- a/tools/deploy-staging.mjs
+++ b/tools/deploy-staging.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+// deploy-staging.mjs — "put my feature on staging."
+//
+// DRAFT — pipeline not yet wired; activate per plan Phase 0. Do not run until
+// the staging deploy credential + repo are confirmed.
+//
+// WHY THIS EXISTS
+// Per the trunk-based redesign (see the two docs below), staging stops being a
+// cron-mirrored repo and becomes a direct push target: a feature branch deploys
+// itself to the staging Pages site so Jac can review the running app at a URL,
+// then says "merge it" (Gate 1, trunk) / "promote it" (Gate 2, production).
+// This script is Phase 1.1 — the FIRST of those two chat-driven gates' plumbing.
+//   - Plan:   docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md  (§Phase 0, §Phase 1.1)
+//   - Design: docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md (D8)
+//
+// WHAT IT DOES
+//   1. refuses to run off main/production — this workflow assumes a short feature branch
+//   2. derives the real set of publishable site files by crawling from the repo's
+//      top-level *.html entry points through their asset/script/import/CSS graph
+//      (NOT a hardcoded list — see deriveSiteFiles() below)
+//   3. bumps the shared ?v= cache-bust token in index.html (style.css/rule-usage.js/app.js
+//      only — never the ES-module import specifiers inside app.js, per CLAUDE.md)
+//   4. clones the staging repo's Pages branch fresh, replaces its tracked files with the
+//      derived set, commits, and pushes
+//   5. prints the staging URL + the new ?v= marker so the deploy is verifiable
+//
+// BUILD-FREE POSTURE: this copies files, it does not bundle/transpile them — same
+// posture as the app itself and as tools/spec-sync.mjs, which this file's shape follows
+// (Node ESM, execFileSync('git', ...), no external deps, small git/gitTry/lines helpers).
+//
+// SECRET HANDLING
+//   The push credential is read from an env var and NEVER logged. Every git operation
+//   that touches the authenticated staging remote (clone, push) is routed through
+//   gitAuthed(), which discards the original error (git does not redact a token embedded
+//   in a remote URL from its own "fatal: unable to access '...'" messages) and throws a
+//   generic, safe-to-print one instead. Local-only git calls (branch check, add, commit,
+//   diff) use the plain git()/gitTry() helpers and print normally.
+//
+// USAGE (once activated)
+//   node tools/deploy-staging.mjs              # derive, bump, clone, push
+//   node tools/deploy-staging.mjs --dry-run    # derive + bump index.html locally, stop
+//                                               # before touching the staging repo
+
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync, mkdirSync, copyFileSync, rmSync, readFileSync, writeFileSync, readdirSync, statSync,
+} from 'node:fs';
+import { join, dirname, extname, posix } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ── Config — CONFIRM before the first real run (these are the Phase 0 blockers) ──
+
+// TODO(jac): confirm — the staging repo; its GitHub Pages serves the staging URL.
+const STAGING_REPO = 'operations-jacrentals/rental-wrangler-staging';
+
+// TODO(jac): confirm — the branch staging's Pages source is configured to build from.
+const STAGING_PAGES_BRANCH = 'main';
+
+// TODO(jac): confirm — which credential this session actually has (plan §0.4 offers
+// either an SSH deploy key or a fine-scoped PAT; this script supports both and prefers
+// the SSH key when both are set, since a leaked SSH key PATH is far safer to fail loudly
+// with than a PAT, which can end up embedded in a git remote URL — see gitAuthed()).
+// Neither set => clean no-op (see resolveCredential()), nothing is pushed.
+const STAGING_DEPLOY_KEY_PATH = process.env.STAGING_DEPLOY_KEY_PATH || ''; // path to the PRIVATE half of the deploy key
+const STAGING_DEPLOY_PAT = process.env.STAGING_DEPLOY_PAT || '';           // fine-scoped PAT, staging repo only
+
+// Refuse to deploy from these — a short feature branch is the whole point of Gate 1.
+const PROTECTED_BRANCHES = ['main', 'production'];
+
+// ── small git helpers (same shape as tools/spec-sync.mjs) ──
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, { encoding: 'utf8', ...opts }).trim();
+}
+function gitTry(args, opts = {}) {
+  try { return { ok: true, out: git(args, opts) }; }
+  catch (e) { return { ok: false, out: (e.stdout || '') + (e.stderr || ''), err: e }; }
+}
+function lines(s) { return s.split('\n').map((x) => x.trim()).filter(Boolean); }
+function fail(msg) { console.error(msg); process.exit(1); }
+
+const ROOT = git(['rev-parse', '--show-toplevel']);
+process.chdir(ROOT);
+
+// ── branch guard ──
+
+function assertFeatureBranch(branch) {
+  if (!branch || branch === 'HEAD') {
+    fail('deploy-staging: detached HEAD — check out a feature branch first.');
+  }
+  if (PROTECTED_BRANCHES.includes(branch)) {
+    fail(`deploy-staging: refusing to run from '${branch}'. This is Gate-1 plumbing for a ` +
+      `short-lived feature branch (see the plan) — check out a feature branch first.`);
+  }
+}
+
+// ── credential resolution + the sanitizing wrapper for network git calls ──
+
+function resolveCredential() {
+  if (STAGING_DEPLOY_KEY_PATH) {
+    if (!existsSync(STAGING_DEPLOY_KEY_PATH)) {
+      fail(`deploy-staging: STAGING_DEPLOY_KEY_PATH is set but no file exists at ${STAGING_DEPLOY_KEY_PATH}.`);
+    }
+    return { kind: 'ssh', keyPath: STAGING_DEPLOY_KEY_PATH };
+  }
+  if (STAGING_DEPLOY_PAT) return { kind: 'pat', token: STAGING_DEPLOY_PAT };
+  return null;
+}
+
+function stagingRemoteUrl(cred) {
+  return cred.kind === 'ssh'
+    ? `git@github.com:${STAGING_REPO}.git`
+    // PAT embedded in the URL — never printed. Every command that uses this URL goes
+    // through gitAuthed(), which never surfaces raw git stderr/argv on failure.
+    : `https://x-access-token:${cred.token}@github.com/${STAGING_REPO}.git`;
+}
+function gitEnv(cred) {
+  if (cred.kind !== 'ssh') return process.env;
+  return { ...process.env, GIT_SSH_COMMAND: `ssh -i ${JSON.stringify(cred.keyPath)} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new` };
+}
+// Network operations against the staging remote ONLY. Deliberately swallows the
+// original error (it can carry the PAT via git's own "fatal: unable to access '<url>'"
+// text) and throws a sanitized one instead.
+function gitAuthed(args, cred, opts = {}) {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8', env: gitEnv(cred), ...opts }).trim();
+  } catch {
+    throw new Error(
+      `deploy-staging: git ${args[0]} against the staging remote failed (credential, network, or ` +
+      `repo/branch-name issue). Message withheld — it may echo the credential. Check ` +
+      `STAGING_REPO/STAGING_PAGES_BRANCH and the credential env var by hand.`
+    );
+  }
+}
+
+// ── deriving the real site-file list (crawl, don't guess) ──
+
+// Explicit defense-in-depth: even if a bug in the crawler ever resolved one of these,
+// never let it into the staging deploy.
+//   - CNAME is the PRODUCTION custom-domain pointer; copying it into the staging repo
+//     would misconfigure that repo's Pages domain.
+//   - the rest are gitignored/never-served-by-Pages per CLAUDE.md (real customer PII,
+//     the GAS backend, local secret dumps).
+const DENY_PATTERNS = [
+  /^CNAME$/, /^backend\//, /\.local\./, /^data\.generated\.js$/, /^data\.demo-backup\.js$/, /^JacTec-handoff\//,
+];
+function isDenied(rel) { return DENY_PATTERNS.some((re) => re.test(rel)); }
+
+// Files no static scan can find, added unconditionally:
+//   - sw.js is registered from app.js via a runtime string ('sw.js?v=' + token), not a
+//     static import or href — the crawler below can't see it.
+//   - .nojekyll is Pages hosting hygiene (skip Jekyll processing); it's a dotfile, so the
+//     *.html-seeded crawl below never reaches it on its own.
+const ALWAYS_SHIP = ['sw.js', '.nojekyll'];
+
+function stripQuery(p) { return p.replace(/^\.\//, '').split(/[?#]/)[0]; }
+function isExternal(ref) { return /^([a-z][\w+.-]*:)?\/\//i.test(ref) || /^(mailto|tel|data):/i.test(ref) || ref.startsWith('#'); }
+
+const HTML_REF_RE = /\b(?:src|href)\s*=\s*["']([^"']+)["']/g;
+const CSS_URL_RE = /url\(\s*(['"]?)([^'")]+)\1\s*\)/g;
+const JS_IMPORT_RE = /\bfrom\s+['"](\.[^'"]+)['"]/g;
+const JS_DYNIMPORT_RE = /\bimport\(\s*['"](\.[^'"]+)['"]\s*\)/g;
+// Safety net for asset paths referenced as plain strings rather than a formal
+// src=/href=/url()/import (e.g. app.js building a <video> src at runtime).
+const ASSET_LITERAL_RE = /\bassets\/[\w.\-/]+\.(?:png|jpe?g|svg|mp4|webp|gif|ico|woff2?|ttf|otf)\b/gi;
+
+function extractHtmlRefs(text) {
+  const out = new Set();
+  for (const m of text.matchAll(HTML_REF_RE)) { if (!isExternal(m[1])) out.add(stripQuery(m[1])); }
+  return out;
+}
+function extractCssRefs(text) {
+  const out = new Set();
+  for (const m of text.matchAll(CSS_URL_RE)) { if (!isExternal(m[2])) out.add(stripQuery(m[2])); }
+  return out;
+}
+function extractJsRefs(text) {
+  const out = new Set();
+  for (const m of text.matchAll(JS_IMPORT_RE)) out.add(stripQuery(m[1]));
+  for (const m of text.matchAll(JS_DYNIMPORT_RE)) out.add(stripQuery(m[1]));
+  return out;
+}
+function extractManifestRefs(text) {
+  const out = new Set();
+  try {
+    const j = JSON.parse(text);
+    for (const icon of j.icons || []) { if (icon && icon.src) out.add(stripQuery(icon.src)); }
+  } catch { /* not JSON we can parse — ignore */ }
+  return out;
+}
+function extractLiteralAssetRefs(text) {
+  const out = new Set();
+  for (const m of text.matchAll(ASSET_LITERAL_RE)) out.add(stripQuery(m[0]));
+  return out;
+}
+// Resolve a ref found inside `fromRel` (repo-relative, posix) to a repo-relative path.
+function resolveRef(fromRel, ref) {
+  const dir = posix.dirname(fromRel);
+  return posix.normalize(posix.join(dir, ref));
+}
+
+const CRAWLABLE_EXT = new Set(['.html', '.css', '.js', '.mjs', '.webmanifest', '.json']);
+
+// Crawl from every top-level *.html entry point (index.html plus any sibling static
+// pages like the SMS opt-in/privacy/terms pages) through hrefs/srcs, the ES-module
+// import graph, CSS url()s, and the manifest's icon list. This is deliberately a crawl,
+// not a hardcoded list, so a new script/asset/page shows up here automatically the next
+// time it's actually wired into the site — and something that's never referenced from
+// index.html (a draft, a dev-only fixture) never gets shipped by accident.
+function deriveSiteFiles() {
+  const entryHtml = readdirSync(ROOT).filter((f) => f.endsWith('.html') && statSync(join(ROOT, f)).isFile());
+  const queue = [...entryHtml, ...ALWAYS_SHIP];
+  const seen = new Set();
+  const discovered = [];
+  const missing = [];
+  const denied = [];
+
+  while (queue.length) {
+    const rel = queue.shift();
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    if (isDenied(rel)) { denied.push(rel); continue; }
+    const abs = join(ROOT, rel);
+    if (!existsSync(abs) || !statSync(abs).isFile()) { missing.push(rel); continue; }
+    discovered.push(rel);
+
+    const ext = extname(rel).toLowerCase();
+    if (!CRAWLABLE_EXT.has(ext)) continue; // binary asset — nothing to crawl further
+    const text = readFileSync(abs, 'utf8');
+
+    const refs = new Set();
+    if (ext === '.html') for (const r of extractHtmlRefs(text)) refs.add(r);
+    if (ext === '.css') for (const r of extractCssRefs(text)) refs.add(r);
+    if (ext === '.js' || ext === '.mjs') for (const r of extractJsRefs(text)) refs.add(r);
+    if (ext === '.webmanifest' || ext === '.json') for (const r of extractManifestRefs(text)) refs.add(r);
+    for (const r of extractLiteralAssetRefs(text)) refs.add(r);
+
+    for (const r of refs) {
+      const resolved = resolveRef(rel, r);
+      if (!seen.has(resolved)) queue.push(resolved);
+    }
+  }
+
+  if (denied.length) {
+    console.warn('deploy-staging: referenced but denylisted (skipped, see DENY_PATTERNS):');
+    denied.forEach((d) => console.warn('   ' + d));
+  }
+  if (missing.length) {
+    console.warn('deploy-staging: referenced but not found on disk (skipped):');
+    missing.forEach((m) => console.warn('   ' + m));
+  }
+  return discovered.sort();
+}
+
+// ── the shared ?v= cache-bust token ──
+
+function todayStamp() {
+  const d = new Date();
+  return `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, '0')}${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+// Matches the existing history in index.html: YYYYMMDD + an alpha suffix that
+// increments for repeat deploys the same day (…20260710e, 20260710f, 20260710g…).
+function incrementSuffix(s) {
+  if (!s) return 'a';
+  const arr = s.split('');
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (arr[i] !== 'z') { arr[i] = String.fromCharCode(arr[i].charCodeAt(0) + 1); return arr.join(''); }
+    arr[i] = 'a';
+  }
+  return 'a' + arr.join('');
+}
+function nextToken(oldToken) {
+  const today = todayStamp();
+  const m = /^(\d{8})([a-z]*)$/i.exec(oldToken);
+  if (!m || m[1] !== today) return today + 'a';
+  return today + incrementSuffix(m[2].toLowerCase());
+}
+
+// Bumps the ONE shared token across style.css/rule-usage.js/app.js in index.html.
+// Deliberately does NOT touch app.js's internal ES-module import specifiers (they never
+// carry ?v= — see CLAUDE.md: a relative import drops the query string, so a versioned +
+// unversioned copy of a sub-module would instantiate twice).
+function bumpVersionToken(indexHtmlAbs) {
+  const html = readFileSync(indexHtmlAbs, 'utf8');
+  const patterns = [
+    ['style.css', /(\bstyle\.css\?v=)([\w-]+)/],
+    ['rule-usage.js', /(\brule-usage\.js\?v=)([\w-]+)/],
+    ['app.js', /(\bapp\.js\?v=)([\w-]+)/],
+  ];
+  const tokens = new Set();
+  for (const [name, re] of patterns) {
+    const m = re.exec(html);
+    if (!m) fail(`deploy-staging: could not find a ?v= token on ${name} in index.html — the cache-bust pattern may have changed; update this script.`);
+    tokens.add(m[2]);
+  }
+  if (tokens.size !== 1) {
+    fail(`deploy-staging: style.css/rule-usage.js/app.js don't share one ?v= token in index.html ` +
+      `(found: ${[...tokens].join(', ')}) — CLAUDE.md requires one shared token. Fix index.html by hand first.`);
+  }
+  const oldToken = [...tokens][0];
+  const newToken = nextToken(oldToken);
+  let next = html;
+  for (const [, re] of patterns) next = next.replace(re, `$1${newToken}`);
+  writeFileSync(indexHtmlAbs, next);
+  return { oldToken, newToken };
+}
+
+// ── syncing files into a fresh clone of the staging repo ──
+
+function freshCloneDir() {
+  const dir = join(tmpdir(), `rw-deploy-staging-${process.pid}-${Date.now()}`);
+  rmSync(dir, { recursive: true, force: true });
+  return dir;
+}
+function removeCloneDir(dir) { rmSync(dir, { recursive: true, force: true }); }
+
+function cloneStaging(dir, cred) {
+  gitAuthed(['clone', '--depth', '1', '--branch', STAGING_PAGES_BRANCH, '--single-branch', stagingRemoteUrl(cred), dir], cred);
+}
+function pushStaging(dir, cred) {
+  // 'origin' already points at the authed URL from the clone above — no need to re-embed it.
+  gitAuthed(['push', 'origin', `HEAD:refs/heads/${STAGING_PAGES_BRANCH}`], cred, { cwd: dir });
+}
+
+// Replace the clone's tracked files with exactly `files` (so a file removed from the
+// source side is removed from staging too, not left behind as a stale orphan).
+function syncFiles(cloneDir, files) {
+  for (const f of lines(git(['ls-files'], { cwd: cloneDir }))) {
+    rmSync(join(cloneDir, f), { force: true });
+  }
+  for (const f of files) {
+    const dst = join(cloneDir, f);
+    mkdirSync(dirname(dst), { recursive: true });
+    copyFileSync(join(ROOT, f), dst);
+  }
+}
+
+// ── main ──
+
+function main() {
+  const DRY_RUN = process.argv.includes('--dry-run');
+
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  assertFeatureBranch(branch);
+
+  const cred = resolveCredential();
+  if (!cred) {
+    console.log('deploy-staging: no staging deploy credential configured — nothing pushed.');
+    console.log('                Set STAGING_DEPLOY_KEY_PATH or STAGING_DEPLOY_PAT once plan §0.4 is done, then re-run.');
+    return;
+  }
+
+  const files = deriveSiteFiles();
+  if (!files.length) fail('deploy-staging: derived an empty site-file list — something upstream is broken.');
+  console.log(`deploy-staging: ${files.length} site file(s) derived from index.html + the module/asset graph:`);
+  files.forEach((f) => console.log('   ' + f));
+
+  const { oldToken, newToken } = bumpVersionToken(join(ROOT, 'index.html'));
+  console.log(`deploy-staging: bumped shared ?v= token ${oldToken} -> ${newToken} in index.html`);
+
+  if (DRY_RUN) {
+    console.log("deploy-staging: --dry-run — stopping before touching the staging repo.");
+    console.log("                index.html was still bumped locally; `git checkout -- index.html` to revert.");
+    return;
+  }
+
+  const dirty = git(['status', '--porcelain']).length > 0;
+  const shortSha = gitTry(['rev-parse', '--short', 'HEAD']).out || 'nocommit';
+
+  const cloneDir = freshCloneDir();
+  try {
+    console.log(`deploy-staging: cloning ${STAGING_REPO}#${STAGING_PAGES_BRANCH} …`);
+    cloneStaging(cloneDir, cred);
+    syncFiles(cloneDir, files);
+    git(['add', '-A'], { cwd: cloneDir });
+    if (gitTry(['diff', '--cached', '--quiet'], { cwd: cloneDir }).ok) {
+      console.log('deploy-staging: staging already matches this working tree. Nothing to push.');
+      return;
+    }
+    const msg = `deploy: ${branch} @ ${shortSha}${dirty ? '+dirty' : ''} (?v=${newToken})`;
+    git(['commit', '-m', msg], { cwd: cloneDir });
+    pushStaging(cloneDir, cred);
+
+    const [owner, repoName] = STAGING_REPO.split('/');
+    console.log('deploy-staging: pushed.');
+    console.log(`  staging URL:  https://${owner}.github.io/${repoName}/`);
+    console.log(`  ?v= marker:   ${newToken}`);
+    console.log(`  verify with:  curl -s https://${owner}.github.io/${repoName}/index.html | grep ${newToken}`);
+  } finally {
+    removeCloneDir(cloneDir);
+  }
+}
+
+try {
+  main();
+} catch (e) {
+  fail(e && e.message ? e.message : String(e));
+}

--- a/tools/deploy-staging.mjs
+++ b/tools/deploy-staging.mjs
@@ -50,10 +50,13 @@ import { tmpdir } from 'node:os';
 
 // ── Config — CONFIRM before the first real run (these are the Phase 0 blockers) ──
 
-// TODO(jac): confirm — the staging repo; its GitHub Pages serves the staging URL.
+// Confirmed 2026-07-13 — the staging repo; its GitHub Pages serves the staging URL
+// (https://operations-jacrentals.github.io/rental-wrangler-staging/).
 const STAGING_REPO = 'operations-jacrentals/rental-wrangler-staging';
 
-// TODO(jac): confirm — the branch staging's Pages source is configured to build from.
+// Confirmed 2026-07-13 — the branch staging's Pages source builds from. The staging
+// repo has exactly one branch, `main`, so a "deploy from a branch" Pages source can
+// only serve `main`.
 const STAGING_PAGES_BRANCH = 'main';
 
 // TODO(jac): confirm — which credential this session actually has (plan §0.4 offers

--- a/tools/promote.mjs
+++ b/tools/promote.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// promote.mjs — Gate 2 of the two-gate trunk-based workflow: trunk (main) -> production.
+//
+// *** DRAFT — go-live pipeline not yet wired; activate per plan Phase 0. This script  ***
+// *** publishes to production when run with --yes; do not run until Phase 0           ***
+// *** (production branch + Pages source) is set up and Jac confirms.                  ***
+//
+// See: docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md (§1.3)
+//      docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md
+//
+// WHY THIS EXISTS
+// Once Phase 0 lands, production Pages stops tracking `main` directly — it serves a
+// `production` release-pointer branch instead. That's what makes Gate 1 ("merge it",
+// feature -> main) safe to run without going live: `main` can run ahead of production,
+// holding blessed-but-not-live work. Gate 2 ("promote it") is the ONLY thing that moves
+// the live site — it fast-forwards `production` to the exact commit already approved on
+// `main` (byte-identical to what was reviewed on staging, per the one-feature-at-a-time
+// flow this plan assumes). That makes this the irreversible go-live step, so it gets the
+// same caution posture as the /clasp production deploy: preview first (commit range +
+// diffstat), a hard STOP-gate behind an explicit --yes, a fast-forward-only push (no
+// --force, ever), then a live-bytes check afterward instead of just trusting the push —
+// the same "a stale snapshot no browser refresh fixes, only a re-sync/re-verify does"
+// trap called out for the staging mirror in CLAUDE.md applies here too.
+//
+// USAGE
+//   node tools/promote.mjs           # PREVIEW ONLY — shows what would go live, does nothing
+//   node tools/promote.mjs --yes     # promote: fast-forward + push `production`, then verify live
+//
+// SAFETY
+//   Without --yes this script only fetches + prints a preview and exits — it never
+//   pushes. With --yes it still refuses to move `production` unless the fast-forward is
+//   clean (production must be a strict ancestor of main); a diverged/rewritten production
+//   is left untouched and reported so a human can reconcile it manually — there is no
+//   --force path in this script. Never echoes secrets (none are needed for this step).
+
+import { execFileSync } from 'node:child_process';
+
+// TODO(jac): confirm — the release-pointer branch Pages serves as PRODUCTION (plan Phase 0.2/0.3).
+const PRODUCTION_BRANCH = 'production';
+// TODO(jac): confirm — the trunk branch Gate 1 ("merge it") lands on.
+const TRUNK = 'main';
+// TODO(jac): confirm — the live site's public URL (what Pages serves for PRODUCTION_BRANCH).
+const LIVE_URL = 'https://app.jacrentals.com';
+
+const REMOTE = 'origin';
+const ARGV = process.argv.slice(2);
+const CONFIRMED = ARGV.includes('--yes');
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, { encoding: 'utf8', ...opts }).trim();
+}
+function gitTry(args, opts = {}) {
+  try { return { ok: true, out: git(args, opts) }; }
+  catch (e) { return { ok: false, out: (e.stdout || '') + (e.stderr || ''), err: e }; }
+}
+function lines(s) { return s.split('\n').map(x => x.trim()).filter(Boolean); }
+
+function fail(msg) {
+  console.error(`promote: ${msg}`);
+  process.exit(1);
+}
+
+const ROOT = git(['rev-parse', '--show-toplevel']);
+process.chdir(ROOT);
+
+// --- Step 1: fetch both refs fresh, so the preview can never be stale -------
+console.log(`promote: fetching ${REMOTE}/${TRUNK} and ${REMOTE}/${PRODUCTION_BRANCH}…`);
+const fetchTrunk = gitTry(['fetch', REMOTE, TRUNK]);
+if (!fetchTrunk.ok) fail(`could not fetch ${REMOTE}/${TRUNK}:\n${fetchTrunk.out}`);
+
+const fetchProd = gitTry(['fetch', REMOTE, PRODUCTION_BRANCH]);
+if (!fetchProd.ok) {
+  fail(
+    `could not fetch ${REMOTE}/${PRODUCTION_BRANCH} — it may not exist yet.\n${fetchProd.out}\n` +
+    `promote: this is expected until plan Phase 0.2 creates it:\n` +
+    `  git branch ${PRODUCTION_BRANCH} ${REMOTE}/${TRUNK} && git push ${REMOTE} ${PRODUCTION_BRANCH}\n` +
+    `promote: (and Phase 0.3 must repoint Pages to it) before this script can run.`
+  );
+}
+
+const trunkRef = `${REMOTE}/${TRUNK}`;
+const prodRef = `${REMOTE}/${PRODUCTION_BRANCH}`;
+const trunkSha = git(['rev-parse', trunkRef]);
+const prodSha = git(['rev-parse', prodRef]);
+
+// --- Step 2: preview — print EXACTLY what would go live, before doing anything ---
+if (trunkSha === prodSha) {
+  console.log(`promote: ${PRODUCTION_BRANCH} already matches ${TRUNK} (${prodSha.slice(0, 8)}) — nothing to promote.`);
+  process.exit(0);
+}
+
+const range = `${prodRef}..${trunkRef}`;
+const commitLog = lines(git(['log', '--oneline', range]));
+const diffStat = lines(git(['diff', '--stat', prodRef, trunkRef]));
+
+console.log('');
+console.log('='.repeat(72));
+console.log(`promote: THIS WILL GO LIVE at ${LIVE_URL}`);
+console.log('='.repeat(72));
+console.log(`  ${PRODUCTION_BRANCH} (${prodSha.slice(0, 8)})  ->  ${TRUNK} (${trunkSha.slice(0, 8)})`);
+console.log(`  ${commitLog.length} commit(s) in range ${range}:`);
+commitLog.forEach(c => console.log('    ' + c));
+console.log('  Files changed:');
+diffStat.forEach(l => console.log('    ' + l));
+console.log('='.repeat(72));
+
+// --- Step 3: hard STOP-gate — mirrors the /clasp prod-deploy posture ---------
+if (!CONFIRMED) {
+  console.log('');
+  console.log('promote: PREVIEW ONLY — no changes made, nothing was pushed.');
+  console.log('promote: *** this is an irreversible go-live step ***');
+  console.log('promote: re-run with --yes ONLY after Jac has explicitly said "promote it" for the range above.');
+  process.exit(0);
+}
+
+console.log('');
+console.log('promote: --yes given — proceeding with the promotion above.');
+
+// --- Step 4: refuse anything that is not a clean fast-forward ---------------
+const ff = gitTry(['merge-base', '--is-ancestor', prodRef, trunkRef]);
+if (!ff.ok) {
+  fail(
+    `${PRODUCTION_BRANCH} is NOT an ancestor of ${TRUNK} — production has diverged ` +
+    `(hotfixed directly, or rewritten) and cannot fast-forward safely.\n` +
+    `promote: refusing to push. A human must reconcile ${PRODUCTION_BRANCH} manually ` +
+    `(rebase the divergence onto ${TRUNK}, or deliberately reset ${PRODUCTION_BRANCH}) ` +
+    `before promote.mjs can run again. There is no --force path in this script.`
+  );
+}
+
+// --- Step 5: fast-forward + push production ----------------------------------
+// Pushes the trunk's exact commit straight to refs/heads/production without needing a
+// local checkout of `production` — git only accepts this as an ordinary (non-force)
+// push because Step 4 already proved it is a fast-forward.
+console.log(`promote: pushing ${trunkRef} -> ${REMOTE}/${PRODUCTION_BRANCH}…`);
+const push = gitTry(['push', REMOTE, `${trunkRef}:refs/heads/${PRODUCTION_BRANCH}`]);
+if (!push.ok) {
+  fail(
+    `push rejected:\n${push.out}\n` +
+    `promote: ${PRODUCTION_BRANCH} may have moved since the preview above — re-run for a fresh preview.`
+  );
+}
+console.log(`promote: pushed. ${PRODUCTION_BRANCH} now at ${trunkSha.slice(0, 8)}. ${LIVE_URL} should update shortly.`);
+
+// --- Step 6: verify the live site actually serves the new bytes -------------
+// The ?v= cache-bust token (bumped on every deploy per CLAUDE.md) is the one
+// generic, feature-agnostic marker this script can check without knowing what any
+// given promotion actually changed. The token itself lives in index.html's script/
+// link tags (not inside app.js's own bytes), so: pull the expected token from the
+// promoted commit's index.html, confirm the LIVE index.html reports the same token,
+// and confirm the live app.js is reachable at that exact versioned URL.
+function extractVersionToken(html) {
+  const m = html.match(/app\.js\?v=([A-Za-z0-9._-]+)/);
+  return m ? m[1] : null;
+}
+
+const expectedHtml = git(['show', `${trunkRef}:index.html`]);
+const expectedToken = extractVersionToken(expectedHtml);
+if (!expectedToken) {
+  console.log('promote: WARNING — could not find an app.js?v= token in the promoted index.html; skipping live-bytes verification.');
+  console.log('promote: push succeeded. Verify the live site manually.');
+  process.exit(0);
+}
+
+console.log(`promote: verifying ${LIVE_URL} serves ?v=${expectedToken}…`);
+
+let liveHtml;
+try {
+  liveHtml = execFileSync('curl', ['-sS', '-L', '--max-time', '15', `${LIVE_URL}/index.html`], { encoding: 'utf8' });
+} catch (e) {
+  console.log(`promote: WARNING — could not curl ${LIVE_URL}/index.html to verify (${e.message}).`);
+  console.log('promote: push succeeded, but live-bytes verification could not run. Verify manually:');
+  console.log(`  curl -s ${LIVE_URL}/index.html | grep 'app.js?v='`);
+  process.exit(0);
+}
+
+const liveToken = extractVersionToken(liveHtml);
+if (liveToken !== expectedToken) {
+  console.log(`promote: WARNING — live site not updated yet. Expected ?v=${expectedToken}, got ?v=${liveToken || '(not found)'}.`);
+  console.log('promote: push succeeded — Pages can take ~1 min to propagate. Re-check shortly:');
+  console.log(`  curl -s ${LIVE_URL}/index.html | grep 'app.js?v='`);
+  process.exit(0); // the push itself succeeded; this is a propagation-timing warning, not a script failure
+}
+
+let assetStatus = null;
+try {
+  assetStatus = execFileSync(
+    'curl', ['-sS', '-o', '/dev/null', '-w', '%{http_code}', '--max-time', '15', `${LIVE_URL}/app.js?v=${expectedToken}`],
+    { encoding: 'utf8' }
+  ).trim();
+} catch (e) {
+  console.log(`promote: index.html confirmed at ?v=${expectedToken}, but could not fetch app.js to double-check (${e.message}).`);
+  process.exit(0);
+}
+
+if (assetStatus === '200') {
+  console.log(`promote: ✅ live site confirmed serving ?v=${expectedToken} (app.js -> HTTP 200). Promotion complete.`);
+} else {
+  console.log(`promote: WARNING — index.html is at ?v=${expectedToken}, but app.js?v=${expectedToken} returned HTTP ${assetStatus}.`);
+  console.log('promote: push succeeded; investigate the asset response before telling Jac it is fully live.');
+}


### PR DESCRIPTION
## What this is

A **draft** capturing the workflow redesign brainstormed on 2026-07-12: replace the `task → area/<domain> → staging → main` branch chain + `spec-sync`/`master-spec` machinery with mainstream **trunk-based development**, while **keeping Jac's staging approval gate**.

Nothing here changes app behavior or goes live — it's docs + drafted, unwired tooling.

## Contents

| File | What |
|---|---|
| `docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md` | Approved design spec (8 decisions, flow, what stays/goes, grounding sources) |
| `docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md` | Phased implementation plan |
| `config.js` / `app.js` | Feature-flag scaffold: `FEATURES` map + `flagOn()` reader. **No feature wired** — additive, no behavior change |
| `tools/deploy-staging.mjs` | **DRAFT** Gate-1 staging deploy (push-based, replaces the cron mirror) |
| `tools/promote.mjs` | **DRAFT** Gate-2 trunk→production go-live, with a hard `--yes` STOP-gate |

## The model

```
feature branch ──deploy──▶ STAGING ──"merge it"──▶ TRUNK (main) ──"promote it"──▶ PRODUCTION
   (Claude builds)         you review               integrated, not live yet       app.jacrentals.com
```

Both gates are chat-driven; big feature *replacements* ride in behind a `FEATURES` flag so backing out is a toggle.

## Status / not-yet-done

The two deploy scripts are **drafts and cannot run** until Phase 0 wiring is in place. Their config constants are marked `// TODO(jac): confirm`. Local gates pass (`gen-rule-usage --check`, code-map guard, `node --check`); the browser gates (`smoke`, `logic-test`) run in CI.

### Blocked on Jac (the go-live wiring — deliberately not done autonomously)
1. Create + push the `production` release-pointer branch.
2. Repoint the prod repo's Pages source to `production` (so merging to `main` stops going live) and verify the live site is unchanged.
3. Provide the cross-repo staging deploy credential (SSH deploy key or fine-scoped PAT).
4. Confirm branch names and the chat-driven promotion mechanism (vs. adding the free native GitHub gate now).

### Notes
- Does **not** touch the `frontend-performance` area (Jac is working it in a separate session).
- The separate "yesterday's specs" catch-up edits are parked and will land as plain trunk commits later (minus `frontend-performance.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_017Pi36s2isSBfGJWfFFFcjf

---
_Generated by [Claude Code](https://claude.ai/code/session_017Pi36s2isSBfGJWfFFFcjf)_