### PR TITLE
Cache-bust: sync ?v= to 20260717i so staging mirrors trunk for the promote

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717h" />
+  <link rel="stylesheet" href="style.css?v=20260717i" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717h"></script>
-  <script type="module" src="app.js?v=20260717h"></script>
+  <script src="rule-usage.js?v=20260717i"></script>
+  <script type="module" src="app.js?v=20260717i"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Config-only cache-bust: bumps the shared `?v=` token in `index.html` to `20260717i`.

Staging was behind trunk (`f` vs `h`) after the inspection merge (#662) plus concurrent trunk churn. I redeployed the current trunk bytes to staging (now serving `?v=20260717i`, verified) and this lands the matching token on trunk so `promote.mjs`'s staging-freshness gate passes for the go-live. No served logic changes — token only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mc2MUZMF2Swp113XC5Sxhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc2MUZMF2Swp113XC5Sxhp)_