### PR TITLE
Add public business + sample-quote pages to fix A2P campaign rejection

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>JacRentals — Heavy-Equipment Rental · Sulphur, LA</title>
+<meta name="description" content="JacRentals is a heavy-equipment rental company in Sulphur, Louisiana, renting excavators, skid steers, lifts, and compaction equipment to contractors and homeowners across Southwest Louisiana. Reach us at (337) 607-1352." />
+<style>
+  :root{
+    --bg:#f7f6f3; --panel:#ffffff; --ink:#1c2126; --ink2:#4c555f; --line:#e3e0d9;
+    --accent:#c25a2b; --accent-ink:#7a3a1a; --ok:#2f7d4f;
+    --serif:'Iowan Old Style','Palatino Linotype',Georgia,'Times New Roman',serif;
+    --sans:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#14171b; --panel:#1b1f24; --ink:#e7ebf0; --ink2:#a3acb6; --line:#2b3138; --accent:#e08a52; --accent-ink:#e08a52; --ok:#5fb98a; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;font-size:17px}
+  .wrap{max-width:760px;margin:0 auto;padding:0 22px 80px}
+  header{border-bottom:3px solid var(--accent);margin-bottom:34px;padding:34px 0 18px}
+  .mark{font-family:var(--sans);font-weight:800;letter-spacing:.5px;font-size:15px;text-transform:uppercase;color:var(--accent-ink)}
+  h1{font-family:var(--serif);font-weight:600;font-size:38px;line-height:1.1;margin:10px 0 6px;text-wrap:balance}
+  .eff{color:var(--ink2);font-size:14px;margin:0}
+  h2{font-family:var(--serif);font-weight:600;font-size:23px;margin:38px 0 8px}
+  p{margin:0 0 14px;color:var(--ink)} p.lead{color:var(--ink2);font-size:18px}
+  ul{margin:0 0 14px;padding-left:22px} li{margin:0 0 8px}
+  a{color:var(--accent-ink);text-decoration:underline}
+  strong{font-weight:700}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:20px 22px;margin:18px 0}
+  .callout{background:var(--panel);border:1px solid var(--line);border-left:4px solid var(--accent);border-radius:8px;padding:14px 18px;margin:18px 0}
+  .contact{display:grid;grid-template-columns:120px 1fr;gap:8px 16px;margin:6px 0 0}
+  .contact dt{font-weight:700;color:var(--ink2);font-size:14.5px}
+  .contact dd{margin:0}
+  .cols{display:flex;flex-wrap:wrap;gap:8px 28px;padding:0;list-style:none;margin:0}
+  .cols li{flex:1 1 200px;margin:0 0 4px;position:relative;padding-left:16px}
+  .cols li::before{content:"";position:absolute;left:0;top:10px;width:7px;height:7px;background:var(--accent);border-radius:2px}
+  .btnrow{display:flex;flex-wrap:wrap;gap:12px;margin:18px 0 0}
+  .btn{display:inline-block;font-weight:800;letter-spacing:.4px;text-decoration:none;
+    background:var(--accent);color:#fff;border-radius:9px;padding:12px 18px}
+  .btn.alt{background:transparent;color:var(--accent-ink);border:1px solid var(--accent)}
+  footer{margin-top:46px;padding-top:18px;border-top:1px solid var(--line);color:var(--ink2);font-size:14px}
+  footer a{color:var(--accent-ink)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="mark">JacRentals</div>
+    <h1>Heavy-equipment rental in Southwest Louisiana</h1>
+    <p class="eff">JacRentals · Sulphur, Louisiana · (337) 607-1352</p>
+  </header>
+
+  <p class="lead">JacRentals is a heavy-equipment rental company based in Sulphur, Louisiana. We rent
+    contractor-grade machines by the day, week, and month to builders, tradespeople, farms, and
+    homeowners across Sulphur, Lake Charles, and the surrounding parishes.</p>
+
+  <h2>What we rent</h2>
+  <p>Our fleet covers the machines a job site actually needs:</p>
+  <ul class="cols">
+    <li>Excavators &amp; mini-excavators</li>
+    <li>Skid steers &amp; track loaders</li>
+    <li>Dozers</li>
+    <li>Boom lifts &amp; scissor lifts</li>
+    <li>Telehandlers &amp; towable lifts</li>
+    <li>Rollers &amp; plate compactors</li>
+    <li>Trenchers &amp; augers</li>
+    <li>Generators, compressors &amp; pumps</li>
+    <li>Utility trailers &amp; tractors</li>
+  </ul>
+
+  <h2>How we work</h2>
+  <p>Call, email, or stop by and we'll quote the right machine for your job, reserve it for your dates,
+    and arrange delivery and pickup to your site. We handle the quote, reservation, delivery ETA,
+    invoice, and return reminders so your crew can stay on the work.</p>
+
+  <h2>Contact us</h2>
+  <div class="card">
+    <dl class="contact">
+      <dt>Business</dt><dd>JacRentals</dd>
+      <dt>Location</dt><dd>Sulphur, Louisiana (serving Southwest Louisiana)</dd>
+      <dt>Phone</dt><dd><a href="tel:+13376071352">(337) 607-1352</a></dd>
+      <dt>Email</dt><dd><a href="mailto:operations@jacrentals.com">operations@jacrentals.com</a></dd>
+      <dt>Website</dt><dd><a href="https://www.jacrentals.com/">www.jacrentals.com</a></dd>
+    </dl>
+  </div>
+
+  <h2>Text-message (SMS) program</h2>
+  <p>JacRentals sends <strong>service (transactional) text messages</strong> to rental customers who
+    have given us their mobile number and opted in — so you never miss a quote, a return date, or a
+    delivery. Messages relate only to your own rentals and account, and may include:</p>
+  <ul>
+    <li>Rental quotes and totals</li>
+    <li>Reservation and return-date reminders</li>
+    <li>Delivery and pickup (ETA) alerts</li>
+    <li>Invoice and balance notices</li>
+    <li>Replies to questions you send us</li>
+  </ul>
+  <div class="callout">
+    <p style="margin:0"><strong>How to opt in:</strong> visit our
+      <a href="./opt-in.html">text-alerts sign-up page</a>, enter your name and mobile number, and
+      check the box agreeing to receive recurring service texts. <strong>Message frequency varies</strong>
+      with your rental activity, and <strong>message and data rates may apply.</strong> Reply
+      <strong>STOP</strong> at any time to opt out, or <strong>HELP</strong> for help. Consent to
+      receive texts is <strong>not</strong> a condition of any rental or purchase. We do not sell or
+      share your mobile number or messaging consent with third parties for their marketing.</p>
+  </div>
+
+  <div class="btnrow">
+    <a class="btn" href="./opt-in.html">Sign up for text alerts</a>
+    <a class="btn alt" href="./sms-terms.html">SMS Terms &amp; Conditions</a>
+    <a class="btn alt" href="./privacy.html">Privacy Policy</a>
+  </div>
+
+  <footer>© 2026 JacRentals · Sulphur, Louisiana · <a href="tel:+13376071352">(337) 607-1352</a> ·
+    <a href="mailto:operations@jacrentals.com">operations@jacrentals.com</a><br>
+    Service text messages are sent only to customers who have opted in. Reply STOP to cancel, HELP for help.</footer>
+</div>
+</body>
+</html>

--- a/sample-quote.html
+++ b/sample-quote.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sample Rental Quote — JacRentals</title>
+<meta name="description" content="An example of the rental quote page a JacRentals customer views from a service text message. Sample data only." />
+<style>
+  :root{
+    --bg:#f7f6f3; --panel:#ffffff; --ink:#1c2126; --ink2:#4c555f; --line:#e3e0d9;
+    --accent:#c25a2b; --accent-ink:#7a3a1a; --ok:#2f7d4f;
+    --serif:'Iowan Old Style','Palatino Linotype',Georgia,'Times New Roman',serif;
+    --sans:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#14171b; --panel:#1b1f24; --ink:#e7ebf0; --ink2:#a3acb6; --line:#2b3138; --accent:#e08a52; --accent-ink:#e08a52; --ok:#5fb98a; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;font-size:17px}
+  .wrap{max-width:680px;margin:0 auto;padding:0 22px 80px}
+  header{border-bottom:3px solid var(--accent);margin-bottom:24px;padding:34px 0 18px}
+  .mark{font-family:var(--sans);font-weight:800;letter-spacing:.5px;font-size:15px;text-transform:uppercase;color:var(--accent-ink)}
+  h1{font-family:var(--serif);font-weight:600;font-size:34px;line-height:1.1;margin:10px 0 6px;text-wrap:balance}
+  .eff{color:var(--ink2);font-size:14px;margin:0}
+  h2{font-family:var(--serif);font-weight:600;font-size:21px;margin:34px 0 8px}
+  p{margin:0 0 14px;color:var(--ink)}
+  a{color:var(--accent-ink);text-decoration:underline}
+  strong{font-weight:700}
+  .sample-note{background:var(--panel);border:1px dashed var(--accent);border-radius:8px;
+    padding:12px 16px;margin:0 0 22px;color:var(--ink2);font-size:14.5px}
+  .quote{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:22px;margin:8px 0}
+  .qhead{display:flex;flex-wrap:wrap;justify-content:space-between;gap:6px 18px;
+    border-bottom:1px solid var(--line);padding-bottom:14px;margin-bottom:14px}
+  .qhead .lbl{color:var(--ink2);font-size:13px;text-transform:uppercase;letter-spacing:.5px}
+  .qhead .val{font-weight:700}
+  table{width:100%;border-collapse:collapse;font-size:15.5px}
+  th,td{text-align:left;padding:9px 6px;border-bottom:1px solid var(--line)}
+  th{color:var(--ink2);font-size:13px;text-transform:uppercase;letter-spacing:.4px;font-weight:700}
+  td.num,th.num{text-align:right;white-space:nowrap}
+  tfoot td{border-bottom:0;font-weight:700;font-size:18px;padding-top:14px}
+  tfoot td.total{color:var(--accent-ink)}
+  .fine{font-size:13px;color:var(--ink2);margin:16px 0 0}
+  footer{margin-top:40px;padding-top:18px;border-top:1px solid var(--line);color:var(--ink2);font-size:14px}
+  footer a{color:var(--accent-ink)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="mark">JacRentals</div>
+    <h1>Rental Quote</h1>
+    <p class="eff">Heavy-equipment rental · Sulphur, Louisiana · (337) 607-1352</p>
+  </header>
+
+  <p class="sample-note"><strong>Example page.</strong> This is a sample of the quote a JacRentals
+    customer opens from a service text message. The details below are illustrative sample data — not a
+    real customer's quote.</p>
+
+  <div class="quote">
+    <div class="qhead">
+      <div><div class="lbl">Quote</div><div class="val">#04i07Ju26</div></div>
+      <div><div class="lbl">Prepared for</div><div class="val">Sample Customer</div></div>
+      <div><div class="lbl">Valid through</div><div class="val">Jul 14, 2026</div></div>
+    </div>
+
+    <table>
+      <thead>
+        <tr><th>Item</th><th class="num">Rate</th><th class="num">Qty</th><th class="num">Amount</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Mini Excavator — daily rental</td><td class="num">$285.00</td><td class="num">3 days</td><td class="num">$855.00</td></tr>
+        <tr><td>Delivery &amp; pickup (Sulphur area)</td><td class="num">$90.00</td><td class="num">1</td><td class="num">$90.00</td></tr>
+        <tr><td>Damage waiver</td><td class="num">$42.75</td><td class="num">1</td><td class="num">$42.75</td></tr>
+      </tbody>
+      <tfoot>
+        <tr><td colspan="3">Estimated total</td><td class="num total">$987.75</td></tr>
+      </tfoot>
+    </table>
+
+    <p class="fine">Estimate only; taxes and final charges are confirmed at contract. Questions about
+      this quote? Call us at <a href="tel:+13376071352">(337) 607-1352</a> or reply to your text.</p>
+  </div>
+
+  <h2>About these texts</h2>
+  <p>JacRentals sends service text messages only to customers who opted in. <strong>Message frequency
+    varies</strong> and <strong>message and data rates may apply.</strong> Reply <strong>STOP</strong>
+    to opt out, <strong>HELP</strong> for help. See our
+    <a href="./sms-terms.html">SMS Terms &amp; Conditions</a> and
+    <a href="./privacy.html">Privacy Policy</a>, or learn more <a href="./about.html">about JacRentals</a>.</p>
+
+  <footer>© 2026 JacRentals · Sulphur, Louisiana · <a href="tel:+13376071352">(337) 607-1352</a> ·
+    <a href="mailto:operations@jacrentals.com">operations@jacrentals.com</a></footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Why

The A2P 10DLC campaign registration has been rejected repeatedly for two reasons:

1. **"The provided website does not contain sufficient business information."** The campaign points reviewers at `app.jacrentals.com`, which is the login-gated rental app — a login wall with **zero** public business info. Confirmed against the live site: the root serves the app shell (title "Rental Wrangler"), no address / phone / services. Additionally, sample messages #1 and #4 linked to `app.jacrentals.com/sample-quote.html`, which **404'd** (GitHub Pages "Page not found") — a dead link a reviewer would follow.
2. **"The multiple opt-in workflow description is incomplete or unclear."** (Addressed in the Twilio console, not this repo — see below.)

The existing `opt-in.html` / `privacy.html` / `sms-terms.html` pages were verified **public** (fetched logged-out, real content, no login) — they were not the problem. The problem was *which URL the campaign points at* and the *dead sample link*.

## What changed

- **`about.html`** — a static, crawlable public business page: legal name, Sulphur, LA location, phone `(337) 607-1352`, email, the equipment fleet, how the business operates, and a full SMS-program description (message types, "frequency varies," "msg & data rates may apply," STOP/HELP, consent-not-a-condition) linking opt-in / SMS terms / privacy. Intended as the campaign's **business-website URL** so a reviewer lands on real business content, not a login wall. Static HTML = no JS-render risk for reviewers.
- **`sample-quote.html`** — resolves the dead link in sample messages #1 and #4 with a clearly-labeled **example** quote page (sample data only, no real customer PII), including the SMS disclosures and legal links.

Both pages reuse the existing standalone legal-page styling (cream/serif/orange, dark-mode aware) for consistency across the public compliance surface — deliberately **not** the app's yard-data-plate UI, matching their `opt-in`/`privacy`/`sms-terms` siblings.

## Not in this PR (Twilio console — Jac's action)

- Point the campaign/brand **website field** at the new `about.html` URL (or www.jacrentals.com).
- Simplify to a **single web opt-in** workflow and fill the blank **opt-in message** field.
- Resubmit. (Paste-ready copy handed to Jac in the session.)

## Gates

No-browser gates pass locally: `gen-rule-usage --check` ✓, `gen-code-map --check` ✓, `check-window-catalog` ✓. New files are standalone public pages — they don't touch `app.js` / `index.html` / `style.css`, the R-rulebook, the window catalog, or the shared `?v=` cache-bust token. Browser gates (`smoke`, `logic-test`) run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mGyVBDca7Ki6G2oz8CexW)_