### PR TITLE
Invoice: real fonts in copy-as-image + email the sheet as a PNG attachment

### DIFF
--- a/app.js
+++ b/app.js
@@ -21293,14 +21293,15 @@ function printInvoice(invoiceId) {
 /* Copy the on-screen invoice sheet to the clipboard as a PNG (right-click → Copy as image,
    Jac 2026-07-17). Library-free rasterization: clone the live .pr-doc, inline every element's
    COMPUTED style (so no stylesheet / CSS-var resolution is needed inside the SVG), data-URI the
-   images so the canvas never taints, wrap the XHTML in an <svg><foreignObject>, paint it to a
-   canvas, hand the PNG blob to the clipboard. The blob is produced INSIDE a ClipboardItem promise
-   so the write still counts as the user's gesture on Safari. Fonts loaded via @font-face may fall
-   back to a system face inside the SVG (a known foreignObject limit) — layout/colors are faithful,
-   the typeface may not be; on any failure we fall back to a clear toast pointing at Save-as-PDF. */
+   images AND embed the real @font-face typefaces (a foreignObject renders in its own scope with no
+   page fonts — so we inline them), wrap the XHTML in an <svg><foreignObject>, paint it to a canvas,
+   hand the PNG blob to the clipboard. The blob is produced INSIDE a ClipboardItem promise so the
+   write still counts as the user's gesture on Safari. **Firefox** deliberately taints a canvas the
+   moment a foreignObject-bearing SVG is drawn (a security stance, no lib-free bypass) → toBlob
+   throws → we catch and point at Save-as-PDF. Works in Chromium + Safari. */
 function copyInvoiceImage(invoiceId) {
-  const fail = () => toast('Couldn’t copy the image on this browser — use 🖨 Save PDF instead.');
-  if (!(navigator.clipboard && window.ClipboardItem)) return fail();   // no clipboard-image support (e.g. older Firefox) → point at Save-as-PDF, don't waste a render
+  const fail = () => toast('Couldn’t copy the image on this browser (Firefox blocks it) — use 🖨 Save PDF instead.');
+  if (!(navigator.clipboard && window.ClipboardItem)) return fail();   // no clipboard-image support → point at Save-as-PDF, don't waste a render
   // Render INSIDE the ClipboardItem promise so the write still counts as the user's gesture on Safari.
   navigator.clipboard.write([new ClipboardItem({ 'image/png': renderInvoicePng(invoiceId) })])
     .then(() => toast('🖼 Invoice copied — paste it into a message, chat, or doc.'))
@@ -21314,6 +21315,8 @@ async function renderInvoicePng(invoiceId) {
   const clone = doc.cloneNode(true);
   inlineComputedStyles(doc, clone);   // resolve classes + CSS vars to concrete values
   await inlineDocImages(clone);       // <img src> → data: so drawImage doesn't taint the canvas
+  const fontCss = await invoiceFontFaceCss();   // embed the real Saira/Geist faces — a foreignObject has no page @font-face
+  if (fontCss) { const st = document.createElement('style'); st.textContent = fontCss; clone.insertBefore(st, clone.firstChild); }
   clone.style.boxShadow = 'none'; clone.style.borderRadius = '0'; clone.style.margin = '0'; clone.style.maxWidth = 'none'; clone.style.width = W + 'px';
   clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
   const xhtml = new XMLSerializer().serializeToString(clone);
@@ -21350,6 +21353,32 @@ async function inlineDocImages(root) {
       im.setAttribute('src', await new Promise((res) => { const fr = new FileReader(); fr.onload = () => res(fr.result); fr.readAsDataURL(b); }));
     } catch (e) { im.removeAttribute('src'); }
   }));
