### PR TITLE
QR scan videos surface in the journey card + drive rental status (reconciliation)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7320,24 +7320,28 @@ function yardToolHtml(u) {
   const C = euT || r;   // §20 this unit's OWN captures (mirrors r.* for the primary)
   const st = getStatus('rentalStatus', euT ? unitStatus(r, euT) : rentalDisplayStatus(r));
   const isDel = !!(euT && euT.transportType && euT.transportType !== 'Self');   // §20 per-unit (was rental-level — diverged on multi-unit)
-  const startLbl = C.startCapture ? 'On Rent' : isDel ? '+Log Delivery' : '+Start';
-  const endLbl = C.endCapture ? 'Returned' : isDel ? '+Log Recovery' : '+End';
+  // A QR-decal scan is ADOPTED into the record as a first-class capture (adoptScanCaptures,
+  // marked scan:true), so the journey reads it straight off C.* like any manual capture — the
+  // `• Filed by QR scan` marker below just keys off that flag. No display-time join needed.
+  const startCap = C.startCapture, endCap = C.endCapture;
+  const startLbl = startCap ? 'On Rent' : isDel ? '+Log Delivery' : '+Start';
+  const endLbl = endCap ? 'Returned' : isDel ? '+Log Recovery' : '+End';
   const kindLbl = isDel ? getStatus('transportType', euT.transportType).label : '';
   const du = `data-unit="${esc(u.unitId)}"`;
   return `<div class="jtool"><div class="journey">
     <div class="jnode pre" style="cursor:default"><span class="jbox" style="color:var(--${st.color})">${CARD_ICON.rentals}</span><span class="jlbl" style="color:var(--${st.color})">${esc(st.label)}</span><span class="jts">${fmtShortDate(r.startDate)}${r.startTime ? ' · ' + esc(r.startTime) : ''}</span></div>
     <div class="jseg">
       <span class="jover"><span class="pill dvd c-orange" data-r="R4" data-pill-card="rentals" data-pill-rec="${esc(r.rentalId)}">${CARD_ICON.rentals}<span class="t">${esc(cust?.name || r.rentalName || 'Rental')}</span></span></span>
-      <span class="jline2 ${C.startCapture ? 'on' : ''}"></span>
+      <span class="jline2 ${startCap ? 'on' : ''}"></span>
       <span class="junder">${fmtShortDate(r.startDate)} – ${fmtShortDate(r.endDate)}</span>
       ${(() => { const addr = (euT && euT.deliveryAddress) || (isPrimaryUnit(r, euT) ? r.deliveryAddress : ''); return addr ? `<span class="jaddr js-site-go" data-rec="${esc(r.rentalId)}" ${du}>${esc(addr)}</span>` : (isDel ? `<span class="jaddr js-site-go" data-rec="${esc(r.rentalId)}" ${du}>+Address</span>` : ''); })()}
       ${kindLbl ? `<span class="jkind">${esc(kindLbl)}</span>` : ''}
     </div>
-    <div class="jnode ${C.startCapture ? 'done green' : ''} js-yard" data-cap="start" data-rec="${esc(r.rentalId)}" ${du}><span class="jbox">${C.startCapture ? '✓' : I.video}</span><span class="jlbl">${esc(startLbl)}</span><span class="jts">${esc(C.startCapture?.clock || '')}</span></div>
-    <div class="jseg"><span class="jover"></span><span class="jline2 ${C.endCapture || C.fcCapture ? 'on' : ''}"></span></div>
+    <div class="jnode ${startCap ? 'done green' : ''} js-yard" data-cap="start" data-rec="${esc(r.rentalId)}" ${du}${startCap?.scan ? ' data-tip="Filed by QR scan"' : ''}><span class="jbox">${startCap ? '✓' : I.video}</span><span class="jlbl">${esc(startLbl)}</span><span class="jts">${esc(startCap?.clock || '')}${startCap?.scan ? ' <span class="jscan">•</span>' : ''}</span></div>
+    <div class="jseg"><span class="jover"></span><span class="jline2 ${endCap || C.fcCapture ? 'on' : ''}"></span></div>
     <div class="jnode fc ${C.fcCapture || r.fieldCall ? 'done' : ''} js-yard" data-cap="fc" data-rec="${esc(r.rentalId)}" ${du}><span class="jbox">${I.video}</span><span class="jlbl">+FC</span><span class="jts">${esc(C.fcCapture?.clock || '')}</span></div>
-    <div class="jseg"><span class="jover"></span><span class="jline2 ${C.endCapture ? 'on' : ''}"></span></div>
-    <div class="jnode ${C.endCapture ? 'done yellow' : ''} js-yard" data-cap="end" data-rec="${esc(r.rentalId)}" ${du}><span class="jbox">${C.endCapture ? '✓' : I.video}</span><span class="jlbl">${esc(endLbl)}</span><span class="jts">${esc(C.endCapture?.clock || '')}</span></div>
+    <div class="jseg"><span class="jover"></span><span class="jline2 ${endCap ? 'on' : ''}"></span></div>
+    <div class="jnode ${endCap ? 'done yellow' : ''} js-yard" data-cap="end" data-rec="${esc(r.rentalId)}" ${du}${endCap?.scan ? ' data-tip="Filed by QR scan"' : ''}><span class="jbox">${endCap ? '✓' : I.video}</span><span class="jlbl">${esc(endLbl)}</span><span class="jts">${esc(endCap?.clock || '')}${endCap?.scan ? ' <span class="jscan">•</span>' : ''}</span></div>
   </div></div>`;
 }
 /* one open-WO section on the Units card: WO name = the title, type+date flags right,
@@ -10944,6 +10948,82 @@ async function loadTripsFromBackend() {
       render();
     }
   } catch (e) { /* offline → keep local cache */ }
