### PR TITLE
Wrangler fix: unblock ACH — stripeSaveBank_ PM-attachment guard vs. microdeposit flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -19440,7 +19440,7 @@ function friendlyPayErr(r) {
     'card_declined': 'The card was declined.', 'expired_card': 'That card is expired.', 'insufficient_funds': 'Insufficient funds.',
     'over-ceiling': 'Amount exceeds the per-charge limit — split it or charge manually.', 'bad-invoice-amount': 'Nothing is due on this invoice.',
     'forbidden': 'Only Office/Admin can take payments.', 'stripe-not-configured': 'Payments aren’t configured on the backend yet.',
-    'pm-customer-mismatch': 'That card isn’t linked to this customer.', 'setupintent-invalid': 'Card setup didn’t verify — try again.',
+    'pm-customer-mismatch': 'That payment method isn’t linked to this customer.', 'setupintent-invalid': 'Setup didn’t verify — try again.',
     'amount-mismatch': 'Amount changed during payment — flagged for review.', 'customer-mismatch': 'Payment didn’t match this customer.',
     'nothing-to-refund': 'Nothing has been paid on this invoice.', 'no-charge-to-refund': 'No card charge found to refund.',
     'refund-failed': 'The refund didn’t go through — try again.', 'invoice-refunded': 'This invoice was already refunded.',

--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -1,6 +1,12 @@
 # Backend deploy queue — DEPLOYED (2026-07-06 late session); doc kept as the deploy runbook
 
-## ⛔ QUEUED, STOP-GATED — ACH unblock: `stripeSaveBank_` PM-attachment guard (2026-07-13)
+## ✅ DEPLOYED 2026-07-13 — ACH unblock: `stripeSaveBank_` PM-attachment guard
+- **Staged to HEAD** (service account push, content-only) + read-back verified, then **editor
+  redeploy by Jac**. Anonymous access confirmed intact afterward (wrong-password `auth` →
+  `{"ok":false,"error":"unauthorized"}`, HTTP 200 JSON — not 403/HTML). Live end-to-end ACH
+  add is Jac's in-app confirmation (needs live Stripe + selfie/signature consent).
+
+### (as-shipped) ACH unblock: `stripeSaveBank_` PM-attachment guard (2026-07-13)
 - **What:** ACH was categorically broken — every "Add bank account" save returned
   `pm-customer-mismatch` ("That card isn't linked to this customer."). Root cause (proven,
   live source pulled read-only): `stripeSaveBank_`'s second ownership check requires the

--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -1,5 +1,28 @@
 # Backend deploy queue — DEPLOYED (2026-07-06 late session); doc kept as the deploy runbook
 
+## ⛔ QUEUED, STOP-GATED — ACH unblock: `stripeSaveBank_` PM-attachment guard (2026-07-13)
+- **What:** ACH was categorically broken — every "Add bank account" save returned
+  `pm-customer-mismatch` ("That card isn't linked to this customer."). Root cause (proven,
+  live source pulled read-only): `stripeSaveBank_`'s second ownership check requires the
+  confirmed PaymentMethod to already be attached to the Stripe customer
+  (`pm.body.customer !== rec.stripeId`), but `stripeBankSetupIntent_` opens the SetupIntent
+  with `verification_method: microdeposits`, so after `confirmUsBankAccountSetup` the intent
+  is `requires_action` (not `succeeded`) and Stripe attaches the PM to the customer only "on
+  successful setup". Store-now-verify-later means the PM is unattached (`pm.customer` null)
+  on every fresh add → the guard fires 100% of the time.
+- **Fix** in `docs/handoffs/ach-pm-mismatch-fix.gs` (REPLACES `stripeSaveBank_` verbatim):
+  accept an unattached PM only when the SetupIntent binding above was verified
+  (`si.customer === rec.stripeId && si.payment_method === pmId`); still reject a PM attached
+  to a DIFFERENT customer, or an unattached PM with no SetupIntent proof. IDOR guard
+  preserved, not weakened. Additive — no signature/schema change. `node --check` passes.
+- **NOT yet staged to HEAD** — awaiting Jac's explicit go (money/auth-critical). Deploy flow:
+  pull live `Code.js` → splice this `stripeSaveBank_` → `node --check` → `push` HEAD via the
+  service account (content-only, safe) → **editor** redeploy (New version, Who has access:
+  Anyone). Verify after: anonymous curl returns JSON, then a real ACH add on a test customer
+  no longer errors. Frontend copy fix (card-worded error neutralized) ships separately on
+  `claude/ach-processing-issue-hu5mtj` (PR #601).
+
+
 > **STATUS UPDATE (2026-07-06 ~23:00):** the queue below IS LIVE (perfReport + unitDaily
 > + the trigger installed by Jac), plus the comms pipe (sendCustomerMessage SMS+email,
 > messagesFor, commsAliases, adminSetProps) — prod versions v66–v70. Deploys now run

--- a/docs/handoffs/ach-pm-mismatch-fix.gs
+++ b/docs/handoffs/ach-pm-mismatch-fix.gs
@@ -1,0 +1,107 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * ACH categorically blocked — `stripeSaveBank_` IDOR guard vs. the
+ * microdeposit us_bank_account flow.  (Reported 2026-07-13: "we can't do
+ * ACH"; the Add-bank popup fails with "That card isn't linked to this
+ * customer." on every save.)
+ *
+ * ── ROOT CAUSE (proven) ─────────────────────────────────────────────────
+ * `stripeBankSetupIntent_` opens the SetupIntent with
+ *   'payment_method_types[]': 'us_bank_account',
+ *   'payment_method_options[us_bank_account][verification_method]': 'microdeposits'
+ * so after `confirmUsBankAccountSetup` the SetupIntent is in `requires_action`
+ * (microdeposits take 1-2 business days to verify), NOT `succeeded`. The
+ * frontend is built for exactly this — `saveAchFlow` stores the account with
+ * `verified: setupIntent.status === 'succeeded'` (i.e. false), "store now,
+ * verify later" (Jac's call).
+ *
+ * Stripe attaches a SetupIntent's payment method to the Customer only "on
+ * successful setup" (SetupIntent API reference) — i.e. when the intent reaches
+ * `succeeded`, AFTER microdeposit verification. So on a fresh ACH add the PM's
+ * `.customer` is still null.
+ *
+ * `stripeSaveBank_`'s second ownership check then does:
+ *     if (pm.body.customer !== rec.stripeId) return {error:'pm-customer-mismatch'};
+ * → `null !== 'cus_…'` → true → EVERY fresh ACH add returns pm-customer-mismatch.
+ * ACH can never be saved. (The frontend maps that code to the card-worded
+ * "That card isn't linked to this customer." — that copy is separately
+ * neutralized on the frontend branch, but the block itself is here.)
+ *
+ * The FIRST ownership check right above it already proves ownership the correct
+ * way for this flow:
+ *     if (!si.ok || si.body.customer !== rec.stripeId || si.body.payment_method !== pmId)
+ *        return {error:'setupintent-invalid'};
+ * The SetupIntent is a server-side Stripe object created with `customer:
+ * rec.stripeId`; matching both `si.customer === rec.stripeId` AND
+ * `si.payment_method === pmId` binds this exact PM to THIS customer and can't be
+ * forged by the client. The redundant PM-level `pm.customer` check is what
+ * over-constrains it — it demands attachment that legitimately hasn't happened
+ * yet.
+ *
+ * ── FIX (does NOT weaken the IDOR guard) ────────────────────────────────
+ * Accept an UNATTACHED PM (pm.customer null — microdeposit-pending) ONLY when
+ * the SetupIntent binding above was verified (siId present → the setupintent-
+ * invalid check already gated it). Still reject a PM attached to a DIFFERENT
+ * customer, and still reject an unattached PM with no SetupIntent proof.
+ *
+ *     var pmCust = pm.body.customer || '';
+ *     if (pmCust ? (pmCust !== rec.stripeId) : !siId) return {error:'pm-customer-mismatch'};
+ *
+ *   - attached PM (card flow, or a verified ACH re-save): must equal rec.stripeId.
+ *   - unattached PM (fresh microdeposit ACH): allowed iff the SetupIntent bound it.
+ *   - unattached PM, no siId: still rejected (no ownership proof).
+ *
+ * ADDITIVE-safe: no signature change, no new action, no schema change. The rest
+ * of the handler already works with an unattached PM (us_bank_account.bank_name/
+ * last4/account_type are PM properties, present pre-verification; metadata write
+ * on an unattached PM is allowed).
+ *
+ * NOTE — sibling of the same class (NOT swept here, by design): `stripeSetDefault_`
+ * has the same `pm.body.customer !== rec.stripeId` guard, but the add flow does
+ * NOT call it for a fresh (unverified) bank, and Stripe rejects setting an
+ * unattached PM as a customer's default_payment_method anyway — so it is not a
+ * live blocker. Leave it as-is unless a "make default" on a still-pending ACH is
+ * ever wired up.
+ *
+ * DEPLOY: STOP-gated (/clasp). push HEAD via the service account (content only,
+ * safe) → EDITOR redeploy (New version, Who has access: Anyone) — the REST-API
+ * deploy breaks anonymous access. See BACKEND-DEPLOY-QUEUE.md.
+ *
+ * REPLACES `stripeSaveBank_` verbatim:
+ * ════════════════════════════════════════════════════════════════════════ */
+function stripeSaveBank_(body, role) {
+  var customerId = String(body.customerId || ''), pmId = String(body.paymentMethodId || ''), siId = String(body.setupIntentId || '');
+  if (!pmId) return { ok: false, error: 'missing-pm' };
+  var lock = tryLock_(15000); if (!lock) return { ok: false, error: 'busy' };
+  try {
+    var rec = readRecord_('customers', customerId);
+    if (!rec) return { ok: false, error: 'customer-not-found' };
+    if (!rec.stripeId) return { ok: false, error: 'no-stripe-customer' };
+    if (siId) {
+      var si = stripeApi_('get', 'setup_intents/' + encodeURIComponent(siId), null);
+      // customer + payment_method MUST match (don't trust the client's pm id alone); ACH status may be requires_action/processing.
+      if (!si.ok || si.body.customer !== rec.stripeId || si.body.payment_method !== pmId) return { ok: false, error: 'setupintent-invalid' };
+    }
+    var pm = stripeApi_('get', 'payment_methods/' + encodeURIComponent(pmId), null);
+    if (!pm.ok) return { ok: false, error: 'pm-fetch-failed' };
+    // IDOR guard. For the microdeposit us_bank_account flow the PM is NOT attached to the
+    // Customer until the SetupIntent reaches `succeeded` (Stripe: "the SetupIntent's payment
+    // method will be attached to the Customer on successful setup"), so pm.customer is null
+    // while the intent is still requires_action (microdeposits pending) — exactly the state a
+    // store-now-verify-later ACH add is in. The SetupIntent check above already binds this PM
+    // to THIS customer (si.customer === rec.stripeId AND si.payment_method === pmId), so an
+    // unattached PM is accepted only when that binding was verified; a PM attached to a
+    // DIFFERENT customer, or an unattached PM with no SetupIntent proof, is still rejected.
+    var pmCust = pm.body.customer || '';
+    if (pmCust ? (pmCust !== rec.stripeId) : !siId) return { ok: false, error: 'pm-customer-mismatch' };
+    var b = pm.body.us_bank_account || {};
+    var bank = { stripePmId: pmId, bankName: b.bank_name || 'Bank', last4: b.last4 || '', accountType: b.account_type || '', verified: false, capturedAt: new Date().toISOString(), capturedByRole: role };
+    rec.achAccounts = (rec.achAccounts || []).filter(function (k) { return k.stripePmId !== pmId; });   // replace any stale entry for the same PM
+    rec.achAccounts.push(bank);
+    writeRecord_('customers', rec);
+    // Best-effort: bind our ACH mandate evidence to the Stripe payment method (audit trail).
+    stripeApi_('post', 'payment_methods/' + encodeURIComponent(pmId), {
+      'metadata[ach_mandate_captured_at]': bank.capturedAt, 'metadata[consent_role]': role, 'metadata[appCustomer]': customerId
+    });
+    return { ok: true, bank: { bankName: bank.bankName, last4: bank.last4, accountType: bank.accountType, verified: false } };
+  } finally { lock.releaseLock(); }
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260713ba" />
+  <link rel="stylesheet" href="style.css?v=20260713ach" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260713ba"></script>
-  <script type="module" src="app.js?v=20260713ba"></script>
+  <script src="rule-usage.js?v=20260713ach"></script>
+  <script type="module" src="app.js?v=20260713ach"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What Jac reported
"We can't do ACH." The **Add bank account** popup fails on every save with **"That card isn't linked to this customer."** (screenshot: a bank form throwing a *card* error).

## Root cause (proven)
The backend `stripeSaveBank_` runs two ownership checks. The first (SetupIntent) **passes**; the second (PaymentMethod) is the culprit:

```js
if (pm.body.customer !== rec.stripeId) return { ok: false, error: 'pm-customer-mismatch' };
```

`stripeBankSetupIntent_` opens the SetupIntent with `verification_method: microdeposits`, so after `confirmUsBankAccountSetup` the intent is in **`requires_action`** (microdeposits take 1–2 days), **not** `succeeded`. Stripe attaches a SetupIntent's PaymentMethod to the Customer only *"on successful setup"* — i.e. after verification. The app is deliberately **store-now-verify-later** (`saveAchFlow` stores `verified:false`). So on every fresh ACH add the PM is **unattached** (`pm.customer` is `null`) → `null !== 'cus_…'` → `pm-customer-mismatch` **100% of the time**. ACH is categorically blocked.

The first check right above already proves ownership correctly for this flow — `si.customer === rec.stripeId && si.payment_method === pmId` binds that exact PM to this customer's server-side SetupIntent. The PM-level `pm.customer` check is redundant *and* over-constrains it.

## Changes
- **Backend** (`docs/handoffs/ach-pm-mismatch-fix.gs`) — the actual unblock. Accept an **unattached** PM only when the SetupIntent binding was verified; still reject a PM attached to a **different** customer, or an unattached PM with **no** SetupIntent proof. IDOR guard preserved, not weakened. **STOP-gated** — ships via `push` HEAD (service account) → **editor** redeploy, on Jac's explicit go (REST-API deploy breaks anonymous access).
- **Frontend** (`app.js`) — the shared `friendlyPayErr` copy for `pm-customer-mismatch` / `setupintent-invalid` was card-worded and leaked "card" onto the bank form. Neutralized to method-agnostic wording so both card and ACH flows read correctly. This is cosmetic; the backend deploy is what restores ACH.
- Cache-bust `?v=` bumped.

## Verification
- All gates green: `smoke` (boots clean), `logic-test` 668/668, `gen-rule-usage --check`, `check-window-catalog` (46 kinds), `gen-code-map --check`.
- Live backend pulled read-only (`projects.getContent`) to confirm the exact `stripeSaveBank_` / `stripeBankSetupIntent_` source — this is not a guess.
- Stripe behavior cited from the SetupIntent API reference + confirm docs.

## Note
Same-class sibling `stripeSetDefault_` has the identical `pm.customer` guard, but the add flow never calls it for an unverified bank and Stripe rejects an unattached PM as a default anyway — not a live blocker, left as-is (documented in the .gs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk31QyjE1dbDNxnqEU53uX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk31QyjE1dbDNxnqEU53uX)_