### PR TITLE
Promote: content-verified staging freshness (hash, not just ?v= token)

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -45,11 +45,11 @@ point of Gate 1: you look at the running app before integrating it. Check:
 
 ## This step — merge to trunk
 1. **Local gates green:** `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
-   `node ci/lease-test.mjs`, `node ci/lease-deploy-test.mjs`,
+   `node ci/lease-test.mjs`, `node ci/lease-deploy-test.mjs`, `node ci/promote-test.mjs`,
    `node ci/gen-rule-usage.mjs --check`, `node ci/check-window-catalog.mjs`,
    `node tools/gen-code-map.mjs --check`. (Port 8000 is reserved → `sed -i 's/8000/9147/g'
-   ci/smoke.mjs ci/logic-test.mjs`, run, then `git checkout -- ci/`. The two `lease-*` suites
-   are pure-Node — **not** part of the port swap.)
+   ci/smoke.mjs ci/logic-test.mjs`, run, then `git checkout -- ci/`. The `lease-*` and
+   `promote-test` suites are pure-Node — **not** part of the port swap.)
 2. **Fresh-context review — the safety net that replaces plan-reading.** Spawn a
    **code-review subagent** (fresh context, no conversation history) on the diff
    `git diff origin/trunk...HEAD`, scoped to correctness + requirement gaps (not style).

--- a/.claude/skills/promote/SKILL.md
+++ b/.claude/skills/promote/SKILL.md
@@ -39,11 +39,16 @@ order** and only then promote:
 1. **Is the thing Jac wants live actually merged to trunk?** If it's still on a feature branch
    (not on trunk), **run `/merge` first** — and `/merge` itself runs `/deploy` if the feature
    was never deployed/reviewed. Do NOT promote work that isn't on trunk.
-2. **Is staging fresh?** `promote.mjs` refuses to promote unless the live staging `?v=` equals
-   the trunk commit's `?v=` (so you never ship what staging never showed). If the work went
-   `/deploy → /merge` in order, staging already matches (the feature deploy IS what got merged).
-   If staging is behind, deploy the trunk commit to staging first (a short branch off trunk →
-   `/deploy` → land its `?v=` bump on trunk) — don't reach for the override blindly.
+2. **Is staging fresh? (content-verified)** `promote.mjs` refuses to promote unless a live
+   staging slot serves the trunk commit's **actual bytes** — a SHA-256 content hash over the
+   files the `?v=` token versions (`app.js`/`style.css`/`rule-usage.js`), not merely a matching
+   `?v=` token (which is hand-bumped and can COLLIDE — a different deploy reaching the same `?v=`
+   looks "fresh" on the token alone). The token is only a pre-filter; the hash is the authority.
+   The preview line reads ✅ *content verified* / 🔴 *TOKEN COLLISION* (right token, wrong bytes →
+   re-deploy) / 🔴 *no slot serves trunk's bytes*. `--slot N` pins a slot (still hash-checked).
+   If the work went `/deploy → /merge` in order, staging already matches (the feature deploy IS
+   what got merged). If it's behind/collided, deploy the trunk commit to staging first — don't
+   reach for the override blindly.
 
 **So if Jac says just "promote it" with nothing done yet:** the chain is **/promote → /merge →
 /deploy**, then back up it — deploy, review, merge, promote. Never skip straight to the push.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Staging-lease deploy seam (pure-Node, injected effects)
         run: node ci/lease-deploy-test.mjs
 
+      - name: Promote content-freshness resolver (pure-Node, injected probe)
+        run: node ci/promote-test.mjs
+
       - name: Rulebook field catalog is current
         run: node ci/gen-rule-usage.mjs --check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,9 @@ say-so:
   HEAD:trunk` (or `HEAD:production`) directly — it's rejected.
 - **Gate 2 `/promote`** — `node tools/promote.mjs` (bare = read-only preview; `--yes` to
   run) fast-forwards `production` to the approved `trunk` commit → app.jacrentals.com goes
-  live. Fast-forward-only; verifies the live `?v=` after; refuses if staging is behind. **The
+  live. Fast-forward-only; verifies the live `?v=` after; refuses unless a staging slot serves
+  trunk's **actual bytes** (a **content hash** over `app.js`/`style.css`/`rule-usage.js`, not just
+  a collision-prone `?v=` token — `--slot N` pins a slot). **The
   only step that changes the live site — always Jac's explicit call.**
 - **`/live`** — one word runs `/deploy → /merge → /promote` end to end and takes the feature
   branch all the way live. Runs straight through (Jac: don't stop unless there's something to
@@ -90,11 +92,12 @@ say-so:
   Pages — never gate a secret/auth check on it.)
 
 **Gates (must pass before push):** `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
