### PR TITLE
Login follow-ups: STAGING badge, backend warm-up, show-password toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -23114,11 +23114,14 @@ function renderLogin(msg) {
       </div>
       <div class="login-field">
         <label class="login-lbl" for="login-pw">Team password</label>
-        <input id="login-pw" type="password" class="login-input" placeholder="••••••••" autocomplete="current-password" />
+        <div class="login-pw-wrap">
+          <input id="login-pw" type="password" class="login-input" placeholder="••••••••" autocomplete="current-password" />
+          <button type="button" class="login-pw-eye" id="login-pw-eye" aria-label="Show password" data-tip="Show password">${I.eye}</button>
+        </div>
       </div>
       <div class="login-actions">
         <button type="button" class="login-mute${state.loginMuted ? ' is-muted' : ''}" id="login-mute" aria-pressed="${state.loginMuted}" aria-label="Mute intro sound" data-tip="${state.loginMuted ? 'Intro sound off — tap to unmute' : 'Intro sound on — tap to mute'}">${state.loginMuted ? I.volumeOff : I.volume}</button>
-        <button type="submit" class="login-btn" data-r="R17" id="login-go">Saddle Up?</button>
+        <button type="submit" class="login-btn" data-r="R17" id="login-go">Saddle Up</button>
       </div>
       <div class="login-err" id="login-err">${msg ? esc(msg) : ''}</div>
     </div>
@@ -23136,6 +23139,17 @@ function renderLogin(msg) {
     muteBtn.setAttribute('data-tip', state.loginMuted ? 'Intro sound off — tap to unmute' : 'Intro sound on — tap to mute');
     muteBtn.innerHTML = state.loginMuted ? I.volumeOff : I.volume;
     const vid = document.getElementById('login-video'); if (vid) vid.muted = state.loginMuted;
+  });
+  // Show/hide the team password — the eye toggle inside the field.
+  const eyeBtn = document.getElementById('login-pw-eye');
+  if (eyeBtn) eyeBtn.addEventListener('click', () => {
+    const pw = document.getElementById('login-pw'); if (!pw) return;
+    const show = pw.type === 'password';
+    pw.type = show ? 'text' : 'password';
+    eyeBtn.innerHTML = show ? I.eyeOff : I.eye;
+    eyeBtn.setAttribute('aria-label', show ? 'Hide password' : 'Show password');
+    eyeBtn.setAttribute('data-tip', show ? 'Hide password' : 'Show password');
+    pw.focus();
   });
   document.getElementById(currentUser ? 'login-pw' : 'login-name').focus();
 }
@@ -23265,6 +23279,32 @@ function applyViewportClass() {
   document.body.classList.toggle('is-phone', window.matchMedia('(max-width: 640px)').matches);
   document.body.classList.toggle('is-narrow', window.matchMedia('(max-width: 1024px)').matches);
 }
