### PR TITLE
Wrangler fix: Work Order card scrolls — bottom line items & buttons reachable

### DIFF
--- a/app.js
+++ b/app.js
@@ -7511,7 +7511,7 @@ function workOrdersSection(u) {
     : '<div class="inv-empty muted">No open work orders.</div>';
   return `<div class="section wo-sec"><h4>Work Orders${wos.length ? ` <span class="hmuted">· ${wos.length}</span>` : ''}</h4>`
     + `<div class="add-row wo-add">${addBtn('Work Order', { js: 'js-new-wo-unit', link: true, data: { rec: u.unitId } })}</div>`
-    + `<div class="inv-scroll wo-scroll">${rows}</div>`
+    + `<div class="inv-scroll wo-scroll${openId ? ' expanded' : ''}">${rows}</div>`
     + `</div>`;
 }
 /* Per-unit SERVICES section (Shop retirement, Jac 2026-07-07): the recurring


### PR DESCRIPTION
## Report
In-app Mr. Wrangler report #623: opening a Work Order and adding enough part/task line items pushes the newest line items and the bottom action buttons (Invoice / Cancel WO / Complete WO) off the bottom of the card with no way to scroll to them.

## Root cause (proven)
`workOrdersSection()` in `app.js` is documented as *"mirrors the customer Invoices section"* but omitted the `.expanded` class that the Invoices section applies when an accordion row is open:

- Invoices (correct): `` `<div class="inv-scroll${openId ? ' expanded' : ''}">` `` — app.js:4505
- Work Orders (bug): `` `<div class="inv-scroll wo-scroll">` `` — app.js:7514

Per Jac's own CSS comment (style.css:3802-3804), `.inv-scroll` caps at `max-height:340px; overflow:auto`, and `.inv-scroll.expanded` sets `max-height:none; overflow:visible` *"so the whole invoice shows in normal flow and pushes the sections below down."* Without `.expanded`, an expanded WO stayed trapped in the 340px box; with several line items the bottom items + foot buttons were clipped below the box and — because the flex container compressed (scrollHeight==clientHeight)—there was no scrollbar to reach them.

## Fix
Mirror the sibling exactly — add `${openId ? ' expanded' : ''}` to the WO section's `inv-scroll`. Minimal, one-token change; matches the established design pattern. No `data-r` stamps, popups, or money/auth logic touched.

## Verification
Reproduced in a real browser (Playwright, 1920×953, `#local`, WO with 7 line items):
- **Before:** Complete WO button laid out below the 340px clip (footBottom 892 vs clipBottom 798), no inner scrollbar → unreachable, overlapping the Specs section.
- **After:** `.inv-scroll.expanded` → `max-height:none`, container grows to 446px, all 7 line items + totals + Invoice/Cancel WO/Complete WO buttons in normal flow, outer column scrolls to reach them.

Gates: `node ci/smoke.mjs` ✅ · `node ci/logic-test.mjs` 669/669 ✅ · `node ci/gen-rule-usage.mjs --check` ✅ (rule usage unchanged).

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)