### PR TITLE
Auto-fix → live: promote merged Wrangler fixes to production (off by default)

### DIFF
--- a/.github/workflows/auto-promote.yml
+++ b/.github/workflows/auto-promote.yml
@@ -1,0 +1,88 @@
+name: Auto-promote — take a merged Wrangler auto-fix live
+
+# ── Mr. Wrangler's go-live step ───────────────────────────────────────────────
+# When an auto-fix PR (opened by the wrangler-fix engine and carrying the
+# `auto-promote` label) squash-merges to `trunk`, this promotes that exact commit
+# to `production` so the fix reaches app.jacrentals.com in real time — with NO
+# human in the loop. It runs the same tools/promote.mjs a human runs for Gate 2.
+#
+# WHY THIS EXISTS
+# Under the trunk model, Pages serves `production`, so merging to `trunk` is NOT
+# live on its own. The wrangler-fix engine merges the fix to trunk but stops
+# there — this closes the last mile so an end-user's reported fix actually goes
+# live without them (or Jac) touching the deploy machinery.
+#
+# ONLY auto-fixes auto-promote. A human's merge to `trunk` carries no
+# `auto-promote` label, so it still waits for the human `/promote` (Gate 2) —
+# your two-gate control is untouched for everything except Wrangler auto-fixes.
+#
+# HOW IT STAYS SAFE (fully machine-gated — no human review, but every gate must pass):
+#   1. `smoke` + `logic-test` CI already gated the merge to trunk (a broken fix
+#      never reaches trunk, so it never reaches here).
+#   2. The fix's own branch already deployed to staging (in wrangler-fix.yml), so
+#      promote.mjs's staging-freshness gate passes AND staging stays in sync with
+#      production (no drift for the next human promote).
+#   3. promote.mjs is fast-forward-only (never --force) and verifies the live
+#      `?v=` bytes after pushing. If anything is off it fails — it never forces a
+#      half-broken state onto the live site.
+#   If any gate is red, this job fails and the fix stays at trunk (not live);
+#   surface it to Jac rather than forcing it live.
+#
+# ── OFF BY DEFAULT — this is Jac's one-time switch ────────────────────────────
+# The job no-ops until the repository VARIABLE `WRANGLER_AUTO_PROMOTE` is set to
+# the string 'true' (Settings → Secrets and variables → Actions → Variables tab).
+# Until then a merged auto-fix stops at trunk exactly like today — NOTHING reaches
+# the live customer app before Jac flips that variable. Flip it back to anything
+# else (or delete it) to instantly disable auto-go-live again.
+#
+# Also required (already needed by wrangler-fix.yml, no new secret):
+#   secrets.WRANGLER_PAT — fine-grained PAT, Contents: Read & write on this repo,
+#   so promote.mjs can fast-forward `production`.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  promote:
+    # Gate: a merged auto-fix PR into trunk, and the switch is ON.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'trunk' &&
+      contains(github.event.pull_request.labels.*.name, 'auto-promote') &&
+      vars.WRANGLER_AUTO_PROMOTE == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so promote.mjs can fetch trunk + production and compute
+          # the fast-forward. The PAT (Contents: write) authenticates the push to
+          # `production` that promote.mjs performs via `origin`.
+          fetch-depth: 0
+          token: ${{ secrets.WRANGLER_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Promote the merged auto-fix to production (go live)
+        # promote.mjs: fetch trunk+production, verify staging is fresh, fast-forward
+        # production -> trunk, then verify the live ?v= bytes. --yes runs it for real.
+        run: node tools/promote.mjs --yes
+
+      - name: Tell the reporter it's live
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.WRANGLER_PAT }}
+        run: |
+          # The merged PR body carries "Closes #<n>" pointing at the original report.
+          ISSUE=$(printf '%s' "${{ github.event.pull_request.body }}" | grep -oiE 'closes #[0-9]+' | grep -oE '[0-9]+' | head -1)
+          if [ -n "$ISSUE" ]; then
+            gh issue comment "$ISSUE" --body "✅ Shipped and **live** now — refresh the page to see it. — Mr. Wrangler"
+          else
+            echo "auto-promote: promoted, but found no 'Closes #<n>' in the PR body to comment on."
+          fi

--- a/.github/workflows/wrangler-fix.yml
+++ b/.github/workflows/wrangler-fix.yml
@@ -3,9 +3,12 @@ name: Wrangler Fix — auto-patch a reported glitch
 # ── Mr. Wrangler's Track B engine ─────────────────────────────────────────────
 # When a glitch is filed as an issue labelled "wrangler-fix", a Claude coding
 # agent reproduces it, patches the FRONTEND (app.js / style.css / index.html /
