### PR TITLE
test: revert pipeline marker — main/production clean again

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!-- pipeline-test 20260713T044556Z — invisible marker to prove the trunk→production promote pipeline end-to-end; removed by the follow-up revert. -->
 <html lang="en" data-theme="bluedsteel">
 <head>
   <meta charset="UTF-8" />
@@ -19,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260713a" />
+  <link rel="stylesheet" href="style.css?v=20260713b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -38,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260713a"></script>
-  <script type="module" src="app.js?v=20260713a"></script>
+  <script src="rule-usage.js?v=20260713b"></script>
+  <script type="module" src="app.js?v=20260713b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

Second half of the two-gate pipeline proof. Removes the invisible `pipeline-test` comment added in #592 and bumps the shared `?v=` token forward (`20260713a → 20260713b`).

After this merges (Gate 1) and is re-promoted (Gate 2), `main` and `production` both end **functionally clean** — byte-identical to the pre-test state except a fresher cache-bust token (monotonic; never rolled backward).

## Why forward, not back to 20260710v

Cache-bust tokens must only increase, or a browser that already cached `20260713a` would be handed a "new" `20260710v` it treats as older. `20260713b` is the correct clean end-state.

## Gates

Fast local guards pass (`gen-rule-usage --check`, `check-window-catalog`, `gen-code-map --check`); `smoke` + `logic-test` run in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yWd28i11acKjDxAWK7Z36

---
_Generated by [Claude Code](https://claude.ai/code/session_014yWd28i11acKjDxAWK7Z36)_