+// ── Which deployment am I running on? — so a STAGING / LOCAL build is unmistakable, and so
+//    the backend warm-up only runs where it helps. Production is the ONE app.jacrentals.com;
+//    the GitHub Pages staging mirror + localhost are non-prod (same signal as swInit). ──
+const APP_ENV = location.hostname === 'app.jacrentals.com' ? 'production'
+  : /^(localhost|127\.0\.0\.1)$/.test(location.hostname) ? 'local'
+  : 'staging';
+// A caution stamp on any non-prod build (fixed corner, never interactive) so you always know
+// which app you're testing — the staging mirror serves the SAME files as production.
+function mountEnvBadge() {
+  if (APP_ENV === 'production' || document.getElementById('env-badge')) return;
+  const b = document.createElement('div');
+  b.id = 'env-badge';
+  b.className = 'env-badge env-' + APP_ENV;
+  b.textContent = APP_ENV === 'local' ? 'LOCAL' : 'STAGING';
+  b.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(b);
+}
+// Warm the (cold-starting ~1-5s) Apps Script container while the login screen is up, so the
+// post-Saddle-Up 'load' hits a warm backend. `no-cors` → the response is OPAQUE and UNUSED
+// (the frontend can't read it, so no data exposure) and no password is sent. Fire-and-forget;
+// never blocks boot or surfaces an error.
+let _backendWarmed = false;
+function warmBackend() {
+  if (_backendWarmed) return; _backendWarmed = true;
+  try { fetch(BACKEND_URL, { method: 'GET', mode: 'no-cors', cache: 'no-store' }).catch(() => {}); } catch (e) {}
+}
 function boot() {
   // Recovery hatch: app.jacrentals.com/#reset-settings (or #safe-mode) wipes saved customizations
   // before they apply — the guaranteed way back if a bad setting ever breaks the screen.
@@ -23274,6 +23314,7 @@ function boot() {
   } catch (e) {}
   applySettings();   // Settings Board: apply admin status overrides (color/icon) before the first render
   if (settingsReverted) setTimeout(() => { try { toast('Customizations reset to defaults (recovery mode).'); } catch (e) {} }, 800);
+  mountEnvBadge();   // STAGING / LOCAL caution stamp (no-op on production) — know which app you're in
   initTooltip();
   // §13.5 — the Units graph legend was removed (hover names each slice); its donut slices /
   // trajectory buckets are SVG, so make a focused one keyboard-activatable (Enter/Space → filter).
@@ -23649,6 +23690,7 @@ function boot() {
     loadFromBackend().then(finishLoad)
       .catch(() => { backendPassword = ''; sessionStorage.removeItem('jactec.pw'); renderLogin('Please sign in again.'); });
   } else {
+    warmBackend();   // no cached password → the login screen is about to show; warm the backend during entry so 'load' after Saddle Up hits a hot container
     renderLogin();
   }
 }

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 24384 lines, 38 chapters
+## app.js — 24426 lines, 38 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -44,8 +44,8 @@
 | APP-34 | 19477–20790 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
 | APP-35 | 20791–21273 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
 | APP-36 | 21274–21276 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 21277–23833 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+159) |