-# config.js), runs the 3 CI gates, opens a PR, and auto-merges it the moment CI
-# is green. Pages then deploys `trunk` to app.jacrentals.com. The one step the
-# browser can't do — rewriting app.js and redeploying — happens here.
+# config.js), runs the 3 CI gates, deploys the fix to the staging site, opens an
+# `auto-promote`-labelled PR to `trunk`, and auto-merges it the moment CI is green.
+# Merging to `trunk` is integrated but NOT live (Pages serves `production`); the
+# sibling workflow auto-promote.yml then fast-forwards `production` so the fix
+# reaches app.jacrentals.com in real time. Rewriting app.js and taking it live —
+# the one thing the browser can't do — happens across these two workflows.
 #
 # ── SWITCH-ON (one-time, in the repo's GitHub settings) ───────────────────────
 #   1. Settings → Secrets and variables → Actions → New repository secret:
@@ -13,6 +16,8 @@ name: Wrangler Fix — auto-patch a reported glitch
 #        WRANGLER_PAT      = <a fine-grained PAT scoped to THIS repo, with:
 #                             Contents: Read & write · Pull requests: Read & write
 #                             · Issues: Read & write · Actions: Read>
+#        STAGING_DEPLOY_PAT = <the same staging-deploy PAT /deploy uses, so the
+#                             agent can publish the fix to the staging site>
 #      Why a PAT and not the built-in GITHUB_TOKEN? A PR opened by GITHUB_TOKEN
 #      does NOT trigger the CI workflow — so it could never go green and could
 #      never auto-merge. The PAT opens the PR as you, so CI runs normally.
@@ -22,10 +27,15 @@ name: Wrangler Fix — auto-patch a reported glitch
 #   3. Settings → Branches → Add branch protection rule for `trunk`:
 #        ✓ Require status checks to pass before merging
 #        → add the "smoke" check (from the "CI — boot check" workflow).
-#      This is the safety net: a fix reaches live ONLY after all 3 gates pass.
+#      This is the safety net: a fix reaches trunk ONLY after all gates pass.
+#   4. GO-LIVE SWITCH (drives auto-promote.yml): Settings → Secrets and variables →
+#        Actions → Variables tab → WRANGLER_AUTO_PROMOTE = true.
+#      Until this is 'true', a merged fix stops at trunk (integrated, not live) —
+#      NOTHING auto-reaches the live customer app. Flipping it is the deliberate
+#      "enable live auto-promote" action; unset it to disable go-live again.
 #
-# Until those are set, this workflow is inert (it just no-ops / errors on the
-# missing secret) — nothing ships without the switch-on above.
+# Until 1–3 are set this workflow is inert (no-op / errors on the missing secret).
+# Until 4 is set, merged fixes stop at trunk — nothing ships live without it.
 
 on:
   issues:
@@ -68,6 +78,9 @@ jobs:
           # gh uses this for PR/comment/merge ops. The PAT (not GITHUB_TOKEN) means
           # the PR it opens actually triggers CI, so auto-merge can go green.
           GH_TOKEN: ${{ secrets.WRANGLER_PAT }}
