### PR TITLE
docs(comms): queue backend v101 — Twilio inbound webhook + activation runbooks

### DIFF
--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -1,16 +1,50 @@
 # Backend deploy queue — DEPLOYED (2026-07-06 late session); doc kept as the deploy runbook
 
-## ⏳ PUSHED + VERSIONED — AWAITING JAC'S EDITOR DEPLOY (2026-07-14) — comms Phase C dedup
-- **Backend v100 — content-aware dedup for the crew broadcast.** `sendStaffMessage_`'s dedup key
-  for a MANUAL broadcast (`isFree`) now folds a short MD5 content hash of the message into
-  `staff|broadcast|<rosterId>|<day>|<hash>`. Effect: two DIFFERENT broadcasts to the same hand in
-  one day both send (the old by-day key silently swallowed the second); an identical double-tap /
-  retry is still deduped. Future job templates (non-free) keep the strict by-day key — one
-  driver-assigned / wo-assigned per hand per day is the intended ceiling there. Additive; `node
-  --check` passes. Pairs with the LIVE frontend composer (#625, promoted to production 2026-07-14).
-- **ACTIVATION (Jac, editor):** point the live deployment (`…trNlObZw`) at **v100**. No dry-run
-  needed — it only changes a dedup key; the roster is empty, so no crew text fires regardless.
-  Nothing sends unattended.
+## ⏳ PUSHED + VERSIONED — AWAITING JAC'S EDITOR DEPLOY (2026-07-14) — Twilio inbound webhook (v101)
+- **Backend v101 — Twilio inbound webhook.** Two anonymous handlers on the existing `?wh=` router
+  (mirrors the Stripe hook). `twilioInbound_` — an inbound SMS: matches the sender to a customer OR a
+  roster hand **by normalized phone**, and on a STOP/START keyword flips that party's
+  `commsConsent.sms`; logs every reply (dedup by SID) so it lands in the customer thread + opt-outs are
+  visible. Returns empty TwiML (no auto-reply, no PII). `twilioStatus_` — the delivery-status callback:
+  reconciles the outbound row `sent → delivered/failed` (matched by `providerId` = SID; never downgrades
+  a terminal delivered/failed). Additive; `node --check` passes; red-teamed (2 medium + 3 low findings all
+  fixed: log-with-`consentPending` on lock contention, terminal-status downgrade guard, atomic dedup,
+  phone-based roster re-match, customer-first documented).
+- **🔒 SECURITY — set `TWILIO_WH_KEY` BEFORE wiring (required here, unlike Stripe).** GAS can't read the
+  `X-Twilio-Signature` header, so auth is a URL token. Stripe defaults open because it re-fetches state;
+  this hook ACTS on the payload (flips consent), so gate it:
+  1. Pick a long random secret → set Script Property **`TWILIO_WH_KEY`** (via `adminSetProps` or the editor; never commit it).
+  2. Deploy: point the live deployment (`…trNlObZw`) at **v101** (anon access must stay intact — verify `smsProviderStatus` still returns JSON after).
+  3. Twilio Console → the number's **"A MESSAGE COMES IN"** (HTTP POST) →
+     `…/exec?wh=twilioIn&whk=<TWILIO_WH_KEY>` ; and the **statusCallback** →
+     `…/exec?wh=twilioStatus&whk=<TWILIO_WH_KEY>`.
+  4. Test: text **STOP** from a number matching a test customer → confirm `commsConsent.sms` flips to
+     `opted-out` (a later send returns `opted-out`); **START** flips it back; send one message + confirm
+     its row reaches `delivered`.
+
+## ✅ DEPLOYED 2026-07-14 — comms Phase C dedup (v100, Jac deployed) + full notification test
+- **Backend v100 — content-aware dedup for the crew broadcast.** `sendStaffMessage_`'s dedup key for a
+  MANUAL broadcast (`isFree`) folds a short MD5 content hash into `staff|broadcast|<rosterId>|<day>|<hash>`
+  — two DIFFERENT broadcasts to a hand in one day both send; identical double-taps still dedup. Deployed +
+  verified live (anon access intact).
+- **End-to-end notification test (2026-07-14, to the Jacob Cameron / C0991 test record):** all four SMS
+  templates (quote $653.43, reminder-start, reminder-return, reminder-balance $631.28) **delivered to the
+  handset**; all four **email** siblings sent from operations@; the **crew broadcast** fired to a temp
+  roster hand (roster restored clean after). Every channel is proven end-to-end.
+
+### 🔲 Phase B auto-sweep activation (customer reminders) — Jac's supervised call
+Engine LIVE (v99); send path proven. Fires nothing until BOTH toggles on AND the cron installed:
+1. **Enable** the reminder(s) in **Settings → Notifications** → Save (enabling alone sends nothing).
+2. **Preview** — `runReminderSweepNow {dryRun:true}` → review who'd get texted today (masked + consent).
+3. **Live one-off** — `runReminderSweepNow {dryRun:false}` on a quiet day (only today's window matches).
+4. **Install cron** — run `installReminderSweepTrigger()` **from the editor** (creates the daily trigger,
+   auto-timed inside the customer window). Editor-only — not reachable via the web app.
+
+### 🔲 Company phone + "Office+ can adjust notifications" — Jac's call
+- Texts read "Call us." with no number until the yard phone is set in **Settings → Company**.
+- "Office+ adjusts notifications" needs an auth change: the pane is Admin-only today, and a naive loosening
+  of `setConfig` (a full-config replace carrying role + admin passwords) would expose credentials to Office
+  staff. Needs a notification-settings-only, Office-gated save path — a short spec before building.
 
 ## ✅ DEPLOYED 2026-07-14 — comms Phase B + C-core (v99, Jac deployed)
 - **Backend v98 — Phase B: customer reminder sweep.** `runReminderSweep_` (start/return/balance;

--- a/docs/handoffs/twilio-inbound-webhook.gs
+++ b/docs/handoffs/twilio-inbound-webhook.gs
@@ -1,0 +1,103 @@
+/* Twilio inbound webhook — v101 snapshot (2026-07-14). PUSHED to HEAD + versioned as v101,
+ * awaiting Jac's editor deploy + Twilio-side URL wiring + the TWILIO_WH_KEY Script Property.
+ * See docs/handoffs/BACKEND-DEPLOY-QUEUE.md for the wiring runbook + security note.
+ *
+ * The live Code.gs is gitignored; this is the reviewable copy of exactly what's on v101.
+ * Two anonymous handlers hang off the existing `?wh=` router in handle() (mirrors stripeWebhook_):
+ *
+ *   // in handle(e), right after the stripe branch, BEFORE the try{} (so a throw would 500, not be swallowed):
+ *   if (e && e.parameter && e.parameter.wh === 'twilioIn') return twilioInbound_(e);
+ *   if (e && e.parameter && e.parameter.wh === 'twilioStatus') return twilioStatus_(e);
+ *
+ * SECURITY: GAS doPost can't read the X-Twilio-Signature header, so authenticity rides on a URL
+ * token (whk) matched against Script Property TWILIO_WH_KEY — the same pattern stripeWebhook_ uses.
+ * Unlike Stripe (which re-fetches authoritative state), this hook ACTS on the payload (flips consent),
+ * so TWILIO_WH_KEY is REQUIRED, not optional. Red-teamed; findings fixed inline (see comments).
+ */
+
+function twilioXml_(s) { return ContentService.createTextOutput(s).setMimeType(ContentService.MimeType.XML); }
+var TWIML_EMPTY = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>';
+
+function twilioInbound_(e) {
+  try {
+    var whKey = PropertiesService.getScriptProperties().getProperty('TWILIO_WH_KEY');
+    if (whKey && (!e || !e.parameter || e.parameter.whk !== whKey)) return twilioXml_(TWIML_EMPTY);   // drop unauthenticated POSTs before any scan/write
+    var p = (e && e.parameter) || {};
+    var from = smsNormalizePhone_(p.From || '');
+    var body = String(p.Body || '').trim();
+    var sid = String(p.MessageSid || p.SmsSid || '');
+    if (!from) return twilioXml_(TWIML_EMPTY);
+    var kw = body.toUpperCase().replace(/[^A-Z]/g, '');
+    var STOPW = { STOP: 1, STOPALL: 1, UNSUBSCRIBE: 1, CANCEL: 1, END: 1, QUIT: 1 };
+    var STARTW = { START: 1, YES: 1, UNSTOP: 1 };
+    var wish = STOPW[kw] ? 'opted-out' : STARTW[kw] ? 'opted-in' : '';   // '' = a normal reply, no consent change
+    // Match the sender to a customer OR (else) a roster hand — by normalized PHONE (the reliable key,
+    // robust to id-less / duplicate-name roster rows). Customer-first is deliberate: if a number is BOTH
+    // a customer and a crew member, a STOP opts them out of the customer (marketing-basis) channel; a
+    // crew member's operational-alert consent is a separate basis, edited on the roster, not by STOP.
+    var matchedCustId = '', rosterMatched = false, matchedRosterId = '';
+    var cs = ss().getSheetByName('customers');
+    if (cs && cs.getLastRow() >= 2) {
+      var cv = cs.getRange(2, 2, cs.getLastRow() - 1, 1).getValues();
+      for (var i = 0; i < cv.length; i++) { var c = null; try { c = JSON.parse(cv[i][0]); } catch (e2) { continue; }
+        if (c && c.customerId && smsNormalizePhone_(c.phone) === from) { matchedCustId = String(c.customerId); break; } }
+    }
+    if (!matchedCustId) {
+      var emps0 = ((getConfigObj().settings || {}).employees) || [];
+      for (var j = 0; j < emps0.length; j++) { if (smsNormalizePhone_(emps0[j].phone) === from) { rosterMatched = true; matchedRosterId = String(emps0[j].id || emps0[j].name || ''); break; } }
+    }
+    // Consent (STOP/START only) + the inbound log go under ONE lock. Twilio does NOT retry inbound
+    // webhooks, so on lock contention we DON'T 500 (that would just error, not retry) — we still log
+    // the reply and stamp `consentPending` so a missed opt-out/in is visible for admin reconciliation
+    // (STOP is enforced at the carrier by Twilio Advanced Opt-Out regardless).
+    var lock = tryLock_(15000);
+    var consentApplied = !(wish && (matchedCustId || rosterMatched));   // nothing to apply → already "applied"
+    try {
+      if (!consentApplied && lock) {
+        if (matchedCustId) { var c2 = readRecord_('customers', matchedCustId); if (c2) { c2.commsConsent = c2.commsConsent || {}; if (c2.commsConsent.sms !== wish) { c2.commsConsent.sms = wish; writeRecord_('customers', c2); } } consentApplied = true; }
+        else { var cfg = getConfigObj(); var emps = (cfg.settings && cfg.settings.employees) || [], ch = false;   // re-match by PHONE under the lock (not a non-unique id||name string)
+          for (var m = 0; m < emps.length; m++) { if (smsNormalizePhone_(emps[m].phone) === from) { emps[m].commsConsent = emps[m].commsConsent || {}; if (emps[m].commsConsent.sms !== wish) { emps[m].commsConsent.sms = wish; ch = true; } break; } }
+          if (ch) saveConfigObj(cfg); consentApplied = true; }
+      }
+      // Log the inbound (dedup by provider sid so a Twilio re-post can't double-log). Roster replies ride
+      // audience:'staff' so messagesFor_ never leaks them into a customer projection.
+      var sh = messagesSheet_(), dup = false;
+      if (sid && sh.getLastRow()) { var rows = sh.getRange(1, 1, sh.getLastRow(), 2).getValues(); for (var k = 0; k < rows.length; k++) { try { if (JSON.parse(rows[k][1]).providerId === sid) { dup = true; break; } } catch (e3) {} } }
+      if (!dup) {
+        var msgId = 'MSG-' + Utilities.getUuid().slice(0, 8);
+        var rowObj = { msgId: msgId, channel: 'sms', provider: 'twilio', direction: 'inbound', audience: rosterMatched ? 'staff' : 'customer', from: from, body: body.slice(0, 600), providerId: sid, keyword: wish, status: 'received', when: new Date().toISOString() };
+        if (matchedCustId) rowObj.customerId = matchedCustId;
+        if (rosterMatched && matchedRosterId) rowObj.rosterId = matchedRosterId;
+        if (!consentApplied) rowObj.consentPending = wish;   // lock was busy — a STOP/START to reconcile by hand
+        sh.appendRow([msgId, JSON.stringify(rowObj)]);
+      }
+    } finally { if (lock) lock.releaseLock(); }
+  } catch (err) { try { console.error('twilioInbound_ ' + (err && err.stack ? err.stack : err)); } catch (e4) {} }
+  return twilioXml_(TWIML_EMPTY);
+}
+
+/* Twilio delivery status callback — reconcile the outbound message row (sent→delivered/failed).
+ * Configure as the statusCallback  …/exec?wh=twilioStatus&whk=<TWILIO_WH_KEY> . Same URL-token
+ * gate. Matches by providerId === MessageSid; never downgrades a terminal delivered/failed to sent. */
+function twilioStatus_(e) {
+  try {
+    var whKey = PropertiesService.getScriptProperties().getProperty('TWILIO_WH_KEY');
+    if (whKey && (!e || !e.parameter || e.parameter.whk !== whKey)) return ContentService.createTextOutput('ok');
+    var p = (e && e.parameter) || {};
+    var sid = String(p.MessageSid || p.SmsSid || ''), st = String(p.MessageStatus || p.SmsStatus || '').toLowerCase();
+    if (!sid || !st) return ContentService.createTextOutput('ok');
+    var MAP = { delivered: 'delivered', undelivered: 'failed', failed: 'failed', sent: 'sent' };
+    var next = MAP[st]; if (!next) return ContentService.createTextOutput('ok');   // ignore queued/sending/accepted
+    var lock = tryLock_(15000);
+    if (lock) { try {
+      var sh = messagesSheet_(), last = sh.getLastRow(); if (!last) return ContentService.createTextOutput('ok');
+      var rows = sh.getRange(1, 1, last, 2).getValues();
+      for (var i = rows.length - 1; i >= 0; i--) { var r = null; try { r = JSON.parse(rows[i][1]); } catch (e2) { continue; }
+        if (r && r.providerId === sid && r.direction === 'outbound') {
+          if ((r.status === 'delivered' || r.status === 'failed') && next === 'sent') break;   // callbacks are unordered — a late 'sent' must not clobber a terminal delivered/failed
+          r.status = next; sh.getRange(i + 1, 2).setValue(JSON.stringify(r)); break;
+        } }
+    } finally { lock.releaseLock(); } }
+  } catch (err) { try { console.error('twilioStatus_ ' + (err && err.stack ? err.stack : err)); } catch (e3) {} }
+  return ContentService.createTextOutput('ok');
+}


### PR DESCRIPTION
## What

Docs-only. Records **backend v101** (Twilio inbound webhook) — pushed to HEAD + versioned, awaiting your editor deploy + Twilio wiring — and captures the rest of today's comms work as runbooks.

## v101 — Twilio inbound webhook (built while you were out, red-teamed)

Two anonymous handlers on the existing `?wh=` router (mirrors the Stripe hook):
- **`twilioInbound_`** — inbound SMS: matches the sender to a customer or roster hand **by normalized phone**, flips `commsConsent.sms` on STOP/START, logs every reply (dedup by SID) so it lands in the customer thread. Empty TwiML, no PII.
- **`twilioStatus_`** — delivery-status callback: reconciles the outbound row `sent → delivered/failed`.

**Security:** GAS can't read `X-Twilio-Signature`, so auth is a URL token (`whk` vs Script Property `TWILIO_WH_KEY`) — the Stripe precedent. Unlike Stripe it acts on the payload, so `TWILIO_WH_KEY` is **required**, not optional.

**Red-team pass:** an independent adversarial review found 2 medium + 3 low issues; all fixed inline — log-with-`consentPending` on lock contention (Twilio doesn't retry inbound, so no futile 500), a terminal delivered/failed downgrade guard, atomic dedup, phone-based roster re-match (not a non-unique id/name), and the customer-first overlap documented. No auth bypass, no PII/isolation leak, no router break.

## This PR changes (docs only — no served code)

- `docs/handoffs/BACKEND-DEPLOY-QUEUE.md` — v101 entry + wiring/security runbook + STOP/START test; v100 moved to DEPLOYED; the full end-to-end notification test record; the Phase B auto-sweep checklist; company-phone + Office+ notes.
- `docs/handoffs/twilio-inbound-webhook.gs` — a reviewable snapshot of the exact v101 code (the live `Code.gs` is gitignored).

## Your move (in the runbook)

1. Set `TWILIO_WH_KEY`, deploy v101 in the editor, wire the two Twilio Console URLs, test STOP/START.
2. Phase B auto-sweep: enable toggles → dry-run → live one-off → `installReminderSweepTrigger()` (editor).
3. Company phone (Settings → Company); the Office+ auth change (needs a short spec first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ)_