+}
+let _invFontCss = null;   // cached self-contained @font-face block (real fonts, data-URI'd) for the copied image
+// The invoice sheet is Saira Condensed (stamps) + Geist (body), loaded from Google Fonts. An
+// <svg><foreignObject> renders in its OWN scope with no access to the page's @font-face, so its text
+// would fall back to a system face. Fetch the two families' LATIN woff2 once, inline them as data
+// URIs, and return a <style>-ready @font-face block for the rasterizer to embed — so the copied PNG
+// carries the real typefaces. Best-effort + cached: if the CDN is unreachable (offline/sandbox) we
+// return '' and the render silently uses the fallback face (unchanged from the first ship).
+async function invoiceFontFaceCss() {
+  if (_invFontCss != null) return _invFontCss;
+  try {
+    const cssUrl = 'https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Saira+Condensed:wght@600;700;800&display=swap';
+    const css = await (await fetch(cssUrl)).text();
+    const faces = css.match(/\/\*\s*latin\s*\*\/\s*@font-face\s*{[^}]*}/g) || [];   // latin subset only — an invoice is latin text, keeps the SVG small
+    const inlined = await Promise.all(faces.map(async (face) => {
+      const m = face.match(/url\((https:\/\/[^)]+\.woff2)\)/);
+      if (!m) return '';
+      try {
+        const b = await (await fetch(m[1])).blob();
+        const uri = await new Promise((res) => { const fr = new FileReader(); fr.onload = () => res(fr.result); fr.readAsDataURL(b); });
+        return face.replace(m[1], uri);
+      } catch (e) { return ''; }
+    }));
+    _invFontCss = inlined.filter(Boolean).join('\n');
+  } catch (e) { _invFontCss = ''; }
+  return _invFontCss;
 }
 // Plain-text quote summary for an emailed quote — mailto can't carry a PDF attachment,
 // so we inline the same figures the print doc shows (§12.5 line items + totals).

--- a/app.js
+++ b/app.js
@@ -21380,6 +21380,29 @@ async function invoiceFontFaceCss() {
   } catch (e) { _invFontCss = ''; }
   return _invFontCss;
 }
+// Raw base64 (no data: prefix) of a blob — for handing an image to the backend email send.
+function blobToBase64(blob) {
+  return new Promise((res, rej) => { const fr = new FileReader(); fr.onload = () => res(String(fr.result).split(',')[1] || ''); fr.onerror = rej; fr.readAsDataURL(blob); });
+}
+// Render the invoice sheet to a PNG blob for an email attachment. Reuses the open .pr-doc if it's
+// on screen; otherwise builds it OFF-SCREEN, renders, and cleans up. Returns null on ANY failure
+// (e.g. Firefox taints a foreignObject canvas) — so the email still sends WITHOUT an attachment and
+// the render never blocks the send.
+async function invoiceSheetPng(invoiceId) {
+  const inv = IDX.invoice.get(invoiceId); if (!inv) return null;
+  let temp = null;
+  try {
+    const onScreen = [...document.querySelectorAll('.pr-doc[data-inv]')].some((d) => d.dataset.inv === invoiceId);
+    if (!onScreen) {
+      temp = document.createElement('div');
+      temp.style.cssText = 'position:absolute;left:-99999px;top:0;width:640px;pointer-events:none';
+      temp.innerHTML = invoiceDocHtml(inv, { interactive: true });
+      document.body.appendChild(temp);
+    }
+    return await renderInvoicePng(invoiceId);
+  } catch (e) { return null; }
+  finally { if (temp) temp.remove(); }
+}
 // Plain-text quote summary for an emailed quote — mailto can't carry a PDF attachment,
 // so we inline the same figures the print doc shows (§12.5 line items + totals).
 function invoiceQuoteSummary(inv) {
@@ -21408,7 +21431,12 @@ async function commsAliasList() {
 async function emailQuoteSend(invoiceId, from) {
   const inv = IDX.invoice.get(invoiceId); if (!inv) return;
   toast('Sending email…');
-  let r; try { r = await backendCall('sendCustomerMessage', { channel: 'email', entity: 'invoice', recId: inv.invoiceId, customerId: inv.customerId, template: 'quote', from: from || '' }); }
+  // Attach the invoice sheet as a PNG (Jac 2026-07-17). Best-effort: a failed render (e.g. Firefox)
+  // just sends the email WITHOUT the image — never blocks the send. The backend re-resolves the
+  // recipient from the invoice's own customer, so the attachment can only reach that customer.
+  let attachment = null;
+  try { const png = await invoiceSheetPng(invoiceId); if (png) attachment = { name: `${invoiceShort(inv.invoiceId)}.png`, mimeType: 'image/png', dataB64: await blobToBase64(png) }; } catch (e) {}
+  let r; try { r = await backendCall('sendCustomerMessage', { channel: 'email', entity: 'invoice', recId: inv.invoiceId, customerId: inv.customerId, template: 'quote', from: from || '', attachment }); }
   catch (e) { r = { ok: false, reason: 'network' }; }
   if (r && r.ok) {
     logAction(inv, `Emailed quote to ${r.maskedTo || 'customer'}${r.fromUsed ? ` (from ${r.fromUsed})` : ''}`);
@@ -25505,7 +25533,7 @@ function exposeTestApi() {
       tripsLS, tripMerge, tripSplit, assignTripDriver, tripLabel, assignStopDriver, tripSetTime,
       tripPushSoon, tripPushNow, loadTripsFromBackend, tripsSyncFooter, setBackendPassword: (pw) => { backendPassword = pw || ''; },   // §2.3 Phase 4 sync — the setter is test-only (mirrors setRole), letting logic-test.mjs exercise the online path via a mocked window.fetch, never a real backend
       autoRunRepair, autoRunAnchorsFor, secToClock, AUTORUN_DAY_START_SEC, AUTORUN_EOD_DEADLINE_SEC, AUTORUN_LOAD_BUFFER_SEC, dispatchPinOf,
-      openCustomerForm, renderOverlay, render, printInvoice, invoiceDocHtml, renderInvoicePng, invoicePrintGroups, invoiceAmendments, cardComplete, cardCaptureState, cardHasSelfie, cardHasSignature, captureSelfie, captureSignature,
+      openCustomerForm, renderOverlay, render, printInvoice, invoiceDocHtml, renderInvoicePng, invoiceSheetPng, invoicePrintGroups, invoiceAmendments, cardComplete, cardCaptureState, cardHasSelfie, cardHasSignature, captureSelfie, captureSignature,
       wranglerSend, wranglerNewChat, openWranglerDock, wranglerDockPollTick, devUnlocked, openWranglerOps, wrOpsAgo, __state: state };   // UI drivers for headless screenshot/e2e tests
 
   } catch (e) { /* no window (non-browser) */ }

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26189 lines, 41 chapters
+## app.js — 26217 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -41,14 +41,14 @@
 | APP-31 | 16740–16743 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-32 | 16744–19209 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
 | APP-33 | 19210–20503 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 20504–21939 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+91) |
-| APP-35 | 21940–22422 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 22423–22425 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 22426–23650 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23651–24578 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
-| APP-39 | 24579–24585 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24586–24839 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+11) |
-| APP-41 | 24840–26189 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-34 | 20504–21967 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+93) |
+| APP-35 | 21968–22450 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 22451–22453 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 22454–23678 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
+| APP-38 | 23679–24606 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
+| APP-39 | 24607–24613 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24614–24867 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+11) |
+| APP-41 | 24868–26217 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 664 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26160 lines, 41 chapters
+## app.js — 26189 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -41,14 +41,14 @@
 | APP-31 | 16740–16743 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-32 | 16744–19209 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
 | APP-33 | 19210–20503 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 20504–21910 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+89) |
