### PR TITLE
Finalize main→trunk rename: drop the main fallback + sweep docs to trunk

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: Jac Rentals session startup routine — run at the top of a session with /start. Probes the toolchain (node/npm/clasp/gh/git + Playwright), orients on the current git branch vs the trunk (main), recalls relevant memory, proposes a short feature branch (or git worktree) off the trunk and a dated session-output folder — waiting for your OK before switching — then sets token-efficiency + role-aware working rules for the rest of the session.
+description: Jac Rentals session startup routine — run at the top of a session with /start. Probes the toolchain (node/npm/clasp/gh/git + Playwright), orients on the current git branch vs the trunk (trunk), recalls relevant memory, proposes a short feature branch (or git worktree) off the trunk and a dated session-output folder — waiting for your OK before switching — then sets token-efficiency + role-aware working rules for the rest of the session.
 ---
 
 # /start — Jac Rentals session startup
@@ -34,26 +34,26 @@ Also check that the app password secret is present (do NOT echo it):
 
 ## 2. Branch + status orientation
 - Run: `git branch --show-current`, `git status -sb`, `git log --oneline -5`.
-- Show how the current branch differs from the trunk: `git diff --stat origin/main...HEAD`.
+- Show how the current branch differs from the trunk: `git diff --stat origin/trunk...HEAD`.
 - Recall memory: read `MEMORY.md` and surface anything relevant to this session's topic (e.g. `[[jactec-skill-build-plan]]`, `[[jactec-tooling]]`, `[[jactec-design-prefs]]`).
-- **The SessionStart hook already oriented you.** It ran `tools/branch-preflight.mjs` (report-only) — a live `git ls-remote` — and printed where you sit relative to the trunk (`main`) and `production`. Read its report; don't re-derive branch state from a shallow clone's stale local refs.
+- **The SessionStart hook already oriented you.** It ran `tools/branch-preflight.mjs` (report-only) — a live `git ls-remote` — and printed where you sit relative to the trunk (`trunk`) and `production`. Read its report; don't re-derive branch state from a shallow clone's stale local refs.
 
 ### 2b. Docs are on the trunk — no spec-sync anymore
 - The SessionStart hook already ran `node tools/branch-preflight.mjs` (report-only). There's nothing to `--ensure` now — the trunk model has no shared `staging`/`master-spec` branches to create.
-- **Docs live on the trunk.** Specs, plans, and decisions are in `docs/` on `main` — just `git pull` (or fetch `origin/main`) to see the latest. The old `spec-sync` / `master-spec` cross-branch sync is retired; don't run it, and don't arm any ~2h spec-sync self-timer.
+- **Docs live on the trunk.** Specs, plans, and decisions are in `docs/` on `trunk` — just `git pull` (or fetch `origin/trunk`) to see the latest. The old `spec-sync` / `master-spec` cross-branch sync is retired; don't run it, and don't arm any ~2h spec-sync self-timer.
 
 ## 3. Cut a SHORT feature branch off the trunk — DO NOT switch without an OK
-The app uses **trunk-based development**: one trunk (`main`), short-lived **feature branches** cut off it, merged the same day and deleted. There is no per-area routing anymore.
-- **Propose a short feature branch** in one line (e.g. *"Invoicing refund rounding → branch `claude/refund-rounding` off `main`?"*). For a **parallel** session, propose a git **worktree** instead (`claude --worktree <task>`) — isolation without divergence. **WAIT for his OK** before switching.
+The app uses **trunk-based development**: one trunk (`trunk`), short-lived **feature branches** cut off it, merged the same day and deleted. There is no per-area routing anymore.
+- **Propose a short feature branch** in one line (e.g. *"Invoicing refund rounding → branch `claude/refund-rounding` off `trunk`?"*). For a **parallel** session, propose a git **worktree** instead (`claude --worktree <task>`) — isolation without divergence. **WAIT for his OK** before switching.
 - On OK, start from the latest trunk:
-  1. `git fetch origin main`
-  2. `git checkout -b claude/<task> origin/main`
+  1. `git fetch origin trunk`
+  2. `git checkout -b claude/<task> origin/trunk`
   3. Commit your work to the feature branch and push there.
 - **The two-gate deploy loop** (build → review → integrate → wait → go-live) — both gates run on Jac's say-so:
   1. **Deploy to staging** — `node tools/deploy-staging.mjs` pushes your feature branch's site files to the staging repo; Jac reviews the running app at the staging URL (`https://operations-jacrentals.github.io/rental-wrangler-staging/` — [[jactec-staging-url]]).
