### PR TITLE
Cache-bust: land go-live ?v= token (20260713bl) on trunk

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260713bk" />
+  <link rel="stylesheet" href="style.css?v=20260713bl" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -37,8 +37,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260713bk"></script>
-  <script type="module" src="app.js?v=20260713bk"></script>
+  <script src="rule-usage.js?v=20260713bl"></script>
+  <script type="module" src="app.js?v=20260713bl"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

Bumps the shared `?v=` cache-bust token in `index.html` from `20260713bk` → `20260713bl` on `style.css`, `rule-usage.js`, and `app.js`.

## Why

Finishing the go-live of the two features already integrated on `trunk` but not yet live in production:
- the mobile bottom-right Back/Forward jog chip (R32, #610)
- the staging-drift guardrails + `/deploy` / `/promote` skills (#613)

`tools/deploy-staging.mjs` bumped the shared token to `20260713bl` when it pushed `trunk`'s content to the staging review site, so the **live staging site now serves `?v=20260713bl`**. This PR lands that same bump on `trunk` so the trunk commit and the staging site match — which is exactly what `promote.mjs`'s staging-freshness gate requires before `production` can fast-forward and go live.

## Verification

- `deploy-staging.mjs` self-verified live staging serves `?v=20260713bl`.
- Rendered the identical bytes at a 390×844 phone viewport: the R32 jog is a snug 66×44 chip pinned 8px from the footer's bottom-right edge, to the right of the scrollable tool row — matching the spec.
- Local no-browser gates pass: `gen-rule-usage --check`, `check-window-catalog`, `gen-code-map --check`. Browser gates (`smoke`, `logic-test`) run in CI.

Content-only change is the token query string — no app/style/rule logic touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F4yuUc5uMHUt9LHofoYCjR)_