-| APP-35 | 21911–22393 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 22394–22396 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 22397–23621 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23622–24549 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
-| APP-39 | 24550–24556 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24557–24810 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+11) |
-| APP-41 | 24811–26160 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-34 | 20504–21939 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+91) |
+| APP-35 | 21940–22422 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 22423–22425 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 22426–23650 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
+| APP-38 | 23651–24578 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
+| APP-39 | 24579–24585 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24586–24839 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+11) |
+| APP-41 | 24840–26189 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 664 lines, 0 chapters
 

--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -19,6 +19,22 @@
 - **Deploy flow:** the standard splice — pull live `Code.js` → append §authz functions + wire the
   router → `node --check` → STOP-gate (show Jac) → SA `push` HEAD → **Jac's editor New-version
   deploy** → verify anonymous JSON + a real approval round-trip on staging.
+## ⏳ READY TO PUSH — invoice email PNG attachment (2026-07-17)
+- **What:** `docs/handoffs/invoice-email-attachment-backend.gs` — a small ADDITIVE splice in
+  `sendCustomerMessage_` (email branch, right before `GmailApp.sendEmail`). The client
+  (`emailQuoteSend`, shipped on `claude/random-improvements-quivhs`) now renders the invoice sheet to
+  a PNG and passes `body.attachment = {name, mimeType:'image/png', dataB64}`; this patch decodes it to
+  a blob and adds `mailOpts.attachments`.
+- **Safety:** recipient is still server-resolved from the invoice's own customer (existing isolation
+  gate), so the image can only reach that customer; gated to `entity==='invoice'`, MIME-whitelisted
+  (png/jpeg), ~3MB size-capped, and a bad blob is dropped (never fails the send). Consent/quiet-hours/
+  cap/dedup all still run first, unchanged.
+- **Fail-safe until deployed:** the client sends the attachment field; the un-patched backend simply
+  ignores it → emails still send text-only (no regression). The image appears once this deploys.
+- **Deploy flow:** pull live `Code.js` → splice the block per the handoff header → `node --check` →
+  STOP-gate (show Jac) → SA `push` HEAD → **Jac's editor New-version deploy** → verify a real invoice
+  email arrives WITH the PNG on staging.
+
 ## ⏳ READY TO PUSH — membership dues PO-hold + create-ahead-regardless-of-payment (2026-07-17)
 - **What:** `docs/handoffs/2026-07-17-membership-po-advance-billing.gs` — additive splice against the LIVE
   membership block (reconciled 2026-07-17 against the live source pulled via the Drive connector; the live

--- a/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
+++ b/docs/handoffs/BACKEND-DEPLOY-QUEUE.md
@@ -19,7 +19,13 @@
 - **Deploy flow:** the standard splice — pull live `Code.js` → append §authz functions + wire the
   router → `node --check` → STOP-gate (show Jac) → SA `push` HEAD → **Jac's editor New-version
   deploy** → verify anonymous JSON + a real approval round-trip on staging.
-## ⏳ READY TO PUSH — invoice email PNG attachment (2026-07-17)
+## 🟡 PUSHED TO HEAD — awaiting Jac's editor deploy — invoice email PNG attachment (2026-07-17)
+- **Status:** spliced against the LIVE `Code.js` (pulled via SA `getContent`, matched the snapshot
+  at `sendCustomerMessage_` 2446-2448), `node --check` passed, **pushed to HEAD via the service
+  account** (content-only — NOT live). **Go-live = Jac's editor deploy** (Deploy → Manage
+  deployments → Edit prod → New version, Execute as Me (operations@), Who has access: Anyone).
+  Verify after: POST `{"action":"auth","password":"__wrong__"}` to the exec URL → expect JSON
+  `{"ok":false,...}` (HTML/403 = anonymous access broke → editor rollback).
 - **What:** `docs/handoffs/invoice-email-attachment-backend.gs` — a small ADDITIVE splice in
   `sendCustomerMessage_` (email branch, right before `GmailApp.sendEmail`). The client
   (`emailQuoteSend`, shipped on `claude/random-improvements-quivhs`) now renders the invoice sheet to

