### PR TITLE
Return-rating: office rates 1–5★ at return → tiered reactions + reputation surfaces

### DIFF
--- a/app.js
+++ b/app.js
@@ -4746,6 +4746,12 @@ const NOTIF_DEFAULTS = {
     woAssigned:     { enabled: false },
     scheduleChange: { enabled: false },
   },
+  // Return-rating follow-up message templates (Settings → Notifications → Rating Follow-ups).
+  // {name} is filled with the customer's name; the office can still tweak per-send in the popup.
+  ratingMsgs: {
+    thankYou: 'Thanks for renting with us, {name} — it was a pleasure! If we earned it, a quick review would mean a lot: [review link]',
+    apology: "Hi {name}, we're sorry your recent rental fell short. We want to make it right — please give our manager a call.",
+  },
 };
 // Deep-fill a settings.notifications draft against NOTIF_DEFAULTS so an absent key (or
 // a config saved before a field existed) never crashes the pane. Arrays (channels.
@@ -4779,7 +4785,9 @@ function ensureNotifDraft(o) {
 // roster row index.
 function captureNotificationEdits(o) {
   const root = document.querySelector('.settings-popup .popup-body'); if (!root) return;
-  const inputs = root.querySelectorAll('[data-notif]'); if (!inputs.length) return;
+  const inputs = root.querySelectorAll('[data-notif]');
+  const texts = root.querySelectorAll('[data-notif-text]');
+  if (!inputs.length && !texts.length) return;
   const n = ensureNotifDraft(o);
   inputs.forEach((el) => {
     const path = el.dataset.notif;
@@ -4787,6 +4795,7 @@ function captureNotificationEdits(o) {
     const raw = String(el.value).trim(), num = Number(raw);
     notifSet(n, path, (raw && isFinite(num)) ? num : Number(el.dataset.notifDefault || 0));
   });
+  texts.forEach((el) => { notifSet(n, el.dataset.notifText, el.value); });   // string templates (rating messages) — stored verbatim, not coerced to a number
 }
 // Kick the ONE admin-read-only provider check (v92 smsProviderStatus) the first time the
 // pane renders; caches on the overlay so a repaint never re-fires it. Demo/offline (no
@@ -4823,62 +4832,58 @@ const notifHourOpts = (val) => Array.from({ length: 24 }, (_, h) => `<option val
 const notifLeadCadence = (n) => (n <= 0 ? 'Reminds the same day' : n === 1 ? 'Reminds the day before' : `Reminds ${n} days before`) + ` — ${n}-day lead`;
 const notifAfterCadence = (n) => (n <= 0 ? "Reminds the day it's due" : n === 1 ? 'Reminds a day after the due date' : `Reminds ${n} days after the due date`) + ` — ${n}-day follow-up`;
 const notifReviewCadence = (n) => (n <= 0 ? 'Asks the day of return' : n === 1 ? 'Asks the day after return' : `Asks ${n} days after return`) + ` — ${n}-day delay`;
+// Collapsible notifications section — the stamped header IS the expand/collapse control
+// (view-local state.notifSecOpen; collapsed by default so this tall pane opens compact).
+// The hazard cap (Channels) stays as card chrome above the header.
+function notifCard(id, icon, title, body, { cap } = {}) {
+  const open = !!(state.notifSecOpen && state.notifSecOpen[id]);
+  return `<div class="notif-card${open ? ' is-open' : ''}">${cap ? '<div class="notif-cap"></div>' : ''}<button class="notif-card-head js-notif-sec" data-sec="${esc(id)}" aria-expanded="${open ? 'true' : 'false'}"><span class="nch-ic">${icon}</span><span class="nch-t">${esc(title)}</span><span class="nch-chev" aria-hidden="true">${I.chev}</span></button>${open ? `<div class="notif-card-body">${body}</div>` : ''}</div>`;
+}
 function settingsNotificationsPane(o) {
   const n = ensureNotifDraft(o);
   ensureProviderStatus(o);
   const div = '<div class="rm-stitch"></div>';
-  const tgl = (label, path, on, tone = 'green') => toggleChip(label, on, { js: 'js-notif-toggle', data: { path }, tone });
+  const tgl = (label, path, on, tone = 'green', tip) => toggleChip(label, on, { js: 'js-notif-toggle', data: tip ? { path, tip } : { path }, tone });
   const numFld = (cap, path, val, dflt, aria) => `<label class="kpi-fld kpi-fld-sm"><span class="kpi-cap">${esc(cap)}</span><input class="kpi-tgt" data-notif="${esc(path)}" data-notif-default="${dflt}" value="${esc(val)}" inputmode="numeric" autocomplete="off" aria-label="${esc(aria || cap)}"/></label>`;
   const remRow = (label, path, cadenceFn, cap, fieldPath, val, dflt) => `<div class="notif-row">${tgl(label, `${path}.enabled`, notifGet(n, `${path}.enabled`))}${numFld(cap, fieldPath, val, dflt, `${label} — ${cap}`)}</div><div class="notif-cadence">${esc(cadenceFn(val))}</div>`;
 
-  const cInternal = `<div class="notif-card"><div class="notif-card-body">
-    <div class="notif-card-head">${I.bell}Internal</div>
+  const cInternal = notifCard('internal', I.bell, 'Internal', `
     <div class="notif-row">${tgl('Team Chat', 'internal.teamChat', n.internal.teamChat)}${tgl('Bell Alerts', 'internal.bell', n.internal.bell)}</div>
-    <div class="notif-sub">The in-app team chat and the header bell — the shop's own signal, independent of SMS/email.</div>
-  </div></div>`;
+    <div class="notif-sub">The in-app team chat and the header bell — the shop's own signal, independent of SMS/email.</div>`);
 
-  const cReminders = `<div class="notif-card"><div class="notif-card-body">
-    <div class="notif-card-head">${I.messageSquare}Customer Reminders</div>
+  const cReminders = notifCard('reminders', I.messageSquare, 'Customer Reminders', `
     ${remRow('Rental Starts', 'customer.reminders.start', notifLeadCadence, 'LEAD (DAYS)', 'customer.reminders.start.leadDays', n.customer.reminders.start.leadDays, 1)}
     ${div}
     ${remRow('Rental Returns', 'customer.reminders.return', notifLeadCadence, 'LEAD (DAYS)', 'customer.reminders.return.leadDays', n.customer.reminders.return.leadDays, 1)}
     ${div}
     ${remRow('Balance Overdue', 'customer.reminders.balance', notifAfterCadence, 'AFTER (DAYS)', 'customer.reminders.balance.afterDueDays', n.customer.reminders.balance.afterDueDays, 3)}
-    <div class="notif-sub">Reminders lock in here now — the sweep that actually sends them (Phase B) isn't installed yet.</div>
-  </div></div>`;
+    <div class="notif-sub">Reminders lock in here now — the sweep that actually sends them (Phase B) isn't installed yet.</div>`);
 
-  const cCrew = `<div class="notif-card"><div class="notif-card-body">
-    <div class="notif-card-head">${I.users}Crew Alerts</div>
-    <div class="notif-row">${tgl('Driver Assigned', 'staff.driverAssigned.enabled', n.staff.driverAssigned.enabled)}</div>
+  const cCrew = notifCard('crew', I.users, 'Crew Alerts', `
+    <div class="notif-row">${tgl('Driver Assigned', 'staff.driverAssigned.enabled', n.staff.driverAssigned.enabled, 'green', 'Texts a driver the moment a delivery or pickup is assigned to them.')}</div>
     ${div}
-    <div class="notif-row">${tgl('Work Order Assigned', 'staff.woAssigned.enabled', n.staff.woAssigned.enabled)}</div>
+    <div class="notif-row">${tgl('Work Order Assigned', 'staff.woAssigned.enabled', n.staff.woAssigned.enabled, 'green', 'Texts a mechanic when a work order lands on their bench.')}</div>
     ${div}
-    <div class="notif-row">${tgl('Schedule Change', 'staff.scheduleChange.enabled', n.staff.scheduleChange.enabled)}</div>
+    <div class="notif-row">${tgl('Shift/Run Change', 'staff.scheduleChange.enabled', n.staff.scheduleChange.enabled, 'green', "Texts a hand when the time of a run or shift they're already assigned to gets moved.")}</div>
     ${div}
     <div class="notif-row">${(!currentRole || roleTier(currentRole) >= tierRank('manager'))
       ? `<button class="pill ignition js-crew-broadcast" data-r="R17">${I.users} Text The Crew</button>`
       : ghostPill('Text The Crew', { disabled: true, tip: 'Managers and up can text the crew' })}</div>
-    <div class="notif-sub">Text the crew now, straight from here. The three alerts above fire on their own once their triggers land — the toggles lock in intent.</div>
-  </div></div>`;
+    <div class="notif-sub">Each alert texts the crew member it names, the moment that thing happens (hover a toggle for exactly what fires it). The triggers land with Phase D — the toggles lock in intent now. Or text the crew yourself, right here.</div>`);
 
-  const cReview = `<div class="notif-card"><div class="notif-card-body">
-    <div class="notif-card-head">${STATUS_ICONS.star}Reviews</div>
-    <div class="notif-row">${tgl('Review Request', 'customer.review.enabled', n.customer.review.enabled)}${numFld('DELAY (DAYS)', 'customer.review.delayDays', n.customer.review.delayDays, 2, 'Review request — delay days')}</div>
-    <div class="notif-cadence">${esc(notifReviewCadence(n.customer.review.delayDays))}</div>
-    <div class="notif-sub">Asks after a completed rental — the send itself, and the Reputation KPI it feeds, are Phase D.</div>
-  </div></div>`;
+  const cReview = notifCard('review', STATUS_ICONS.star, 'Rating Follow-ups', `
+    <div class="notif-sub">The default texts the office sends after rating a return — they can still tweak each one before it goes out. <b>{name}</b> fills in the customer's name.</div>
+    <div class="notif-fld-lbl">Thank-you + review · 4–5★</div>
+    <textarea class="insp-desc notif-msg" data-notif-text="ratingMsgs.thankYou" rows="3" maxlength="400" aria-label="Thank-you message template">${esc(n.ratingMsgs.thankYou)}</textarea>
+    <div class="notif-fld-lbl">Apology · 1★</div>
+    <textarea class="insp-desc notif-msg" data-notif-text="ratingMsgs.apology" rows="3" maxlength="400" aria-label="Apology message template">${esc(n.ratingMsgs.apology)}</textarea>`);
 
-  const cDispatch = `<div class="notif-card"><div class="notif-card-body">
-    <div class="notif-card-head">${I.truck}Dispatch</div>
+  const cDispatch = notifCard('dispatch', I.truck, 'Dispatch', `
     <div class="notif-row">${tgl('On The Way Text', 'customer.dispatchEta', n.customer.dispatchEta)}</div>
-    <div class="notif-sub">Texts customers when their unit's on the way — the trigger lands in Phase D; this locks in the setting now.</div>
-  </div></div>`;
+    <div class="notif-sub">Texts customers when their unit's on the way — the trigger lands in Phase D; this locks in the setting now.</div>`);
 
   const w = n.channels.windows;
-  const cChannels = `<div class="notif-card">
-    <div class="notif-cap"></div>
-    <div class="notif-card-body">
-      <div class="notif-card-head">${STATUS_ICONS.zap}Channels</div>
+  const cChannels = notifCard('channels', STATUS_ICONS.zap, 'Channels', `
       <div class="notif-row">${notifSmsBadge(o._provStatus)}${notifEmailBadge()}</div>
       ${div}
       <div class="notif-row">${kv(notifPriorityLabel(n.channels.priority), { pfx: 'Send Priority', derived: true })}</div>
@@ -4893,11 +4898,9 @@ function settingsNotificationsPane(o) {
       </div>
       ${div}
       <div class="notif-row">${tgl('After-Hours Override', 'channels.adminOverride', n.channels.adminOverride, 'yellow')}${numFld('DAILY CAP', 'channels.dailyCap', n.channels.dailyCap, 50, 'Daily send cap')}</div>
-      <div class="notif-sub">Admins can send anyway after hours on a manual text; the daily cap applies across both audiences.</div>
-    </div>
-  </div>`;
+      <div class="notif-sub">Admins can send anyway after hours on a manual text; the daily cap applies across both audiences.</div>`, { cap: true });
 
-  return `<div class="set-pane-head"><h4>Notifications</h4><p>Round up who hears what, and when. Every toggle saves right away — the reminder sweep (Phase B) and the crew SMS channel (Phase C) read these settings once they ship.</p></div>
+  return `<div class="set-pane-head"><h4>Notifications</h4><p>Round up who hears what, and when — tap a section to open it. Every toggle saves right away; the reminder sweep (Phase B) and the crew SMS channel (Phase C) read these settings once they ship.</p></div>
     ${cInternal}${cReminders}${cCrew}${cReview}${cDispatch}${cChannels}`;
 }
 function settingsPaneFor(o) {
@@ -6573,7 +6576,7 @@ const ROWS = {
     }).filter(Boolean).join('<span class="rcc-usep">, </span>') || (units ? `<span class="rcc-uname">${esc(units)}</span>` : '');
     const headHtml = `<div class="rcc-head">
       <div class="rcc-h1">${unitNameHtml ? `<span class="rcc-units">${unitNameHtml}</span>` : ''}${stPill}</div>
-      <div class="rcc-h2"><span class="rcc-cust">${cust ? esc(cust.name) : ''}</span>${
+      <div class="rcc-h2"><span class="rcc-cust">${cust ? esc(cust.name) : ''}</span>${(r.rating && r.rating.stars) ? `<span class="rcc-rating" data-tip="Return rated ${r.rating.stars}★${r.rating.by ? ' by ' + esc(r.rating.by) : ''}">${STATUS_ICONS.star}${r.rating.stars}</span>` : ''}${
         bal ? `<span class="rcc-bal ${balCls}">${esc(bal)}</span>` : (!(s && e) ? '<span class="rcc-bal rcc-set">Set window</span>' : '')
       }</div>
     </div>`;
@@ -7267,18 +7270,28 @@ function rentalAmt(r) {
 /* spend bucketed by month for the last n months (ending this month) */
 function customerMonthly(c, n = 9) {
   const today = parseISO(TODAY_ISO), out = [];
-  for (let i = n - 1; i >= 0; i--) { const dt = new Date(today.getFullYear(), today.getMonth() - i, 1); out.push({ y: dt.getFullYear(), m: dt.getMonth(), label: ACT_MONTHS[dt.getMonth()], total: 0, days: 0 }); }
+  for (let i = n - 1; i >= 0; i--) { const dt = new Date(today.getFullYear(), today.getMonth() - i, 1); out.push({ y: dt.getFullYear(), m: dt.getMonth(), label: ACT_MONTHS[dt.getMonth()], total: 0, days: 0, ratings: [] }); }
   DATA.rentals.filter((r) => r.customerId === c.customerId && r.startDate).forEach((r) => {
     const s = parseISO(r.startDate); if (!s) return;
     const b = out.find((x) => x.y === s.getFullYear() && x.m === s.getMonth());
-    if (b) { b.total += rentalAmt(r) || 0; const e = parseISO(r.endDate); b.days += e ? Math.max(1, Math.round((e - s) / 86400000) + 1) : 1; }   // D2 — days the customer held equipment (a 7-day rental = 7)
+    if (b) { b.total += rentalAmt(r) || 0; const e = parseISO(r.endDate); b.days += e ? Math.max(1, Math.round((e - s) / 86400000) + 1) : 1; if (r.rating && r.rating.stars) b.ratings.push(r.rating.stars); }   // D2 — days held; + return-rating stars for the rating series
   });
   return out;
+}
+/* Overall customer experience — the average of every return the office has rated for this
+   customer (all-time, not just the chart window). Null when they've never been rated. Feeds the
+   profile summary + is NEVER wired into the Reputation KPI (an employee can't move their own number). */
+function customerRatingSummary(c) {
+  const rated = DATA.rentals.filter((r) => r.customerId === c.customerId && r.rating && r.rating.stars);
+  if (!rated.length) return null;
+  return { avg: +(rated.reduce((s, r) => s + r.rating.stars, 0) / rated.length).toFixed(1), n: rated.length };
 }
 /* the activity panel — spend-by-month area chart + the five-stage cadence track */
 function customerActivityChart(c) {
   const a = customerActivity(c);
   const months = customerMonthly(c, 9);
+  const exp = customerRatingSummary(c);
+  const expSpan = exp ? `<span class="ca-exp" data-tip="Average of ${exp.n} rated return${exp.n > 1 ? 's' : ''}">${STATUS_ICONS.star} <b>${exp.avg}★</b> · ${exp.n}</span>` : '';
   const max = Math.max(1, ...months.map((b) => b.total));
   const H = 150, padT = 30, baseY = 124;
   const today = parseISO(TODAY_ISO);
@@ -7298,7 +7311,25 @@ function customerActivityChart(c) {
   const ptsD = months.map((b, i) => ({ x: pts[i].x, y: baseY - (b.days / maxDays) * (baseY - padT) }));
   const lineD = sm(ptsD);
   const dotsD = ptsD.map((p) => `<span class="ca-dot d" style="left:${p.x.toFixed(1)}%;top:${p.y.toFixed(1)}px"></span>`).join('');
-  const caData = JSON.stringify(months.map((b, i) => ({ l: b.label, t: b.total, d: b.days, x: +pts[i].x.toFixed(1) })));
+  // Return-rating series — a third LINE like Spend/Days, but drawn as orange STARS instead of
+  // dashes (Jac). A star sits at each month from the first rated month to the last, interpolating
+  // the 1–5 value across gaps so the stars trace the rating trend; real rated months carry the
+  // tooltip, the in-between "dash" stars don't.
+  const py5 = (v) => baseY - (Math.max(1, Math.min(5, v)) / 5) * (baseY - padT);
+  const ratePts = months.map((b, i) => (b.ratings && b.ratings.length)
+    ? { mi: i, x: pts[i].x, v: b.ratings.reduce((s, x) => s + x, 0) / b.ratings.length, n: b.ratings.length } : null).filter(Boolean);
+  const rTip = (p) => `${p.v.toFixed(1)}★ · ${p.n} return${p.n > 1 ? 's' : ''}`;
+  const rateStar = (x, y, tip) => `<span class="ca-star${tip ? '' : ' dash'}" style="left:${x.toFixed(1)}%;top:${y.toFixed(1)}px"${tip ? ` data-tip="${tip}"` : ''}>${STATUS_ICONS.star}</span>`;
+  let rateStars = '';
+  if (ratePts.length === 1) { const p = ratePts[0]; rateStars = rateStar(p.x, py5(p.v), rTip(p)); }
+  else if (ratePts.length > 1) {
+    for (let i = 0; i < ratePts.length - 1; i++) {
+      const a0 = ratePts[i], a1 = ratePts[i + 1];
+      for (let m = a0.mi; m < a1.mi; m++) { const t = (m - a0.mi) / (a1.mi - a0.mi); rateStars += rateStar(pts[m].x, py5(a0.v + (a1.v - a0.v) * t), m === a0.mi ? rTip(a0) : ''); }
+    }
+    const last = ratePts[ratePts.length - 1]; rateStars += rateStar(last.x, py5(last.v), rTip(last));
+  }
+  const caData = JSON.stringify(months.map((b, i) => ({ l: b.label, t: b.total, d: b.days, x: +pts[i].x.toFixed(1), r: (b.ratings && b.ratings.length) ? +(b.ratings.reduce((s, v) => s + v, 0) / b.ratings.length).toFixed(1) : null, rn: (b.ratings || []).length })));
   const peakI = months.reduce((bi, b, i, arr) => (b.total > arr[bi].total ? i : bi), 0);
   const peak = months[peakI];
   const dots = pts.map((p, i) => `<span class="ca-dot${i === peakI ? ' big' : ''}" style="left:${p.x.toFixed(1)}%;top:${p.y.toFixed(1)}px"></span>`).join('');
@@ -7316,16 +7347,16 @@ function customerActivityChart(c) {
       + `<span class="ca-vline ca-tdy" style="left:${tx.toFixed(1)}%;background:var(--${a.color});box-shadow:0 0 8px color-mix(in srgb, var(--${a.color}) 55%, transparent)"></span>`;
     const days = Math.abs(a.since - a.f);
     const rel = a.pastPct <= 0 ? `${days}d out` : `${days}d past`;
-    caption = `<div class="ca-cap"><span>Last <b>${lastD ? fmtShortDate(a.lastDate) : '—'}</b></span><span>Today <b style="color:var(--${a.color})">${fmtShortDate(TODAY_ISO)}</b></span><span>Next <b>${fmtShortDate(a.expDate)}</b> · <b style="color:var(--${a.color})">${rel}</b></span></div>`;
+    caption = `<div class="ca-cap"><span>Last <b>${lastD ? fmtShortDate(a.lastDate) : '—'}</b></span><span>Today <b style="color:var(--${a.color})">${fmtShortDate(TODAY_ISO)}</b></span><span>Next <b>${fmtShortDate(a.expDate)}</b> · <b style="color:var(--${a.color})">${rel}</b></span>${expSpan}</div>`;
   } else {
-    caption = `<div class="ca-cap"><span class="muted">No rental cadence yet — needs a few rentals to read the pattern.</span></div>`;
+    caption = `<div class="ca-cap"><span class="muted">No rental cadence yet — needs a few rentals to read the pattern.</span>${expSpan}</div>`;
   }
   return `<div class="ca-panel" data-tip="Customer activity — spend by month, with last rental, next expected, and where today sits in their cadence">
     <div class="ca-stage c-${a.color}${a.deep ? ' deep' : ''}">${esc(a.stage)}</div>
     <div class="ca-chart" data-ca='${caData}'>
       <svg class="ca-svg" viewBox="0 0 100 ${H}" preserveAspectRatio="none"><defs><linearGradient id="caFill" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="var(--accent)" stop-opacity=".5"/><stop offset="1" stop-color="var(--accent)" stop-opacity=".02"/></linearGradient></defs><path d="${area}" fill="url(#caFill)"/><path d="${line}" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke"/><path d="${lineD}" fill="none" stroke="#c2925a" stroke-width="1.8" stroke-dasharray="4 3" stroke-linecap="round" vector-effect="non-scaling-stroke"/></svg>
-      <div class="ca-legend"><span><i style="background:var(--accent)"></i>Spend</span><span><i style="background:#c2925a"></i>Days rented</span></div>
-      ${markers}${dots}${dotsD}${peakCo}
+      <div class="ca-legend"><span><i style="background:var(--accent)"></i>Spend</span><span><i style="background:#c2925a"></i>Days rented</span><span class="ca-leg-r">${STATUS_ICONS.star}Rating</span></div>
+      ${markers}${dots}${dotsD}${rateStars}${peakCo}
       <span class="ca-scrub"></span><div class="ca-tip"></div>
       <div class="ca-lbls">${labels}</div>
     </div>
@@ -7345,7 +7376,7 @@ function caScrub(e) {
   let best = data[0], bd = Infinity; data.forEach((d) => { const dd = Math.abs(d.x - xpct); if (dd < bd) { bd = dd; best = d; } });
   const scrub = chart.querySelector('.ca-scrub'), tip = chart.querySelector('.ca-tip');
   if (scrub) { scrub.style.left = best.x + '%'; scrub.classList.add('on'); }
-  if (tip) { tip.innerHTML = `<b>${esc(best.l)}</b><span class="ca-tip-s">${best.t ? money(best.t) : '$0'}</span><span class="ca-tip-d">${best.d} day${best.d === 1 ? '' : 's'}</span>`; tip.style.left = Math.max(9, Math.min(91, best.x)) + '%'; tip.classList.add('on'); }
+  if (tip) { tip.innerHTML = `<b>${esc(best.l)}</b><span class="ca-tip-s">${best.t ? money(best.t) : '$0'}</span><span class="ca-tip-d">${best.d} day${best.d === 1 ? '' : 's'}</span>${best.r != null ? `<span class="ca-tip-r">${best.r}★ · ${best.rn} return${best.rn === 1 ? '' : 's'}</span>` : ''}`; tip.style.left = Math.max(9, Math.min(91, best.x)) + '%'; tip.classList.add('on'); }
 }
 
 /* ── COMMENTS (Jac, Phase 6) — a structured note with a color (red/yellow/green) that
@@ -12280,6 +12311,7 @@ let swipeFired = false;   // §M1/§M3 — a footer or grid section-switch swipe
 function anyDismissable() { return !!(state.overlay || state.datesearch || state.chat.open || state.wrangler.open); }
 function dismissTopSheet() {
   if (state.datesearch) { closeDateSearch(); return true; }
+  if (overlayLocked()) { attnFlash('.rr-stars'); toast('Rate the return first — it can’t be skipped.'); return true; }   // required modal: refuse Esc/back
   if (state.overlay) { closeOverlay(); return true; }
   if (state.wrangler.open) { wranglerRailSnapshot(); state.wrangler.open = false; render(); return true; }   // mirror js-wr-close
   if (state.chat.open) { state.chat.open = false; render(); return true; }                                    // mirror js-chat-close
@@ -12303,7 +12335,7 @@ function renderOverlay() {
   const o = state.overlay;
   if (o.kind !== _popDragKind) { _popDragKind = o.kind; _popDrag = { x: 0, y: 0 }; }   // a new popup opens centered; re-renders of the same one keep the dragged spot
   const overlay = el('div', 'overlay');
-  overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) closeOverlay(); });
+  overlay.addEventListener('mousedown', (e) => { if (e.target === overlay) { if (overlayLocked()) { attnFlash('.rr-stars'); return; } closeOverlay(); } });
   if (buildPopupEl(o, overlay) === false) { state.overlay = null; return; }
   root.appendChild(overlay);
   wirePopupDrag(overlay);
@@ -13326,6 +13358,10 @@ function buildPopupEl(o, overlay, opts = {}) {
     const pop = el('div', 'popup cb-popup'); pop.style.width = '480px';
     pop.innerHTML = crewBroadcastHtml(o);
     overlay.appendChild(pop);
+  } else if (o.kind === 'returnRating') {
+    const pop = el('div', 'popup rr-popup'); pop.style.width = '440px';
+    pop.innerHTML = returnRatingHtml(o);
+    overlay.appendChild(pop);
   } else if (o.kind === 'board') {
     const board = BACKOFFICE_BOARDS.find((b) => b.id === o.board);
     const pop = el('div', 'popup board-popup');
@@ -13885,6 +13921,7 @@ const WINDOW_CATALOG = [
   { kind: 'roadmap',       label: 'Coming in 2026',          tag: 'Roadmap · the docket',      sample: () => ({}) },
   { kind: 'feedback',      label: 'Report a bug or request', tag: 'Mr. Wrangler · report',     sample: () => ({}) },
   { kind: 'crewBroadcast', label: 'Text the crew',           tag: 'Crew · broadcast',          sample: () => ({ sel: [], text: '' }) },
+  { kind: 'returnRating',  label: 'Rate the return',         tag: 'Office · customer experience', sample: () => ({ stars: 5, reject: {} }) },
   { kind: 'board',         label: 'Back-office board',       tag: 'Back office · records',     sample: () => ({ board: (BACKOFFICE_BOARDS[0] || {}).id }) },
   { kind: 'roundup',       label: 'The Round-Up',            tag: 'Reports · board',           sample: () => ({}) },
   { kind: 'boardview',     label: 'Board View',              tag: 'Card · board view',         sample: () => ({ card: 'units', query: '', sort: {}, calc: {}, colOrder: null, extraRows: [], cellData: {}, seq: 0 }) },
@@ -13998,6 +14035,126 @@ function crewBroadcastEmps() {
     out.push({ rid, name, role: em.role || 'Crew', rc: (rmap[em.role] && rmap[em.role].color) || 'gray', blocked });
   });
   return out;
+}
+/* ── Return rating — the office rates a customer's experience when every unit is back ───
+   Opens as a REQUIRED modal off the return hook (setUnitStatus / setRentalStatus). The
+   rating is NOT skippable (no ✕, no backdrop/Esc dismiss — only Save closes it); the tiered
+   follow-up actions are armed by DEFAULT and the office can tap any to skip it. The rating
+   feeds the customer's own profile + the customer-detail graph — it deliberately does NOT
+   feed the Reputation KPI (an employee can't be allowed to move their own number). */
+const RR_STAR_TIP = { 1: 'Bad — apology + loop in the manager', 2: 'Below par — Sales follows up', 3: 'Okay — Sales follows up', 4: 'Good — thank-you + review ask', 5: 'Great — thank-you + review ask' };
+const rrBand = (stars) => (stars >= 4 ? 'good' : stars >= 2 ? 'mid' : 'low');
+const RR_BAND_LABEL = { good: 'Great visit — we’ll thank them and ask for a review.', mid: 'Room to improve — Sales will follow up.', low: 'Rough one — we’ll apologize and loop in the manager.' };
+// Default follow-up action(s) per band; `id` keys the reject map. Armed unless the office skips it.
+// The shop's editable default templates (Settings → Notifications → Rating Follow-ups),
+// falling back to the shipped NOTIF_DEFAULTS text. {name} → the customer's name at send.
+function notifRatingTemplate(key) {
+  const m = (state.settings && state.settings.notifications && state.settings.notifications.ratingMsgs) || {};
+  return (typeof m[key] === 'string' && m[key].trim()) ? m[key] : NOTIF_DEFAULTS.ratingMsgs[key];
+}
+const rrFillName = (tpl, nm) => String(tpl || '').replace(/\{name\}/g, nm);
+function rrActions(stars) {
+  const b = rrBand(stars);
+  if (b === 'good') return [{ id: 'thankYou', icon: STATUS_ICONS.star, desc: (nm) => `Text ${nm} a thank-you + a review link`,
+    field: { kind: 'message', ph: 'Message to the customer — edit before it sends', def: (nm) => rrFillName(notifRatingTemplate('thankYou'), nm) } }];
+  if (b === 'mid') return [{ id: 'salesFollow', icon: I.users, desc: () => 'Flag Sales to follow up',
+    field: { kind: 'note', ph: 'What should Sales do? (optional)', def: () => '' } }];
+  return [
+    { id: 'apology', icon: I.messageSquare, desc: (nm) => `Text ${nm} an apology + invite to call the manager`,
+      field: { kind: 'message', ph: 'Message to the customer — edit before it sends', def: (nm) => rrFillName(notifRatingTemplate('apology'), nm) } },
+    { id: 'managerNotify', icon: I.bell, desc: () => 'Notify the manager', always: true },   // 1★ always reaches a manager — never skippable
+  ];
+}
+// A required modal is open — used to refuse backdrop/Esc dismissal until it's resolved.
+function overlayLocked() { return !!(state.overlay && state.overlay.kind === 'returnRating' && !state.overlay.done); }
+// Prompt the office to rate the experience once every unit is back (returned), skipping a
+// fully-cancelled rental and never re-prompting a rental that's already rated.
+function maybePromptReturnRating(r) {
+  if (!r || r.rating || !r.customerId) return;
+  if (!allUnitsTerminal(r)) return;
+  if (!rentalUnits(r).some((eu) => unitStatus(r, eu) === 'Returned')) return;   // all cancelled/no-show → nothing to rate
+  openOverlay({ kind: 'returnRating', rentalId: r.rentalId, stars: 0, note: '', reject: {} });
+}
+function returnRatingHtml(o) {
+  const r = IDX.rental.get(o.rentalId);
+  const cust = r && r.customerId ? IDX.customer.get(r.customerId) : null;
+  const name = cust ? cust.name : 'this customer';
+  const stars = o.stars || 0, reject = o.reject || {};
+  const starRow = `<div class="rr-stars" role="radiogroup" aria-label="Experience rating, 1 to 5 stars">${[1, 2, 3, 4, 5].map((s) =>
+    `<button class="rr-star${s <= stars ? ' on' : ''} js-rr-star" data-s="${s}" role="radio" aria-checked="${s === stars ? 'true' : 'false'}" aria-label="${s} star${s > 1 ? 's' : ''} — ${esc(RR_STAR_TIP[s])}" data-tip="${esc(RR_STAR_TIP[s])}">${STATUS_ICONS.star}</button>`).join('')}</div>`;
+  const rrText = (a) => (o.text && o.text[a.id] != null) ? o.text[a.id] : a.field.def(name);
+  const actionsHtml = stars ? rrActions(stars).map((a) => {
+    const armed = a.always || !reject[a.id];
+    const ctrl = a.always
+      ? `<span data-tip="Always happens on a 1★ — can’t be skipped">${badge('Always', 'gray')}</span>`
+      : toggleChip(armed ? 'Will send' : 'Skipped', armed, { js: 'js-rr-reject', data: { act: a.id }, tone: armed ? 'green' : 'gray' });
+    const field = (a.field && armed) ? `<textarea class="insp-desc rr-note js-rr-fld" data-act="${esc(a.id)}" rows="2" maxlength="400" placeholder="${esc(a.field.ph)}" aria-label="${esc(a.field.ph)}">${esc(rrText(a))}</textarea>` : '';
+    return `<div class="rr-action${armed ? '' : ' is-skip'}"><span class="rr-action-ic">${a.icon}</span><span class="rr-action-desc">${esc(a.desc(name))}</span>${ctrl}</div>${field}`;
+  }).join('') : '';
+  const body = `
+    <div class="rr-intro">Every unit's back in the yard. How was <b>${esc(name)}</b>'s experience? Rate it straight — it steers how the crew responds, and it's never scored against you.</div>
+    ${starRow}
+    <div class="rr-band rr-band-${stars ? rrBand(stars) : 'none'}">${stars ? esc(RR_BAND_LABEL[rrBand(stars)]) : 'Tap a star to log this return.'}</div>
+    ${stars ? `<div class="rr-actions"><div class="rr-actions-cap">What happens next — tap any to skip it</div>${actionsHtml}</div>` : ''}
+    ${o.error ? `<div class="login-err" style="text-align:left;margin-top:8px">${esc(o.error)}</div>` : ''}`;
+  const canSave = !!stars && !o.busy;
+  const foot = `<span class="rr-req-note">${I.lock} Rating required</span><span class="spacer"></span><button class="pill ignition js-rr-save${canSave ? '' : ' is-disabled'}" data-r="R17"${canSave ? '' : ' disabled'}>${o.busy ? 'Saving…' : 'Save rating'}</button>`;
+  // Custom shell — NO ✕: the rating is required, so Save is the only way out.
+  return `<div class="pl-cap"></div><span class="pl-rivet tl"></span><span class="pl-rivet tr"></span><span class="pl-rivet bl"></span><span class="pl-rivet br"></span>
+    <div class="popup-head"><span class="pl-ic">${STATUS_ICONS.star}</span><div class="pl-title"><h3>Rate the Return</h3><span class="pl-tag">${esc(r ? rentalDisplayName(r) : 'Rental')} · customer experience</span></div></div>
+    <div class="popup-body rr-body">${body}</div>
+    <div class="popup-foot">${foot}</div>`;
+}
+// Snapshot every editable follow-up field (thank-you / apology message, sales note) into
+// o.text keyed by action id, so a re-render (star change, arm/skip) never loses a typed edit.
+function captureRrFields(o) {
+  if (!o) return; o.text = o.text || {};
+  document.querySelectorAll('.overlay .js-rr-fld').forEach((el) => { o.text[el.dataset.act] = el.value; });
+}
+function saveReturnRating() {
+  const o = state.overlay; if (!o || o.kind !== 'returnRating') return;
+  if (!o.stars) { o.error = 'Pick a rating first.'; attnFlash('.rr-stars'); return renderOverlay(); }
+  const r = IDX.rental.get(o.rentalId); if (!r) { o.done = true; closeOverlay(); return; }
+  captureRrFields(o);
+  const cust = r.customerId ? IDX.customer.get(r.customerId) : null;
+  const name = cust ? cust.name : 'this customer';
+  const armedA = rrActions(o.stars).filter((a) => a.always || !(o.reject || {})[a.id]);
+  const armed = armedA.map((a) => a.id);
+  const messages = {};   // each armed action's FINAL text — the office's edit, else the default template
+  armedA.forEach((a) => { if (a.field) messages[a.id] = ((o.text && o.text[a.id] != null) ? o.text[a.id] : a.field.def(name)).trim(); });
+  r.rating = { stars: o.stars, band: rrBand(o.stars), when: TODAY_ISO, by: currentRole || 'office', actions: armed, messages };
+  reindex('rentals', r);
+  logAction(r, `Return rated ${o.stars}★ by ${currentRole || 'office'}${armed.length ? ` — ${armed.join(', ')}` : ' — no follow-up'}`);
+  fireRatingActions(r, o.stars, armed, messages);
+  o.done = true; closeOverlay(); toast(`Return rated ${o.stars}★.`); render();
+}
+// Fire the armed follow-ups. Sales flag → a customer activityLog entry; manager alert → a red
+// comment marker on the customer (surfaces in-app for the manager); customer sends (thank-you /
+// apology, the office's edited text) → the live sendCustomerMessage freeform SMS path, which
+// gates consent/window/cap server-side. Sends are best-effort + demo/offline = no-op.
+function fireRatingActions(r, stars, armed, messages) {
+  const cust = r.customerId ? IDX.customer.get(r.customerId) : null; if (!cust) return;
+  if (armed.includes('salesFollow')) {
+    const note = (messages && messages.salesFollow) || '';
+    cust.activityLog = cust.activityLog || [];
+    cust.activityLog.push({ when: TODAY_ISO, text: `Sales follow-up — ${stars}★ return${note ? `: ${note}` : ''}` });
+    reindex('customers', cust);
+  }
+  if (armed.includes('managerNotify')) addRecComment(cust, `${stars}★ return on ${rentalDisplayName(r)} — manager review requested.`, 'red');   // manager-visible flag on the customer
+  ['thankYou', 'apology'].forEach((id) => {   // one customer-facing send per rating (good → thankYou, low → apology)
+    if (!armed.includes(id)) return;
+    const text = ((messages && messages[id]) || '').trim(); if (text) ratingSend(cust.customerId, text);
+  });
+}
+// Send a rating-triggered text via the live customer-message pipeline (consent/window/cap all
+// enforced server-side). No backend (demo/offline) → silently does nothing.
+async function ratingSend(customerId, text) {
+  if (!commsOnline()) return;
+  let r; try { r = await backendCall('sendCustomerMessage', { channel: 'sms', entity: 'customer', recId: customerId, customerId, template: 'freeform', text, from: '' }); }
+  catch (e) { toast('Couldn’t reach the database to send the text.'); return; }
+  if (r && r.ok) toast('Text sent.');
+  else if (r && r.reason === 'opted-out') toast('Customer has opted out — no text sent.');
+  else toast('Couldn’t send the text.');
 }
 function crewBroadcastHtml(o) {
   const list = crewBroadcastEmps();
@@ -17439,6 +17596,10 @@ function onClick(e) {
   // numeric edit sitting in the live DOM isn't lost when reSettings() repaints the
   // pane's HTML from draft (same reason js-flag-ov/js-emp-add capture before mutating).
   if (closest('.js-notif-toggle')) { e.stopPropagation(); const o = state.overlay; if (!o || o.kind !== 'settings') return; captureNotificationEdits(o); const n = ensureNotifDraft(o); const path = closest('.js-notif-toggle').dataset.path; notifSet(n, path, !notifGet(n, path)); reSettings(); return; }
+  if (closest('.js-notif-sec')) { e.stopPropagation(); const o = state.overlay; if (!o || o.kind !== 'settings') return; captureNotificationEdits(o); const id = closest('.js-notif-sec').dataset.sec; state.notifSecOpen = state.notifSecOpen || {}; state.notifSecOpen[id] = !state.notifSecOpen[id]; reSettings(); return; }   // collapse/expand a notifications section (capture typed fields first so a collapse never loses them)
+  if (closest('.js-rr-star')) { e.stopPropagation(); const o = state.overlay; if (!o || o.kind !== 'returnRating') return; captureRrFields(o); o.stars = Number(closest('.js-rr-star').dataset.s) || 0; o.error = ''; renderOverlay(); return; }   // pick a 1–5★ return rating (reveals the reaction)
+  if (closest('.js-rr-reject')) { e.stopPropagation(); const o = state.overlay; if (!o || o.kind !== 'returnRating') return; captureRrFields(o); const act = closest('.js-rr-reject').dataset.act; o.reject = o.reject || {}; o.reject[act] = !o.reject[act]; renderOverlay(); return; }   // arm/skip a default follow-up action
+  if (closest('.js-rr-save')) { e.stopPropagation(); return saveReturnRating(); }
   // "Text The Crew" launcher — stash the settings overlay (with any unsaved notif draft captured) as returnTo so the composer's Close lands back in the pane, edits intact.
   if (closest('.js-crew-broadcast')) { e.stopPropagation(); const o = state.overlay; if (!o || o.kind !== 'settings') return; if (currentRole && roleTier(currentRole) < tierRank('manager')) { toast('Managers and up can text the crew.'); return; } captureNotificationEdits(o); openOverlay({ kind: 'crewBroadcast', sel: [], text: '', returnTo: o }); return; }
   if (closest('.js-sales-schedule')) { e.stopPropagation(); return openOverlay({ kind: 'schedule', customerId: closest('.js-sales-schedule').dataset.rec }); }
@@ -18642,6 +18803,7 @@ function setRentalStatus(rentalId, val, opts = {}) {
   }
   toast(warn || `Status → ${getStatus('rentalStatus', val).label}`);
   render();
+  if (val === 'Returned') maybePromptReturnRating(r);   // master gate closed the whole rental to Returned → rate it
 }
 /* §20 set ONE unit's status (the per-unit gate). Diverging from its siblings locks
    the master gate to the mix label; re-converging frees it. Same §9 gates per unit. */
@@ -18671,6 +18833,7 @@ function setUnitStatus(rentalId, unitId, val, opts = {}) {
   reindex('rentals', r);
   logAction(r, `${IDX.unit.get(unitId)?.name || unitId} → ${getStatus('rentalStatus', val).label}`);
   render();
+  if (val === 'Returned') maybePromptReturnRating(r);   // all units back → rate the customer's experience
 }
 /* §20 is any of this unit's invoice lines paid? (blocks No-Show/Cancel — refund first) */
 function unitLinePaid(r, unitId) {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 24971 lines, 39 chapters
+## app.js — 25134 lines, 39 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -16,37 +16,37 @@
 | APP-06 | 1432–2179 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+61) |
 | APP-07 | 2180–3046 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+81) |
 | APP-08 | 3047–3054 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 3055–5352 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+153) |
-| APP-10 | 5353–5373 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 5374–6093 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+49) |
-| APP-12 | 6094–6261 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 6262–6501 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
-| APP-14 | 6502–6911 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
-| APP-15 | 6912–7111 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 7112–8630 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+44) |
-| APP-17 | 8631–8889 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 8890–9274 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, mobileNavEl, colTabButtonsHtml, colActionsHtml, memberCardEl, …(+6) |
-| APP-19 | 9275–9399 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 9400–9571 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 9572–9847 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+11) |
-| APP-22 | 9848–11354 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+133) |
-| APP-23 | 11355–11397 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 11398–12240 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 12241–13854 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-26 | 13855–14072 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, crewBroadcastHtml, sendCrewBroadcast |
-| APP-27 | 14073–14557 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 14558–15752 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+112) |
-| APP-29 | 15753–16038 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
-| APP-30 | 16039–16344 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+5) |
-| APP-31 | 16345–16348 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 16349–18720 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+58) |
-| APP-33 | 18721–19875 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
-| APP-34 | 19876–21189 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
-| APP-35 | 21190–21672 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 21673–21675 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 21676–23677 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+148) |
-| APP-38 | 23678–23684 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-39 | 23685–24971 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, phoneBoot, pidErr, pidCall, renderPhoneLogin, …(+65) |
+| APP-09 | 3055–5355 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+154) |
+| APP-10 | 5356–5376 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 5377–6096 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+49) |
+| APP-12 | 6097–6264 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 6265–6504 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
+| APP-14 | 6505–6914 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
+| APP-15 | 6915–7114 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 7115–8661 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+45) |
+| APP-17 | 8662–8920 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 8921–9305 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, mobileNavEl, colTabButtonsHtml, colActionsHtml, memberCardEl, …(+6) |
+| APP-19 | 9306–9430 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 9431–9602 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 9603–9878 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+11) |
+| APP-22 | 9879–11385 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+133) |
+| APP-23 | 11386–11428 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 11429–12271 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 12272–13890 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-26 | 13891–14229 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+11) |
+| APP-27 | 14230–14714 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 14715–15909 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+112) |
+| APP-29 | 15910–16195 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+18) |
+| APP-30 | 16196–16501 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+5) |
+| APP-31 | 16502–16505 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 16506–18883 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+58) |
+| APP-33 | 18884–20038 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, pendingInspForUnit, openChecklist, completeChecklist, setUnitWash, sellUnit, captureUnit, setUnitCapture, yardCapture, saveYardCapture, uploadCaptureMedia, offloadPhotoNow, …(+44) |
+| APP-34 | 20039–21352 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+84) |
+| APP-35 | 21353–21835 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 21836–21838 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 21839–23840 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, gpsFetch, gpsLogin, …(+148) |
+| APP-38 | 23841–23847 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-39 | 23848–25134 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, phoneBoot, pidErr, pidCall, renderPhoneLogin, …(+65) |
 
 ## config.js — 646 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260715f" />
