### PR TITLE
MEMORY: capture login-session UX decision + 2 cloud-session gotchas

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -33,6 +33,15 @@
   review must ALL pass; any failure hard-stops and pings Jac — never a broken fix to
   live. Flipping the live auto-promote switch (`wrangler-fix.yml` + an automated
   promote path) is Jac's explicit one-time go.
+- **2026-07-17 — Phone-login sign-in UX** (#655, #664). The per-person
+  (`phoneIdentity: true`) login now: holds the button at **"Wrangling the herd…"**
+  through the whole `pidEnter` data load (no flip-back to a clickable "Verify"/"Saddle
+  Up?" mid-sign-in — the old bug); plays the Mr. Wrangler intro **video** behind the
+  plate during sign-in (mute toggle **ported from the classic screen** for audio
+  parity, retries muted if unmuted autoplay is blocked); **auto-submits** the 6-digit
+  code on entry (also catches the OS one-time-code autofill); and the code button reads
+  **"Confirm"** (was "Verify"). Busy label unified to "Wrangling the herd…" across both
+  login screens.
 
 ## Design prefs
 - Yard **"data-plate"** design language: dark industrial steel, **ONE** safety-orange
@@ -72,6 +81,19 @@
 - **The git proxy rejects delete-refspec pushes** (2026-07-17) — `git push origin --delete
   <branch>` / `:<branch>` throws "send-pack: unexpected disconnect" from a cloud session.
   Merged feature branches can't be deleted here; leave them for GitHub-side cleanup.
+- **The phone-identity login can't be driven headlessly** (2026-07-17) — the live login
+  is **SMS-gated** (a real code to a roster phone) and `app.js` is an **ES module** (login
+  internals aren't on `window`), so you can't drive it past the "enter phone" step even
+  with Playwright, and you must **never** fire `authStart` on a real number (it texts a
+  real hand). Staging-review of login changes = **served-bytes verification**
+  (`curl … | grep`); the real end-to-end drive is Jac on a phone.
+- **Land merges through a degraded GitHub API with auto-merge** (2026-07-17) — during a
+  REST-API Major outage, `merge_pull_request` failed repeatedly, but
+  `enable_pr_auto_merge` (SQUASH) landed the PR once `smoke` passed **and** closed the
+  "trunk moved during CI → merge conflict" race. Corollary: the shared `?v=` token
+  conflicts on nearly every concurrent merge — resolve mechanically
+  (`git checkout --ours/--theirs index.html` to pick the forward token, then
+  `node tools/gen-code-map.mjs`), never by hand-editing the generated map.
 
 ## Open threads
 - **Repo privacy** — parked on Jac's GitHub billing-tier check. Pages-from-private


### PR DESCRIPTION
## What

Cross-session memory refresh at `/end` for the login-status session. Docs-only (`MEMORY.md`, not served by Pages) — no `?v=` bump, no deploy/promote.

Adds:
- **Decisions** — the #655/#664 phone-login sign-in UX: hold "Wrangling the herd…" through the load (no flip-back), intro video during sign-in with a mute toggle ported from the classic screen, 6-digit auto-submit (catches OS one-time-code autofill), Verify→Confirm.
- **Gotchas** — (1) the phone-identity login can't be driven headlessly (SMS-gated + `app.js` is an ES module), so login staging-review is served-bytes verification only; (2) `enable_pr_auto_merge` lands merges through a degraded GitHub API and closes the trunk-moved-during-CI race.

Complements #663's earlier 2026-07-17 entry (no overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F89py8tRdvSmkh6dL3iH1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01F89py8tRdvSmkh6dL3iH1a)_