--- a/docs/handoffs/invoice-email-attachment-backend.gs
+++ b/docs/handoffs/invoice-email-attachment-backend.gs
@@ -1,0 +1,48 @@
+/**
+ * Invoice email — attach the client-rendered sheet PNG (Jac, 2026-07-17)
+ * ─────────────────────────────────────────────────────────────────────────
+ * ADDITIVE. Client change already shipped (app.js): emailQuoteSend renders the
+ * invoice sheet to a PNG (invoiceSheetPng → renderInvoicePng) and passes it as
+ *   body.attachment = { name, mimeType: 'image/png', dataB64 }
+ * to sendCustomerMessage. This patch makes the backend attach it to the email.
+ *
+ * WHERE: sendCustomerMessage_() in Code.js (the live copy of customer-sms-backend.gs),
+ * the `channel === 'email'` branch — right BEFORE `GmailApp.sendEmail(to, subject, text, mailOpts)`.
+ *
+ * SAFETY (all preserved / added):
+ *  - Recipient is still server-resolved from the invoice's own customer (the isolation
+ *    gate above, ~line 118-120). The attachment can ONLY reach that customer — the client
+ *    never picks the recipient. So a client-supplied image is no broader than the invoice
+ *    the sender already has access to.
+ *  - Gated to entity === 'invoice' (an image attachment only makes sense there).
+ *  - MIME whitelist (png/jpeg only) + a ~3MB size cap (base64 length) to bound abuse.
+ *  - A bad/oversized blob is dropped silently → the email still sends WITHOUT the
+ *    attachment. Attaching NEVER fails the send.
+ *
+ * Nothing else changes: consent (opted-out hard block), quiet-hours, the shared daily
+ * cap, and the dedup ledger all still run before this point, unchanged.
+ *
+ * ── DROP-IN: replace the two lines that build mailOpts + call sendEmail ──
+ * BEFORE:
+ *     var mailOpts = { name: company };
+ *     if (fromUsed && aliases[0] && fromUsed.toLowerCase() !== String(aliases[0]).toLowerCase()) mailOpts.from = fromUsed;
+ *     GmailApp.sendEmail(to, subject, text, mailOpts);
+ * AFTER:
+ */
+var mailOpts = { name: company };
+if (fromUsed && aliases[0] && fromUsed.toLowerCase() !== String(aliases[0]).toLowerCase()) mailOpts.from = fromUsed;
+// Optional client-rendered invoice image → email attachment. Recipient is already
+// server-resolved to THIS invoice's own customer (isolation gate above), so the image
+// can only reach that customer. Whitelist image types + cap the size; a bad blob is
+// dropped, never fatal to the send.
+var att = body.attachment;
+if (att && entity === 'invoice' && att.dataB64 &&
+    (att.mimeType === 'image/png' || att.mimeType === 'image/jpeg') &&
+    String(att.dataB64).length < 4000000) {
+  try {
+    var attName = String(att.name || 'invoice.png').replace(/[^\w.\-]/g, '').slice(0, 80) || 'invoice.png';
+    var attBlob = Utilities.newBlob(Utilities.base64Decode(att.dataB64), att.mimeType, attName);
+    mailOpts.attachments = [attBlob];
+  } catch (e) { /* bad blob → send without the attachment */ }
+}
+GmailApp.sendEmail(to, subject, text, mailOpts);

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717p" />
+  <link rel="stylesheet" href="style.css?v=20260717q" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717p"></script>
-  <script type="module" src="app.js?v=20260717p"></script>
+  <script src="rule-usage.js?v=20260717q"></script>
+  <script type="module" src="app.js?v=20260717q"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Two invoice follow-ups Jac asked for after #682 shipped live.

