### PR TITLE
Cache-bust: sync trunk ?v= → 20260715h so staging matches for the return-rating promote

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260715g" />
+  <link rel="stylesheet" href="style.css?v=20260715h" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260715g"></script>
-  <script type="module" src="app.js?v=20260715g"></script>
+  <script src="rule-usage.js?v=20260715h"></script>
+  <script type="module" src="app.js?v=20260715h"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

`index.html` `?v=` bump only (`20260715g → 20260715h`), no code change. Trunk's return-rating merge (#645) landed with `?v=20260715g`, but `deploy-staging` auto-bumps the token, so the staging review of that exact trunk build lands on `?v=20260715h`. This syncs trunk's token to staging so `promote.mjs`'s staging-freshness gate passes **without** the `--skip-staging-check` override.

## Verification
`app.js`/`style.css` are byte-identical to trunk `adfe1713`; only the cache token changes. Staging already serves this build at `?v=20260715h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtQJSF7ahFddJRAZzCiTJJ)_