### PR TITLE
Cutover: flip FEATURES.phoneIdentity ON — per-person login goes live

### DIFF
--- a/config.js
+++ b/config.js
@@ -624,7 +624,7 @@ export const FEATURES = {
   // verify → personal device trusted 30d / shared device takes a PIN each session);
   // OFF = today's shared team-password login. The BACKEND enforces the real auth
   // independently — this flag only switches the login EXPERIENCE, never the gate.
-  phoneIdentity: false,
+  phoneIdentity: true,
 };
 
 /* Phone-identity client constants (non-secret — display/UX only; the backend owns the

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260715a" />
+  <link rel="stylesheet" href="style.css?v=20260715b" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +47,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260715a"></script>
-  <script type="module" src="app.js?v=20260715a"></script>
+  <script src="rule-usage.js?v=20260715b"></script>
+  <script type="module" src="app.js?v=20260715b"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

Flips `FEATURES.phoneIdentity` **false → true** — the cutover from the shared team-password login to **per-person phone-verified device identity** for the whole crew.

The full phone-identity system shipped **dormant** in #632 (merged to trunk, already on production behind the flag). The backend authenticates every call independently and has been deployed + hardened + verified. This PR flips only the client login **experience**; **flag-off remains the instant backout** with no code surgery.

## In this PR
- `config.js` — `FEATURES.phoneIdentity: false → true`
- `index.html` — cache-bust the shared `?v=` token `20260715a → 20260715b` on `style.css`, `rule-usage.js`, `app.js` so the cutover build loads immediately (Pages `max-age=600`, no per-file hashing)

## Verified
- All local gates green: `smoke`, `logic-test`, `gen-rule-usage --check`, `check-window-catalog`, `gen-code-map --check`
- Per-person flow driven end-to-end on staging at this build (`?v=20260715b`): personal 30-day login + code→verify, Developer-tier admin access after the roster role-picker fix
- Backend already live: shared-password path intact (backout safety), `sessionToken` authz, `auth*` POST-only, anon access healthy

## Rollout after promote
Fire **"Text everyone a setup code"** (Settings → Team Roster) so the crew enrolls; self-serve "Need a code?" is the on-ramp for anyone who misses the blast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pFg5MbQzqc8ycNtxX2odE

---
_Generated by [Claude Code](https://claude.ai/code/session_019pFg5MbQzqc8ycNtxX2odE)_