## 1. Copy-as-image now uses the real typefaces
An `<svg><foreignObject>` renders in its own scope with **no** access to the page's `@font-face`, so the copied PNG fell back to a system face. `renderInvoicePng` now fetches the two families' **latin** woff2 once (Geist + Saira Condensed), inlines them as data-URIs, and embeds a self-contained `@font-face` `<style>` in the clone — so the PNG carries the real fonts. Cached; **graceful** — if the CDN is unreachable it returns `''` and falls back to the system face (unchanged). **Firefox** deliberately taints a foreignObject canvas (no lib-free bypass) → caught → the Save-PDF toast now names Firefox.

## 2. Email the invoice with the sheet attached (PNG)
You chose a **PNG attachment** (no client PDF lib).

**Client (shipped here):** `emailQuoteSend` renders the sheet to a PNG via `invoiceSheetPng` (reusing `renderInvoicePng`; builds it **off-screen** when the sheet isn't open) and passes `body.attachment = {name, mimeType:'image/png', dataB64}`. Best-effort: a failed render (Firefox) just sends the email **without** the image — never blocks the send.

**Backend (queued — additive):** `docs/handoffs/invoice-email-attachment-backend.gs` + the deploy queue. `sendCustomerMessage_` decodes the attachment to a blob and adds `mailOpts.attachments` before `GmailApp.sendEmail`.
- **Isolation preserved:** the recipient stays server-resolved from the invoice's own customer — the client never picks it, so the image can only ever reach that customer.
- Gated to `entity==='invoice'`, MIME-whitelisted (png/jpeg), ~3MB size-capped, bad-blob-dropped.
- **Fail-safe until deployed:** the un-patched backend ignores the new field → emails still send text-only (no regression). The image appears once the backend deploys — **that go-live is your Apps Script editor deploy.**

### Verified (headless Chromium)
- Font-parse extracts exactly the latin Geist + Saira woff2 URLs (drops other subsets).
- Enhanced rasterizer still produces a valid PNG; graceful when the CDN is blocked.
- `invoiceSheetPng` builds the sheet **off-screen**, renders a 56KB PNG, and cleans up.
- Gates: smoke · logic 668/668 · lease 76 · lease-deploy 42 · rule-usage · window-catalog · code-map — all green.

**Real font fidelity + the actual email round-trip need a staging/device check** (the sandbox blocks the fonts CDN; the email needs the backend deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQX1Xiw6NYNF48mmVhvvXm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQX1Xiw6NYNF48mmVhvvXm)_