+          # deploy-staging.mjs uses this to publish the fix to the staging site, so
+          # auto-promote's staging-freshness gate passes and staging stays in sync.
+          STAGING_DEPLOY_PAT: ${{ secrets.STAGING_DEPLOY_PAT }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # PAT (not GITHUB_TOKEN) so the PR it opens actually triggers CI.
@@ -130,8 +143,14 @@ jobs:
               • Proven → make the MINIMAL fix that satisfies the cited rule (match the code +
                 the design language). Run all 3 gates (node ci/smoke.mjs · node ci/logic-test.mjs
                 · node ci/gen-rule-usage.mjs --check; regenerate rule-usage.js if usage changed).
+                Then PUBLISH the fix to staging so the go-live step can verify it and staging
+                stays in sync: `node tools/deploy-staging.mjs` (it bumps the shared ?v= cache-bust
+                token for you and pushes to the staging site — do NOT bump ?v= by hand). Commit the
+                fix AND the bumped index.html together.
                 Open a PR to `trunk` titled "Wrangler fix: <summary>" with body incl.
-                "Closes #${{ github.event.issue.number }}", then `gh pr merge --auto --squash <pr>`.
+                "Closes #${{ github.event.issue.number }}", add the `auto-promote` label
+                (`gh pr edit <pr> --add-label auto-promote`) so the merged fix goes live, then
+                `gh pr merge --auto --squash <pr>`.
               • Can't prove it / it contradicts the canon / it's ambiguous → do NOT ship.
                 Comment your verdict + why on #${{ github.event.issue.number }}; if it's a
                 `wrangler-fix` you couldn't justify, relabel it `wrangler-request` so it lands

--- a/tools/deploy-staging.mjs
+++ b/tools/deploy-staging.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // deploy-staging.mjs — "put my feature on staging."
 //
-// DRAFT — pipeline not yet wired; activate per plan Phase 0. Do not run until
-// the staging deploy credential + repo are confirmed.
+// OPERATIONAL (2026-07-15) — the staging repo + STAGING_DEPLOY_PAT are confirmed and the
+// staging site serves live; this is the working Gate-1 review deploy (/deploy wraps it).
 //
 // WHY THIS EXISTS
 // Per the trunk-based redesign (see the two docs below), staging stops being a

--- a/tools/promote.mjs
+++ b/tools/promote.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 // promote.mjs — Gate 2 of the two-gate trunk-based workflow: trunk (main) -> production.
 //
-// *** DRAFT — go-live pipeline not yet wired; activate per plan Phase 0. This script  ***
-// *** publishes to production when run with --yes; do not run until Phase 0           ***
-// *** (production branch + Pages source) is set up and Jac confirms.                  ***
+// GO-LIVE step (Gate 2). With --yes this fast-forwards `production` to the approved trunk
+// commit — the live deploy. `production` exists and is kept in sync with trunk; Pages is
+// expected to serve it (per CLAUDE.md). ⚠️ Confirm Pages' source branch is `production`
+// before relying on auto-promote.yml: if Pages still serves `trunk`, merging is already live
+// and this step is a no-op. Run only on Jac's explicit "promote it", or from
+// .github/workflows/auto-promote.yml for a Wrangler auto-fix.
 //
 // See: docs/superpowers/plans/2026-07-12-dev-workflow-trunk-based-redesign-plan.md (§1.3)
 //      docs/superpowers/specs/2026-07-12-dev-workflow-trunk-based-redesign-design.md


### PR DESCRIPTION
**Draft — the live-deploy automation for the auto-fix engine. OFF until you flip the switch.**

Closes the last mile so an end-user's reported fix reaches app.jacrentals.com in real time, with no one touching the deploy machinery — but fully machine-gated, and nothing goes live until you enable it.

### What it does
- **`auto-promote.yml` (new):** when a Wrangler auto-fix PR (labelled `auto-promote`) squash-merges to `trunk`, it runs `tools/promote.mjs` to fast-forward `production` → live. **Only auto-fixes carry the label**, so your own merges to trunk still wait for your `/promote`.
- **`wrangler-fix.yml`:** the agent now also deploys the fix to staging (so staging stays in sync + the go-live step can verify) and labels the PR `auto-promote`. Stale "Pages deploys trunk = live" comments corrected.
- **`promote.mjs` / `deploy-staging.mjs`:** removed the stale "DRAFT — do not run" headers (both operational).

### Safety (fully machine-gated — no human review, but every gate must pass)
`smoke` + `logic-test` CI gate the merge → `promote.mjs` enforces staging-freshness + verifies the live `?v=` bytes after. Any red gate fails and the fix **stays at trunk, not live**.

### Your one-time switch-on (when you're ready)
1. Repo **secret** `STAGING_DEPLOY_PAT` (same one `/deploy` uses) — so the CI agent can publish to staging.
2. Confirm secrets `ANTHROPIC_API_KEY` + `WRANGLER_PAT` are set (already needed by the fix engine).
3. **The go-live switch:** Settings → Secrets and variables → Actions → **Variables** → `WRANGLER_AUTO_PROMOTE = true`. Until this is `true`, merged fixes stop at trunk (not live).

### Please verify before flipping the switch
- **Pages source branch = `production`?** This whole thing assumes it. If Pages still serves `trunk`, merging is already live and none of this is needed — tell me and I'll adjust.
- **Not tested end-to-end** (needs a real test issue + live deploy). Recommend: with the switch **on**, file one throwaway `wrangler-fix` test issue and watch it flow report → fix → staging → merge → promote → live, before trusting it.

### Known limitation
Two auto-fixes merging within seconds of each other can make the staging-freshness gate fail-*safe* (the second waits at trunk rather than promoting a stale mismatch) — rare, and it never promotes bad bytes; you'd just `/promote` it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3Qzor6hTRSvcXnarrDuCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3Qzor6hTRSvcXnarrDuCi)_