+  <link rel="stylesheet" href="style.css?v=20260715g" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260715f"></script>
-  <script type="module" src="app.js?v=20260715f"></script>
+  <script src="rule-usage.js?v=20260715g"></script>
+  <script type="module" src="app.js?v=20260715g"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1210,6 +1210,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 .ca-dot.d { width:4px; height:4px; background:#c2925a; }
 .ca-legend { position:absolute; top:6px; right:10px; display:flex; gap:11px; font-size:10px; color:var(--txt-3); z-index:5; pointer-events:none; }
 .ca-legend i { display:inline-block; width:9px; height:2px; vertical-align:middle; margin-right:4px; border-radius:1px; }
+.ca-legend .ca-leg-r { display:inline-flex; align-items:center; gap:3px; }
+.ca-legend .ca-leg-r svg { width:11px; height:11px; fill:var(--accent); stroke:none; }
+/* return-rating markers on the activity chart — orange stars on a fixed 1–5 scale (Jac) */
+.ca-star { position:absolute; transform:translate(-50%,-50%); line-height:0; z-index:4; cursor:default; }
+.ca-star svg { width:13px; height:13px; fill:var(--accent); stroke:#0c0e11; stroke-width:1px; filter:drop-shadow(0 1px 2px rgba(0,0,0,.55)); }
+.ca-star.dash svg { width:9px; height:9px; opacity:.78; }   /* the in-between "dashes" of the star line — smaller than the real rated-month points */
 .ca-scrub { position:absolute; top:24px; bottom:26px; width:1px; background:rgba(255,255,255,.4); left:0; opacity:0; pointer-events:none; z-index:5; transition:opacity .1s; }
 .ca-scrub.on { opacity:1; }
 .ca-tip { position:absolute; top:24px; transform:translateX(-50%); background:#14181d; border:1px solid rgba(255,255,255,.16); border-radius:7px; padding:4px 9px; display:flex; flex-direction:column; gap:1px; line-height:1.3; opacity:0; pointer-events:none; z-index:6; white-space:nowrap; box-shadow:0 4px 14px rgba(0,0,0,.5); }
@@ -1217,6 +1223,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .ca-tip b { font-family:'Saira Condensed',sans-serif; font-size:11px; letter-spacing:.5px; text-transform:uppercase; }
 .ca-tip .ca-tip-s { color:var(--accent); font-size:12px; font-weight:600; }
 .ca-tip .ca-tip-d { color:#c2925a; font-size:11px; }
+.ca-tip .ca-tip-r { color:var(--accent); font-size:11px; font-weight:600; }
 .ca-co { position:absolute; transform:translateX(-50%); z-index:6; white-space:nowrap; display:flex; align-items:center; gap:6px; }
 .ca-bag { width:26px; height:26px; border-radius:50%; display:grid; place-items:center; font-size:13px; background:#0c0f14; border:1px solid #2a313b; flex:0 0 auto; }
 .ca-cc { background:#12161c; border:1px solid #2a313b; border-radius:8px; padding:4px 8px; box-shadow:0 8px 18px -8px rgba(0,0,0,.7); }
@@ -1230,6 +1237,9 @@ select.lf-in { appearance: none; cursor: pointer; }
 .ca-cap { display:flex; justify-content:space-between; gap:8px; margin-top:9px;
   font-family:'Saira Condensed',system-ui,sans-serif; text-transform:uppercase; letter-spacing:.5px; font-size:10px; color:var(--txt-3); }
 .ca-cap b { color:var(--txt-2); font-weight:700; }
+.ca-cap .ca-exp { display:inline-flex; align-items:center; gap:3px; color:var(--txt-2); }
+.ca-cap .ca-exp b { color:var(--accent); }
+.ca-cap .ca-exp svg { width:11px; height:11px; fill:var(--accent); stroke:none; }
 .ca-cap .muted { color:var(--txt-3); text-transform:none; letter-spacing:0; font-family:var(--font); }
 
 /* §12 Comment markers (Jac, Phase 6) — a colored dot on a record that FLASHES until
@@ -2044,9 +2054,49 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .notif-card { border: 1px solid var(--line); border-radius: var(--radius, 16px); background: var(--panel-2); margin-bottom: 12px; overflow: hidden; }
 .notif-card:last-child { margin-bottom: 0; }
 .notif-cap { height: 5px; background: repeating-linear-gradient(135deg, var(--yellow) 0 13px, #14181d 13px 26px); }
-.notif-card-body { padding: 12px 14px; display: flex; flex-direction: column; gap: 9px; }
-.notif-card-head { display: flex; align-items: center; gap: 7px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12.5px; color: var(--txt); }
-.notif-card-head svg { width: 15px; height: 15px; color: var(--txt-2); }
+.notif-card-body { padding: 3px 14px 13px; display: flex; flex-direction: column; gap: 9px; }
+/* Section header = the collapse control (a full-width button). Collapsed by default so the
+   tall pane opens compact; the chevron flips up when the section is open. */
+.notif-card-head { width: 100%; display: flex; align-items: center; gap: 8px; padding: 11px 14px; background: transparent; border: none; cursor: pointer; text-align: left; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12.5px; color: var(--txt); }
+.notif-card-head:hover { background: var(--panel); }
+.notif-card-head:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.notif-card-head .nch-t { flex: 1 1 auto; }
+.notif-card-head .nch-ic { display: inline-flex; }
+.notif-card-head .nch-ic svg { width: 15px; height: 15px; color: var(--txt-2); }
+.notif-card-head .nch-chev { display: inline-flex; margin-left: auto; }
+.notif-card-head .nch-chev svg { width: 15px; height: 15px; color: var(--txt-3); transition: transform .15s ease; }
+.notif-card.is-open .notif-card-head .nch-chev svg { transform: rotate(180deg); }
+@media (prefers-reduced-motion: reduce) { .notif-card-head .nch-chev svg { transition: none; } }
+/* ── Return-rating popup — customer-experience stars + tiered follow-ups (2026-07-15) ── */
+.rr-body { display: flex; flex-direction: column; gap: 12px; }
+.rr-intro { font-size: 12.5px; line-height: 1.5; color: var(--txt-2); }
+.rr-intro b { color: var(--txt); }
+.rr-stars { display: flex; justify-content: center; gap: 9px; padding: 3px 0 1px; }
+.rr-star { background: none; border: none; cursor: pointer; padding: 4px; line-height: 0; border-radius: 9px; }
+.rr-star svg { width: 34px; height: 34px; fill: none; stroke: var(--line); stroke-width: 1.6px; transition: stroke .12s ease, fill .12s ease; }
+.rr-star:hover svg { stroke: var(--accent); }
+.rr-star.on svg { fill: var(--accent); stroke: var(--accent); }
+.rr-star:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) { .rr-star svg { transition: none; } }
+.rr-band { text-align: center; font-size: 12px; font-weight: 600; padding: 7px 10px; border-radius: 10px; line-height: 1.35; }
+.rr-band-none { color: var(--txt-3); font-weight: 500; }
+.rr-band-good { color: var(--green); background: var(--green-bg); }
+.rr-band-mid { color: var(--yellow); background: var(--yellow-bg); }
+.rr-band-low { color: var(--red); background: var(--red-bg); }
+.rr-actions { border: 1px solid var(--line); border-radius: 12px; padding: 10px 12px; display: flex; flex-direction: column; gap: 10px; background: var(--panel-2); }
+.rr-actions-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
+.rr-action { display: flex; align-items: center; gap: 9px; }
+.rr-action-ic { display: inline-flex; flex: 0 0 auto; }
+.rr-action-ic svg { width: 16px; height: 16px; color: var(--txt-2); }
+.rr-action-desc { flex: 1 1 auto; font-size: 12.5px; color: var(--txt); }
+.rr-action.is-skip .rr-action-desc { color: var(--txt-3); text-decoration: line-through; }
+.rr-action.is-skip .rr-action-ic svg { color: var(--txt-3); }
+.rr-note { width: 100%; margin-top: -2px; }
+.rr-req-note { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--txt-3); }
+.rr-req-note svg { width: 12px; height: 12px; }
+/* Editable rating-message templates in Settings → Notifications → Rating Follow-ups */
+.notif-fld-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 10px; color: var(--txt-3); margin-top: 2px; }
+.notif-msg { width: 100%; resize: vertical; }
 .notif-row { display: flex; align-items: center; gap: 10px; }
 .notif-row .notif-label { flex: 1 1 auto; min-width: 110px; font-size: 12.5px; font-weight: 600; color: var(--txt); }
 .notif-sub { font-size: 11px; line-height: 1.4; color: var(--txt-3); }
@@ -4039,6 +4089,8 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .rcc-h2 { display: flex; align-items: baseline; justify-content: space-between; gap: 7px; min-width: 0; }
 .rcc-cust { font-size: 12px; font-weight: 600; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
 .rcc-bal { font-size: 12.5px; font-weight: 800; white-space: nowrap; flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.rcc-rating { display: inline-flex; align-items: center; gap: 2px; font-size: 11.5px; font-weight: 800; color: var(--accent); flex-shrink: 0; margin-left: 2px; font-variant-numeric: tabular-nums; }
+.rcc-rating svg { width: 12px; height: 12px; fill: var(--accent); stroke: none; }
 .rcc-bal.paid { color: var(--green); }
 .rcc-bal.due { color: var(--yellow); }
 .rcc-bal.overdue { color: var(--red); }


### PR DESCRIPTION
## What

When all of a rental's units hit **Returned**, a required popup lets the **office** rate the customer's experience **1–5★**, driving tiered follow-ups and feeding customer-experience surfaces (but **never** the Reputation KPI — the rater can't move their own number).

Rebased cleanly onto the current phone-identity trunk: `app.js`/`style.css` auto-merged with no hand-resolution; only the shared `?v=` token (→`20260715e`) and the generated code-map needed resolving. Both features verified present post-merge.

## Feature
- **Required popup** at return (`setUnitStatus`/`setRentalStatus`), no skip — only Save closes it.
- **Tiered reactions**, armed by default, office can skip each per-send:
  - **4–5★** → thank-you + review-request text
  - **2–3★** → Sales follow-up task (+ office note)
  - **1★** → apology text + **ALWAYS** notify a manager (non-skippable)
- **Editable messages** per-send; shop **default templates** in Settings → Notifications → **Rating Follow-ups**.
- **Surfaces:** rating on the rental (row + detail badge), customer **overall-experience** average, and an **orange star-line** on the customer activity graph (fixed 1–5 scale).
- **Sends** ride the live `sendCustomerMessage` SMS path (consent/quiet-hours/daily-cap enforced server-side); Sales flag → customer `activityLog`; manager alert → red comment marker.
- **Notifications pane** made collapsible; `Schedule Change` → `Shift/Run Change` with tooltips.

## Verification
All gates green: `smoke`, `logic-test` 669/669, `gen-rule-usage --check`, `check-window-catalog` (48 popups), `gen-code-map --check`.

⚠️ ③'s customer sends are a **live-only path** (demo has no backend) — needs a post-promote click-through with the C0991 test customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ)_