-`node ci/lease-test.mjs`, `node ci/lease-deploy-test.mjs`, `node ci/gen-rule-usage.mjs --check`,
-`node ci/check-window-catalog.mjs`, `node tools/gen-code-map.mjs --check`. Port 8000 is reserved —
+`node ci/lease-test.mjs`, `node ci/lease-deploy-test.mjs`, `node ci/promote-test.mjs`,
+`node ci/gen-rule-usage.mjs --check`, `node ci/check-window-catalog.mjs`,
+`node tools/gen-code-map.mjs --check`. Port 8000 is reserved —
 swap to 9147 first: `sed -i 's/8000/9147/g' ci/smoke.mjs ci/logic-test.mjs`, run, then `git
-checkout -- ci/`. The two `lease-*` suites are **pure-Node** (mocked git seam, no browser/server)
-— **excluded from the port swap** and never touch the network.
+checkout -- ci/`. The `lease-*` and `promote-test` suites are **pure-Node** (mocked git seam /
+injected probe, no browser/server) — **excluded from the port swap** and never touch the network.
 
 **Cache-bust every deploy:** bump the shared `?v=` on `style.css`, `rule-usage.js`, and
 `app.js` in `index.html` (Pages serves `max-age=600`, no per-file hashing). Don't add `?v=`

--- a/ci/lease-test.mjs
+++ b/ci/lease-test.mjs
@@ -480,7 +480,8 @@ async function run() {
     ok(!/stagingRemoteUrl\(cred\)\s*,\s*dir/.test(deploySrc), '4.22 deploy no longer clones the hardcoded default repo');
 
     const promoteSrc = readFileSync(new URL('../tools/promote.mjs', import.meta.url), 'utf8');
-    ok(/resolveStagingSlotUrl\(expectedToken,\s*SLOT_ARG\)/.test(promoteSrc), '4.22 promote resolves the slot by trunk token / --slot');
+    ok(/resolveFreshSlot\(/.test(promoteSrc), '4.22 promote resolves the slot via content-verified resolveFreshSlot (--slot / content)');
+    ok(/from '\.\/lib\/promote-freshness\.mjs'/.test(promoteSrc), '4.22 promote imports the content-freshness resolver');
     ok(/from '\.\/lib\/staging-control\.mjs'/.test(promoteSrc), '4.22 promote imports SLOT_URLS from the slot map');
     ok(!/const STAGING_URL\s*=/.test(promoteSrc), '4.22 promote no longer hardcodes a single STAGING_URL');
   });

--- a/ci/promote-test.mjs
+++ b/ci/promote-test.mjs
@@ -1,0 +1,154 @@
+// promote-test.mjs — pure-Node tests for the content-verified staging-freshness resolver.
+//
+// NO network, NO browser, NO Playwright — this is NOT part of the port-8000→9147 swap. It
+// imports the PURE helpers from tools/lib/promote-freshness.mjs (normalizeForHash / contentHash
+// / resolveFreshSlot) and drives resolveFreshSlot with a fully in-memory `probe`, so every
+// freshness branch (content-match, token-collision, multi-slot pick, --slot pin, none,
+// unreachable, N=1) is exercised without touching git or the network.
+//
+// Reporting idiom mirrors ci/logic-test.mjs / ci/lease-test.mjs: collect {ok,m}, print ✓/✗,
+// process.exit(anyFail?1:0).
+
+import { normalizeForHash, contentHash, resolveFreshSlot } from '../tools/lib/promote-freshness.mjs';
+
+const results = [];
+const ok = (c, m) => results.push({ ok: !!c, m });
+function group(label, fn) {
+  try { fn(); }
+  catch (e) { ok(false, `${label} — UNEXPECTED THROW: ${e && e.message || e}`); }
+}
+
+// A read() over the three FRESHNESS_FILES from a {file: text} map (missing → undefined).
+const readerFrom = (map) => (f) => map[f];
+const TRUNK_FILES = { 'app.js': 'APP//v1', 'style.css': 'CSS//v1', 'rule-usage.js': 'RULES//v1' };
+const H = contentHash(readerFrom(TRUNK_FILES)); // trunk's authoritative content hash
+
+// deps builder: slotIds + a probe map {id: {token,hash} | {error}}.
+function deps(slotIds, probeMap) {
+  return {
+    slotIds,
+    urlOf: (id) => `https://staging.example/slot-${id}/`,
+    probe: (id) => probeMap[id],
+  };
+}
+const P = (token, files) => ({ token, hash: contentHash(readerFrom(files)) }); // a probe from real files
+
+// ── 1. normalizeForHash + contentHash ──
+group('hash', () => {
+  ok(normalizeForHash('a\r\nb\rc') === 'a\nb\nc', 'normalizeForHash collapses CRLF and lone CR to LF');
+  ok(normalizeForHash(null) === '' && normalizeForHash(undefined) === '', 'normalizeForHash treats null/undefined as empty');
+
+  const h2 = contentHash(readerFrom({ ...TRUNK_FILES }));
+  ok(H === h2, 'contentHash is deterministic (same content → same hash)');
+
+  const changed = contentHash(readerFrom({ ...TRUNK_FILES, 'app.js': 'APP//v2' }));
+  ok(H !== changed, 'contentHash changes when app.js bytes change');
+
+  const crlf = contentHash(readerFrom({ 'app.js': 'APP\r\n//v1', 'style.css': 'CSS//v1', 'rule-usage.js': 'RULES//v1' }));
+  const lf = contentHash(readerFrom({ 'app.js': 'APP\n//v1', 'style.css': 'CSS//v1', 'rule-usage.js': 'RULES//v1' }));
+  ok(crlf === lf, 'contentHash ignores CRLF-vs-LF (normalized) — no false mismatch from line endings');
+
+  const missing = contentHash(readerFrom({ 'style.css': 'CSS//v1', 'rule-usage.js': 'RULES//v1' })); // no app.js
+  ok(H !== missing, 'a missing file (empty) never hash-matches a present file');
+});
+
+// ── 2. resolveFreshSlot: content is authoritative ──
+group('content-match', () => {
+  // slot 2 serves trunk's exact bytes → fresh by content, even though slots 1/3 differ.
+  const d = deps([1, 2, 3], {
+    1: P('o', { ...TRUNK_FILES, 'app.js': 'OTHER' }),
+    2: P('p', TRUNK_FILES),
+    3: P('q', { ...TRUNK_FILES, 'app.js': 'THIRD' }),
+  });
+  const r = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, d);
+  ok(r.fresh === true && r.slotId === 2 && r.resolvedBy === 'content', 'content match → fresh, correct slot, resolvedBy=content');
+});
+
+group('token-collision', () => {
+  // slot 1 serves trunk's TOKEN (p) but DIFFERENT bytes → collision, NOT fresh.
+  const d = deps([1, 2, 3], {
+    1: P('p', { ...TRUNK_FILES, 'app.js': 'DIFFERENT-BUT-SAME-TOKEN' }),
+    2: P('o', { ...TRUNK_FILES, 'app.js': 'X' }),
+    3: { error: 'unreachable' },
+  });
+  const r = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, d);
+  ok(r.fresh === false, 'token collision → NOT fresh (the whole point)');
+  ok(r.resolvedBy === 'collision' && r.slotId === 1, 'collision reported on the token-matching slot');
+  ok(r.probe && r.probe.hash !== H, 'collision probe carries the mismatching hash for the diagnostic');
+});
+
+group('content-beats-colliding-token', () => {
+  // slot 1 collides on the token (wrong bytes); slot 2 actually serves trunk's bytes.
+  // The resolver MUST pick slot 2 (content), never be steered to slot 1 by the token.
+  const d = deps([1, 2], {
+    1: P('p', { ...TRUNK_FILES, 'app.js': 'WRONG' }),
+    2: P('p', TRUNK_FILES),
+  });
+  const r = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, d);
+  ok(r.fresh === true && r.slotId === 2 && r.resolvedBy === 'content', 'content match wins over an earlier token-colliding slot');
+});
+
+group('content-authoritative-over-token', () => {
+  // A slot serving trunk's bytes with a DIFFERENT token is still fresh — content is the source
+  // of truth, not the token (documents the design decision).
+  const d = deps([1], { 1: P('different-token', TRUNK_FILES) });
+  const r = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, d);
+  ok(r.fresh === true && r.resolvedBy === 'content', 'matching content with a differing token → still fresh');
+});
+
+// ── 3. --slot pin ──
+group('flag-pin', () => {
+  const d = deps([1, 2, 3], { 1: P('o', { ...TRUNK_FILES, 'app.js': 'X' }), 2: P('p', TRUNK_FILES), 3: P('q', { ...TRUNK_FILES, 'app.js': 'Y' }) });
+  const fresh = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: 2 }, d);
+  ok(fresh.fresh === true && fresh.slotId === 2 && fresh.resolvedBy === 'flag', '--slot 2 (matching) → fresh, resolvedBy=flag');
+  const mismatch = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: 1 }, d);
+  ok(mismatch.fresh === false && mismatch.resolvedBy === 'flag', '--slot 1 (wrong bytes) → NOT fresh (pin does not bypass the hash)');
+  const bad = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: 9 }, d);
+  ok(bad.badPin === true && bad.fresh === false, '--slot 9 (unconfigured) → badPin, not fresh');
+});
+
+// ── 4. none / unreachable ──
+group('none', () => {
+  const d = deps([1, 2, 3], {
+    1: P('a', { ...TRUNK_FILES, 'app.js': 'A' }),
+    2: P('b', { ...TRUNK_FILES, 'app.js': 'B' }),
+    3: P('c', { ...TRUNK_FILES, 'app.js': 'C' }),
+  });
+  const r = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, d);
+  ok(r.fresh === false && r.resolvedBy === 'none', 'no slot matches token or content → resolvedBy=none, not fresh');
+  ok(Array.isArray(r.probes) && r.probes.length === 3, 'none carries the full per-slot probe list for diagnostics');
+});
+
+group('unreachable', () => {
+  // All slots unreachable → none, not fresh (never a spurious "fresh").
+  const allErr = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, deps([1, 2], { 1: { error: 'x' }, 2: { error: 'y' } }));
+  ok(allErr.fresh === false && allErr.resolvedBy === 'none', 'all slots unreachable → not fresh');
+  // A reachable fresh slot alongside an unreachable one still resolves fresh.
+  const mixed = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, deps([1, 2], { 1: { error: 'x' }, 2: P('p', TRUNK_FILES) }));
+  ok(mixed.fresh === true && mixed.slotId === 2, 'an unreachable slot never blocks a genuinely fresh one');
+});
+
+// ── 5. N=1 parity ──
+group('n1', () => {
+  const freshOne = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, deps([1], { 1: P('p', TRUNK_FILES) }));
+  ok(freshOne.fresh === true && freshOne.slotId === 1 && freshOne.resolvedBy === 'content', 'N=1: matching content → fresh');
+  const staleOne = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, deps([1], { 1: P('x', { ...TRUNK_FILES, 'app.js': 'STALE' }) }));
+  ok(staleOne.fresh === false && staleOne.resolvedBy === 'none', 'N=1: stale bytes → not fresh');
+  // N=1 token collision: same token, different bytes → collision, not fresh (the bug this fixes).
+  const collideOne = resolveFreshSlot({ expectedToken: 'p', expectedHash: H, slotArg: NaN }, deps([1], { 1: P('p', { ...TRUNK_FILES, 'app.js': 'COLLIDE' }) }));
+  ok(collideOne.fresh === false && collideOne.resolvedBy === 'collision', 'N=1: token collision → NOT fresh (content-verified)');
+});
+
+// ── 6. empty expected hash (degenerate: trunk had no hashable files) ──
+group('empty-hash-guard', () => {
+  // With no expectedHash, content can't be the authority; a token match is reported as a
+  // collision (not fresh) — never a spurious pass.
+  const r = resolveFreshSlot({ expectedToken: 'p', expectedHash: '', slotArg: NaN }, deps([1], { 1: P('p', TRUNK_FILES) }));
+  ok(r.fresh === false, 'empty expectedHash → never fresh (no authority to confirm bytes)');
+});
+
+const passed = results.filter((r) => r.ok).length;
+results.forEach((r) => console.log(`${r.ok ? '  ✓' : '  ✗ FAIL:'} ${r.m}`));
+const anyFail = results.some((r) => !r.ok);
+console.log(`\n${anyFail ? '❌' : '✅'} Promote-freshness suite: ${passed}/${results.length} checks passed.`);
+process.exit(anyFail ? 1 : 0);

