### PR TITLE
MEMORY: capture the inspection-toggle decision + 2 ops gotchas

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -62,6 +62,18 @@
   border color (green insured / yellow uninsured); there is **no** separate Coverage section
   (#659, Jac's call). Added a **"Check for updates"** row to the tools menu (#661) that clears
   the SW + HTTP caches and hard-reloads past a stale cache — the escape hatch for pinned builds.
+- **2026-07-17 — Inspection toggle IS the interface** (#662, #676). The unit-card Inspection
+  section always shows the `Pass · Not Ready · Fail` segmented toggle (stacked on its own row
+  to match mobile); the old `+ Inspection` / `Resume inspection` checklist button is **retired**.
+  **Pass gates** the inspection: a required-checklist category opens the checklist takeover
+  (completion cascades to Pass); no checklist → a direct, wash-gated (R19) pass; already-passed →
+  Pass re-opens the completed inspection to **view** (`openInspectionRecord`, which materialises a
+  lightweight pass record if none is on file so it's never a dead-end, never a blank pending
+  checklist). **Not Ready** resets. **Fail** smart-routes: a unit out on an active rental →
+  `markFieldCall` (field call — red-flag the rental, dispatch); a yard unit → bench
+  failed-inspection. The shared §12.8 inspection popup is now **pass-aware** — it drops the
+  "Failure report" title, danger styling, and "Charge the customer?" bill gate when the
+  inspection passed. Reuses `segCtl` (R14); multi-unit field-call granularity is a parked thread.
 
 ## Design prefs
 - Yard **"data-plate"** design language: dark industrial steel, **ONE** safety-orange
@@ -127,6 +139,17 @@
   conflicts on nearly every concurrent merge — resolve mechanically
   (`git checkout --ours/--theirs index.html` to pick the forward token, then
   `node tools/gen-code-map.mjs`), never by hand-editing the generated map.
+- **The Bash guard false-positives on compound git commands** (2026-07-17) — a single Bash
+  command containing BOTH `git push` AND a `trunk`/`production` token (e.g. a `git push …; git …
+  origin/trunk` chain, or a `git merge-base --is-ancestor origin/trunk HEAD` check alongside a
+  push) is blocked as "Direct push to a protected release branch," even when the push targets a
+  feature branch. Run the push in its OWN command with no `trunk`/`production` token in the string.
+- **promote.mjs's staging gate matches the ?v= TOKEN, not content** (2026-07-17) — it passes when
+  live staging's `?v=` equals the trunk commit's `?v=`. On a fast-churning shared-staging trunk,
+  your feature's token can ride the squash onto trunk and match staging even though a concurrent
+  commit that landed between your `/deploy` and merge isn't on staging. It's still the sanctioned
+  bar (that commit was CI-gated + staged by its own session), but token-match ≠ full content-match
+  — re-deploy trunk to staging if you need a faithful mirror before a go-live.
 
 ## Open threads
 - **Repo privacy** — parked on Jac's GitHub billing-tier check. Pages-from-private


### PR DESCRIPTION
Docs-only — appends to `MEMORY.md` (no served logic changes, so this merges to trunk with no promote).

- **Decisions** — the inspection-toggle redesign (#662, #676): the toggle is the whole interface (Pass gates / button retired / Fail smart-routes on-rent → field call / pass-aware §12.8 popup / record-less Pass-again materialises a pass record).
- **Gotchas** — (1) the Bash guard false-positives when one command mixes `git push` with a `trunk`/`production` token (keep the push isolated); (2) `promote.mjs`'s staging-freshness gate matches the `?v=` token, not content, so it can pass when staging lacks a concurrent trunk commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mc2MUZMF2Swp113XC5Sxhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc2MUZMF2Swp113XC5Sxhp)_