-| APP-38 | 23834–24384 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
+| APP-37 | 21277–23875 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+163) |
+| APP-38 | 23876–24426 | — | D8/D9 THE COMMS RAIL (spec comms-notifications D8 + D9, Jac | COMMS_CAT_META, commsOnline, commsSess, commsCatOfChannel, commsThreads, commsThreadsAt, refreshCommsThreads, commsThreadChannel, commsThreadsFor, commsConvStatus, COMMS_ST_RANK, commsCatWorst, …(+33) |
 
 ## config.js — 623 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260713muy" />
+  <link rel="stylesheet" href="style.css?v=20260714a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +47,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260713muy"></script>
-  <script type="module" src="app.js?v=20260713muy"></script>
+  <script src="rule-usage.js?v=20260714a"></script>
+  <script type="module" src="app.js?v=20260714a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -2981,7 +2981,34 @@ select.nc-in { cursor: pointer; }
 .login-mute:active { transform: translateY(1px); }
 .login-mute.is-muted { color: #8b94a3; }   /* sound off = dimmed */
 .login-mute:focus-visible { outline: none; border-color: var(--accent, #ff7a1a); box-shadow: 0 0 0 3px rgba(255, 122, 26, .17); }
+/* Show-password eye — sits inside the Team password field (icon-only utility toggle like
+   .set-reveal / .login-mute; not a lint-family element, so no data-r). */
+.login-pw-wrap { position: relative; width: 100%; }
+.login-pw-wrap .login-input { padding-right: 42px; }   /* clear the eye */
+.login-pw-eye {
+  position: absolute; top: 0; right: 0; height: 44px; width: 40px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: none; border: none; cursor: pointer; color: #8b94a3; transition: color .12s; }
+.login-pw-eye svg { width: 18px; height: 18px; }
+.login-pw-eye:hover { color: #eef2f6; }
+.login-pw-eye:focus-visible { outline: 2px solid var(--accent, #ff7a1a); outline-offset: -3px; border-radius: 7px; color: #eef2f6; }
 .login-err { font-size: 12px; font-weight: 600; color: var(--red, #ff4242); text-align: center; margin-top: 11px; min-height: 14px; }
+/* Env badge — a hazard-caution stamp on any NON-production build (the staging mirror or
+   localhost, which serve the SAME files as production) so you always know which app you're
+   testing. Never rendered on app.jacrentals.com; pointer-events:none so it never blocks. */
+.env-badge {
+  position: fixed; z-index: 90; left: 12px; bottom: 12px; pointer-events: none;
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 11px;
+  letter-spacing: 2.5px; text-transform: uppercase; color: var(--yellow, #f5c542);
+  padding: 5px 11px 5px 9px; border-radius: 7px;
+  background: linear-gradient(180deg, #1b2129, #0c0e11);
+  border: 1px solid #2a313b; box-shadow: 0 7px 20px -7px #000; }
+.env-badge::before {   /* hi-vis hazard chip — the signature motif, in miniature */
+  content: ''; width: 13px; height: 13px; border-radius: 3px;
+  background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 4px, #14181d 4px 8px); }
+.env-badge.env-local { color: var(--tan, #c2925a); }   /* localhost = leather-tan, distinct from staging yellow */
+.env-badge.env-local::before { background: repeating-linear-gradient(135deg, var(--tan, #c2925a) 0 4px, #14181d 4px 8px); }
 @media (prefers-reduced-motion: no-preference) {
   .login-box { animation: plateIn .5s cubic-bezier(.2, .7, .2, 1) both; }
   @keyframes plateIn { from { opacity: 0; transform: translateY(11px) scale(.985); } to { opacity: 1; transform: none; } }


### PR DESCRIPTION
## What & why
Three login-area follow-ups from the mute-button session.

### 1. STAGING / LOCAL badge
A hazard-caution stamp (Saira Condensed, hi-vis chip) fixed **bottom-left**, shown **only on non-production builds** — the staging mirror (`operations-jacrentals.github.io`) and localhost serve the *same files* as production, so this is the reliable "which app am I testing?" signal. Keyed on `location.hostname` (same signal `swInit` already uses). `pointer-events:none` (never blocks); **no-op on `app.jacrentals.com`**. Localhost shows `LOCAL` in leather-tan; staging shows `STAGING` in caution-yellow.

### 2. Backend warm-up (the faster-login win we deferred)
Fires a **credential-less `no-cors` GET** at the Apps Script backend while the login screen is up, so the container is warm (GAS cold-starts ~1–5s) by the time `load` runs after Saddle Up. The response is **opaque and unused** (the frontend can't read it → no data exposure) and **no password is sent**. Fire-and-forget, only in the no-cached-password (login-showing) branch of `boot()`.

### 3. Show-password toggle + copy
An eye toggle inside the Team password field (reuses `I.eye`/`I.eyeOff`; icon-only utility toggle like `.set-reveal`, so no `data-r`, tooltip via `data-tip`, visible focus ring). Dropped the tentative `?` from **"Saddle Up"**.

## Design
Through the `jactec-ui` yard data-plate language — hazard-stripe as the one bold beat on the badge, tokens (`--yellow`/`--tan`) themed, `data-tip` over native `title`, focus-visible on the eye.

## Testing
- Local gates green: `gen-icons --check`, `gen-rule-usage --check`, `check-window-catalog`, `gen-code-map --check`, `node --check app.js`.
- Deployed to staging (`20260714a`) and byte-verified serving all three.
- `smoke`/`logic-test` run in CI.

## Security note
The warm-up request is deliberately unauthenticated + opaque + unused so it can't expose PII; it only wakes the container. Reviewed as an auth-adjacent change on the main session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeWVd5z7xENJBtiLLitjUi)_