--- a/tools/lib/promote-freshness.mjs
+++ b/tools/lib/promote-freshness.mjs
@@ -1,0 +1,92 @@
+// promote-freshness.mjs — content-verified staging freshness for tools/promote.mjs.
+//
+// WHY THIS EXISTS
+// The staging-freshness gate asks: "is the live staging slot showing the EXACT bytes we're
+// about to promote to production?" It used to answer by comparing the `app.js?v=<token>`
+// cache-bust marker in index.html. But that token is HAND-BUMPED per deploy (…o → …p → …q),
+// NOT derived from file contents — so two INDEPENDENT deploys of DIFFERENT code can land on
+// the SAME token on the same day. Comparing only the token then reports "fresh" when a slot is
+// actually serving different bytes (a real collision was observed 2026-07-17: a throwaway test
+// deploy reached ?v=…p, the same token trunk happened to hold, so the token check matched
+// despite different code). At N=3 the multi-slot scan widens the collision surface.
+//
+// THE FIX: keep the token as a cheap PRE-FILTER, but make an authoritative CONTENT HASH the
+// source of truth. We hash the files the shared ?v= token versions (app.js / style.css /
+// rule-usage.js, per CLAUDE.md) and a slot is fresh ONLY when its served bytes hash-match
+// trunk. This closes both failure modes: the false POSITIVE (token collision → "fresh" when
+// bytes differ) and the false NEGATIVE (a collision making the scan pick the wrong slot).
+//
+// PURE + TESTABLE: this module does NO I/O. promote.mjs injects a `probe(id)` that curls the
+// slot + hashes it, and reads trunk bytes via `git show`. That keeps the go-live tool's flow
+// intact and lets ci/promote-test.mjs exercise every branch with zero network.
+
+import { createHash } from 'node:crypto';
+
+// The served files the shared ?v= cache-bust token versions (CLAUDE.md: "bump the shared ?v=
+// on style.css, rule-usage.js, and app.js"). Hashing exactly these is the faithful answer to
+// "are the meaningful served bytes trunk's bytes?" — app.js is where features live; the other
+// two carry design + the R-rulebook usage map.
+export const FRESHNESS_FILES = ['app.js', 'style.css', 'rule-usage.js'];
+
+// Newline-normalize before hashing so a CRLF-vs-LF checkout (e.g. a deploy from a Windows box
+// vs. `git show` on a Linux promote host) can never cause a FALSE mismatch. Real content
+// differences still register; only \r is neutralized.
+export function normalizeForHash(text) {
+  return String(text == null ? '' : text).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+// A deterministic SHA-256 over FRESHNESS_FILES. `read(file)` returns the file's raw text, or
+// null/undefined if it couldn't be read (hashed as empty — which can never equal a present
+// file's hash, so a missing/unreachable file is correctly "not fresh"). Each file's bytes are
+// bound to its name + delimited, so a rename/reorder can't produce a coincidental match.
+export function contentHash(read) {
+  const h = createHash('sha256');
+  for (const f of FRESHNESS_FILES) {
+    h.update(f);
+    h.update('\0');
+    h.update(normalizeForHash(read(f)));
+    h.update('\0');
+  }
+  return h.digest('hex');
+}
+
+// Resolve which staging slot (if any) is genuinely showing trunk's bytes.
+//
+//   opts.expectedToken — trunk index.html's ?v= token (cheap pre-filter / diagnostics).
+//   opts.expectedHash  — trunk's contentHash over FRESHNESS_FILES (the AUTHORITY).
+//   opts.slotArg       — a `--slot N` human pin (integer), or NaN/undefined to auto-resolve.
+//   deps.slotIds       — configured slot ids, e.g. [1,2,3].
+//   deps.urlOf(id)     — a slot's display URL (for messaging).
+//   deps.probe(id)     — { token, hash } | { error } for a slot: token from its index.html,
+//                        hash over its served FRESHNESS_FILES. Injected → this fn does NO I/O.
+//
+// Returns { slotId, resolvedBy, fresh, probe, probes, badPin }:
+//   resolvedBy: 'flag' (pinned) | 'content' (bytes matched) | 'collision' (token matched but
+//               bytes differ) | 'none' (nothing matched).
+//   fresh: TRUE only when the resolved slot's content hash === expectedHash.
+//   badPin: true when --slot named an unconfigured id (caller should fail loudly).
+export function resolveFreshSlot({ expectedToken, expectedHash, slotArg }, deps) {
+  const ids = [...deps.slotIds].sort((a, b) => a - b);
+  const probeOf = (id) => ({ id, url: deps.urlOf(id), ...deps.probe(id) });
+
+  // --slot pin: check exactly that slot; the content hash is still the authority.
+  if (Number.isInteger(slotArg)) {
+    if (!ids.includes(slotArg)) {
+      return { slotId: slotArg, resolvedBy: 'flag', fresh: false, probe: null, probes: null, badPin: true };
+    }
+    const p = probeOf(slotArg);
+    const fresh = !p.error && !!expectedHash && p.hash === expectedHash;
+    return { slotId: slotArg, resolvedBy: 'flag', fresh, probe: p, probes: [p], badPin: false };
+  }
+
+  // Auto-resolve: probe each slot ONCE. The fresh slot is the one whose CONTENT matches trunk
+  // (not merely its token) — so a token collision can neither fake freshness nor steer the pick
+  // to the wrong slot. A slot whose token matches but whose content does not is recorded as a
+  // 'collision' for a precise diagnostic, but is NOT fresh.
+  const probes = ids.map(probeOf);
+  const byContent = expectedHash ? probes.find((p) => !p.error && p.hash === expectedHash) : null;
+  if (byContent) return { slotId: byContent.id, resolvedBy: 'content', fresh: true, probe: byContent, probes, badPin: false };
+  const byTokenOnly = expectedToken ? probes.find((p) => !p.error && p.token === expectedToken) : null;
+  if (byTokenOnly) return { slotId: byTokenOnly.id, resolvedBy: 'collision', fresh: false, probe: byTokenOnly, probes, badPin: false };
+  return { slotId: ids[0], resolvedBy: 'none', fresh: false, probe: null, probes, badPin: false };
+}

--- a/tools/promote.mjs
+++ b/tools/promote.mjs
@@ -43,6 +43,9 @@ import { join } from 'node:path';
 // Imported for value only — staging-control.mjs has no import-time side effects. promote stays
 // credential-free: it only ever curls these PUBLIC Pages URLs, never touches the control branch.
 import { SLOT_URLS } from './lib/staging-control.mjs';
+// Content-verified freshness — confirm a slot serves trunk's ACTUAL bytes (a content hash over
+// the files the ?v= token versions), not merely a matching, collision-prone token. See the lib.
+import { resolveFreshSlot, contentHash } from './lib/promote-freshness.mjs';
 
 // TODO(jac): confirm — the release-pointer branch Pages serves as PRODUCTION (plan Phase 0.2/0.3).
 const PRODUCTION_BRANCH = 'production';
@@ -68,31 +71,6 @@ function readMarkerToken() {
     const m = JSON.parse(readFileSync(p, 'utf8'));
     return m && m.token != null ? String(m.token) : null;
   } catch { return null; }
-}
-
-// Resolve which staging slot's URL the freshness gate should check.
-//   --slot N  → that slot's URL (a deliberate human pin).
-//   otherwise → SCAN every slot's live Pages URL and pick the one already serving the trunk
-//               token we're about to promote (that's the slot the feature was deployed+reviewed
-//               on). Resolving by the served token — NOT the /merge-deleted marker — is what
-//               makes the freshness gate correct at N>1 (§8.2 step 3). If no slot serves it, we
-//               return slot 1 so the existing gate reports "behind" (with per-slot detail).
-// Credential-free: only curls PUBLIC Pages URLs. At N=1 this collapses to the single slot, so
-// the verdict is byte-identical to before.
-function resolveStagingSlotUrl(expectedToken, slotArg) {
-  const ids = Object.keys(SLOT_URLS).map(Number).sort((a, b) => a - b);
-  if (Number.isInteger(slotArg)) {
-    const url = SLOT_URLS[slotArg];
-    if (!url) fail(`--slot ${slotArg} is not a configured staging slot (have ${ids.join(', ')}).`);
-    return { slotId: slotArg, url, resolvedBy: 'flag', probes: null };
-  }
-  if (expectedToken && ids.length > 1) {
-    const probes = ids.map((id) => ({ id, url: SLOT_URLS[id], token: fetchLiveToken(stripSlash(SLOT_URLS[id])).token }));
-    const hit = probes.find((p) => p.token === expectedToken);
-    if (hit) return { slotId: hit.id, url: hit.url, resolvedBy: 'token', probes };
-    return { slotId: ids[0], url: SLOT_URLS[ids[0]], resolvedBy: 'none-fresh', probes };
-  }
-  return { slotId: ids[0], url: SLOT_URLS[ids[0]], resolvedBy: 'default', probes: null };
 }
 
 const REMOTE = 'origin';
