### PR TITLE
Fix the black screen on signed-in app open: boot splash + parallel resume

### DIFF
--- a/app.js
+++ b/app.js
@@ -23980,7 +23980,7 @@ function pidAdopt(r, tok, personal) {
   try { sessionStorage.setItem('jactec.role', currentRole); localStorage.setItem('jactec.user', currentUser); } catch (e) {}
 }
 function pidLoadFail() { pidTokenClear(); backendPassword = ''; pidUI.step = 'identify'; renderPhoneLogin("Couldn't reach the database. Try again."); }
-function pidEnter() {
+function pidEnter(loadP) {
   const s = document.querySelector('.login-screen');
   if (s) {
     s.classList.add('signing-in');
@@ -23996,16 +23996,42 @@ function pidEnter() {
   // rejected, retry muted so the video still rolls — audio is the bonus, the video is the point.
   const vid = document.getElementById('login-video');
   if (vid) { try { vid.muted = state.loginMuted; const p = vid.play(); if (p && p.catch) p.catch(() => { vid.muted = true; const p2 = vid.play(); if (p2 && p2.catch) p2.catch(() => {}); }); } catch (e) {} }
-  loadFromBackend().then(finishLoad).then(applyRoleLanding).catch(pidLoadFail);
+  (loadP || loadFromBackend()).then(finishLoad).then(applyRoleLanding).catch(pidLoadFail);   // §instant-cache #650: loadP = the pre-fired parallel load from phoneBoot's resume path (falls back to a fresh load on the normal PIN sign-in)
+}
+// Boot splash — the signed-in resume paths (trusted-device token / cached same-tab
+// password) go straight to the backend, and #app sat EMPTY until the data landed: a
+// long black screen that read as broken (Jac 2026-07-15). Paint the plate immediately
+// in its signing-in state — the same barber-pole treatment the post-Saddle-Up load
+// shows — so the wait reads as "working". No inputs, and no intro video (its 2.4MB
+// fetch would compete with the load call); reduced-motion freezes the band as on login.
+function renderBootSplash() {
+  $('#app').innerHTML = `<div class="login-screen signing-in"><div class="login-box">
+    <span class="rivet tl"></span><span class="rivet tr"></span><span class="rivet bl"></span><span class="rivet br"></span>
+    <div class="login-plate">
+      <img class="login-logo" src="assets/jac-rentals-logo.jpg" alt="Jac Rentals" />
+      <div class="login-title">Rental Wrangler</div>
+      <div class="login-sub">JacRentals · Sulphur, LA</div>
+      <div class="login-hint" role="status">${currentUser ? 'Saddling up, ' + esc(currentUser) + '…' : 'Saddling up…'}</div>
+    </div></div></div>`;
 }
 // Boot (flag on): resume a trusted device, else show the phone login.
 function phoneBoot() {
   const tok = pidTokenGet();
   if (!tok) { warmBackend(); return renderPhoneLogin(); }
+  // Trusted-device resume used to await authResume THEN load with nothing painted in
+  // #app — a black screen for two serial backend round-trips (cold GAS ≈ 1–5s each).
+  // Paint the splash first, and fire the two calls in PARALLEL: both carry the token
+  // and are validated server-side per call, nothing applies until BOTH succeed, and a
+  // rejected resume discards the load result outright — the auth outcome is identical
+  // to the serial path, in roughly half the wall-clock.
+  renderBootSplash();
+  backendPassword = tok;                       // backendCall sends it as sessionToken on both calls
+  const loadP = backendCall('load');
+  loadP.catch(() => {});                       // may settle before pidEnter attaches the real handler — silence the interim rejection (the chain below still sees it)
   backendCall('authResume', { token: tok }).then((r) => {
-    if (r && r.ok) { pidAdopt(r, tok, !!(function () { try { return localStorage.getItem('jactec.pidToken'); } catch (e) { return null; } })()); pidEnter(); }
+    if (r && r.ok) { pidAdopt(r, tok, !!(function () { try { return localStorage.getItem('jactec.pidToken'); } catch (e) { return null; } })()); pidEnter(loadP.then(applyLoadResponse)); }
     else { pidTokenClear(); backendPassword = ''; warmBackend(); renderPhoneLogin(); }
-  }).catch(() => { warmBackend(); renderPhoneLogin(); });
+  }).catch(() => { backendPassword = ''; warmBackend(); renderPhoneLogin(); });
 }
 function pidErr(msg) { pidUI.err = msg || ''; const e = document.getElementById('pid-err'); if (e) e.textContent = pidUI.err; return null; }
 async function pidCall(btnId, fn) {
@@ -24566,6 +24592,7 @@ function boot() {
   // §16 — gate on the shared password: load from the backend if we already have it
   // this session, otherwise show the login screen. The app only renders once data is in.
   if (backendPassword) {
+    renderBootSplash();   // same-tab reload with a cached password: paint before the load round-trip (no black screen)
     loadFromBackend().then(finishLoad)
       .catch(() => { backendPassword = ''; sessionStorage.removeItem('jactec.pw'); renderLogin('Please sign in again.'); });
   } else {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 25305 lines, 39 chapters
+## app.js — 25332 lines, 39 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -46,7 +46,7 @@
 | APP-36 | 21934–21936 | §18 | §18 PERSISTENCE & BOOT | — |
 | APP-37 | 21937–23961 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+150) |
 | APP-38 | 23962–23968 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-39 | 23969–25305 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, phoneBoot, pidErr, pidCall, renderPhoneLogin, …(+65) |
+| APP-39 | 23969–25332 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+66) |
 
 ## config.js — 646 lines, 0 chapters
 


### PR DESCRIPTION
## What

Jac reported a long black screen when opening the app while already signed in. Confirmed and root-caused: the signed-in resume paths painted **nothing** into `#app` until all backend data landed.

- **Trusted-device resume** (`phoneIdentity` personal token): `phoneBoot()` awaited `authResume` **then** `load` — two *serial* GAS round-trips (1–5s cold start each) with an empty `#app` the whole time.
- **Cached-password same-tab reload**: `boot()`'s `backendPassword` branch had the same await-with-nothing-painted defect (one round-trip).

## Fix

- `renderBootSplash()` — paints the login data-plate immediately in its `signing-in` state (the existing barber-pole caution-band loading treatment; reuses `.login-*` classes wholesale, no new tokens/CSS) with a `Saddling up, <name>…` status line (`role="status"`). No inputs; no intro video (its 2.4 MB fetch would compete with the load call). Called on both resume paths.
- `phoneBoot()` now fires `authResume` + `load` **in parallel** — roughly halving the wait. ⚠️ This touches the auth resume flow, flagged per the money/auth caution rule: it does **not** weaken the gate. Both calls carry the token and are validated server-side per call; nothing is applied or rendered until *both* succeed; a rejected resume discards the load result outright, clears the token, and falls back to the phone login — identical auth outcome to the serial path.
- `pidEnter(loadP)` accepts the pre-fired load promise; the verify/PIN login flows are unchanged (they pass nothing and load serially as before).
- `docs/code-map.generated.md` regenerated (line shifts only).

## Proof (failed-before / passes-after)

Playwright against a stubbed 1.6s-per-call backend, trusted token pre-seeded, probed mid-load:

| | mid-load `#app` | call order |
|---|---|---|
| pre-fix (trunk) | **empty — black screen** | `authResume` → `load` (serial) |
| this branch | splash visible, barber-pole running | `load` + `authResume` (parallel) |

Both runs complete to the fully rendered grid with no page errors. Stale-token path re-verified: resume rejected → token cleared, phone login shown, parallel load discarded, no errors. Splash screenshot checked at 1440px and 390px.

## Gates

`ci/smoke.mjs` ✅ · `ci/logic-test.mjs` 669/669 ✅ · `gen-rule-usage --check` ✅ (no rule-usage change — splash adds no lint-family elements) · `check-window-catalog` ✅ (screen, not a popup) · `gen-code-map --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PAvS5cWW6P9LeHVng8Z44

---
_Generated by [Claude Code](https://claude.ai/code/session_011PAvS5cWW6P9LeHVng8Z44)_