### PR TITLE
Login code button: "Verify" → "Confirm"

### DIFF
--- a/app.js
+++ b/app.js
@@ -24039,7 +24039,7 @@ function renderPhoneLogin(msg) {
   } else if (step === 'code') {
     inner = `<div class="login-hint">Enter the ${P.codeLen}-digit code sent to ${esc(pidUI.masked)}</div>
       <div class="login-field"><input id="pid-code" class="login-input login-otp" inputmode="numeric" autocomplete="one-time-code" maxlength="${P.codeLen}" placeholder="000000" /></div>
-      <div class="login-actions">${muteBtn}<button type="submit" class="login-btn" data-r="R17" id="pid-verify">Verify</button></div>
+      <div class="login-actions">${muteBtn}<button type="submit" class="login-btn" data-r="R17" id="pid-verify">Confirm</button></div>
       <button type="button" class="login-ghost" id="pid-resend">Resend code</button>`;
   } else if (step === 'setpin') {
     inner = `<div class="login-hint">Set a PIN for this shared computer, ${esc(pidUI.name || 'partner')}</div>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717d" />
+  <link rel="stylesheet" href="style.css?v=20260717e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717d"></script>
-  <script type="module" src="app.js?v=20260717d"></script>
+  <script src="rule-usage.js?v=20260717e"></script>
+  <script type="module" src="app.js?v=20260717e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What

Renames the phone-login code-step button from **"Verify"** to **"Confirm"** (Jac's pick).

With the 6-digit auto-submit (shipped in #655), this button is rarely tapped — it flashes to the "Wrangling the herd…" busy state — so it's mostly the pre-submit fallback label.

## Diff

- `app.js` — one label string: `>Verify<` → `>Confirm<` on `#pid-verify`
- `index.html` — shared `?v=` cache-bust bump `20260717d` → `20260717e`

## Verification

- Local gates green: `node --check`, `gen-rule-usage --check`, `check-window-catalog`, `gen-code-map --check`
- Deployed to staging (`?v=20260717e`), Confirm label confirmed in the served bytes
- `smoke` CI runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F89py8tRdvSmkh6dL3iH1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01F89py8tRdvSmkh6dL3iH1a)_