### PR TITLE
Rename-ready: tooling handles main OR trunk (prep for main→trunk rename)

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -66,7 +66,7 @@ jobs:
           while IFS= read -r b; do
             [ -z "$b" ] && continue
             case "$b" in
-              main|staging|area/*|backup/*) continue ;;   # never touch the structure
+              main|trunk|staging|area/*|backup/*) continue ;;   # never touch the structure (trunk = post-rename default)
             esac
             grep -qxF "$b" merged.txt || continue   # must have a merged PR
             grep -qxF "$b" open.txt   && continue   # but no open PR
@@ -149,7 +149,7 @@ jobs:
           for b in $STRANDED; do
             [ -z "$b" ] && continue
             case "$b" in
-              main|staging|area/*|backup/*) echo "  GUARD skip (structural): $b"; skipped=$((skipped+1)); continue ;;
+              main|trunk|staging|area/*|backup/*) echo "  GUARD skip (structural): $b"; skipped=$((skipped+1)); continue ;;
             esac
             grep -qxF "$b" live.txt || { echo "  already gone: $b"; continue; }
             if grep -qxF "$b" open.txt; then echo "  GUARD skip (has open PR): $b"; skipped=$((skipped+1)); continue; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: CI — boot check
 
-# Runs on every push/PR to main. Flags a broken version (syntax error or boot crash)
+# Runs on every push/PR to the trunk. Flags a broken version (syntax error or boot crash)
 # so it can be caught before it affects the live site (app.jacrentals.com).
+# Both 'main' and 'trunk' are listed to span the main -> trunk rename with zero downtime
+# for the required check (drop 'main' in the post-rename cleanup PR).
 on:
   push:
-    branches: [main]
+    branches: [main, trunk]
   pull_request:
-    branches: [main]
+    branches: [main, trunk]
   workflow_dispatch:
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,12 @@ Reference implementations: `.login-*` and `.cancel-arc` blocks in `style.css`.
 
 ## Deploy & gates
 
+- **Rename in progress — the trunk branch `main` is being renamed to `trunk` (Jac, 2026-07-13).**
+  Until the GitHub rename lands, the trunk branch is still literally named `main`; the tooling
+  already handles **both** names (CI triggers on `[main, trunk]`; `promote.mjs` /
+  `branch-preflight.mjs` resolve the trunk dynamically; `deploy-staging.mjs` + the branch-janitor
+  guard both). Once Jac renames it in the GitHub UI, a cleanup PR drops the `main` fallback and
+  sweeps the docs to `trunk`. Read "`main`" below as "the trunk branch (soon `trunk`)".
 - **Ship model — trunk + two chat-driven gates (2026-07-13).** `main` is the **trunk**:
   integrated but **NOT live**. Pages serves the separate **`production`** release-pointer
   branch, so a merge to `main` no longer goes live — only a `production` update does. Both

--- a/tools/branch-preflight.mjs
+++ b/tools/branch-preflight.mjs
@@ -18,7 +18,8 @@
 import { execFileSync } from 'node:child_process';
 
 const REMOTE = 'origin';
-const TRUNK = 'main';
+// TRUNK is resolved dynamically inside main() (prefer 'trunk' if the remote has it, else 'main')
+// so this survives the main -> trunk rename with no code change.
 const RELEASE = 'production';   // the release-pointer branch GitHub Pages serves as PRODUCTION
 const NET_TIMEOUT = 8000;
 
@@ -39,9 +40,11 @@ function main() {
 
   // One best-effort network probe for the trunk + release branches. Offline is fine —
   // a live ls-remote so a shallow clone's missing local refs never read as "gone".
-  const ls = gitTry(['ls-remote', '--heads', REMOTE, TRUNK, RELEASE]);
+  const ls = gitTry(['ls-remote', '--heads', REMOTE, 'main', 'trunk', RELEASE]);
   const online = ls.ok;
   const has = (b) => online && new RegExp(`refs/heads/${b}$`, 'm').test(ls.out);
+  // main -> trunk rename transition: prefer 'trunk' once the remote has it, else 'main'.
+  const TRUNK = has('trunk') ? 'trunk' : 'main';
   const trunkUp = has(TRUNK);
   const releaseUp = has(RELEASE);
 

--- a/tools/deploy-staging.mjs
+++ b/tools/deploy-staging.mjs
@@ -68,7 +68,10 @@ const STAGING_DEPLOY_KEY_PATH = process.env.STAGING_DEPLOY_KEY_PATH || ''; // pa
 const STAGING_DEPLOY_PAT = process.env.STAGING_DEPLOY_PAT || '';           // fine-scoped PAT, staging repo only
 
 // Refuse to deploy from these — a short feature branch is the whole point of Gate 1.
-const PROTECTED_BRANCHES = ['main', 'production'];
+// 'main' and 'trunk' both listed to span the main -> trunk rename (the trunk keeps its
+// no-deploy guard under either name). NB: STAGING_PAGES_BRANCH below is the STAGING repo's
+// own Pages branch — unrelated to this rename, leave it as 'main'.
+const PROTECTED_BRANCHES = ['main', 'trunk', 'production'];
 
 // ── small git helpers (same shape as tools/spec-sync.mjs) ──
 

--- a/tools/promote.mjs
+++ b/tools/promote.mjs
@@ -37,8 +37,8 @@ import { execFileSync } from 'node:child_process';
 
 // TODO(jac): confirm — the release-pointer branch Pages serves as PRODUCTION (plan Phase 0.2/0.3).
 const PRODUCTION_BRANCH = 'production';
-// TODO(jac): confirm — the trunk branch Gate 1 ("merge it") lands on.
-const TRUNK = 'main';
+// The trunk branch Gate 1 ("merge it") lands on. Resolved dynamically below (after the git
+// helpers) to survive the main -> trunk rename: prefer 'trunk' once the remote has it, else 'main'.
 // TODO(jac): confirm — the live site's public URL (what Pages serves for PRODUCTION_BRANCH).
 const LIVE_URL = 'https://app.jacrentals.com';
 
@@ -62,6 +62,10 @@ function fail(msg) {
 
 const ROOT = git(['rev-parse', '--show-toplevel']);
 process.chdir(ROOT);
+
+// main -> trunk rename transition: use 'trunk' once the remote has it, else fall back to 'main'.
+// A transient ls-remote failure falls back to 'main'; the fetch below then surfaces a clear error.
+const TRUNK = ((gitTry(['ls-remote', '--heads', REMOTE, 'trunk']).out) || '').trim() ? 'trunk' : 'main';
 
 // --- Step 1: fetch both refs fresh, so the preview can never be stale -------
 console.log(`promote: fetching ${REMOTE}/${TRUNK} and ${REMOTE}/${PRODUCTION_BRANCH}…`);


### PR DESCRIPTION
Prep so the `main` → `trunk` default-branch rename can be done in the GitHub UI with **zero downtime** for CI or deploys. The atomic rename itself is a UI action (no rename API available to the agent); this PR makes everything tolerant of *both* names so the flip is safe at any moment.

## Changes
- **`ci.yml`** — the required `smoke` check triggers on `[main, trunk]` (runs before *and* after the rename).
- **`promote.mjs`, `branch-preflight.mjs`** — resolve the trunk **dynamically** via `ls-remote` (prefer `origin/trunk`, fall back to `main`). No code change needed at rename time.
- **`deploy-staging.mjs`** — `PROTECTED_BRANCHES` guards `trunk` too. (`STAGING_PAGES_BRANCH` stays `'main'` — that's the *staging repo's own* Pages branch, unrelated to this rename.)
- **`branch-janitor.yml`** — the never-prune structural guard now covers `trunk`.
- **CLAUDE.md** — transition note in Deploy & gates.

## Verified
- `promote.mjs` preview and `branch-preflight.mjs` both resolve to `main` today → unchanged behavior (preview: `production already matches main`).
- YAML parses; all three scripts syntax-check.
- They auto-switch to `trunk` once the remote has it.

## After this merges
1. Jac renames `main` → `trunk` in **Settings → Branches** (atomically moves protection + the required check, retargets open PRs, adds redirects).
2. A cleanup PR drops the `main` fallback (`ci.yml` → `[trunk]`, constants → `trunk`) and sweeps docs (CLAUDE.md, start skill) to `trunk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5vTWWjNWJoExtTN4SMtez)_