### PR TITLE
docs: add Phase 7 — reconcile the pre-existing staging divergence

### DIFF
--- a/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
+++ b/docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md
@@ -133,3 +133,26 @@ The session-lifecycle pair needs a rewrite for the trunk model. Capturing the ap
 3. ⛔ 0.4 provide the cross-repo deploy key/PAT secret.
 4. Confirm branch names (`production` release pointer) and that "Claude does it from chat" promotion is the intended mechanism vs. adding the free native gate now.
 5. Green-light Phase 2's throwaway test feature.
+
+---
+
+## Phase 7 — Reconcile the pre-existing `staging` divergence into the trunk (added 2026-07-13)
+
+**Why this was missing.** Phases 0–6 assumed `main` was already the integrated latest. It wasn't. At cutover the long-lived `staging` branch was **~1089 commits ahead of `main`** (real *net* divergence: **26 files**), carrying features that never rode a `Promote staging → main` squash. Trunk-based development can't be "clean" until that pre-existing work is reconciled onto the trunk. (Surfaced 2026-07-13 when a `deploy-staging.mjs` run during the Phase-2 proof overwrote the staging *site*, which had been serving the `staging`-branch build — the branch itself was never at risk, and the site was restored from `staging`. The old cron mirror that used to publish the `staging` branch, `sync-staging.yml`, was already retired, which is also why the site had gone stale/behind the branch.)
+
+**Audit (2026-07-13).** Net divergence = 26 files. `main` was ahead only by the Phase-0–5 redesign commits. `staging` held:
+- ✅ **Account / Agreements + Membership auto-enrollment + payment-gate hardening** (design 2026-07-10) — *reconcile* (payment-gate = security-sensitive → main-session review, never delegated).
+- ✅ **Customer Details reorg** — retire the Invoice card, embed invoices, Rental|Equipment-Sales funnel toggle (design 2026-07-08) — *reconcile*.
+- ✅ **Assorted fixes/tweaks** — unit-detail accordions, KPI/invoice tweaks, a card-search perf fix, `design-system`/`rentals-dispatch` spec touches, `ci/logic-test.mjs` — *reconcile* (review first).
+- ❌ **Mobile scroll-snap paging** (design 2026-07-12) — *excluded*: superseded by the newer side-scroll/swipe system built in the separate **frontend-performance** session. Mobile stays that session's domain; this reconcile does not touch it.
+
+**Approach.**
+- **Reconcile-into-the-trunk, NOT `staging → production`.** `staging`↔`main` is not a fast-forward either way, and the 1089 commits are unaudited — a blind promote would ship regressions. Instead: bring each *wanted* feature onto `main`, then promote `main → production` the normal (Gate-2) way.
+- **Feature-by-feature, cleanest first, each its own trunk-flow PR** (feature branch → `deploy-staging` review → "merge it" → wait → "promote it"). Suggested order: **Customer Details reorg** (cleanest, a contiguous pre-mobile 07-08 block) → **Account/Membership** (largest; payment-gate care) → **assorted fixes**.
+- **Port net feature diffs against `main`'s current state — do NOT cherry-pick blindly.** The squash-merge history plus the interleaving of the *excluded* mobile commits (07-11→07-13) with wanted work (account-field tweaks, unit-detail, perf) make raw cherry-picks fragile. Port each feature's `app.js`/`style.css`/spec hunks onto `main`, run every gate, and review on staging before "merge it."
+
+**Guardrails.**
+- **Never delete or force-push `staging`** — those commits are the only copy of that history until reconciliation is complete and confirmed.
+- **Do not touch the frontend-performance area / mobile** (active in a separate session).
+- `STAGING_DEPLOY_PAT` never echoed/hardcoded.
+- The **A-vs-B** "where the combined accumulation surface lives" question (staging-as-preview vs staging-as-accumulation) is **deferred** until reconciliation lands: once `main` is the true latest, the separate combined surface largely dissolves and the staging URL can settle into the per-feature preview role (likely Option A).

--- a/docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md
@@ -137,3 +137,7 @@ Trunk-based development & branch lifetime: DORA (dora.dev/capabilities/trunk-bas
 - Cross-repo push mechanism for the staging site (deploy key vs PAT).
 - Whether to add **content-hashed asset filenames** to retire the manual `?v=` cache-bust token (a small CI hashing step can do this without adopting a full bundler, preserving the build-free posture).
 - Where feature-flag reads live in `app.js` and how `config.js` `FEATURES` defaults are set per environment.
+
+## 12. Correction (2026-07-13) — `main` was not the latest; a reconciliation phase is required
+
+This design assumed `main` was the integrated latest. At cutover it was not: the long-lived `staging` branch was ~1089 commits (26 files *net*) ahead, holding real unmerged features (Account/Agreements + Membership, Customer Details reorg, assorted fixes). Trunk-based development requires reconciling that pre-existing divergence onto `main` **first** — see the plan's **Phase 7 — Reconcile the pre-existing `staging` divergence**. The reconcile is feature-by-feature onto the trunk (NOT a `staging → production` promote), with the mobile scroll-snap paging work excluded (superseded by the separate frontend-performance session's side-scroll/swipe system).


### PR DESCRIPTION
## What

Records the reality the trunk redesign under-scoped: **`main` was not the integrated latest at cutover** — the long-lived `staging` branch was ~1089 commits (26 files *net*) ahead with real unmerged work. Adds **Phase 7 — Reconcile the pre-existing `staging` divergence** to the plan and a correction (§12) to the design. Docs only.

## The 2026-07-13 audit it captures
- ✅ Reconcile onto `main` (each its own trunk-flow PR): **Account/Agreements + Membership + payment-gate hardening**; **Customer Details reorg**; **assorted fixes/spec touches**.
- ❌ Excluded: **mobile scroll-snap paging** — superseded by the frontend-performance session's side-scroll/swipe system; mobile stays that session's domain.

## Approach recorded
Reconcile-into-the-trunk (**not** `staging → production`), feature-by-feature, cleanest-first, **porting net diffs** (blind cherry-picks are fragile due to squash history + interleaving with the excluded mobile commits), verifying + staging-reviewing each. Guardrails: never delete/force-push `staging`; don't touch frontend-performance/mobile; A-vs-B staging-role decision deferred until reconciliation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yWd28i11acKjDxAWK7Z36

---
_Generated by [Claude Code](https://claude.ai/code/session_014yWd28i11acKjDxAWK7Z36)_