### PR TITLE
Customizable crew-welcome text + wrangler copy (phone-identity polish)

### DIFF
--- a/app.js
+++ b/app.js
@@ -4611,8 +4611,10 @@ function setDraftStatus(o, set, val, patch) {
 }
 function captureTeamEdits(o) {   // keep typed roster edits across re-renders + into Save
   const root = document.querySelector('.settings-popup .popup-body'); if (!root) return;
-  const inputs = root.querySelectorAll('.set-input[data-emp]'); if (!inputs.length) return;
   if (!o.draftSettings) o.draftSettings = JSON.parse(JSON.stringify((o.config && o.config.settings) || state.settings || {}));
+  const wt = root.querySelector('[data-emp-welcome]');   // the customizable crew-welcome SMS (may exist with an empty roster)
+  if (wt) o.draftSettings.phoneWelcome = wt.value;
+  const inputs = root.querySelectorAll('.set-input[data-emp]'); if (!inputs.length) return;
   const emps = o.draftSettings.employees || (o.draftSettings.employees = []);
   inputs.forEach((i) => { const idx = Number(i.dataset.i); if (emps[idx]) emps[idx][i.dataset.emp] = i.value; });
 }
@@ -4691,12 +4693,21 @@ function settingsTeamPane(o) {
     <input class="set-input" data-emp="note" data-i="${i}" placeholder="Note" value="${esc(em.note || '')}" style="flex:2;min-width:110px" />
     ${toggleChip(((em.commsConsent && em.commsConsent.sms) === 'opted-out') ? 'Texts off' : 'Texts OK', (em.commsConsent && em.commsConsent.sms) !== 'opted-out', { js: 'js-emp-consent', data: { i }, tone: 'green' })}
     ${closeX('js-emp-del', { data: { i } })}</div>${showAuth && em.id ? `<div class="set-row emp-auth" style="gap:7px;margin:-3px 0 8px;padding-left:2px">
-    <button type="button" class="emp-act js-emp-code" data-id="${esc(em.id)}" data-tip="Text this hand a one-time setup code">Text setup code</button>
+    <button type="button" class="emp-act js-emp-code" data-id="${esc(em.id)}" data-tip="Text this hand the app link + welcome">Text app invite</button>
     <button type="button" class="emp-act js-emp-signout" data-id="${esc(em.id)}" data-tip="Sign them out on every device">Sign out everywhere</button></div>` : ''}`).join('');
   const note = flagOn('phoneIdentity')
     ? 'Per-person logins are ON — this roster is the login list. Each hand needs a name, phone, and role; they set their own PIN from a texted code. Removing someone cuts their access on the next save.'
     : 'The crew — name, role, phone, note, and whether we can text them (a hand who opts out is skipped by every crew text). No credentials or compliance PII lives here (dropped from scope, Jac 2026-06-29).';
-  return `<div class="set-pane"><div class="muted" style="font-size:11.5px;margin-bottom:9px">${esc(note)}</div>${rows || '<div class="muted" style="font-size:12px">No hands on the roster yet.</div>'}<div class="kv pillrow" style="margin-top:9px">${addBtn('Employee', { link: true, js: 'js-emp-add' })}${showAuth ? `<button type="button" class="emp-act js-emp-blast" data-tip="Text a one-time setup code to every hand on the roster at once (cutover)">Text everyone a setup code</button>` : ''}</div></div>`;
+  // Customizable crew-welcome SMS (phone-identity mode) — the text auto-sent on a new hire or
+  // a number change, and by the per-person / whole-crew invite buttons. Placeholder shows the
+  // shipped default so an admin sees what sends even before they edit it.
+  const welcomeDefault = (PHONE_IDENTITY && PHONE_IDENTITY.welcomeText) || '';
+  const welcomeVal = o.draftSettings.phoneWelcome || '';
+  const welcomeBlock = showAuth ? `<div class="emp-welcome">
+    <div class="emp-welcome-lbl">Crew welcome text</div>
+    <textarea class="emp-welcome-ta" data-emp-welcome rows="3" placeholder="${esc(welcomeDefault)}" data-tip="Sent to a hand when they're added or their number changes">${esc(welcomeVal)}</textarea>
+    <div class="emp-welcome-foot"><span class="emp-welcome-tok">Tokens <em>{name}</em> and <em>{link}</em> (the app link) fill in when it sends — no login code, they get that in the app.</span><button type="button" class="emp-act js-emp-welcome-reset" data-tip="Restore the default welcome wording">Reset to default</button></div></div>` : '';
+  return `<div class="set-pane"><div class="muted" style="font-size:11.5px;margin-bottom:9px">${esc(note)}</div>${rows || '<div class="muted" style="font-size:12px">No hands on the roster yet.</div>'}${welcomeBlock}<div class="kv pillrow" style="margin-top:9px">${addBtn('Employee', { link: true, js: 'js-emp-add' })}${showAuth ? `<button type="button" class="emp-act js-emp-blast" data-tip="Text the whole roster the app link + welcome">Round up the crew</button>` : ''}</div></div>`;
 }
 /* ── Settings → Notifications (Phase A control center — design spec
    docs/superpowers/specs/2026-07-14-notifications-pane-design.md) ────────────────────
@@ -17411,10 +17422,11 @@ function onClick(e) {
   // Phase-3 per-person auth actions (phone-identity mode) — act immediately against the SAVED
   // roster; the backend admin-gates them (docs/handoffs/phone-identity-backend.gs). A just-added
   // unsaved row has no server enrollment yet → authStart returns sent:false, so we say "save first".
-  if (closest('.js-emp-code')) { e.stopPropagation(); const id = closest('.js-emp-code').dataset.id; toast('Texting a setup code…'); backendCall('authStart', { personId: id, purpose: 'enroll' }).then((r) => toast(r && r.ok && r.sent ? 'Setup code texted.' : 'Could not text a code — save the roster first, and check their phone number.')).catch(() => toast('Could not reach the backend.')); return; }
+  if (closest('.js-emp-code')) { e.stopPropagation(); const id = closest('.js-emp-code').dataset.id; toast('Texting the app invite…'); backendCall('authEnrollBlast', { personId: id }).then((r) => toast(r && r.ok && r.sent ? 'App invite texted.' : 'Could not text the invite — save the roster first, and check their phone number.')).catch(() => toast('Could not reach the backend.')); return; }
+  if (closest('.js-emp-welcome-reset')) { e.stopPropagation(); const o = state.overlay; if (!o || o.kind !== 'settings') return; captureTeamEdits(o); o.draftSettings.phoneWelcome = (PHONE_IDENTITY && PHONE_IDENTITY.welcomeText) || ''; reSettings(); return; }
   if (closest('.js-emp-signout')) { e.stopPropagation(); const id = closest('.js-emp-signout').dataset.id; backendCall('authRevoke', { personId: id }).then((r) => toast(r && r.ok ? 'Signed out on all their devices.' : 'Could not sign them out (admin only).')).catch(() => toast('Could not reach the backend.')); return; }
-  // Phase-4 cutover: text every rostered hand a one-time setup code at once (authEnrollBlast, admin-gated backend).
-  if (closest('.js-emp-blast')) { e.stopPropagation(); toast('Texting setup codes to the crew…'); backendCall('authEnrollBlast', {}).then((r) => toast(r && r.ok ? `Setup codes sent to ${r.sent} hand${r.sent === 1 ? '' : 's'}${r.skipped ? ` (${r.skipped} skipped — no phone on file)` : ''}.` : 'Could not send the blast (admin only).')).catch(() => toast('Could not reach the backend.')); return; }
+  // Round up the crew: text every rostered hand the app link + welcome at once (authEnrollBlast, admin-gated backend).
+  if (closest('.js-emp-blast')) { e.stopPropagation(); toast('Rounding up the crew…'); backendCall('authEnrollBlast', {}).then((r) => toast(r && r.ok ? `App link sent to ${r.sent} hand${r.sent === 1 ? '' : 's'}${r.skipped ? ` (${r.skipped} skipped — no phone on file)` : ''}.` : 'Could not send the invite (admin only).')).catch(() => toast('Could not reach the backend.')); return; }
   // Crew SMS consent: capture typed roster edits first (mirror js-emp-del), then flip this hand's commsConsent.sms between opted-out and opted-in (unknown/absent counts as textable). Read server-side by sendStaffMessage_.
   if (closest('.js-emp-consent')) { e.stopPropagation(); const o = state.overlay; if (!o || o.kind !== 'settings') return; const i = Number(closest('.js-emp-consent').dataset.i); captureTeamEdits(o); const emps = o.draftSettings.employees || []; if (emps[i]) { const cur = (emps[i].commsConsent && emps[i].commsConsent.sms) || 'unknown'; emps[i].commsConsent = Object.assign({}, emps[i].commsConsent, { sms: cur === 'opted-out' ? 'opted-in' : 'opted-out' }); } reSettings(); return; }
   // Settings → Notifications: single on/off toggles (R31) write straight into the draft

--- a/config.js
+++ b/config.js
@@ -636,4 +636,10 @@ export const PHONE_IDENTITY = {
   trustDays: 30,            // how long a personal device stays trusted before re-verify
   codeTtlMin: 10,           // verification-code lifetime (a login someone's waiting on)
   linkTtlMin: 45,           // enrollment/welcome link lifetime
+  // Default crew-welcome SMS (customizable in Settings → Team Roster; the backend is the
+  // authoritative default and substitutes the tokens at send time). Tokens: {name} = the
+  // hand's roster name (falls back to "partner"), {link} = the app URL. No login code —
+  // the phone-first sign-in issues that in-app when they enter their mobile number.
+  welcomeText:
+    "Saddle up, {name}! You're on the JacRentals crew. Open {link} and sign in with your mobile number to get rolling.",
 };

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 24956 lines, 39 chapters
+## app.js — 24968 lines, 39 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -16,39 +16,39 @@
 | APP-06 | 1432–2179 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+61) |
 | APP-07 | 2180–3046 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+81) |
 | APP-08 | 3047–3054 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 3055–5339 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+153) |
-| APP-10 | 5340–5360 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 5361–6080 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+49) |
-| APP-12 | 6081–6248 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 6249–6488 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
-| APP-14 | 6489–6898 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 6899–7098 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 7099–8617 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+44) |
-| APP-17 | 8618–8876 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 8877–9261 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, mobileNavEl, colTabButtonsHtml, colActionsHtml, memberCardEl, …(+6) |
-| APP-19 | 9262–9386 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 9387–9558 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 9559–9834 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+11) |
-| APP-22 | 9835–11341 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+133) |
-| APP-23 | 11342–11384 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 11385–12227 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 12228–13841 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-26 | 13842–14059 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, crewBroadcastHtml, sendCrewBroadcast |
-| APP-27 | 14060–14544 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 14545–15739 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+112) |
-| APP-29 | 15740–16025 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-30 | 16026–16331 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+5) |
-| APP-31 | 16332–16335 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 16336–18703 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+58) |
-| APP-33 | 18704–19860 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
-| APP-34 | 19861–21174 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
-| APP-35 | 21175–21657 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 21658–21660 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 21661–23662 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+148) |
-| APP-38 | 23663–23669 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-39 | 23670–24956 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, phoneBoot, pidErr, pidCall, renderPhoneLogin, …(+65) |
+| APP-09 | 3055–5350 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+153) |
+| APP-10 | 5351–5371 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 5372–6091 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+49) |
+| APP-12 | 6092–6259 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 6260–6499 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
+| APP-14 | 6500–6909 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 6910–7109 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 7110–8628 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+44) |
+| APP-17 | 8629–8887 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 8888–9272 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, mobileNavEl, colTabButtonsHtml, colActionsHtml, memberCardEl, …(+6) |
+| APP-19 | 9273–9397 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 9398–9569 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 9570–9845 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+11) |
+| APP-22 | 9846–11352 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+133) |
+| APP-23 | 11353–11395 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 11396–12238 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 12239–13852 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-26 | 13853–14070 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, crewBroadcastHtml, sendCrewBroadcast |
+| APP-27 | 14071–14555 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 14556–15750 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+112) |
+| APP-29 | 15751–16036 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-30 | 16037–16342 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+5) |
+| APP-31 | 16343–16346 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 16347–18715 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+58) |
+| APP-33 | 18716–19872 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
+| APP-34 | 19873–21186 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
+| APP-35 | 21187–21669 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 21670–21672 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 21673–23674 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+148) |
+| APP-38 | 23675–23681 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-39 | 23682–24968 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, phoneBoot, pidErr, pidCall, renderPhoneLogin, …(+65) |
 
-## config.js — 640 lines, 0 chapters
+## config.js — 646 lines, 0 chapters
 
 Chapter **CFG** — no internal banners, the whole file is one chapter.
 

--- a/docs/handoffs/phone-identity-STATUS.md
+++ b/docs/handoffs/phone-identity-STATUS.md
@@ -24,6 +24,18 @@ the app), shared device takes a PIN each session. No passwords.
 `FEATURES.phoneIdentity` is **ON** in production (app.jacrentals.com, `?v=20260715b`). The
 whole crew is on per-person phone login. Flag-OFF remains the instant backout.
 
+## Customizable crew-welcome + copy fix — 2026-07-15 (polish pass)
+
+The auto-enroll / blast / per-person send now text a **crew-welcome** (app link, **no
+code**) instead of a code, fixing the phone-first copy ("enter your name" was wrong) AND the
+30-sec rate-limit snag (the welcome doesn't touch the login-code bucket). The welcome is
+**admin-editable** in Settings → Team Roster (`settings.phoneWelcome`, tokens `{name}`/`{link}`,
+Reset-to-default = `config.js PHONE_IDENTITY.welcomeText`); the backend `pidWelcomeText_` reads
+it, `pidSendWelcome_` sends it. The in-app sign-in **code** SMS is unchanged (security). Buttons
+relabeled to wrangler voice: "Round up the crew" / "Text app invite". `authEnrollBlast` now takes
+an optional `personId` (per-person invite). Backend mirror updated; needs the editor New-version
+deploy.
+
 ## Auto-enroll on roster add / number change — 2026-07-15 (backend)
 
 `pidReconcileRoster_` now, on a config save: **added** person w/ phone → auto-text a setup

--- a/docs/handoffs/phone-identity-backend.gs
+++ b/docs/handoffs/phone-identity-backend.gs
@@ -116,15 +116,34 @@ function pidSendSms_(phoneRaw, text) {
  * login/reset variant stays terse (the person is already at the app). Override the URL
  * with a PID_APP_URL Script Property. App-store download links for the native
  * Android/iOS apps get appended to the enroll copy here once those ship. */
-function pidCodeSms_(code, purpose, ttlMs) {
-  var mins = Math.round(ttlMs / 60000);
-  if (purpose === 'enroll') {
-    var url = pidProps_().getProperty('PID_APP_URL') || 'https://app.jacrentals.com';
-    return 'JacRentals — Rental Wrangler: you\'re set up. Open ' + url + ' , enter your name, '
-         + 'then code ' + code + ' to finish (expires in ' + mins + ' min). Never share it.';
-    // TODO(native apps): append the Android/iOS store download links here when they ship.
-  }
-  return 'JacRentals: your sign-in code is ' + code + '. Expires in ' + mins + ' min. Never share it.';
+/* App URL used in crew messaging (override with a PID_APP_URL Script Property). */
+function pidAppUrl_() { return pidProps_().getProperty('PID_APP_URL') || 'https://app.jacrentals.com'; }
+
+/* Terse, FIXED sign-in code SMS — security/transactional, deliberately NOT customizable. */
+function pidCodeSms_(code, ttlMs) {
+  return 'JacRentals: your sign-in code is ' + code + '. Expires in ' + Math.round(ttlMs / 60000) + ' min. Never share it.';
+}
+
+/* Backend-authoritative default crew-welcome copy (mirrors config.js PHONE_IDENTITY.welcomeText);
+ * used when settings.phoneWelcome is blank. Tokens: {name}, {link}. */
+var PID_WELCOME_DEFAULT = "Saddle up, {name}! You're on the JacRentals crew. Open {link} and sign in with your mobile number to get rolling.";
+
+/* Build a hand's crew-welcome from the (admin-customizable) template + token substitution.
+ * NO login code — the phone-first sign-in issues that in-app when they enter their number. */
+function pidWelcomeText_(person) {
+  var tpl = '';
+  try { tpl = String((getConfigObj().settings || {}).phoneWelcome || ''); } catch (e) { tpl = ''; }
+  if (!tpl.trim()) tpl = PID_WELCOME_DEFAULT;
+  var name = (person && person.name ? String(person.name) : '').trim() || 'partner';
+  return tpl.replace(/\{name\}/g, name).replace(/\{link\}/g, pidAppUrl_());
+}
+
+/* Send the crew-welcome to one roster person. Roster-scoped, quiet-hours bypassed
+ * (transactional onboarding), and it does NOT touch the login-code rate-limit bucket — so a
+ * hand added seconds before opening the app still gets their in-app sign-in code cleanly. */
+function pidSendWelcome_(person) {
+  if (!person || !smsNormalizePhone_(person.phone)) return { ok: false, reason: 'no-phone' };
+  return pidSendSms_(person.phone, pidWelcomeText_(person));
 }
 
 /* ── ACTION: authStart — text a one-time code to a roster person's own phone ──
@@ -143,7 +162,7 @@ function authStart_(body) {
   var code = pidCode_(), salt = pidSalt_();
   var ttl = purpose === 'enroll' ? PID_LINK_TTL_MS : PID_CODE_TTL_MS;
   pidPut_('PID_CODE_' + pid, { hash: pidHash_(code, salt), salt: salt, purpose: purpose, exp: now + ttl, tries: 0 });
-  var send = pidSendSms_(person.phone, pidCodeSms_(code, purpose, ttl));
+  var send = pidSendSms_(person.phone, pidCodeSms_(code, ttl));
   if (!send.ok) return { ok: true, sent: false, reason: send.reason };
   rl.n += 1; rl.last = now; pidPut_('PID_RL_' + pid, rl);
   return { ok: true, sent: true, personId: pid, name: person.name || '', masked: smsMaskPhone_(person.phone) };
@@ -234,17 +253,20 @@ function authRevoke_(body, role) {
   return { ok: true };
 }
 
-/* ── ACTION: authEnrollBlast — text every rostered person a code (cutover; admin only) ── */
+/* ── ACTION: authEnrollBlast — text the crew-welcome (app link, NO code) to the roster.
+ * body: { personId? , token? }. Admin only. With personId → welcome just that one hand (the
+ * per-person "send invite" button); without → the whole-crew blast. ── */
 function authEnrollBlast_(body, role) {
+  body = body || {};
   if (roleTierRank_(role) < ROLE_TIER_RANK.admin) {
-    var caller = pidResolveCaller_((body || {}).token);
+    var caller = pidResolveCaller_(body.token);
     if (!caller || caller.tier < ROLE_TIER_RANK.admin) return { ok: false, error: 'forbidden' };
   }
   var list = pidRoster_(), sent = 0, skipped = 0;
+  if (body.personId != null) list = list.filter(function (e) { return e && String(e.id) === String(body.personId); });
   for (var i = 0; i < list.length; i++) {
-    if (!smsNormalizePhone_(list[i].phone)) { skipped++; continue; }
-    var r = authStart_({ personId: list[i].id, purpose: 'enroll' });
-    if (r && r.sent) sent++; else skipped++;
+    var r = pidSendWelcome_(list[i]);
+    if (r && r.ok) sent++; else skipped++;
   }
   return { ok: true, sent: sent, skipped: skipped };
 }
@@ -276,13 +298,15 @@ function pidPurgePerson_(pid) {
  *    saveConfigFromBody, just before returning ok. Three transitions:
  *      • REMOVED (id gone)        → pidPurgePerson_: cut device trust + PIN even if the
  *                                   client never calls authRevoke.
- *      • ADDED (new id w/ phone)  → auto-text a setup code so a new hire self-enrolls.
+ *      • ADDED (new id w/ phone)  → pidSendWelcome_: text the crew-welcome (app link, no
+ *                                   code) so a new hire knows where to sign in.
  *      • NUMBER CHANGED           → purge the old device trust/PIN (the phone IS the
  *                                   identity, so a moved number must re-prove possession)
- *                                   then text the NEW number a fresh setup code.
- *    A name-only edit sends nothing. Sends reuse authStart_(…,'enroll'): roster-scoped,
- *    rate-limited, 45-min code. Runs AFTER saveConfigObj so authStart_ reads the new
- *    roster; each send is guarded so one failure can't skip the rest of a bulk add. ── */
+ *                                   then welcome the NEW number.
+ *    A name-only edit sends nothing. The welcome carries NO login code and does NOT touch the
+ *    login rate-limit, so a hand can sign in immediately after being added. Runs AFTER
+ *    saveConfigObj so pidWelcomeText_ reads the fresh roster + template; each send is guarded
+ *    so one failure can't skip the rest of a bulk add. ── */
 function pidReconcileRoster_(prevList, nextList) {
   var prevPhone = {};   // id → normalized phone at the previous save ('' if none)
   (prevList || []).forEach(function (e) { if (e && e.id) prevPhone[String(e.id)] = smsNormalizePhone_(e.phone) || ''; });
@@ -298,7 +322,7 @@ function pidReconcileRoster_(prevList, nextList) {
     if (had && prevPhone[id] === toPhone) return;                 // unchanged number → no text
     try {
       if (had && prevPhone[id] !== toPhone) pidPurgePerson_(id);  // number moved → re-verify on the new one
-      authStart_({ personId: id, purpose: 'enroll' });            // welcome / setup code to the (new) number
+      pidSendWelcome_(e);                                          // crew-welcome (app link, no code) to the (new) number
     } catch (err) { /* one bad send must not skip the rest of the roster */ }
   });
 }

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260715b" />
+  <link rel="stylesheet" href="style.css?v=20260715c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +47,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260715b"></script>
-  <script type="module" src="app.js?v=20260715b"></script>
+  <script src="rule-usage.js?v=20260715c"></script>
+  <script type="module" src="app.js?v=20260715c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -3088,6 +3088,20 @@ select.nc-in { cursor: pointer; }
   transition: border-color .12s, color .12s; }
 .emp-act:hover { color: var(--txt); border-color: var(--accent-line, var(--accent)); }
 .emp-act:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+/* Settings → Team Roster: the customizable crew-welcome SMS (phone-identity mode). A
+   saddle-stitch (tan dashed) top rule seasons it as its own wrangler block; the textarea
+   matches the .set-input wells. Not a lint-family element, so no data-r. */
+.emp-welcome { margin: 11px 0 3px; padding-top: 11px; border-top: 1px dashed color-mix(in srgb, var(--tan, #c2925a) 62%, transparent); }
+.emp-welcome-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 11.5px; color: var(--txt-2); margin-bottom: 6px; }
+.emp-welcome-ta { width: 100%; min-height: 60px; padding: 8px 10px; border-radius: 8px;
+  background: var(--panel); border: 1px solid var(--line); color: var(--txt);
+  font-family: var(--font); font-size: 13px; line-height: 1.45; resize: vertical; }
+.emp-welcome-ta::placeholder { color: var(--txt-3); }
+.emp-welcome-ta:focus { outline: none; border-color: var(--accent-line, var(--accent)); }
+.emp-welcome-foot { display: flex; align-items: flex-start; gap: 12px; margin-top: 7px; }
+.emp-welcome-tok { flex: 1; min-width: 0; font-size: 11px; line-height: 1.5; color: var(--txt-3); }
+.emp-welcome-tok em { font-style: normal; font-family: ui-monospace, monospace; color: var(--txt-2); }
+.emp-welcome-foot .emp-act { flex: 0 0 auto; }
 
 /* §7.1 — R5 ADD affordance: dashed "+Thing" (no word "Add", no space after +) */
 .add-field { color: var(--txt-2); font-weight: 700; border: 1px dashed var(--line); border-radius: 11px; padding: 0 12px; height: 30px; display: inline-flex; align-items: center; background: transparent; font-family: inherit; font-size: 13px; cursor: pointer; }


### PR DESCRIPTION
## What

Polish pass on the phone-identity setup messaging (Jac's two asks: make it **customizable** and stop the copy saying "enter your name" — the login is phone-first, it asks for the mobile number).

The auto-enroll / blast / per-person send now text a **crew-welcome** (app link, **no login code**) instead of an enroll code. This:
- matches the phone-first login (code is issued in-app when they enter their number),
- fixes the wrong "enter your name" copy,
- and sidesteps the 30-sec login rate-limit (the welcome no longer touches that bucket).

## Frontend (Settings → Team Roster; admin + phone-identity ON)
- **Editable "Crew welcome text"** — textarea bound to `settings.phoneWelcome`, `{name}` / `{link}` tokens, stamped label, token help, **Reset to default** (`config.js PHONE_IDENTITY.welcomeText`). Saddle-stitch (tan) block; `.set-input`/`.emp-act` tokens; wrangler voice.
- **Wrangler relabels:** "Text setup code" → **"Text app invite"**; "Text everyone a setup code" → **"Round up the crew"**.
- Per-person invite calls `authEnrollBlast` with a `personId`; `captureTeamEdits` persists the welcome across re-renders/save.

## Backend (mirror in `docs/handoffs/phone-identity-backend.gs`; real `Code.gs` deployed separately)
- `pidWelcomeText_` reads the customizable template + substitutes `{name}`/`{link}`; `pidSendWelcome_` sends it with **no code** and **without** the login rate-limit bucket.
- `pidReconcileRoster_` (add / number-change) and `authEnrollBlast_` (now `personId`-aware) send the welcome. The in-app **sign-in code** SMS (`pidCodeSms_`) is unchanged (security/transactional).

## Verified
Gates green: smoke, logic-test (669/669), gen-rule-usage --check, check-window-catalog, gen-code-map --check (regenerated). Deployed to staging (`?v=20260715c`). Backend pushed to Apps Script HEAD; goes live on the editor New-version deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pFg5MbQzqc8ycNtxX2odE

---
_Generated by [Claude Code](https://claude.ai/code/session_019pFg5MbQzqc8ycNtxX2odE)_