### PR TITLE
Activate QR scan-to-log: flip qrScanLog ON

### DIFF
--- a/config.js
+++ b/config.js
@@ -631,7 +631,7 @@ export const FEATURES = {
   // captureByScan handler is deployed (Jac deploys the backend last); flipped ON only
   // after that deploy. The flag gates EXPERIENCE only — the real auth is the server-side
   // write-only scanDeviceToken check in captureByScan, never this flag.
-  qrScanLog: false,   // PRODUCTION switch (staging + localhost auto-enable via APP_ENV, so review needs no flip)
+  qrScanLog: true,   // PRODUCTION switch — ON (2026-07-17): backend captureByScan + history-derivation deployed; scan-to-log live
   // Staging-review aid for the scan flow: when ON, the client short-circuits captureByScan to
   // CANNED responses (no backend needed) so every state is walkable before the handler is deployed.
   // Test-decal id suffix → state: …1 start · …2 end · …3 blocked · …4 not-found. OFF in production

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717t" />
+  <link rel="stylesheet" href="style.css?v=20260717u" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717t"></script>
-  <script type="module" src="app.js?v=20260717t"></script>
+  <script src="rule-usage.js?v=20260717u"></script>
+  <script type="module" src="app.js?v=20260717u"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Final activation of the QR scan-to-log feature. The backend (`captureByScan` + the scan history-derivation) is deployed and the frontend reconciliation is live (#694), so this flips the production experience flag on.

## What changes
`config.js`: `qrScanLog: false → true`. A `#u=<unitId>` decal scan now opens the capture screen for real staff in production, records one video, files it to the unit's rental log, and drives the rental's status (delivery → On Rent, recovery → Returned). The "Fleet QR Codes" export in Company Files also lights up.

The flag gates **experience only** — the real auth is always the server-side write-only `scanDeviceToken` check in `captureByScan`, never this flag.

## Verified
- Backend health-probed live (clean JSON router response — compiled OK).
- Frontend reconciliation already live on production (#694), 686/686 logic suite, 3 reviews + a 4-lens adversarial pass.
- Local gates green (smoke, logic, rule-usage, window-catalog, code-map); reviewed on staging.

Real-world proof is a live test scan with a phone once a decal is printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7k3jEXZmLnuhbDbtwiZVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7k3jEXZmLnuhbDbtwiZVo)_