### PR TITLE
Restore "Saddle Up?" login copy

### DIFF
--- a/app.js
+++ b/app.js
@@ -23121,7 +23121,7 @@ function renderLogin(msg) {
       </div>
       <div class="login-actions">
         <button type="button" class="login-mute${state.loginMuted ? ' is-muted' : ''}" id="login-mute" aria-pressed="${state.loginMuted}" aria-label="Mute intro sound" data-tip="${state.loginMuted ? 'Intro sound off — tap to unmute' : 'Intro sound on — tap to mute'}">${state.loginMuted ? I.volumeOff : I.volume}</button>
-        <button type="submit" class="login-btn" data-r="R17" id="login-go">Saddle Up</button>
+        <button type="submit" class="login-btn" data-r="R17" id="login-go">Saddle Up?</button>
       </div>
       <div class="login-err" id="login-err">${msg ? esc(msg) : ''}</div>
     </div>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260714a" />
+  <link rel="stylesheet" href="style.css?v=20260714b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +47,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260714a"></script>
-  <script type="module" src="app.js?v=20260714a"></script>
+  <script src="rule-usage.js?v=20260714b"></script>
+  <script type="module" src="app.js?v=20260714b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What & why
Revert the login ignition button copy from "Saddle Up" back to **"Saddle Up?"** — Jac prefers the question mark. One-line change in `renderLogin`, plus the shared `?v=` cache-bust token.

## Testing
- Local gates green (`gen-rule-usage --check`, `node --check app.js`).
- Deployed to staging (`20260714b`) and byte-verified serving "Saddle Up?".

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeWVd5z7xENJBtiLLitjUi)_