-  2. **Gate 1 — "merge it"** — run the local gates, open a PR to `main`, let CI (`smoke`) pass, squash-merge, delete the branch. Integrated on the trunk but **NOT live** (Pages serves the `production` release-pointer branch).
+  2. **Gate 1 — "merge it"** — run the local gates, open a PR to `trunk`, let CI (`smoke`) pass, squash-merge, delete the branch. Integrated on the trunk but **NOT live** (Pages serves the `production` release-pointer branch).
   3. **Wait** — as long as Jac likes; the trunk holds blessed-but-not-live work.
-  4. **Gate 2 — "promote it"** — `node tools/promote.mjs` (run bare first for a read-only preview, then `--yes`) fast-forwards `production` to the approved `main` commit → app.jacrentals.com goes live. This is the ONLY step that changes the live site; it is fast-forward-only and **always Jac's explicit call.**
+  4. **Gate 2 — "promote it"** — `node tools/promote.mjs` (run bare first for a read-only preview, then `--yes`) fast-forwards `production` to the approved `trunk` commit → app.jacrentals.com goes live. This is the ONLY step that changes the live site; it is fast-forward-only and **always Jac's explicit call.**
 - **Big replacements ride behind a `FEATURES` flag** in `config.js` (`flagOn()` reader) so backing out is a runtime toggle, not code surgery. (A flag hides execution, not source, on a public Pages site — never gate a secret/auth check on it.)
 - **The old `area/*` branches are FROZEN legacy — don't build on them.** ~19 `area/*` branches remain from the previous workflow; they're dormant (kept, not deleted — they carry large unaudited divergence and some hold live content, so a "what's stranded" audit precedes any cleanup). New work is always a feature branch off the trunk. `references/branch-map.md` is kept only as a **domain reference** (which domain owns which surface), not a routing target.
 - **Optional quick local look.** To eyeball your working tree before a staging deploy, serve it statically on `localhost:9147` (8000 is reserved). It's the dev-loop version of what `ci/smoke.mjs` does (a static server), minus Playwright:
@@ -103,21 +103,21 @@ The app uses **trunk-based development**: one trunk (`main`), short-lived **feat
 - **Specs:** after generating or changing a spec/feature/screen, offer to run the `/role` audit (now folded into `/jactec-ui` — § "The /role audit") to review it through the 15 role lenses.
 - **Something reported broken → `wrangler-fix` first.** Anything reported not-working or broken — an in-app `wrangler-fix`/`wrangler-request` issue OR Jac just saying it in-session — runs through the `wrangler-fix` skill before any code change: prove the claim against the canon (R-Rulebook, SPEC v8, docs, code) with citations, trace the symptom UP to its root cause, sweep for sibling bugs of the same class, fix only what's proven at the cause, then re-reproduce to confirm it failed-before/passes-after. No fix without a cited root cause.
 - **Efficiency:** `/audit` is available anytime; the ~1M-token auto-audit hook will also prompt a coaching report.