+}
+/* Scan-sourced capture videos (QR-decal scans, SCAN-TO-LOG above) are filed server-side via
+   captureByScan into an append-only ScanLog (NOT onto the rental record, so a client sync can't
+   clobber the server write). SCAN_CAPS is the boot-pulled feed (getScanCaptures), keyed
+   "<unitId>|<rentalId>|<cap>" → { video, ts }. adoptScanCaptures() then folds each one INTO the
+   rental it belongs to — client-side, synced via the normal diff-sync — so downstream everything
+   reads it as an ordinary capture. Mirrors loadTripsFromBackend: same offline/local guard. */
+let SCAN_CAPS = {};
+async function loadScanCapturesFromBackend() {
+  if (typeof backendPassword === 'undefined' || !backendPassword) return;
+  try {
+    const r = await backendCall('getScanCaptures');
+    if (r && r.ok && r.captures && typeof r.captures === 'object') {
+      SCAN_CAPS = r.captures || {};
+      const changed = adoptScanCaptures();     // fold new scan videos into their rentals (stamp capture + advance status)
+      if (!booting && changed) render();
+    }
+  } catch (e) { /* offline → keep whatever SCAN_CAPS already holds (possibly empty) */ }
+}
+/* Fold each scan-filed video into its rental as a FIRST-CLASS capture: stamp the unit's
+   start/end capture (marked scan:true) and advance that unit's status the way a manual Log
+   Delivery/Recovery would — so the journey, the status pill, availability, billing and every
+   status-driven surface agree, with ZERO display/gate special-casing (they read cur.* like any
+   manual capture). Client-side + persisted through the normal diff-sync (reindex → saveSoon),
+   so it never clobbers a server write. Status is set DIRECTLY, bypassing the §9 booking gates —
+   the unit physically moved, so a scan records that fact; a missing invoice is FLAGGED in the
+   activity log, not blocked (Jac: don't stop a truck that already left). Idempotent: a slot that
+   already carries a video (a manual capture, or an earlier adoption) is left untouched, so this
+   re-runs harmlessly on every load and never fights a manual edit. §scan-reconcile. */
+function adoptScanCaptures() {
+  // Parse the flat SCAN_CAPS map, then process in CHRONOLOGICAL order (ts, with a start-before-
+  // end tiebreak) — never key order. A unit's START must be adopted before its END, or a full
+  // backlog (both scans landed before anyone opened the app) would advance Reserved → On Rent on
+  // the start AFTER the end already skipped its own status move, stranding the unit at On Rent
+  // forever (the endCapture is stamped, so idempotency then blocks the Returned move). §bug-1.
+  const entries = [];
+  for (const k in SCAN_CAPS) {
+    const cap = SCAN_CAPS[k]; if (!cap || !cap.video) continue;
+    const b1 = k.indexOf('|'); if (b1 < 0) continue;
+    const b2 = k.indexOf('|', b1 + 1); if (b2 < 0) continue;
+    const slot = k.slice(b2 + 1); if (slot !== 'start' && slot !== 'end') continue;
+    entries.push({ unitId: k.slice(0, b1), rentalId: k.slice(b1 + 1, b2), slot, video: cap.video, ts: cap.ts });
+  }
+  entries.sort((a, b) => (Number(new Date(a.ts)) - Number(new Date(b.ts))) || ((a.slot === 'end') - (b.slot === 'end')));
+  let changed = false;
+  for (const e of entries) {
+    const r = IDX.rental.get(e.rentalId); if (!r) continue;
+    const eu = unitEntry(r, e.unitId);
+    if (Array.isArray(r.units) ? !eu : String(r.unitId) !== String(e.unitId)) continue;   // must match the scanned unit
+    const tgt = eu || r, key = e.slot === 'start' ? 'startCapture' : 'endCapture';
+    if (tgt[key]) continue;   // ANY capture already on this slot wins — a manual stamp (even mid-upload, video:'' before Drive resolves), or an earlier adoption. Never overwrite it. §bug-2
+    // Adopt ONLY when the resulting (capture + status) stays self-consistent — else leave the scan
+    // in ScanLog rather than paint a contradictory card (a green "delivered" node over a "No Show"/
+    // "Reserved" pill). Read the STORED status, not the derived one, so a backlog delivery on a
+    // derived-No-Show unit (stored 'Reserved', start date passed) still advances to On Rent. §bug-3
+    const storedSt = (eu && eu.status) || r.status || 'Reserved';
+    if (e.slot === 'start') { if (['Returned', 'Cancelled', 'No Show'].includes(storedSt)) continue; }   // terminal → don't un-terminal
+    else { if (!OUT_RENTAL_STATUSES.has(storedSt) && storedSt !== 'Returned') continue; }             // recovery with no delivery on file → skip
+    let clock = '', date = TODAY_ISO;
+    // Derive date + clock in LOCAL time (isoOf, like the manual capture path's TODAY_ISO) — NOT
+    // toISOString(), whose UTC day would stamp tomorrow's date on an evening scan in a negative-
+    // offset yard (America/Chicago), diverging from the local `clock` on the same stamp. §bug-4
+    try { const d = new Date(e.ts); if (!isNaN(d.getTime())) { clock = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); date = isoOf(d); } } catch (err) {}
+    const drvId = eu ? (e.slot === 'end' ? (eu.recoveryDriverId || eu.deliveryDriverId) : eu.deliveryDriverId) : null;
+    setUnitCapture(r, eu, key, { date, clock, video: e.video, driver: drvId ? driverName(drvId) : '', scan: true });
+    if (e.slot === 'start' && !OUT_RENTAL_STATUSES.has(storedSt)) {   // pre-delivery → this scan delivered it
+      if (eu) { eu.status = 'On Rent'; syncRentalPrimary(r); } else { r.status = 'On Rent'; }
+      if (!r.invoiceId) logAction(r, '⚠ Delivered by QR scan — no invoice linked yet');
+    } else if (e.slot === 'end' && OUT_RENTAL_STATUSES.has(storedSt)) {   // out → this scan recovered it
+      if (eu) { eu.status = 'Returned'; syncRentalPrimary(r); } else { r.status = 'Returned'; }
+    }
+    logAction(r, `${IDX.unit.get(e.unitId)?.name || e.unitId} — ${e.slot === 'start' ? 'Delivery' : 'Recovery'} video filed by QR scan`);
+    reindex('rentals', r);   // → saveSoon() diff-syncs this client-side write (no clobber)
+    changed = true;
+  }
+  return changed;
 }
 /* §2.3 Phase 4 — the Trips card footer's live sync state (replaces the Phase 1 static
    placeholder). 'Synced · rev N' (N = the highest rev among TODAY's materialized trips) only
@@ -19378,6 +19458,8 @@ function yardCapture(rentalId, cap, unitId, opts = {}) {
   // A video already on file → this tap RE-RECORDS it (Jac: "delete that video in trade
   // for a new one by doing the same process again"). A re-record only swaps the video —
   // it must NOT move status again, re-run the §9 delivery gates, or re-raise a field call.
+  // (A scanned delivery/recovery is ADOPTED onto cur.* by adoptScanCaptures, so cur[key] is
+  // already set here — no scan-specific gate branch needed; it reads as a normal capture.)
   const replace = !!cur[key] || (cap === 'fc' && !!r.fieldCall);
   // §14 a first Start/Delivery moves the unit On Rent — run the §9 gates UP FRONT so a
   // blocked delivery never opens the camera (mirrors setRentalStatus/setUnitStatus so the
@@ -19424,6 +19506,7 @@ function commitYardCapture(rentalId, cap, unitId, dataUrl, opts = {}) {
   const uname = IDX.unit.get(unitId)?.name || '';
   const key = cap === 'start' ? 'startCapture' : cap === 'end' ? 'endCapture' : 'fcCapture';
   // Re-record → swap the video only; keep the status where it is and don't re-raise the FC.
+  // (A scanned capture is already adopted onto tgt.* by adoptScanCaptures — a normal capture here.)
   const replace = !!tgt[key] || (cap === 'fc' && !!r.fieldCall);
   // The media NEVER rides the record (a Sheets cell caps at 50k chars) — the stamp
   // persists immediately; the video uploads to Drive and only its URL lands on the
@@ -24493,6 +24576,7 @@ function finishLoad() {
   // (views no longer pull from the backend — personal per-device "my views", spec search-views D2)
   loadGroupOrderFromBackend();                                  // pull THIS role's saved card-group order
   loadTripsFromBackend();                                       // §2.3 Phase 4 — pull the trips store (getTrips), server wins at boot
+  loadScanCapturesFromBackend();                                // pull QR-decal scan captures (getScanCaptures) to join into the yard journey
   salePricingAutoApply();                                       // used-sale price engine, auto mode (manager+ sessions only)
   loadChats();                                                  // pull the shared team-chat threads (§ team-chat sync)
   wranglerRailLoad();                                           // load the Mr. Wrangler rail from IndexedDB (+ one-time localStorage migration)
@@ -25540,6 +25624,7 @@ function exposeTestApi() {
       tripsFor, tripTown, telHref, tripMatches, tripSort, stopDone, dispatchStopId, tripRowHTML: (t) => ROWS.calendar(t), yardCapture, openYardCamera, commitYardCapture, nextCategoryId, nextUnitId,
       tripsLS, tripMerge, tripSplit, assignTripDriver, tripLabel, assignStopDriver, tripSetTime,
       tripPushSoon, tripPushNow, loadTripsFromBackend, tripsSyncFooter, setBackendPassword: (pw) => { backendPassword = pw || ''; },   // §2.3 Phase 4 sync — the setter is test-only (mirrors setRole), letting logic-test.mjs exercise the online path via a mocked window.fetch, never a real backend
+      adoptScanCaptures, setScanCaps: (m) => { SCAN_CAPS = m || {}; },   // §scan-reconcile — test seam: seed SCAN_CAPS then run adoption (logic-test)
       autoRunRepair, autoRunAnchorsFor, secToClock, AUTORUN_DAY_START_SEC, AUTORUN_EOD_DEADLINE_SEC, AUTORUN_LOAD_BUFFER_SEC, dispatchPinOf,
       openCustomerForm, renderOverlay, render, printInvoice, invoiceDocHtml, renderInvoicePng, invoiceSheetPng, invoicePrintGroups, invoiceAmendments, cardComplete, cardCaptureState, cardHasSelfie, cardHasSignature, captureSelfie, captureSignature,
       wranglerSend, wranglerNewChat, openWranglerDock, wranglerDockPollTick, devUnlocked, openWranglerOps, wrOpsAgo, __state: state };   // UI drivers for headless screenshot/e2e tests

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -2709,6 +2709,95 @@ try {
       ok(T.wrOpsAgo(now - 2 * 86400000) === '2d', 'wrops#5: 2 days → "2d"');
     }
 
+    // ── §scan-reconcile — adoptScanCaptures(): a QR-decal scan is folded into its rental as a
+    //    FIRST-CLASS capture (stamped scan:true) + advances status like a manual Log Delivery/
+    //    Recovery, client-side, bypassing the §9 booking gates (records a physical fact). (2026-07-17)
+    {
+      const mk = (id, uid, status, extra = {}) => { const r = { rentalId: id, customerId: 'C0009', unitId: uid, categoryId: null, rentalName: id, startDate: T.TODAY_ISO, endDate: T.TODAY_ISO, status, transportType: 'Self', units: [{ unitId: uid, status }], invoiceId: null, actions: [], mock: true, ...extra }; T.DATA.rentals.push(r); T.IDX.rental.set(id, r); return r; };
+      const clean = (id) => { T.DATA.rentals = T.DATA.rentals.filter((r) => r.rentalId !== id); T.IDX.rental.delete(id); };
+
+      // 1) START adoption: Reserved + no invoice → stamps the capture (scan:true) + On Rent + FLAGS the missing invoice
+      const rA = mk('SC-ADOPT-A', 'U-SCA', 'Reserved');
+      const tsA = Date.now();
+      T.setScanCaps({ 'U-SCA|SC-ADOPT-A|start': { video: 'https://drive/v-a', ts: tsA } });
+      const chgA = T.adoptScanCaptures();
+      const euA = T.unitEntry(rA, 'U-SCA');
+      ok(chgA === true, 'scan-adopt: reports changed on a fresh adoption');
+      ok(euA.startCapture && euA.startCapture.video === 'https://drive/v-a' && euA.startCapture.scan === true, 'scan-adopt: START stamps the unit capture, marked scan:true');
+      ok(T.unitStatus(rA, euA) === 'On Rent', 'scan-adopt: START advances the unit to On Rent');
+      ok(rA.actions.some((a) => /no invoice/i.test(a.text)), 'scan-adopt: missing invoice is FLAGGED in the log, not blocked');
+      // §bug-4 — the capture date is stamped in LOCAL time (isoOf), matching the manual path's
+      // TODAY_ISO, NOT toISOString()'s UTC day (which would be tomorrow for an evening scan in a
+      // negative-offset yard). Contract assertion — in a UTC CI runtime both agree, but this guards
+      // the local-format contract + a gross regression; the TZ-specific proof is a standalone check.
+      { const d = new Date(tsA), p = (n) => String(n).padStart(2, '0'); const localYMD = `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+        ok(euA.startCapture.date === localYMD, 'scan-adopt: capture date is stamped LOCAL (isoOf), matching the manual Log Delivery path'); }
+
+      // 2) Idempotent — a second run leaves an already-adopted slot (and its status) untouched
+      const capBefore = euA.startCapture;
+      const chgA2 = T.adoptScanCaptures();
+      ok(chgA2 === false && T.unitEntry(rA, 'U-SCA').startCapture === capBefore, 'scan-adopt: idempotent — a re-run never re-stamps or re-moves an adopted slot');
+
+      // 3) Manual wins — a capture already on the slot is NEVER overwritten by a scan
+      const rB = mk('SC-ADOPT-B', 'U-SCB', 'Reserved');
+      const manual = { date: T.TODAY_ISO, clock: '9:00 AM', video: 'https://drive/manual', driver: 'Sam' };
+      T.unitEntry(rB, 'U-SCB').startCapture = manual;
+      T.setScanCaps({ 'U-SCB|SC-ADOPT-B|start': { video: 'https://drive/v-b', ts: Date.now() } });
+      T.adoptScanCaptures();
+      ok(T.unitEntry(rB, 'U-SCB').startCapture === manual, 'scan-adopt: a manual capture wins — adoption never overwrites it');
+
+      // 4) END adoption: an out unit + end scan → Returned + endCapture
+      const rC = mk('SC-ADOPT-C', 'U-SCC', 'On Rent', { invoiceId: 'I-X' });
+      T.setScanCaps({ 'U-SCC|SC-ADOPT-C|end': { video: 'https://drive/v-c', ts: Date.now() } });
+      T.adoptScanCaptures();
+      const euC = T.unitEntry(rC, 'U-SCC');
+      ok(euC.endCapture && euC.endCapture.video === 'https://drive/v-c' && euC.endCapture.scan === true, 'scan-adopt: END stamps the recovery capture, marked scan:true');
+      ok(T.unitStatus(rC, euC) === 'Returned', 'scan-adopt: END advances an out unit to Returned');
+
+      // 5) END on a never-delivered (pre-delivery) unit → NOT adopted — stamping a recovery with
+      //    no delivery on file would paint a contradictory card, so leave it in ScanLog (§bug-3)
+      const rD = mk('SC-ADOPT-D', 'U-SCD', 'Reserved');
+      T.setScanCaps({ 'U-SCD|SC-ADOPT-D|end': { video: 'https://drive/v-d', ts: Date.now() } });
+      T.adoptScanCaptures();
+      const euD = T.unitEntry(rD, 'U-SCD');
+      ok(!euD.endCapture, 'scan-adopt: END on a never-delivered unit is NOT adopted (no delivery on file → skip)');
+      ok(T.unitStatus(rD, euD) === 'Reserved', 'scan-adopt: END on a never-delivered unit leaves status untouched');
+
+      // 6) An unknown rental in SCAN_CAPS is skipped cleanly (no throw)
+      T.setScanCaps({ 'U-GHOST|NO-SUCH-RENTAL|start': { video: 'x', ts: Date.now() } });
+      ok(T.adoptScanCaptures() === false, 'scan-adopt: a scan for an unknown rental is skipped, not fatal');
+
+      // 7) Backlog START on a derived-No-Show unit (Reserved, start date long past) → adopts +
+      //    On Rent (physical proof it went out; overrides the derived No-Show → card stays consistent) (§bug-3)
+      const rNS = mk('SC-ADOPT-NS', 'U-SNS', 'Reserved', { startDate: '2020-01-01', endDate: '2020-01-02' });
+      ok(T.unitStatus(rNS, T.unitEntry(rNS, 'U-SNS')) === 'No Show', 'scan-adopt: precondition — a past-date Reserved unit derives No Show');
+      T.setScanCaps({ 'U-SNS|SC-ADOPT-NS|start': { video: 'https://drive/v-ns', ts: Date.now() } });
+      T.adoptScanCaptures();
+      const euNS = T.unitEntry(rNS, 'U-SNS');
+      ok(euNS.startCapture && euNS.startCapture.video === 'https://drive/v-ns', 'scan-adopt: backlog START on a No-Show unit files the delivery video');
+      ok(T.unitStatus(rNS, euNS) === 'On Rent', 'scan-adopt: backlog START overrides the derived No-Show → On Rent (consistent card)');
+
+      // 8) A full backlog on ONE rental with keys enumerated END-before-START still ends Returned —
+      //    adoption orders start-before-end by ts regardless of key order (§bug-1 guard)
+      const rBK = mk('SC-ADOPT-BK', 'U-SBK', 'Reserved');
+      T.setScanCaps({ 'U-SBK|SC-ADOPT-BK|end': { video: 'https://drive/bk-end', ts: 2000 }, 'U-SBK|SC-ADOPT-BK|start': { video: 'https://drive/bk-start', ts: 1000 } });
+      T.adoptScanCaptures();
+      const euBK = T.unitEntry(rBK, 'U-SBK');
+      ok(euBK.startCapture && euBK.endCapture, 'scan-adopt: a full backlog files BOTH the delivery and recovery videos');
+      ok(T.unitStatus(rBK, euBK) === 'Returned', 'scan-adopt: start-before-end ordering — a delivered+recovered unit ends Returned, not stuck On Rent');
+
+      // 9) A manual capture MID-UPLOAD (video:'' before Drive resolves) is never clobbered by a scan (§bug-2)
+      const rMU = mk('SC-ADOPT-MU', 'U-SMU', 'On Rent', { invoiceId: 'I-Y' });
+      const inflight = { date: T.TODAY_ISO, clock: '8:00 AM', video: '', driver: 'Pat' };
+      T.unitEntry(rMU, 'U-SMU').startCapture = inflight;
+      T.setScanCaps({ 'U-SMU|SC-ADOPT-MU|start': { video: 'https://drive/scan-mu', ts: Date.now() } });
+      T.adoptScanCaptures();
+      ok(T.unitEntry(rMU, 'U-SMU').startCapture === inflight, "scan-adopt: an in-flight manual capture (video:'') is NOT overwritten by a scan");
+
+      T.setScanCaps({});   // reset the seam so no later test sees stray captures
+      ['SC-ADOPT-A', 'SC-ADOPT-B', 'SC-ADOPT-C', 'SC-ADOPT-D', 'SC-ADOPT-NS', 'SC-ADOPT-BK', 'SC-ADOPT-MU'].forEach(clean);
+    }
+
     return out;
   });
 

--- a/docs/backend-snippets/captureByScan.md
+++ b/docs/backend-snippets/captureByScan.md
@@ -56,12 +56,33 @@ OR (b) a valid session cred is present (existing password/role check). Else
 
 | unit rental status | result |
 |---|---|
-| `Today`, `Tomorrow` | `action='start'` (delivery video) |
 | `On Rent`, `End Rent` | `action='end'` (recovery video) |
+| `Today`/`Tomorrow` (i.e. `Reserved`, start today/tomorrow) **AND a delivery already on file** | `action='end'` (recovery video) |
+| `Today`/`Tomorrow` (`Reserved`, start today/tomorrow), no delivery yet | `action='start'` (delivery video) |
 | `Reserved` (future, not Today/Tomorrow) | blocked · `"<unitName> is reserved for <startDate>, not out today — nothing to log yet."` |
 | `Quote`, `Off Rent`, `Returned`, `Cancelled`, `No Show`, no active rental | blocked · `"<unitName> isn't on a rental or reservation right now — nothing to log."` |
 
 Out-wins tiebreak: if a unit is out AND has a future reservation, the out status wins → `end`.
+
+> **Derive start-vs-end from HISTORY, not stored status alone (`scanLoggedActions_`). §scan-reconcile.**
+> A scan files to the append-only `ScanLog` (below) and — by design, to avoid a client sync
+> clobbering a server write — **never advances the rental's stored status past `Reserved`**. So
+> "is this unit already delivered?" can't be read from the status field alone: a pure-scan flow
+> (staff never open the app to move the rental `On Rent`) would sit at `Reserved` forever, and a
+> second scan at pickup would wrongly re-derive `start`. `scanDeriveUnitStatus_` therefore treats
+> the unit as **delivered → `end`** when a delivery is already on file — a manual `startCapture`
+> stamp on the record **OR** an earlier `start` row in `ScanLog` (`scanLoggedActions_(unitId,
+> rentalId).start`). First scan → `start`; every scan after a logged delivery → `end`.
+>
+> The client then ADOPTS each scan capture into its rental (`app.js` `adoptScanCaptures`, run
+> from `loadScanCapturesFromBackend`): it stamps the unit's `startCapture`/`endCapture` (marked
+> `scan:true`) and advances that unit's status the way a manual Log Delivery/Recovery would —
+> client-side, persisted through the normal diff-sync (so it never clobbers a server write).
+> Downstream everything then reads a scan as an ordinary capture (journey, status pill,
+> availability, billing) with no display/gate special-casing. Status is set directly, bypassing
+> the §9 booking gates (the unit physically moved); a missing invoice is FLAGGED in the rental's
+> activity log, not blocked. Adoption is idempotent — a slot already carrying a video (manual, or
+> already-adopted) is left untouched — so it re-runs harmlessly and never fights a manual edit.
 
 > **Derive `Today`/`Tomorrow` from dates — don't read them raw.** In `config.js` these are
 > DERIVED display states; the STORED `rentalStatus` stays `Reserved` for a reservation whose

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26225 lines, 41 chapters
+## app.js — 26310 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -23,32 +23,32 @@
 | APP-13 | 6376–6615 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
 | APP-14 | 6616–7025 | §6b | §6b PER-CARD ROWS | rowEl, genericRow, ROWS |
 | APP-15 | 7026–7225 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 7226–8797 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
-| APP-17 | 8798–9056 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 9057–9475 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, mobileNavEl, colTabButtonsHtml, colActionsHtml, memberCardEl, …(+7) |
-| APP-19 | 9476–9600 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 9601–9772 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 9773–10062 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+11) |
-| APP-22 | 10063–11555 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+132) |
-| APP-23 | 11556–11598 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 11599–12441 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 12442–14069 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
-| APP-26 | 14070–14413 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
-| APP-27 | 14414–14898 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 14899–16094 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+112) |
-| APP-29 | 16095–16392 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+19) |
-| APP-30 | 16393–16740 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+8) |
-| APP-31 | 16741–16744 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 16745–19210 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 19211–20504 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 20505–21975 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+93) |
-| APP-35 | 21976–22458 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 22459–22461 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 22462–23686 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23687–24614 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
-| APP-39 | 24615–24621 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24622–24875 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+11) |
-| APP-41 | 24876–26225 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-16 | 7226–8801 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
+| APP-17 | 8802–9060 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 9061–9479 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, colTabsEl, mobileNavEl, colTabButtonsHtml, colActionsHtml, memberCardEl, …(+7) |
+| APP-19 | 9480–9604 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 9605–9776 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 9777–10066 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+11) |
+| APP-22 | 10067–11635 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+135) |
+| APP-23 | 11636–11678 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 11679–12521 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 12522–14149 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, renderOverlay, buildPopupEl, openOverlay |
+| APP-26 | 14150–14493 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
+| APP-27 | 14494–14978 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 14979–16174 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+112) |
+| APP-29 | 16175–16472 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, MEMBERSHIP_FUNNEL_ORDER, …(+19) |
+| APP-30 | 16473–16820 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+8) |
+| APP-31 | 16821–16824 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 16825–19290 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 19291–20587 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 20588–22058 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+93) |
+| APP-35 | 22059–22541 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 22542–22544 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 22545–23769 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
+| APP-38 | 23770–24698 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
+| APP-39 | 24699–24705 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24706–24959 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+11) |
+| APP-41 | 24960–26310 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 664 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717s" />
+  <link rel="stylesheet" href="style.css?v=20260717t" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717s"></script>
-  <script type="module" src="app.js?v=20260717s"></script>
+  <script src="rule-usage.js?v=20260717t"></script>
+  <script type="module" src="app.js?v=20260717t"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -3460,6 +3460,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .jnode.fc .jlbl { color: var(--red); }
 .jlbl { font-size: 9.5px; font-weight: 700; color: var(--txt-2); }
 .jts { font-size: 8.5px; color: var(--txt-3); font-variant-numeric: tabular-nums; min-height: 10px; }
+.jts .jscan { color: var(--accent); font-weight: 800; margin-left: 1px; }   /* scan-sourced capture marker — tasteful, tokens-only (jactec-ui) */
 .jseg { flex: 1 1 auto; display: flex; flex-direction: column; align-items: center; gap: 2px; padding-top: 8px; min-width: 0; }
 .jseg .jover { font-size: 9px; font-weight: 700; color: var(--txt-2); white-space: nowrap; display: inline-flex; align-items: center; gap: 3px; min-height: 11px; max-width: 100%; }
 .jseg .jover.loglink { color: var(--txt); font-weight: 800; cursor: pointer; }


