### PR TITLE
Harden the auto-fix engine: dedupe double-trigger + promote-drag heads-up

### DIFF
--- a/.github/workflows/auto-promote.yml
+++ b/.github/workflows/auto-promote.yml
@@ -12,9 +12,14 @@ name: Auto-promote — take a merged Wrangler auto-fix live
 # there — this closes the last mile so an end-user's reported fix actually goes
 # live without them (or Jac) touching the deploy machinery.
 #
-# ONLY auto-fixes auto-promote. A human's merge to `trunk` carries no
-# `auto-promote` label, so it still waits for the human `/promote` (Gate 2) —
-# your two-gate control is untouched for everything except Wrangler auto-fixes.
+# ONLY auto-fixes TRIGGER an auto-promote. A human's merge to `trunk` carries no
+# `auto-promote` label, so it never triggers this job on its own — it still waits
+# for the human `/promote` (Gate 2). One caveat, made explicit: promote.mjs
+# fast-forwards `production` to the FULL `trunk` tip, so when an auto-fix does
+# promote, any CI-green human work already merged to trunk but not yet `/promote`d
+# rides live with it. That's safe (everything on trunk passed CI), and the final
+# step below leaves a heads-up comment on the PR listing anything that rode along,
+# so an auto-fix never takes other work live silently.
 #
 # HOW IT STAYS SAFE (fully machine-gated — no human review, but every gate must pass):
 #   1. `smoke` + `logic-test` CI already gated the merge to trunk (a broken fix
@@ -69,6 +74,15 @@ jobs:
         with:
           node-version: 20
 
+      - name: Record the production tip before promoting
+        # Baseline for the heads-up step below: where production sat BEFORE the
+        # fast-forward. Captured to $GITHUB_ENV now (before promote.mjs moves the
+        # ref) so we can diff old→new production afterward and report anything that
+        # rode live besides this auto-fix. FETCH_HEAD is reliable right after fetch.
+        run: |
+          git fetch origin production
+          echo "PROD_BEFORE=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_ENV"
+
       - name: Promote the merged auto-fix to production (go live)
         # promote.mjs: fetch trunk+production, verify staging is fresh, fast-forward
         # production -> trunk, then verify the live ?v= bytes. --yes runs it for real.
@@ -85,4 +99,40 @@ jobs:
             gh issue comment "$ISSUE" --body "✅ Shipped and **live** now — refresh the page to see it. — Mr. Wrangler"
           else
             echo "auto-promote: promoted, but found no 'Closes #<n>' in the PR body to comment on."
+          fi
+
+      - name: Heads-up if other trunk commits rode live with this auto-fix
+        # promote.mjs fast-forwards production to the whole trunk tip, so this
+        # auto-fix can carry CI-green work that was merged to trunk but deliberately
+        # left for a manual /promote. Safe (all of trunk passed CI) but it means
+        # "/promote is my gate" isn't strict — so leave a developer-facing audit
+        # trail on the PR when it happens. Never blocks: the fix already went live.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.WRANGLER_PAT }}
+          PROD_BEFORE: ${{ env.PROD_BEFORE }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch origin production
+          PROD_AFTER=$(git rev-parse FETCH_HEAD)
+          # Fallback so an (unexpected) empty merge sha can't over-report every commit.
+          [ -z "$MERGE_SHA" ] && MERGE_SHA="$PROD_AFTER"
+          # Everything this promote took live, minus the auto-fix's own squash commit.
+          RODE=$(git log --no-merges --format='%H %h %s' "$PROD_BEFORE..$PROD_AFTER" \
+                   | grep -vi "^$MERGE_SHA " || true)
+          if [ -n "$RODE" ]; then
+            COUNT=$(printf '%s\n' "$RODE" | grep -c '')
+            {
+              echo "⚠️ **Heads-up — this auto-promote also took $COUNT other trunk commit(s) live.**"
+              echo
+              echo "\`promote.mjs\` fast-forwards \`production\` to the whole \`trunk\` tip, so work merged to trunk but not yet \`/promote\`d rode live with this auto-fix:"
+              echo
+              printf '%s\n' "$RODE" | sed -E 's/^[^ ]+ ([^ ]+) /- `\1` /'
+              echo
+              echo "All were CI-green on trunk, so nothing unverified shipped — but if you meant to hold any for a batched \`/promote\`, that's why they're live now."
+            } > "$RUNNER_TEMP/rode.md"
+            gh pr comment "$PR_NUMBER" --body-file "$RUNNER_TEMP/rode.md"
+          else
+            echo "auto-promote: no other commits rode along — clean single-fix promote."
           fi

--- a/.github/workflows/wrangler-fix.yml
+++ b/.github/workflows/wrangler-fix.yml
@@ -43,6 +43,17 @@ on:
     # reporter, which files a pre-filled issue that already carries the label.
     types: [opened, labeled]
 
+# De-dupe the opened+labeled double-fire: the in-app reporter files an issue that
+# ALREADY carries the label, so GitHub emits BOTH `opened` and `labeled` for the
+# same issue — which otherwise starts two identical fix runs that race on the same
+# branch/PR (2× the API spend, and a real collision risk). One group per issue
+# with cancel-in-progress collapses them to a single run (the later event
+# supersedes the earlier), and also means a quick re-label restarts the fix
+# cleanly instead of stacking a second agent on top of the first.
+concurrency:
+  group: wrangler-fix-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
**Draft — two follow-ups to the now-live auto-fix→live pipeline (#639), both surfaced by the end-to-end test (#643 → #644).** Workflow-YAML only; no served bytes change, so there's no `production` promote here — a plain `/merge` when you're happy.

### 1. Dedupe the double-trigger — `wrangler-fix.yml`
The in-app reporter files a **pre-labelled** issue, so GitHub emits both `opened` **and** `labeled` for the same issue → two identical fix runs race on the same branch/PR (2× the API spend + a real collision risk). Observed live on #643.

**Fix:** a per-issue `concurrency` group with `cancel-in-progress: true` collapses the pair to a single run (the later event supersedes the earlier). Bonus: a quick re-label now restarts the fix cleanly instead of stacking a second agent.

### 2. Promote-drag heads-up — `auto-promote.yml`
`promote.mjs` fast-forwards `production` to the **whole `trunk` tip**, so when an auto-fix promotes, any CI-green human work merged to trunk but not yet `/promote`d **rides live with it**. This happened in the test: #642 (a human UI change, deliberately held) went live as a passenger on #644's auto-promote.

It's safe — everything on trunk already passed CI — but it means "/promote is my gate" isn't strictly true. Rather than break your real-time guarantee by *blocking* (which would defeat the whole point), this **never blocks**; it just:
- records production's tip before promoting, and
- posts a developer-facing heads-up comment on the PR listing any commits that rode live besides the auto-fix.

The header comment is corrected to state the drag behaviour explicitly instead of implying human merges are fully insulated.

### Why the heads-up, not a hard guard
Blocking auto-promote until pending human commits are manually promoted would break the #1 goal (users' fixes reach live in real time). Everything on trunk is CI-green, so nothing unverified ships. The audit trail gives you visibility without sacrificing the real-time path — if you'd rather have a hard hold instead, that's a one-line change and I'll swap it.

### Verified
YAML validated (`yaml.safe_load` both files). Diff is the 2 workflow files only. Static gates green: `gen-code-map --check`, `gen-rule-usage --check`, `check-window-catalog`. Runtime gates (`smoke`/`logic-test`) boot the served app, which a workflow-YAML change can't affect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3Qzor6hTRSvcXnarrDuCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3Qzor6hTRSvcXnarrDuCi)_