-- **Ship cadence — propose the gates, never auto-promote to live.** Build on the feature branch, then: **deploy to staging** (`deploy-staging.mjs`) for Jac's review → on **"merge it"** run the local gate set + PR to `main` + CI (`smoke`) + squash-merge (Gate 1, integrated but not live) → **wait** → on **"promote it"** run `promote.mjs` (Gate 2, `main → production`). **`production` is live at app.jacrentals.com — promoting is ALWAYS Jac's explicit call**, and the only step that changes the live site. Big replacements ride behind a `FEATURES` flag so a swap can be backed out with a toggle.
+- **Ship cadence — propose the gates, never auto-promote to live.** Build on the feature branch, then: **deploy to staging** (`deploy-staging.mjs`) for Jac's review → on **"merge it"** run the local gate set + PR to `trunk` + CI (`smoke`) + squash-merge (Gate 1, integrated but not live) → **wait** → on **"promote it"** run `promote.mjs` (Gate 2, `trunk → production`). **`production` is live at app.jacrentals.com — promoting is ALWAYS Jac's explicit call**, and the only step that changes the live site. Big replacements ride behind a `FEATURES` flag so a swap can be backed out with a toggle.
 - **Staging review — DRIVE THE RUNNING APP before "merge it" (don't trust unit tests alone).** After `deploy-staging.mjs` pushes your feature to the staging repo, verify the live staging site serves the new bytes (`curl -s https://operations-jacrentals.github.io/rental-wrangler-staging/index.html | grep <the new ?v= token deploy-staging printed>`), then drive it with **Claude-in-Chrome** (needs **no local install**, unlike Playwright): open the staging URL, log in (password from `$RW_PW` — **never hardcode or echo it**), and **exercise exactly what you built** end-to-end plus a known sanity flow — e.g. run a sample CSV through **Mr. Wrangler** and confirm the expected output, not merely that the page renders. No console/page errors on boot; the feature's visible result matches expectation; save a screenshot for the handoff. A red review STOPs the merge — fix on the feature branch, redeploy, re-check. `deploy-staging.mjs` is a direct push (no cron), so the staging URL updates within ~1 min.
 
 ## 5. Ready summary
 End with 3–4 lines: tools OK/missing, current branch + what's in flight, the proposed feature branch/folder (awaiting OK), and "what are we working on?"
 
 ## 6. Wrap-up — when a feature ships, or when the session winds down
-- **Report shipped-state plainly.** Say what's **merged to the trunk** (`main`, integrated but maybe not live) vs **promoted to production** (live) vs **still pending / uncommitted**, so a session never ends in a fuzzy "did this actually ship?" state.
+- **Report shipped-state plainly.** Say what's **merged to the trunk** (`trunk`, integrated but maybe not live) vs **promoted to production** (live) vs **still pending / uncommitted**, so a session never ends in a fuzzy "did this actually ship?" state.
 - **Catch loose work before it's lost.** Scan the session for ideas, half-done threads, or follow-ups worth keeping and **park each on its own branch** so closing the chat never drops a good idea or unfinished piece.
 - **Don't archive if anything's pending.** If work is parked, uncommitted, or awaiting a promote, say so and stop — don't sweep it away.
 - **Run `/tidy-sessions`** (or the end-of-session skill once it lands) only as the LAST step, once the above are clean — to archive finished/stale chats. It never touches the current chat or open-PR work.
 - **Handoff note.** Write a short note (what shipped, what's pending, which feature branch) into the session-output folder so the next chat — local or cloud — picks up cleanly.
 
 ## Conventions reference
-- **Branches (trunk-based):** cut a short feature branch `claude/<task>` (or a `claude --worktree <task>`) off **`main`** → build → `deploy-staging.mjs` → review on the staging URL → **"merge it"** (PR → `smoke` CI → squash-merge to `main`, integrated but NOT live) → **wait** → **"promote it"** (`promote.mjs` fast-forwards `production`; app.jacrentals.com goes live — Jac's explicit call only). `main` is the trunk (protected, PR + CI); `production` is the release pointer Pages serves. The ~19 `area/*` branches are frozen legacy, not routing targets (`references/branch-map.md` is now just a domain reference).
+- **Branches (trunk-based):** cut a short feature branch `claude/<task>` (or a `claude --worktree <task>`) off **`trunk`** → build → `deploy-staging.mjs` → review on the staging URL → **"merge it"** (PR → `smoke` CI → squash-merge to `trunk`, integrated but NOT live) → **wait** → **"promote it"** (`promote.mjs` fast-forwards `production`; app.jacrentals.com goes live — Jac's explicit call only). `trunk` is the trunk (protected, PR + CI); `production` is the release pointer Pages serves. The ~19 `area/*` branches are frozen legacy, not routing targets (`references/branch-map.md` is now just a domain reference).
 - **Backend:** ships via `/clasp`, never git. `Code.gs`/`Code.js` are gitignored (public repo). **Deploy auth is currently the service account (`GAS_SA_KEY_B64` + `docs/handoffs/gas-deploy-service-account.mjs`), not clasp OAuth** — clasp's `CLASPRC_JSON_B64` path is RAPT-blocked as of 2026-07-06 (see `/clasp`). Full runbook + queue: `docs/handoffs/BACKEND-DEPLOY-QUEUE.md`.
 - **Sibling skills:** `/clasp` (backend deploy), `/audit` (token + model-fit coaching), `/tidy-sessions` (archive finished chats), `/brainstorming` (design/spec before building — invoke before touching UI code), `/jactec-ui` (**the single design skill — mandatory for any UI**; absorbed the former `/frontend` aesthetic direction, the `mobile-*` skills, `/design-md`, and the `/role` spec audit), `webapp-testing`, `wrangler-fix`.
 - **At session end:** write a short handoff note (what changed, what's pending, which feature branch) into the session folder so the next chat — local or cloud — picks up cleanly.

--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -2,7 +2,7 @@ name: Branch janitor
 
 # Prunes merged task branches so the repo stays tidy on its own.
 # SAFE BY DESIGN: only deletes a branch that (a) is the head of a MERGED PR,
-# (b) has NO open PR, and (c) is NOT a structural branch (main / staging / area/*).
+# (b) has NO open PR, and (c) is NOT a structural branch (trunk / staging / area/*).
 # So long-lived chapters (area/*) and the trunk/integration branches are never touched.
 #
 # There is also a ONE-TIME, opt-in cleanup job (prune_stranded) for the branches the
@@ -52,7 +52,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
     steps:
-      - name: Prune merged task branches (never main/staging/area/*)
+      - name: Prune merged task branches (never trunk/staging/area/*)
         run: |
           set -euo pipefail
           # #552 audit item 18: --paginate (not a --limit cap) so the "never delete a branch
@@ -66,7 +66,7 @@ jobs:
           while IFS= read -r b; do
             [ -z "$b" ] && continue
             case "$b" in
-              main|trunk|staging|area/*|backup/*) continue ;;   # never touch the structure (trunk = post-rename default)
+              trunk|staging|area/*|backup/*) continue ;;   # never touch the structure (trunk = post-rename default)
             esac
             grep -qxF "$b" merged.txt || continue   # must have a merged PR
             grep -qxF "$b" open.txt   && continue   # but no open PR
@@ -149,7 +149,7 @@ jobs:
           for b in $STRANDED; do
             [ -z "$b" ] && continue
             case "$b" in
-              main|trunk|staging|area/*|backup/*) echo "  GUARD skip (structural): $b"; skipped=$((skipped+1)); continue ;;
+              trunk|staging|area/*|backup/*) echo "  GUARD skip (structural): $b"; skipped=$((skipped+1)); continue ;;
             esac
             grep -qxF "$b" live.txt || { echo "  already gone: $b"; continue; }
             if grep -qxF "$b" open.txt; then echo "  GUARD skip (has open PR): $b"; skipped=$((skipped+1)); continue; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,11 @@ name: CI — boot check
 
 # Runs on every push/PR to the trunk. Flags a broken version (syntax error or boot crash)
 # so it can be caught before it affects the live site (app.jacrentals.com).
-# Both 'main' and 'trunk' are listed to span the main -> trunk rename with zero downtime
-# for the required check (drop 'main' in the post-rename cleanup PR).
 on:
   push:
-    branches: [main, trunk]
+    branches: [trunk]
   pull_request:
-    branches: [main, trunk]
+    branches: [trunk]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/wrangler-fix.yml
+++ b/.github/workflows/wrangler-fix.yml
@@ -4,7 +4,7 @@ name: Wrangler Fix — auto-patch a reported glitch
 # When a glitch is filed as an issue labelled "wrangler-fix", a Claude coding
 # agent reproduces it, patches the FRONTEND (app.js / style.css / index.html /
 # config.js), runs the 3 CI gates, opens a PR, and auto-merges it the moment CI
-# is green. Pages then deploys `main` to app.jacrentals.com. The one step the
+# is green. Pages then deploys `trunk` to app.jacrentals.com. The one step the
 # browser can't do — rewriting app.js and redeploying — happens here.
 #
 # ── SWITCH-ON (one-time, in the repo's GitHub settings) ───────────────────────
@@ -19,7 +19,7 @@ name: Wrangler Fix — auto-patch a reported glitch
 #      (Alternative: run `/install-github-app` to use the Claude GitHub App
 #       token instead of a PAT — same effect.)
 #   2. Settings → General → Pull Requests → ✓ Allow auto-merge.
-#   3. Settings → Branches → Add branch protection rule for `main`:
+#   3. Settings → Branches → Add branch protection rule for `trunk`:
 #        ✓ Require status checks to pass before merging
 #        → add the "smoke" check (from the "CI — boot check" workflow).
 #      This is the safety net: a fix reaches live ONLY after all 3 gates pass.
@@ -130,7 +130,7 @@ jobs:
               • Proven → make the MINIMAL fix that satisfies the cited rule (match the code +
                 the design language). Run all 3 gates (node ci/smoke.mjs · node ci/logic-test.mjs
                 · node ci/gen-rule-usage.mjs --check; regenerate rule-usage.js if usage changed).
-                Open a PR to `main` titled "Wrangler fix: <summary>" with body incl.
+                Open a PR to `trunk` titled "Wrangler fix: <summary>" with body incl.
                 "Closes #${{ github.event.issue.number }}", then `gh pr merge --auto --squash <pr>`.
               • Can't prove it / it contradicts the canon / it's ambiguous → do NOT ship.
                 Comment your verdict + why on #${{ github.event.issue.number }}; if it's a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,24 +58,18 @@ Reference implementations: `.login-*` and `.cancel-arc` blocks in `style.css`.
 
 ## Deploy & gates
 
-- **Rename in progress — the trunk branch `main` is being renamed to `trunk` (Jac, 2026-07-13).**
-  Until the GitHub rename lands, the trunk branch is still literally named `main`; the tooling
-  already handles **both** names (CI triggers on `[main, trunk]`; `promote.mjs` /
-  `branch-preflight.mjs` resolve the trunk dynamically; `deploy-staging.mjs` + the branch-janitor
-  guard both). Once Jac renames it in the GitHub UI, a cleanup PR drops the `main` fallback and
-  sweeps the docs to `trunk`. Read "`main`" below as "the trunk branch (soon `trunk`)".
-- **Ship model — trunk + two chat-driven gates (2026-07-13).** `main` is the **trunk**:
+- **Ship model — trunk + two chat-driven gates (2026-07-13; the trunk branch was renamed `main`→`trunk` on 2026-07-13).** `trunk` is the **trunk branch**:
   integrated but **NOT live**. Pages serves the separate **`production`** release-pointer
-  branch, so a merge to `main` no longer goes live — only a `production` update does. Both
+  branch, so a merge to `trunk` no longer goes live — only a `production` update does. Both
   gates run on Jac's say-so:
   - **Deploy to staging** — `node tools/deploy-staging.mjs` pushes the current feature
     branch's site files to the staging repo so Jac reviews the running app at the staging URL.
-  - **Gate 1, "merge it"** — feature branch → `main` (PR → squash-merge → delete branch);
-    integrated on the trunk, still not live. `main` is **branch-protected** (required
-    `smoke` CI check): feature branch → PR → squash-merge. NEVER `git push origin HEAD:main`
+  - **Gate 1, "merge it"** — feature branch → `trunk` (PR → squash-merge → delete branch);
+    integrated on the trunk, still not live. `trunk` is **branch-protected** (required
+    `smoke` CI check): feature branch → PR → squash-merge. NEVER `git push origin HEAD:trunk`
     (or `HEAD:production`) directly -- it will be rejected.
   - **Gate 2, "promote it"** — `node tools/promote.mjs --yes` fast-forwards `production` to
-    the approved `main` commit → app.jacrentals.com goes live. Run it with no args first for a
+    the approved `trunk` commit → app.jacrentals.com goes live. Run it with no args first for a
     read-only preview; it is fast-forward-only (never `--force`) and verifies the live `?v=`
     afterward. This is the ONLY step that changes the live site — **always Jac's explicit call.**
   - Big *replacements* ship behind a `FEATURES` flag in `config.js` (`flagOn()` reader) so

--- a/tools/branch-preflight.mjs
+++ b/tools/branch-preflight.mjs
@@ -18,8 +18,7 @@
 import { execFileSync } from 'node:child_process';
 
 const REMOTE = 'origin';
-// TRUNK is resolved dynamically inside main() (prefer 'trunk' if the remote has it, else 'main')
-// so this survives the main -> trunk rename with no code change.
+const TRUNK = 'trunk';          // the trunk branch (renamed main -> trunk, 2026-07-13)
 const RELEASE = 'production';   // the release-pointer branch GitHub Pages serves as PRODUCTION
 const NET_TIMEOUT = 8000;
 
@@ -40,11 +39,9 @@ function main() {
 
   // One best-effort network probe for the trunk + release branches. Offline is fine —
   // a live ls-remote so a shallow clone's missing local refs never read as "gone".
-  const ls = gitTry(['ls-remote', '--heads', REMOTE, 'main', 'trunk', RELEASE]);
+  const ls = gitTry(['ls-remote', '--heads', REMOTE, TRUNK, RELEASE]);
   const online = ls.ok;
   const has = (b) => online && new RegExp(`refs/heads/${b}$`, 'm').test(ls.out);
-  // main -> trunk rename transition: prefer 'trunk' once the remote has it, else 'main'.
-  const TRUNK = has('trunk') ? 'trunk' : 'main';
   const trunkUp = has(TRUNK);
   const releaseUp = has(RELEASE);
 

--- a/tools/deploy-staging.mjs
+++ b/tools/deploy-staging.mjs
@@ -68,10 +68,9 @@ const STAGING_DEPLOY_KEY_PATH = process.env.STAGING_DEPLOY_KEY_PATH || ''; // pa
 const STAGING_DEPLOY_PAT = process.env.STAGING_DEPLOY_PAT || '';           // fine-scoped PAT, staging repo only
 
 // Refuse to deploy from these — a short feature branch is the whole point of Gate 1.
-// 'main' and 'trunk' both listed to span the main -> trunk rename (the trunk keeps its
-// no-deploy guard under either name). NB: STAGING_PAGES_BRANCH below is the STAGING repo's
-// own Pages branch — unrelated to this rename, leave it as 'main'.
-const PROTECTED_BRANCHES = ['main', 'trunk', 'production'];
+// NB: STAGING_PAGES_BRANCH below is the STAGING repo's own Pages branch (still 'main') —
+// unrelated to this repo's trunk, which was renamed main -> trunk.
+const PROTECTED_BRANCHES = ['trunk', 'production'];
 
 // ── small git helpers (same shape as tools/spec-sync.mjs) ──
 

--- a/tools/promote.mjs
+++ b/tools/promote.mjs
@@ -37,8 +37,8 @@ import { execFileSync } from 'node:child_process';
 
 // TODO(jac): confirm — the release-pointer branch Pages serves as PRODUCTION (plan Phase 0.2/0.3).
 const PRODUCTION_BRANCH = 'production';
-// The trunk branch Gate 1 ("merge it") lands on. Resolved dynamically below (after the git
-// helpers) to survive the main -> trunk rename: prefer 'trunk' once the remote has it, else 'main'.
+// The trunk branch Gate 1 ("merge it") lands on (branch renamed main -> trunk, 2026-07-13).
+const TRUNK = 'trunk';
 // TODO(jac): confirm — the live site's public URL (what Pages serves for PRODUCTION_BRANCH).
 const LIVE_URL = 'https://app.jacrentals.com';
 
@@ -62,10 +62,6 @@ function fail(msg) {
 
 const ROOT = git(['rev-parse', '--show-toplevel']);
 process.chdir(ROOT);
-
-// main -> trunk rename transition: use 'trunk' once the remote has it, else fall back to 'main'.
-// A transient ls-remote failure falls back to 'main'; the fetch below then surfaces a clear error.
-const TRUNK = ((gitTry(['ls-remote', '--heads', REMOTE, 'trunk']).out) || '').trim() ? 'trunk' : 'main';
 
 // --- Step 1: fetch both refs fresh, so the preview can never be stale -------
 console.log(`promote: fetching ${REMOTE}/${TRUNK} and ${REMOTE}/${PRODUCTION_BRANCH}…`);


### PR DESCRIPTION
The default-branch rename `main` → `trunk` is done (via the GitHub UI). This finalizes it: removes the transitional both-names handling from #607 and sweeps the docs.

## Changes
- **`ci.yml`** — trigger on `[trunk]` only.
- **`promote.mjs` / `branch-preflight.mjs`** — static `TRUNK = 'trunk'`. (The dynamic fallback added in #607 would now resolve to the *deleted* `main` on a transient `ls-remote` failure — a liability once the rename is done.)
- **`deploy-staging.mjs`** — `PROTECTED_BRANCHES = ['trunk', 'production']`. (`STAGING_PAGES_BRANCH` stays `'main'` — the *staging repo's own* Pages branch.)
- **`branch-janitor.yml`** — structural never-prune guard is now `trunk|staging|area/*`.
- **Docs** — CLAUDE.md, the start skill, and `wrangler-fix.yml` comments: trunk-branch refs swept to `trunk`. Deliberately left untouched: "main session / thread / context / chat" (the Claude session, not the branch) and the staging repo's own `main`.

## Verified
- All three workflow YAMLs parse.
- `promote.mjs` preview + `branch-preflight.mjs` resolve `origin/trunk` correctly; all scripts syntax-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5vTWWjNWJoExtTN4SMtez)_