### PR TITLE
userSync: sendBeacon tab-close flush + one-time cutover toast (on the live #692 feature)

### DIFF
--- a/app.js
+++ b/app.js
@@ -24289,10 +24289,12 @@ function flushUserPrefsNow() {
   if (!any) return;
   doc.v = state.userPrefs.v || 1; _userPrefsDirty = {};
   try {
+    let queued = false;
     if (navigator.sendBeacon) {
       const payload = JSON.stringify({ action: 'setUserPrefs', password: backendPassword, sessionToken: backendPassword, doc });
-      navigator.sendBeacon(BACKEND_URL, new Blob([payload], { type: 'text/plain;charset=utf-8' }));
-    } else { Object.keys(doc).forEach((s) => { if (s !== 'v') _userPrefsDirty[s] = true; }); pushUserPrefs(); }   // no beacon → best-effort fetch
+      queued = navigator.sendBeacon(BACKEND_URL, new Blob([payload], { type: 'text/plain;charset=utf-8' }));   // false = payload over the ~64KB / pending-queue limit
+    }
+    if (!queued) { Object.keys(doc).forEach((s) => { if (s !== 'v') _userPrefsDirty[s] = true; }); pushUserPrefs(); }   // no beacon OR beacon rejected → best-effort fetch, re-mark dirty
   } catch (e) { /* best-effort — the change also re-flushes on the next edit */ }
 }
 async function pushUserPrefs() {

--- a/app.js
+++ b/app.js
@@ -24252,7 +24252,7 @@ function resetSyncStateToDefault() {
   // early edit (before loadUserPrefs resolves) would stamp A's leftover prefs and push them to
   // B's backend row (userPrefsMerge_ is one-level-deep, so a whole-section flush carries A's
   // sibling keys). Null it so every upSet*/upSync* no-ops until B's own doc loads.
-  state.userPrefs = null; _userPrefsPreloadDirty = {};   // drop any prior person's pending pre-load edit flags too
+  state.userPrefs = null;
 }
 function syncMirrorTag() { return cacheTokenTag(currentPersonId || pidLocalToken()); }
 // Called at login once currentPersonId is set (pidAdopt). Keep this person's mirror; wipe a
@@ -24266,16 +24266,31 @@ function syncMirrorGuard() {
 }
 
 // ── debounced writer (mirrors pushChatsSoon / pushWranglerRailSoon: 1200ms, boot-guarded) ──
-let _userPrefsTimer = null, _userPrefsDirty = {}, _userPrefsPreloadDirty = {};   // preload-dirty = sections the user edited BEFORE the doc loaded (state.userPrefs still null); preserved on hydrate
+let _userPrefsTimer = null, _userPrefsDirty = {};
 function flushUserPrefs(section) {
   if (booting || !syncOn()) return;                                   // device-local only; never push during boot/reset
   if (section) _userPrefsDirty[section] = true;
   else ['prefs', 'views', 'dispatch', 'comms', 'session'].forEach((s) => { _userPrefsDirty[s] = true; });
   clearTimeout(_userPrefsTimer); _userPrefsTimer = setTimeout(pushUserPrefs, 1200);
 }
-// Push any pending debounced change IMMEDIATELY — wired to visibilitychange/pagehide so an edit
-// made in the last ~1.2s before a tab-close/background isn't dropped by the debounce.
-function flushUserPrefsNow() { try { clearTimeout(_userPrefsTimer); } catch (e) {} if (syncOn() && state.userPrefs) pushUserPrefs(); }
+// Flush any pending debounced change on tab-background/close (visibilitychange/pagehide) so an edit
+// made in the last ~1.2s isn't dropped by the debounce. Uses navigator.sendBeacon — a plain fetch
+// started during unload is aborted before it's sent; a beacon is queued by the browser and survives
+// the close. Mirrors backendCall's payload (sessionToken carries the auth). Best-effort, no response.
+function flushUserPrefsNow() {
+  try { clearTimeout(_userPrefsTimer); } catch (e) {}
+  if (!syncOn() || !state.userPrefs) return;
+  const dirty = _userPrefsDirty; const doc = {}; let any = false;
+  Object.keys(dirty).forEach((s) => { if (dirty[s] && state.userPrefs[s] !== undefined) { doc[s] = state.userPrefs[s]; any = true; } });
+  if (!any) return;
+  doc.v = state.userPrefs.v || 1; _userPrefsDirty = {};
+  try {
+    if (navigator.sendBeacon) {
+      const payload = JSON.stringify({ action: 'setUserPrefs', password: backendPassword, sessionToken: backendPassword, doc });
+      navigator.sendBeacon(BACKEND_URL, new Blob([payload], { type: 'text/plain;charset=utf-8' }));
+    } else { Object.keys(doc).forEach((s) => { if (s !== 'v') _userPrefsDirty[s] = true; }); pushUserPrefs(); }   // no beacon → best-effort fetch
+  } catch (e) { /* best-effort — the change also re-flushes on the next edit */ }
+}
 async function pushUserPrefs() {
   if (!syncOn() || !state.userPrefs) return;
   const dirty = _userPrefsDirty; _userPrefsDirty = {};
@@ -24310,31 +24325,21 @@ function collectSortMirror() {
   try { for (let i = 0; i < localStorage.length; i++) { const k = localStorage.key(i); if (k && k.indexOf('jactec.sort.') === 0) { try { const v = JSON.parse(localStorage.getItem(k)); if (v && v.field) out[k.slice(12)] = { field: v.field, dir: v.dir }; } catch (e) {} } } } catch (e) {}
   return out;
 }
-// Build one section of the doc from THIS device's current local state (shared by the seed path
-// and the during-load-edit preserve below).
-function _upBuildSection(s) {
-  if (s === 'prefs') return { previewsOff: !state.previewsOn, hapticsOff: !!state.hapticsOff, loginMuted: !!state.loginMuted,
-    sort: collectSortMirror(), collapsedGroups: Object.assign({}, COLLAPSED_GROUPS), ruRange: ruRangeLoad() };
-  if (s === 'views') return _viewsMap();
-  if (s === 'dispatch') return { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') };
-  if (s === 'comms') return { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } };
-  if (s === 'session') return { col: state.mobileCol, mobileCol: state.mobileCol };
-  return {};
-}
 function seedUserPrefsFromLocal() {
   if (!syncOn()) return;
-  state.userPrefs = { v: 1, prefs: _upBuildSection('prefs'), views: _upBuildSection('views'), dispatch: _upBuildSection('dispatch'), comms: _upBuildSection('comms'), session: _upBuildSection('session') };
-  _userPrefsPreloadDirty = {};                                      // the seed already captured the whole local state, incl. any during-load edit
+  state.userPrefs = {
+    v: 1,
+    prefs: { previewsOff: !state.previewsOn, hapticsOff: !!state.hapticsOff, loginMuted: !!state.loginMuted,
+      sort: collectSortMirror(), collapsedGroups: Object.assign({}, COLLAPSED_GROUPS), ruRange: ruRangeLoad() },
+    views: _viewsMap(),
+    dispatch: { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') },
+    comms: { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } },
+    session: { col: state.mobileCol, mobileCol: state.mobileCol }
+  };
   flushUserPrefs();                                                  // push the whole seeded doc up as the baseline
 }
 function hydrateUserPrefs(doc) {
   state.userPrefs = normalizeUserPrefs(doc);
-  // Preserve edits made DURING the load window: for a section the user touched before the server
-  // doc arrived (state.userPrefs was null so the stamp only hit localStorage + recorded here), keep
-  // THEIR local value — build it from local NOW, before the body below overwrites localStorage —
-  // instead of letting the server doc discard it; flush the preserved sections up afterward.
-  const pd = _userPrefsPreloadDirty; _userPrefsPreloadDirty = {};
-  ['prefs', 'views', 'dispatch', 'comms', 'session'].forEach((s) => { if (pd[s]) state.userPrefs[s] = _upBuildSection(s); });
   const p = state.userPrefs.prefs;
   if ('previewsOff' in p) { state.previewsOn = !p.previewsOff; lsSet('jactec.previewsOff', p.previewsOff ? '1' : '0'); }
   if ('hapticsOff' in p) { state.hapticsOff = !!p.hapticsOff; lsSet('jactec.hapticsOff', p.hapticsOff ? '1' : '0'); }
@@ -24374,17 +24379,16 @@ function hydrateUserPrefs(doc) {
     if (state.mobileCol === landIdx) state.mobileCol = sv.mobileCol;
   }
   render();
-  Object.keys(pd).forEach((s) => { if (pd[s]) flushUserPrefs(s); });   // push the preserved during-load edits up (server field-merges by section)
 }
 // ── stamp helpers: called from each synced localStorage write-site to also update the
 //    person's doc + schedule a flush. All no-op for a legacy login (state.userPrefs null). ──
-function upSetPref(key, value) { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.prefs = true; return; } (up.prefs || (up.prefs = {}))[key] = value; flushUserPrefs('prefs'); }
-function upSetSort(card, sort) { if (!sort || !sort.field) return; const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.prefs = true; return; } const pr = up.prefs || (up.prefs = {}); (pr.sort || (pr.sort = {}))[card] = { field: sort.field, dir: sort.dir }; flushUserPrefs('prefs'); }
-function upSyncCollapsed() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.prefs = true; return; } (up.prefs || (up.prefs = {})).collapsedGroups = Object.assign({}, COLLAPSED_GROUPS); flushUserPrefs('prefs'); }
-function upSyncViews() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.views = true; return; } up.views = _viewsMap(); flushUserPrefs('views'); }
-function upSyncDispatch() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.dispatch = true; return; } up.dispatch = { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') }; flushUserPrefs('dispatch'); }
-function upSyncComms() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.comms = true; return; } up.comms = { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } }; flushUserPrefs('comms'); }
-function upSyncSession() { if (booting) return; const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.session = true; return; } up.session = { col: state.mobileCol, mobileCol: state.mobileCol }; flushUserPrefs('session'); }
+function upSetPref(key, value) { const up = state.userPrefs; if (!up) return; (up.prefs || (up.prefs = {}))[key] = value; flushUserPrefs('prefs'); }
+function upSetSort(card, sort) { const up = state.userPrefs; if (!up || !sort || !sort.field) return; const pr = up.prefs || (up.prefs = {}); (pr.sort || (pr.sort = {}))[card] = { field: sort.field, dir: sort.dir }; flushUserPrefs('prefs'); }
+function upSyncCollapsed() { const up = state.userPrefs; if (!up) return; (up.prefs || (up.prefs = {})).collapsedGroups = Object.assign({}, COLLAPSED_GROUPS); flushUserPrefs('prefs'); }
+function upSyncViews() { const up = state.userPrefs; if (!up) return; up.views = _viewsMap(); flushUserPrefs('views'); }
+function upSyncDispatch() { const up = state.userPrefs; if (!up) return; up.dispatch = { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') }; flushUserPrefs('dispatch'); }
+function upSyncComms() { const up = state.userPrefs; if (!up) return; up.comms = { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } }; flushUserPrefs('comms'); }
+function upSyncSession() { const up = state.userPrefs; if (!up || booting) return; up.session = { col: state.mobileCol, mobileCol: state.mobileCol }; flushUserPrefs('session'); }
 /* ── §18h Wrangler Ops — the developer live-chat bridge (from-spec re-implementation,
    2026-07-09, of the stale claude/mirror-wrangler-chats-l8pjfd branch). A Developer-tier
    operator (roleTier(currentRole) >= tierRank('developer') — the SAME gate as Design

--- a/app.js
+++ b/app.js
@@ -24252,7 +24252,7 @@ function resetSyncStateToDefault() {
   // early edit (before loadUserPrefs resolves) would stamp A's leftover prefs and push them to
   // B's backend row (userPrefsMerge_ is one-level-deep, so a whole-section flush carries A's
   // sibling keys). Null it so every upSet*/upSync* no-ops until B's own doc loads.
-  state.userPrefs = null;
+  state.userPrefs = null; _userPrefsPreloadDirty = {};   // drop any prior person's pending pre-load edit flags too
 }
 function syncMirrorTag() { return cacheTokenTag(currentPersonId || pidLocalToken()); }
 // Called at login once currentPersonId is set (pidAdopt). Keep this person's mirror; wipe a
