### PR TITLE
test: invisible pipeline marker (trunk→production promote proof)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- pipeline-test 20260713T044556Z — invisible marker to prove the trunk→production promote pipeline end-to-end; removed by the follow-up revert. -->
 <html lang="en" data-theme="bluedsteel">
 <head>
   <meta charset="UTF-8" />
@@ -18,7 +19,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260710v" />
+  <link rel="stylesheet" href="style.css?v=20260713a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +38,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260710v"></script>
-  <script type="module" src="app.js?v=20260710v"></script>
+  <script src="rule-usage.js?v=20260713a"></script>
+  <script type="module" src="app.js?v=20260713a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

A throwaway, **functionally-invisible** change to prove the new two-gate deploy pipeline end to end (Phase 0→2 of the trunk-based redesign).

- `index.html` line 2: an invisible HTML comment `<!-- pipeline-test <ts> -->`.
- The shared `?v=` cache-bust token bumped `20260710v → 20260713a` (normal per-deploy behavior).

No user-visible change; no logic touched.

## Why

This is **Gate 1 ("merge it")** of the pipeline proof: merging to `main` should **integrate but NOT go live**, because Pages now serves the `production` branch. After merge, `main` runs one commit ahead of `production`; loading app.jacrentals.com should still show the *old* bytes (no marker) — that's the proof the Pages repoint took effect. **Gate 2 (`tools/promote.mjs`)** then moves `production` and is the only thing that changes the live site.

## After merge

The marker is reverted immediately (a follow-up PR to `main`) and re-promoted, so `main` and `production` both end clean. This PR is self-canceling by design.

## Gates

Fast local guards pass (`gen-rule-usage --check`, `check-window-catalog`, `gen-code-map --check`, `node --check`); `smoke` + `logic-test` run in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yWd28i11acKjDxAWK7Z36

---
_Generated by [Claude Code](https://claude.ai/code/session_014yWd28i11acKjDxAWK7Z36)_