### PR DESCRIPTION
Follow-up to #660 (which landed the scan-to-log flow, dormant). This makes a scanned delivery/recovery video **surface in the yard journey** and **drive the rental's status**, so scanning is genuinely "set it and forget it."

## What's in it
A QR-decal scan files its video to an append-only `ScanLog` server-side (never onto the rental record, so a client sync can't clobber it). On load the client **adopts** each scan capture into its rental — `adoptScanCaptures()`:
- **stamps** the unit's start/end capture (marked `scan:true`) so the journey card, both transport rails, and every capture reader show it as a normal capture — with a `•` "Filed by QR scan" marker;
- **advances status** the way a manual Log Delivery/Recovery would (delivery → On Rent, recovery → Returned), so availability, dashboards, double-booking checks, and billing all stay in sync;
- persists via the normal diff-sync (`reindex → saveSoon`) — a client-side write, so it **never clobbers** the server;
- sets status directly, **bypassing the §9 booking gates** (the unit physically moved) and **flagging** a missing invoice in the activity log rather than blocking a truck that already left;
- is **idempotent** — a slot already holding a video (manual, even mid-upload, or already adopted) is left untouched, so it re-runs harmlessly and never fights a manual edit.

Because a scan becomes a first-class capture, no display-join or gate special-casing is needed.

Backend (`Code.gs`, gitignored, deploys separately): `scanDeriveUnitStatus_` now derives start-vs-end from scan **history** (`scanLoggedActions_`) as a fallback for when two scans land before any office adoption. Contract doc `docs/backend-snippets/captureByScan.md` updated to match.

## Verification
- **Three fresh-context code reviews** plus a **four-lens adversarial workflow** — surfaced and fixed a stuck-status regression, a manual mid-upload clobber, a start/end batch-ordering strand, a contradictory-card case, and a UTC/local date-stamp bug (evening scans in the yard's timezone). All fixed and proven.
- **11 → 18 adoption cases** added to `ci/logic-test.mjs`: stamp + status transitions, idempotency, manual-wins, mid-upload safety, start-before-end ordering, No-Show backlog override, and local-date stamping. Suite green (686 checks).
- Local gates green: smoke, logic, lease, lease-deploy, rule-usage, window-catalog, code-map. Reviewed on staging.

## Still Jac's, after this merges + promotes
- **Backend redeploy** — the `scanDeriveUnitStatus_` / `scanLoggedActions_` change (editor-deploy).
- **Flip `qrScanLog` on** — the final switch that activates scanning for real users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7k3jEXZmLnuhbDbtwiZVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7k3jEXZmLnuhbDbtwiZVo)_