@@ -175,38 +153,69 @@ console.log('  Files changed:');
 diffStat.forEach(l => console.log('    ' + l));
 console.log('='.repeat(72));
 
-// --- Step 2b: STAGING-FRESHNESS GATE ----------------------------------------
-// Staging must be showing the EXACT commit we're about to promote. If it's behind (or
+// --- Step 2b: STAGING-FRESHNESS GATE (content-verified) ----------------------
+// Staging must be showing the EXACT bytes we're about to promote. If it's behind (or
 // unreachable), promoting would put production AHEAD of the review site — the drift this gate
-// exists to prevent (2026-07-13). Reported in the preview; ENFORCED under --yes (Step 3b).
-function fetchLiveToken(url) {
-  try {
-    const html = execFileSync('curl', ['-sS', '-L', '--max-time', '15', `${url}/index.html`], { encoding: 'utf8' });
-    return { token: extractVersionToken(html) };
-  } catch (e) {
-    return { error: e.message };
-  }
+// exists to prevent (2026-07-13). The ?v= token is only a cheap pre-filter; the AUTHORITY is a
+// content hash over the files the token versions (app.js/style.css/rule-usage.js) — so a token
+// collision (a different deploy that reached the same ?v=) can neither fake freshness nor steer
+// the pick to the wrong slot. Reported in the preview; ENFORCED under --yes (Step 3b).
+
+// Trunk's authoritative content hash. Read RAW (untrimmed) — hashing must see the exact bytes,
+// and git() trims. A missing file hashes as empty (→ never matches a present file).
+const expectedHash = contentHash((f) => {
+  try { return execFileSync('git', ['show', `${trunkRef}:${f}`], { encoding: 'utf8' }); }
+  catch { return null; }
+});
+
+// Probe a slot: its served ?v= token (from index.html) + a content hash over its served
+// FRESHNESS_FILES (fetched at the version the slot advertises). Untrimmed curls — hashing must
+// see exact bytes. A fetch failure → { error } (token) or an empty file in the hash (→ not fresh).
+function curlRaw(url) {
+  return execFileSync('curl', ['-sS', '-L', '--max-time', '20', url], { encoding: 'utf8' });
 }
-const slot = resolveStagingSlotUrl(expectedToken, SLOT_ARG);
-const slotName = `staging slot ${slot.slotId}`;
-const staging = fetchLiveToken(stripSlash(slot.url));
-const stagingFresh = !staging.error && !!expectedToken && staging.token === expectedToken;
+function probeSlot(id) {
+  const base = stripSlash(SLOT_URLS[id]);
+  let token;
+  try { token = extractVersionToken(curlRaw(`${base}/index.html`)); }
+  catch (e) { return { error: e.message }; }
+  const q = token ? `?v=${token}` : '';
+  const hash = contentHash((f) => { try { return curlRaw(`${base}/${f}${q}`); } catch { return null; } });
+  return { token, hash };
+}
+
+const resolved = resolveFreshSlot(
+  { expectedToken, expectedHash, slotArg: SLOT_ARG },
+  { slotIds: Object.keys(SLOT_URLS).map(Number), urlOf: (id) => SLOT_URLS[id], probe: probeSlot },
+);
+if (resolved.badPin) fail(`--slot ${resolved.slotId} is not a configured staging slot (have ${Object.keys(SLOT_URLS).join(', ')}).`);
+const slotName = `staging slot ${resolved.slotId}`;
+const stagingFresh = resolved.fresh;
+const shortHash = (h) => (h ? String(h).slice(0, 10) : '(none)');
 console.log('');
-if (!expectedToken) {
-  console.log('promote: staging freshness — ⚠️ no app.js?v= token in the promoted index.html; cannot verify.');
-} else if (staging.error) {
-  console.log(`promote: staging freshness — ⚠️ could not reach ${slotName} at ${slot.url} (${staging.error}).`);
+if (!expectedToken && !expectedHash) {
+  console.log('promote: staging freshness — ⚠️ no app.js?v= token / content in the promoted commit; cannot verify.');
 } else if (stagingFresh) {
-  const how = slot.resolvedBy === 'flag' ? ' (pinned via --slot)' : slot.resolvedBy === 'token' ? ' (auto-resolved by served token)' : '';
-  console.log(`promote: staging freshness — ✅ ${slotName} serves ?v=${expectedToken}, matching the trunk commit${how}.`);
+  const how = resolved.resolvedBy === 'flag' ? 'pinned via --slot' : 'auto-resolved by content';
+  const served = resolved.probe && resolved.probe.token;
+  // Normally the fresh slot's served token == trunk's token; show the served one only when it
+  // differs (same bytes deployed under a different ?v= bump) so the line is never misleading.
+  const tok = served && served !== expectedToken
+    ? `content verified; served ?v=${served}, trunk ?v=${expectedToken}`
+    : `?v=${expectedToken}, content verified`;
+  console.log(`promote: staging freshness — ✅ ${slotName} serves trunk's bytes (${tok}; ${how}).`);
+} else if (resolved.resolvedBy === 'collision') {
+  const p = resolved.probe;
+  console.log(`promote: staging freshness — 🔴 TOKEN COLLISION at ${slotName}: it serves ?v=${p.token} (matching trunk's token) but DIFFERENT bytes.`);
+  console.log(`promote:   trunk content ${shortHash(expectedHash)} ≠ ${slotName} content ${shortHash(p.hash)} — a different deploy reached the same ?v=.`);
+  console.log('promote:   re-deploy THIS commit to staging (node tools/deploy-staging.mjs) and review it before promoting.');
 } else {
-  console.log(`promote: staging freshness — 🔴 NO STAGING SLOT SERVES THE TRUNK TOKEN. Trunk = ?v=${expectedToken}.`);
-  // When we scanned every slot, show what each one is actually serving so it's obvious the
-  // feature was never deployed (or landed on a slot that has since been redeployed).
-  if (slot.probes) {
-    slot.probes.forEach((p) => console.log(`promote:   slot ${p.id} (${stripSlash(p.url)}) = ?v=${p.token || '(unreachable)'}`));
-  } else {
-    console.log(`promote:   ${slotName} = ?v=${staging.token || '(none)'}.`);
+  console.log(`promote: staging freshness — 🔴 NO STAGING SLOT SERVES TRUNK'S BYTES. Trunk = ?v=${expectedToken} / content ${shortHash(expectedHash)}.`);
+  if (resolved.probes) {
+    resolved.probes.forEach((p) => console.log(
+      `promote:   slot ${p.id} (${stripSlash(p.url)}) = ` +
+      `?v=${p.token || (p.error ? '(unreachable)' : '(none)')}${p.hash ? ` / content ${shortHash(p.hash)}` : ''}`,
+    ));
   }
   console.log('promote:   no slot is showing what you\'re about to promote — deploy this commit to staging and review it first.');
 }


### PR DESCRIPTION
## Why
The staging-freshness gate in `promote.mjs` answered *"is staging showing the exact bytes I'm about to promote?"* by comparing the `app.js?v=` **token**. That token is **hand-bumped per deploy, not derived from file contents** — so two independent deploys of *different* code can collide on the same `?v=`. We hit exactly this on 2026-07-17: a throwaway test deploy reached the same token trunk held, and the token check reported "fresh" despite different bytes. At N=3 the multi-slot scan widened that surface.

## Fix
Keep the token as a cheap **pre-filter**; make an authoritative **SHA-256 content hash** over the files the token versions (`app.js` / `style.css` / `rule-usage.js`, newline-normalized) the **source of truth**. A slot is fresh **only** when its served bytes hash-match trunk. This closes both:
- **False positive** — token collision → "fresh" when bytes differ (now → `🔴 TOKEN COLLISION`).
- **False negative** — a collision steering the scan to the wrong slot (now the pick is content-authoritative).

Preview verdicts: `✅ content verified` / `🔴 TOKEN COLLISION` (right token, wrong bytes → re-deploy) / `🔴 no slot serves trunk's bytes`. `--slot N` still pins a slot (still hash-checked).

## Changes
- **`tools/lib/promote-freshness.mjs`** (new) — pure, injectable `resolveFreshSlot` + `contentHash` + `normalizeForHash`. Zero I/O → fully unit-testable.
- **`tools/promote.mjs`** — reads trunk bytes (raw, untrimmed `git show`) + probes each slot (curl + hash), resolves via the lib; content-aware messaging (shows the served token when it differs from trunk's).
- **`ci/promote-test.mjs`** (new) — 23 checks over every branch: content match, collision, content-beats-colliding-token, `--slot` pin/mismatch/bad-pin, none, unreachable, N=1 parity, CRLF/LF normalization, empty-hash guard. Pure-Node.
- Wired into `ci.yml` + `CLAUDE.md` gates + `merge/SKILL.md`; updated the `4.22` source-lint; documented in `promote/SKILL.md` + `CLAUDE.md`.

## Validation
- All gates green: `promote-test` 23/23, `lease-test` 77/77, `lease-deploy-test` 42/42, rule-usage/window-catalog/code-map ✓.
- **Live end-to-end:** a slot serving trunk's exact bytes under a *different* `?v=` was correctly **content-verified fresh** (token mismatch seen through); confirms `git show`-vs-served-bytes hashing matches on real data (newline-normalized) — no false negative that would block real promotes.

## Ship path
Non-served tooling only (`tools/` + `ci/` + docs) → ships by **`/merge` alone**; production untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_016cKZkVpmqL9ETySE11BKUi)_