### PR TITLE
Wrangler fix: add meta description to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover" />   <!-- §M0 responsive + NO zoom (Jac): lock scale at 1:1 so the app never opens zoomed in -->
   <title>Rental Wrangler — JacTec</title>
+  <meta name="description" content="Rental Wrangler — heavy-equipment rental operations for JacRentals (Sulphur, LA)." />
   <!-- App icons — the JacRentals logo for the browser tab, the iOS/Android home screen
        (Add to Home Screen), and PWA installs. PNGs in assets/ are generated from
        assets/jac-rentals-logo (4800² source) via tools/gen-app-icons. -->
@@ -28,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260715d" />
+  <link rel="stylesheet" href="style.css?v=20260715f" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -47,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260715d"></script>
-  <script type="module" src="app.js?v=20260715d"></script>
+  <script src="rule-usage.js?v=20260715f"></script>
+  <script type="module" src="app.js?v=20260715f"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## Report (#643, wrangler-fix)
`index.html`'s `<head>` carried every page-level meta tag — charset, viewport, title, theme-color, application-name, apple-mobile-web-app-title — but was missing `<meta name="description">`.

## Root cause
Simple omission in the static `<head>`. Verified by reading the actual file: no `name="description"` meta existed. Not a UI element (no `data-r` stamp), not a popup (no `WINDOW_CATALOG` entry) — so no rulebook/window-catalog change.

## Fix (matches the approved plan exactly)
Added one line immediately after `<title>`:
```html
<meta name="description" content="Rental Wrangler — heavy-equipment rental operations for JacRentals (Sulphur, LA)." />
```
Purely additive (SEO/accessibility); cannot affect existing behavior. `data-theme="bluedsteel"` left untouched.

## Gates
All green: `smoke`, `logic-test` (669/669), `gen-rule-usage --check` (current), plus `check-window-catalog` (47/47) and `gen-code-map --check`. Deployed + verified on staging (`?v=20260715f`).

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)