### PR TITLE
sw: stop serving the app-shell login for standalone public pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260713bd" />
+  <link rel="stylesheet" href="style.css?v=20260713be" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260713bd"></script>
-  <script type="module" src="app.js?v=20260713bd"></script>
+  <script src="rule-usage.js?v=20260713be"></script>
+  <script type="module" src="app.js?v=20260713be"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/sw.js
+++ b/sw.js
@@ -14,6 +14,13 @@ const SHELL = ['./', './index.html', './app.js', './style.css', './config.js', '
   './cascade.js', './icons.js', './icons-anim.js', './agreements.js', './service-countdown.js',
   './rule-usage.js', './manifest.webmanifest'];
 const SHELL_SET = new Set(SHELL.map((p) => new URL(p, self.location.href).pathname));
+/* Standalone PUBLIC pages (SMS-compliance + business info) are their OWN documents, NOT the SPA
+ * shell. They must NEVER be served the cached index.html nav-fallback below — otherwise any visitor
+ * who has the app's SW installed (Jac, staff, a returning customer) navigating to one of these gets
+ * the login wall instead of the real page. That broke A2P campaign vetting: the carrier's business /
+ * opt-in URLs appeared to be a login screen (2026-07-13). Nav requests to these bypass the SW. */
+const PUBLIC = ['./about.html', './sample-quote.html', './opt-in.html', './privacy.html', './sms-terms.html'];
+const PUBLIC_SET = new Set(PUBLIC.map((p) => new URL(p, self.location.href).pathname));
 
 self.addEventListener('install', (e) => {
   e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));
@@ -28,6 +35,7 @@ self.addEventListener('fetch', (e) => {
   const url = new URL(req.url);
   if (url.origin !== self.location.origin) return;                    // third-party (Stripe/Maps/fonts/GAS) → network-only
   const isNav = req.mode === 'navigate';
+  if (isNav && PUBLIC_SET.has(url.pathname)) return;                  // standalone public page → network, NEVER the SPA shell
   if (!isNav && !SHELL_SET.has(url.pathname)) return;                 // not on the shell allowlist → network-only, never cached
   // stale-while-revalidate on the shell; navigation falls back to the cached index.html offline
   e.respondWith(caches.open(CACHE).then(async (c) => {


### PR DESCRIPTION
## Why

Follow-up to #606. After the A2P business/opt-in pages went live, the campaign's URLs still appeared to be a **login screen** for anyone who had previously opened the app.

**Root cause (`sw.js` fetch handler):** the offline service worker served the cached `index.html` shell for *every* same-origin navigation:

```js
const hit = await c.match(isNav ? './index.html' : req, { ignoreSearch: true });
```

So a browser with the SW installed (Jac, staff, a returning customer) navigating directly to a standalone public page — `about.html`, `sample-quote.html`, `opt-in.html`, `privacy.html`, `sms-terms.html` — got the Rental Wrangler login wall instead of the real page. A **fresh** browser (the carrier reviewer, or an incognito window) has no SW and was unaffected — which is why it reproduced only for already-cached visitors and passed in incognito.

## What changed

- **`sw.js`** — navigations whose path is one of the five standalone public pages now **bypass the SW entirely** (normal network fetch, never the `index.html` shell). No new `cache.put()` — the allowlist-by-construction security model (only app-shell assets are ever cached; no PII/pricing/data touches Cache Storage) is unchanged, and the SPA's own offline-shell behavior is untouched.
- **`index.html`** — bump the shared `?v=` cache-bust token (`20260713bd` → `20260713be`) so the corrected SW installs and activates for existing visitors (the token is also what `swInit` uses to register `sw.js?v=<token>`).

## Verification

- `curl` (no SW) returned the real pages before and after.
- Reproduced the login-wall on a browser with the SW installed; incognito (no SW) showed the real page — consistent with the diagnosis.
- After this ships, a cached browser picks up the new SW (via the token bump) and the five public pages load their real content directly.

## Gates

No-browser gates pass locally: `node --check sw.js` ✓, `gen-rule-usage --check` ✓, `gen-code-map --check` ✓, `check-window-catalog` ✓. Browser gates (`smoke`, `logic-test`) run in CI. Does not touch the R-rulebook, window catalog, or app UI. Rebased onto the latest `trunk` (post main→trunk rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mGyVBDca7Ki6G2oz8CexW)_