### PR TITLE
docs(comms): v101 webhook deployed+wired; park v102 (opt-out + delivery) as HELD

### DIFF
--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -1,26 +1,33 @@
 # Backend deploy queue — DEPLOYED (2026-07-06 late session); doc kept as the deploy runbook
 
-## ⏳ PUSHED + VERSIONED — AWAITING JAC'S EDITOR DEPLOY (2026-07-14) — Twilio inbound webhook (v101)
-- **Backend v101 — Twilio inbound webhook.** Two anonymous handlers on the existing `?wh=` router
-  (mirrors the Stripe hook). `twilioInbound_` — an inbound SMS: matches the sender to a customer OR a
-  roster hand **by normalized phone**, and on a STOP/START keyword flips that party's
-  `commsConsent.sms`; logs every reply (dedup by SID) so it lands in the customer thread + opt-outs are
-  visible. Returns empty TwiML (no auto-reply, no PII). `twilioStatus_` — the delivery-status callback:
-  reconciles the outbound row `sent → delivered/failed` (matched by `providerId` = SID; never downgrades
-  a terminal delivered/failed). Additive; `node --check` passes; red-teamed (2 medium + 3 low findings all
-  fixed: log-with-`consentPending` on lock contention, terminal-status downgrade guard, atomic dedup,
-  phone-based roster re-match, customer-first documented).
-- **🔒 SECURITY — set `TWILIO_WH_KEY` BEFORE wiring (required here, unlike Stripe).** GAS can't read the
-  `X-Twilio-Signature` header, so auth is a URL token. Stripe defaults open because it re-fetches state;
-  this hook ACTS on the payload (flips consent), so gate it:
-  1. Pick a long random secret → set Script Property **`TWILIO_WH_KEY`** (via `adminSetProps` or the editor; never commit it).
-  2. Deploy: point the live deployment (`…trNlObZw`) at **v101** (anon access must stay intact — verify `smsProviderStatus` still returns JSON after).
-  3. Twilio Console → the number's **"A MESSAGE COMES IN"** (HTTP POST) →
-     `…/exec?wh=twilioIn&whk=<TWILIO_WH_KEY>` ; and the **statusCallback** →
-     `…/exec?wh=twilioStatus&whk=<TWILIO_WH_KEY>`.
-  4. Test: text **STOP** from a number matching a test customer → confirm `commsConsent.sms` flips to
-     `opted-out` (a later send returns `opted-out`); **START** flips it back; send one message + confirm
-     its row reaches `delivered`.
+## 🅗 BUILT + HELD (2026-07-14) — comms v102 (opt-out sync + delivery receipts)
+- **Backend v102 — NOT pushed, NOT versioned.** Two additive comms enhancements: `syncCarrierOptOut_`
+  (on Twilio error **21610** → flip `commsConsent.sms` to opted-out, so records reflect carrier-level STOPs
+  the webhook never sees) + `twilioSmsPayload_` (attach a per-message `StatusCallback` so delivery receipts
+  reach `twilioStatus_`). Code parked verbatim in `docs/handoffs/comms-v102-optout-delivery.gs`.
+- **WHY HELD:** the shared `Code.gs` HEAD has **DIVERGED** — a concurrent session pushed a large
+  phone-identity auth feature (spec `2026-07-13-text-link-identity`: authStart/authVerify/session tokens,
+  `pidRole_`/`pidAdmin_` gates, `pidReconcileRoster_`). GAS versions snapshot the WHOLE HEAD, so versioning
+  v102 now would bundle these comms changes with that in-progress, unreviewed auth work into one deployable
+  version. Held to avoid shipping someone else's half-built auth in a "comms" version.
+- **UN-HOLD when** the phone-identity feature is versioned + deployed (i.e. the live baseline): pull HEAD
+  fresh, splice the two helpers + the 4 one-line hooks (per the `.gs`), `node --check`, push → version →
+  editor-deploy → anon-access check.
+
+## ✅ DEPLOYED + WIRED 2026-07-14 — Twilio inbound webhook (v101, Jac deployed)
+- **v101 live + verified.** `twilioInbound_` (reply capture + STOP/START sync, URL-token gated via
+  `TWILIO_WH_KEY`) + `twilioStatus_` (delivery reconcile). Red-teamed (2 med + 3 low fixed). Anon access
+  confirmed intact after deploy (`smsProviderStatus` → JSON).
+- **Wiring (done):** `TWILIO_WH_KEY` set as a Script Property. The number is a **Sender in a Messaging
+  Service**, so the inbound webhook lives on the SERVICE → Integration → Incoming Messages → **"Send a
+  webhook"** = `…/exec?wh=twilioIn&whk=<key>` (NOT the number's "A message comes in" field). Verified live:
+  a non-keyword reply ("Testing") logged an inbound row against C0991. ✅
+- **STOP/START = Advanced Opt-Out (carrier).** Twilio's OPT-OUT tab consumes STOP/START/HELP and does NOT
+  forward them to the webhook (confirmed: STOP → Twilio's canned "unsubscribed" reply, no inbound row). So
+  the webhook's keyword-sync branch won't fire for them — expected + compliant (the number is blocked at the
+  carrier). Our records will reflect these opt-outs via the **v102 21610 sync (held, above)**.
+- **Delivery receipts: not live yet** — we send `From:<number>` directly (bypassing the Messaging Service),
+  so no Twilio-side callback config applies; needs the **v102 `StatusCallback` payload (held, above)**.
 
 ## ✅ DEPLOYED 2026-07-14 — comms Phase C dedup (v100, Jac deployed) + full notification test
 - **Backend v100 — content-aware dedup for the crew broadcast.** `sendStaffMessage_`'s dedup key for a

--- a/docs/handoffs/comms-v102-optout-delivery.gs
+++ b/docs/handoffs/comms-v102-optout-delivery.gs
@@ -1,0 +1,70 @@
+/* comms v102 — BUILT + HELD (2026-07-14). NOT pushed to HEAD, NOT versioned.
+ *
+ * WHY HELD: a concurrent session pushed a large phone-identity auth feature
+ * (spec 2026-07-13-text-link-identity: authStart/authVerify/session tokens, pidRole_/pidAdmin_
+ * gates, pidReconcileRoster_) onto the shared Code.gs HEAD. GAS versions snapshot the WHOLE
+ * HEAD, so versioning these comms changes now would bundle them with that in-progress auth
+ * work into one deployable version. Rather than ship someone else's half-built auth in a "comms"
+ * version, this is parked here verbatim.
+ *
+ * UN-HOLD when the phone-identity feature is versioned + DEPLOYED (i.e., it's the live baseline):
+ *   1) pull live HEAD fresh, 2) splice the two helpers below + the 4 one-line hooks, 3) node --check,
+ *   4) push HEAD → versions.create → Jac editor-deploy. (Anon-access check after, as always.)
+ *
+ * WHAT IT DOES (two comms enhancements, both additive):
+ *   (a) Carrier opt-out sync — Twilio Advanced Opt-Out owns STOP/START, so our inbound webhook
+ *       never sees them. When a send fails with Twilio error 21610 ("unsubscribed recipient"),
+ *       flip that party's commsConsent.sms → 'opted-out' so our records reflect reality.
+ *   (b) Delivery receipts — we send From:<number> directly (bypassing the Messaging Service, whose
+ *       callback config therefore doesn't apply), so attach a per-message StatusCallback pointing
+ *       at twilioStatus_ (needs the v101 webhook, already live) so rows move sent→delivered/failed.
+ */
+
+// ── (1) HELPERS — paste both just ABOVE `function sendCustomerMessage_(` ──────────────
+
+// Twilio error 21610 = "Attempt to send to unsubscribed recipient": the party STOP'd at the
+// carrier (Advanced Opt-Out owns STOP/START, so our inbound webhook never sees it). Sync our OWN
+// consent record from the send-failure so the UI/records reflect the opt-out. Idempotent; own lock.
+function syncCarrierOptOut_(kind, id) {
+  try {
+    var lk = tryLock_(10000); if (!lk) return;
+    try {
+      if (kind === 'customer') {
+        var c = readRecord_('customers', id);
+        if (c) { c.commsConsent = c.commsConsent || {}; if (c.commsConsent.sms !== 'opted-out') { c.commsConsent.sms = 'opted-out'; writeRecord_('customers', c); } }
+      } else {   // roster hand — match by stable ref (id||name) in settings.employees
+        var cfg = getConfigObj(); var emps = (cfg.settings && cfg.settings.employees) || [], ch = false;
+        for (var i = 0; i < emps.length; i++) { if (String(emps[i].id || emps[i].name || '') === String(id)) { emps[i].commsConsent = emps[i].commsConsent || {}; if (emps[i].commsConsent.sms !== 'opted-out') { emps[i].commsConsent.sms = 'opted-out'; ch = true; } break; } }
+        if (ch) saveConfigObj(cfg);
+      }
+    } finally { lk.releaseLock(); }
+  } catch (e) { try { console.error('syncCarrierOptOut_ ' + e); } catch (e2) {} }
+}
+
+// Build the Twilio SMS payload + attach a StatusCallback so Twilio POSTs delivery status back to
+// twilioStatus_ (we send From:<number> directly, bypassing the Messaging Service, so its callback
+// config doesn't apply — the per-message StatusCallback is the reliable path). URL derived from the
+// running web-app deployment + the TWILIO_WH_KEY gate; omitted if the URL can't be resolved.
+function twilioSmsPayload_(from, to, text) {
+  var p = { From: from, To: '+' + to, Body: text };
+  try {
+    var k = PropertiesService.getScriptProperties().getProperty('TWILIO_WH_KEY') || '';
+    var url = ScriptApp.getService().getUrl();
+    if (url) p.StatusCallback = url + '?wh=twilioStatus' + (k ? '&whk=' + encodeURIComponent(k) : '');
+  } catch (e) {}
+  return p;
+}
+
+// ── (2) FOUR ONE-LINE HOOKS — in the Twilio branch of BOTH send functions ─────────────
+//
+// sendCustomerMessage_  (twilio branch):
+//   payload line:  payload: { From: twFrom, To: '+' + to, Body: text },
+//        becomes:  payload: twilioSmsPayload_(twFrom, to, text),
+//   error else:    else providerErr = String(tout.message || tout.error_message || tres.getResponseCode()).slice(0, 80);
+//        becomes:  else { providerErr = String(tout.message || tout.error_message || tres.getResponseCode()).slice(0, 80); if (Number(tout.code) === 21610 && custId) syncCarrierOptOut_('customer', custId); }
+//
+// sendStaffMessage_  (twilio branch — identical lines, different scope var `rid`):
+//   payload line:  payload: { From: twFrom, To: '+' + to, Body: text },
+//        becomes:  payload: twilioSmsPayload_(twFrom, to, text),
+//   error else:    else providerErr = String(tout.message || tout.error_message || tres.getResponseCode()).slice(0, 80);
+//        becomes:  else { providerErr = String(tout.message || tout.error_message || tres.getResponseCode()).slice(0, 80); if (Number(tout.code) === 21610 && rid) syncCarrierOptOut_('roster', rid); }


### PR DESCRIPTION
## What

Docs-only. Records that the **v101 inbound webhook is live + wired + verified**, and parks the **v102** comms enhancements (which are built) as **HELD** with their code preserved, because the shared backend HEAD diverged.

## v101 — deployed, wired, verified ✅
- Deployed by Jac; anon access confirmed intact.
- Wiring solved a Messaging-Service gotcha: the number is a **Sender in a Messaging Service**, so the inbound webhook belongs on the **service's** Integration → Incoming Messages → "Send a webhook" (`?wh=twilioIn&whk=<key>`), not the number's field. **Verified live** — a non-keyword reply logged an inbound row against the test customer.
- **STOP/START** are handled by Twilio **Advanced Opt-Out** at the carrier (confirmed: Twilio's canned "unsubscribed" reply, no inbound row). Compliant; the webhook's keyword-sync branch simply doesn't fire for them.

## v102 — BUILT but HELD ⏸
`docs/handoffs/comms-v102-optout-delivery.gs` holds the verbatim code:
- `syncCarrierOptOut_` — on Twilio **error 21610** ("unsubscribed recipient"), flip `commsConsent.sms → opted-out` so our records reflect carrier-level STOPs the webhook never sees.
- `twilioSmsPayload_` — attach a per-message `StatusCallback` so **delivery receipts** reach `twilioStatus_` (we send `From:<number>` directly, so no Twilio-side config applies).

**Why held:** a concurrent session pushed a large phone-identity auth feature onto the shared `Code.gs` HEAD. GAS versions snapshot the whole HEAD, so versioning v102 now would bundle it with that in-progress, unreviewed auth work. Un-hold once the phone-identity feature is versioned + deployed, then splice + push v102 clean (steps in the `.gs`).

## No served-code change
Documentation + a parked backend snapshot only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ)_