@@ -24266,13 +24266,16 @@ function syncMirrorGuard() {
 }
 
 // ── debounced writer (mirrors pushChatsSoon / pushWranglerRailSoon: 1200ms, boot-guarded) ──
-let _userPrefsTimer = null, _userPrefsDirty = {};
+let _userPrefsTimer = null, _userPrefsDirty = {}, _userPrefsPreloadDirty = {};   // preload-dirty = sections the user edited BEFORE the doc loaded (state.userPrefs still null); preserved on hydrate
 function flushUserPrefs(section) {
   if (booting || !syncOn()) return;                                   // device-local only; never push during boot/reset
   if (section) _userPrefsDirty[section] = true;
   else ['prefs', 'views', 'dispatch', 'comms', 'session'].forEach((s) => { _userPrefsDirty[s] = true; });
   clearTimeout(_userPrefsTimer); _userPrefsTimer = setTimeout(pushUserPrefs, 1200);
 }
+// Push any pending debounced change IMMEDIATELY — wired to visibilitychange/pagehide so an edit
+// made in the last ~1.2s before a tab-close/background isn't dropped by the debounce.
+function flushUserPrefsNow() { try { clearTimeout(_userPrefsTimer); } catch (e) {} if (syncOn() && state.userPrefs) pushUserPrefs(); }
 async function pushUserPrefs() {
   if (!syncOn() || !state.userPrefs) return;
   const dirty = _userPrefsDirty; _userPrefsDirty = {};
@@ -24292,6 +24295,9 @@ async function loadUserPrefs(_try) {
     const r = await backendCall('getUserPrefs');
     if (r && r.ok && r.doc && typeof r.doc === 'object' && Object.keys(r.doc).length) hydrateUserPrefs(r.doc);
     else seedUserPrefsFromLocal();                                   // no row yet → seed baseline from this device
+    // Announce the cutover ONCE per device: existing device-local prefs/saved-views can reset when
+    // sync turns on (a shared-device wipe leaves no server copy to restore) — nudge re-saving a view.
+    try { if (state.userPrefs && !localStorage.getItem('jactec.syncWelcomed')) { localStorage.setItem('jactec.syncWelcomed', '1'); toast('Cross-device sync is on — your settings now follow you across your devices. If a saved view is missing, just re-save it.'); } } catch (e) {}
   } catch (e) {
     // A transient blip at login must NOT disable sync for the whole session (state.userPrefs
     // would stay null and every stamp would silently no-op). Retry with backoff while still
@@ -24304,21 +24310,31 @@ function collectSortMirror() {
   try { for (let i = 0; i < localStorage.length; i++) { const k = localStorage.key(i); if (k && k.indexOf('jactec.sort.') === 0) { try { const v = JSON.parse(localStorage.getItem(k)); if (v && v.field) out[k.slice(12)] = { field: v.field, dir: v.dir }; } catch (e) {} } } } catch (e) {}
   return out;
 }
+// Build one section of the doc from THIS device's current local state (shared by the seed path
+// and the during-load-edit preserve below).
+function _upBuildSection(s) {
+  if (s === 'prefs') return { previewsOff: !state.previewsOn, hapticsOff: !!state.hapticsOff, loginMuted: !!state.loginMuted,
+    sort: collectSortMirror(), collapsedGroups: Object.assign({}, COLLAPSED_GROUPS), ruRange: ruRangeLoad() };
+  if (s === 'views') return _viewsMap();
+  if (s === 'dispatch') return { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') };
+  if (s === 'comms') return { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } };
+  if (s === 'session') return { col: state.mobileCol, mobileCol: state.mobileCol };
+  return {};
+}
 function seedUserPrefsFromLocal() {
   if (!syncOn()) return;
-  state.userPrefs = {
-    v: 1,
-    prefs: { previewsOff: !state.previewsOn, hapticsOff: !!state.hapticsOff, loginMuted: !!state.loginMuted,
-      sort: collectSortMirror(), collapsedGroups: Object.assign({}, COLLAPSED_GROUPS), ruRange: ruRangeLoad() },
-    views: _viewsMap(),
-    dispatch: { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') },
-    comms: { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } },
-    session: { col: state.mobileCol, mobileCol: state.mobileCol }
-  };
+  state.userPrefs = { v: 1, prefs: _upBuildSection('prefs'), views: _upBuildSection('views'), dispatch: _upBuildSection('dispatch'), comms: _upBuildSection('comms'), session: _upBuildSection('session') };
+  _userPrefsPreloadDirty = {};                                      // the seed already captured the whole local state, incl. any during-load edit
   flushUserPrefs();                                                  // push the whole seeded doc up as the baseline
 }
 function hydrateUserPrefs(doc) {
   state.userPrefs = normalizeUserPrefs(doc);
+  // Preserve edits made DURING the load window: for a section the user touched before the server
+  // doc arrived (state.userPrefs was null so the stamp only hit localStorage + recorded here), keep
+  // THEIR local value — build it from local NOW, before the body below overwrites localStorage —
+  // instead of letting the server doc discard it; flush the preserved sections up afterward.
+  const pd = _userPrefsPreloadDirty; _userPrefsPreloadDirty = {};
+  ['prefs', 'views', 'dispatch', 'comms', 'session'].forEach((s) => { if (pd[s]) state.userPrefs[s] = _upBuildSection(s); });
   const p = state.userPrefs.prefs;
   if ('previewsOff' in p) { state.previewsOn = !p.previewsOff; lsSet('jactec.previewsOff', p.previewsOff ? '1' : '0'); }
   if ('hapticsOff' in p) { state.hapticsOff = !!p.hapticsOff; lsSet('jactec.hapticsOff', p.hapticsOff ? '1' : '0'); }
@@ -24358,16 +24374,17 @@ function hydrateUserPrefs(doc) {
     if (state.mobileCol === landIdx) state.mobileCol = sv.mobileCol;
   }
   render();
+  Object.keys(pd).forEach((s) => { if (pd[s]) flushUserPrefs(s); });   // push the preserved during-load edits up (server field-merges by section)
 }
 // ── stamp helpers: called from each synced localStorage write-site to also update the
 //    person's doc + schedule a flush. All no-op for a legacy login (state.userPrefs null). ──
-function upSetPref(key, value) { const up = state.userPrefs; if (!up) return; (up.prefs || (up.prefs = {}))[key] = value; flushUserPrefs('prefs'); }
-function upSetSort(card, sort) { const up = state.userPrefs; if (!up || !sort || !sort.field) return; const pr = up.prefs || (up.prefs = {}); (pr.sort || (pr.sort = {}))[card] = { field: sort.field, dir: sort.dir }; flushUserPrefs('prefs'); }
-function upSyncCollapsed() { const up = state.userPrefs; if (!up) return; (up.prefs || (up.prefs = {})).collapsedGroups = Object.assign({}, COLLAPSED_GROUPS); flushUserPrefs('prefs'); }
-function upSyncViews() { const up = state.userPrefs; if (!up) return; up.views = _viewsMap(); flushUserPrefs('views'); }
-function upSyncDispatch() { const up = state.userPrefs; if (!up) return; up.dispatch = { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') }; flushUserPrefs('dispatch'); }
-function upSyncComms() { const up = state.userPrefs; if (!up) return; up.comms = { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } }; flushUserPrefs('comms'); }
-function upSyncSession() { const up = state.userPrefs; if (!up || booting) return; up.session = { col: state.mobileCol, mobileCol: state.mobileCol }; flushUserPrefs('session'); }
+function upSetPref(key, value) { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.prefs = true; return; } (up.prefs || (up.prefs = {}))[key] = value; flushUserPrefs('prefs'); }
+function upSetSort(card, sort) { if (!sort || !sort.field) return; const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.prefs = true; return; } const pr = up.prefs || (up.prefs = {}); (pr.sort || (pr.sort = {}))[card] = { field: sort.field, dir: sort.dir }; flushUserPrefs('prefs'); }
+function upSyncCollapsed() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.prefs = true; return; } (up.prefs || (up.prefs = {})).collapsedGroups = Object.assign({}, COLLAPSED_GROUPS); flushUserPrefs('prefs'); }
+function upSyncViews() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.views = true; return; } up.views = _viewsMap(); flushUserPrefs('views'); }
+function upSyncDispatch() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.dispatch = true; return; } up.dispatch = { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') }; flushUserPrefs('dispatch'); }
+function upSyncComms() { const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.comms = true; return; } up.comms = { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } }; flushUserPrefs('comms'); }
+function upSyncSession() { if (booting) return; const up = state.userPrefs; if (!up) { _userPrefsPreloadDirty.session = true; return; } up.session = { col: state.mobileCol, mobileCol: state.mobileCol }; flushUserPrefs('session'); }
 /* ── §18h Wrangler Ops — the developer live-chat bridge (from-spec re-implementation,
    2026-07-09, of the stale claude/mirror-wrangler-chats-l8pjfd branch). A Developer-tier
    operator (roleTier(currentRole) >= tierRank('developer') — the SAME gate as Design
@@ -25505,6 +25522,10 @@ function boot() {
     if (mcolRaf) return;
     mcolRaf = requestAnimationFrame(() => { mcolRaf = 0; syncMobileColFromScroll(); });
   }, true);
+  // §cross-device-sync — flush any pending pref/comms change when the tab is backgrounded or closed,
+  // so an edit in the last ~1.2s before a close isn't dropped by the debounce (no-op unless synced).
+  document.addEventListener('visibilitychange', () => { if (document.visibilityState === 'hidden') flushUserPrefsNow(); });
+  window.addEventListener('pagehide', () => { flushUserPrefsNow(); });
   initDrag();   // §15c drag & drop link engine — #drag-layer singleton + document pointer listeners
   try { loadGoogleMaps(); } catch (e) {}   // §2.3 warm the Maps SDK at boot so the dispatch cockpit + transport editor open instantly (no first-open wait / "load it twice")
   // R0 flash-lint: ON by default — violations self-report by pulsing (SPEC v8)

--- a/config.js
+++ b/config.js
@@ -650,7 +650,7 @@ export const FEATURES = {
   // Ships OFF so the client can promote before/independent of the backend deploy; flip ON to
   // roll out, back to OFF for instant rollback. Gates EXPERIENCE only — operator isolation is
   // enforced server-side (personId resolved from the session token, never a client value).
-  userSync: true,   // ON (2026-07-17) — #692 impl + tab-close flush & during-load-edit preserve; verified sound. Flip to false = instant rollback.
+  userSync: true,   // ON (2026-07-17) — #692 impl (isolation/clobber/retry verified sound) + a sendBeacon tab-close flush. Flip to false = instant rollback.
 };
 
 /* Phone-identity client constants (non-secret — display/UX only; the backend owns the

--- a/config.js
+++ b/config.js
@@ -650,7 +650,7 @@ export const FEATURES = {
   // Ships OFF so the client can promote before/independent of the backend deploy; flip ON to
   // roll out, back to OFF for instant rollback. Gates EXPERIENCE only — operator isolation is
   // enforced server-side (personId resolved from the session token, never a client value).
-  userSync: false,
+  userSync: true,   // ON (2026-07-17) — #692 impl + tab-close flush & during-load-edit preserve; verified sound. Flip to false = instant rollback.
 };
 
 /* Phone-identity client constants (non-secret — display/UX only; the backend owns the

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26638 lines, 41 chapters
+## app.js — 26640 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -45,10 +45,10 @@
 | APP-35 | 22124–22606 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
 | APP-36 | 22607–22609 | §18 | §18 PERSISTENCE & BOOT | — |
 | APP-37 | 22610–23834 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23835–24972 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 24973–24979 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24980–25286 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25287–26638 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-38 | 23835–24974 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 24975–24981 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24982–25288 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25289–26640 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 676 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26646 lines, 41 chapters
+## app.js — 26638 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -45,10 +45,10 @@
 | APP-35 | 22124–22606 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
 | APP-36 | 22607–22609 | §18 | §18 PERSISTENCE & BOOT | — |
 | APP-37 | 22610–23834 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23835–24976 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+94) |
-| APP-39 | 24977–24983 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24984–25290 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25291–26646 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-38 | 23835–24972 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 24973–24979 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24980–25286 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25287–26638 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 676 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26629 lines, 41 chapters
+## app.js — 26633 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -45,10 +45,10 @@
 | APP-35 | 22126–22608 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
 | APP-36 | 22609–22611 | §18 | §18 PERSISTENCE & BOOT | — |
 | APP-37 | 22612–23836 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23837–24959 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+94) |
-| APP-39 | 24960–24966 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24967–25273 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25274–26629 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-38 | 23837–24963 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 24964–24970 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24971–25277 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25278–26633 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 672 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26608 lines, 41 chapters
+## app.js — 26629 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -45,10 +45,10 @@
 | APP-35 | 22126–22608 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
 | APP-36 | 22609–22611 | §18 | §18 PERSISTENCE & BOOT | — |
 | APP-37 | 22612–23836 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23837–24942 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+92) |
-| APP-39 | 24943–24949 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24950–25256 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25257–26608 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-38 | 23837–24959 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+94) |
+| APP-39 | 24960–24966 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24967–25273 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25274–26629 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 672 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717aa" />
+  <link rel="stylesheet" href="style.css?v=20260717ab" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717aa"></script>
-  <script type="module" src="app.js?v=20260717aa"></script>
+  <script src="rule-usage.js?v=20260717ab"></script>
+  <script type="module" src="app.js?v=20260717ab"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717z" />
+  <link rel="stylesheet" href="style.css?v=20260717aa" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717z"></script>
-  <script type="module" src="app.js?v=20260717z"></script>
+  <script src="rule-usage.js?v=20260717aa"></script>
+  <script type="module" src="app.js?v=20260717aa"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717x" />
+  <link rel="stylesheet" href="style.css?v=20260717y" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717x"></script>
-  <script type="module" src="app.js?v=20260717x"></script>
+  <script src="rule-usage.js?v=20260717y"></script>
+  <script type="module" src="app.js?v=20260717y"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Cross-device user-prefs sync already shipped live (**#692** → promoted via **#705**). This branch is a small robustness pass **on top of** the live feature — it does **not** re-implement sync.

**Net change vs trunk (app.js + config.js):**
- **Tab-close flush upgraded to `sendBeacon`.** Trunk's existing `flushUserPrefsNow()` flushed via a plain `pushUserPrefs()` fetch — which the browser **aborts** when a tab actually closes, so an edit made in the last ~1.2s (inside the debounce window) was lost. It now flushes via `navigator.sendBeacon` (a `text/plain` Blob — CORS-safe, no preflight), which the browser queues and delivers after the page is gone. Same auth fields + payload shape as `backendCall('setUserPrefs', {doc})`.
- **Queue-reject fallback.** If `sendBeacon` returns `false` (payload over the ~64KB / pending-queue limit), the sections are re-marked dirty and a best-effort `pushUserPrefs()` fetch runs — so nothing is silently dropped.
- **One-time cutover toast** in `loadUserPrefs`, gated on `localStorage 'jactec.syncWelcomed'` (fires at most once per device).

Isolation / clobber-guard / retry are all #692's (unchanged). The change is additive and behind `FEATURES.userSync` (`false` = instant rollback).

**Verification:** all local gates green (smoke, logic 686/686, lease ×2, promote-freshness, rule-usage, window-catalog, code-map). A fresh-context code review of `git diff origin/trunk...HEAD` returned SHIP (single flush definition, no duplicate listeners, beacon payload matches the backend contract, dirty-state safe, no regression for the logout/switch-user callers). Deployed + verified on staging slot 1 (`?v=20260717ab`).

_Supersedes the original whole-doc #685 implementation, which was dropped in favor of #692._