### PR TITLE
Cache-bust: ?v=20260714e — restage full trunk for promote gate

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260714d" />
+  <link rel="stylesheet" href="style.css?v=20260714e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +47,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260714d"></script>
-  <script type="module" src="app.js?v=20260714d"></script>
+  <script src="rule-usage.js?v=20260714e"></script>
+  <script type="module" src="app.js?v=20260714e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Bumps the shared `?v=` to `20260714e` so staging and `trunk` match, clearing `promote.mjs`'s staging-freshness gate.

The full current trunk (Comms/Twilio go-live + login work + the membership-billing flag) was deployed to staging at `?v=20260714e` and verified live for a combined pre-promote review. This trivial token bump lands the same marker on `trunk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U637koTTc9nNsKfQKwz8x

---
_Generated by [Claude Code](https://claude.ai/code/session_013U637koTTc9nNsKfQKwz8x)_