### PR TITLE
Cache-bust: bump ?v= to 20260714g (release notification-bell open-any-chat fix)

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260714f" />
+  <link rel="stylesheet" href="style.css?v=20260714g" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +47,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260714f"></script>
-  <script type="module" src="app.js?v=20260714f"></script>
+  <script src="rule-usage.js?v=20260714g"></script>
+  <script type="module" src="app.js?v=20260714g"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Release cache-bust for the notification-bell "open any chat" fix (merged in #626 without a token bump).

`tools/deploy-staging.mjs` bumped the shared `style.css` / `rule-usage.js` / `app.js` `?v=` token **f → g** in `index.html` and pushed the current site (including the merged fix) to staging — live staging now serves `?v=20260714g` (app.js → HTTP 200, verified). Landing the same bump on `trunk` so:
- `promote.mjs`'s staging==trunk freshness gate passes, and
- users' browsers actually reload the new `app.js` instead of the cached `f` bytes.

Only `index.html` changes (the three shared tokens). No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013PGNLh6bgqiGieHSpKShgM)_