### PR TITLE
Cache-bust: bump shared ?v= to 20260714g for the production promote

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260714f" />
+  <link rel="stylesheet" href="style.css?v=20260714g" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +47,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260714f"></script>
-  <script type="module" src="app.js?v=20260714f"></script>
+  <script src="rule-usage.js?v=20260714g"></script>
+  <script type="module" src="app.js?v=20260714g"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Why

Trunk carries **#626** ("Wrangler fix: open any Mr. Wrangler notification's chat in-app (bell)") which changed `app.js` **without bumping the shared `?v=` token**. Production currently serves `?v=20260714f`; promoting trunk as-is would ship the new `app.js` under that same token, so every already-loaded client would keep the **stale cached JS** and never load #626's fix (Pages serves `max-age=600`, no per-file hashing).

## Change

- `index.html` only: bump the shared `?v=` token `20260714f → 20260714g` on `style.css` / `rule-usage.js` / `app.js` (not the ES-module import specifiers).

Staging already serves `?v=20260714g`, so this brings trunk in line and lets the promote's staging-freshness gate pass. This is the Deploy-step cache-bust that #626 skipped when it merged straight to trunk.

## Next

Merge → promote trunk to production so #626 (+ the Phase C composer #625 and the v100 deploy-queue doc #627) go live cache-correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ)_