### PR TITLE
Invoice copy/email image fidelity: restore separators, drop edit affordances, font-readiness

### DIFF
--- a/app.js
+++ b/app.js
@@ -21392,20 +21392,23 @@ function copyInvoiceImage(invoiceId) {
     .catch(fail);
 }
 async function renderInvoicePng(invoiceId) {
-  const doc = [...document.querySelectorAll('.pr-doc[data-inv]')].find((d) => d.dataset.inv === invoiceId);
-  if (!doc) throw new Error('invoice sheet not on screen');
-  // The raster paints ONCE, into boxes we freeze to px below (inlineComputedStyles). If a face decodes
-  // AFTER that single paint, a box sized under the on-screen face gets painted with a different-width
-  // fallback and text clips (notably the right-flush date stamp). So settle the fonts FIRST — embed the
-  // data-URI'd raster faces, decode them + the page faces — THEN measure and snapshot.
+  // Settle fonts FIRST — before we snapshot — so the freeze-measure and the one-shot SVG paint use the
+  // SAME face; otherwise a late-decoding fallback paints into boxes frozen under the on-screen face and
+  // text clips (notably the right-flush date stamp). On a cold cache these awaits are network-bound.
   const fontCss = await invoiceFontFaceCss();   // embed the real Saira/Geist faces — a foreignObject has no page @font-face
   try { if (document.fonts) { if (fontCss) await ensureEmbeddedFacesReady(fontCss); if (document.fonts.ready) await document.fonts.ready; } } catch (e) {}
+  // Resolve + snapshot the node AFTER the awaits, with NO async gap in between: a render() during a font
+  // await (e.g. the background poll applying a remote edit does a wholesale #app.replaceChildren) would
+  // detach a node captured earlier, and measuring/cloning a detached node yields a 0×0 blank PNG.
+  const doc = [...document.querySelectorAll('.pr-doc[data-inv]')].find((d) => d.dataset.inv === invoiceId);
+  if (!doc) throw new Error('invoice sheet not on screen');
   const rect = doc.getBoundingClientRect();
   const W = Math.ceil(rect.width), H = Math.ceil(rect.height);
+  const bg = getComputedStyle(doc).backgroundColor;   // capture now, while doc is known-connected — the only later read (fill) sits after an await
   const clone = doc.cloneNode(true);
   inlineComputedStyles(doc, clone);      // resolve classes + CSS vars to concrete values (index-aligned walk — must precede any clone mutation)
   normalizeCloneForRaster(doc, clone);   // a foreignObject drops ::before/::after — materialize them as real nodes so the ' · ' separators survive; strip screen-only edit affordances
-  await inlineDocImages(clone);          // <img src> → data: so drawImage doesn't taint the canvas
+  await inlineDocImages(clone);          // <img src> → data: so drawImage doesn't taint the canvas (operates on the detached clone only — safe past here)
   if (fontCss) { const st = document.createElement('style'); st.textContent = fontCss; clone.insertBefore(st, clone.firstChild); }
   clone.style.boxShadow = 'none'; clone.style.borderRadius = '0'; clone.style.margin = '0'; clone.style.maxWidth = 'none'; clone.style.width = W + 'px'; clone.style.height = H + 'px';
   clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
@@ -21416,8 +21419,7 @@ async function renderInvoicePng(invoiceId) {
   const canvas = document.createElement('canvas');
   canvas.width = Math.max(1, W * dpr); canvas.height = Math.max(1, H * dpr);
   const cx = canvas.getContext('2d'); cx.scale(dpr, dpr);
-  const bg = getComputedStyle(doc).backgroundColor;
-  cx.fillStyle = (bg && bg !== 'rgba(0, 0, 0, 0)') ? bg : '#f7f2ea';   // kraft fallback if the doc bg is transparent
+  cx.fillStyle = (bg && bg !== 'rgba(0, 0, 0, 0)') ? bg : '#f7f2ea';   // kraft fallback if the doc bg is transparent (bg captured pre-await, above)
   cx.fillRect(0, 0, W, H);
   cx.drawImage(img, 0, 0);
   return await new Promise((res, rej) => canvas.toBlob((b) => (b ? res(b) : rej(new Error('encode failed'))), 'image/png'));

--- a/app.js
+++ b/app.js
@@ -21394,14 +21394,20 @@ function copyInvoiceImage(invoiceId) {
 async function renderInvoicePng(invoiceId) {
   const doc = [...document.querySelectorAll('.pr-doc[data-inv]')].find((d) => d.dataset.inv === invoiceId);
   if (!doc) throw new Error('invoice sheet not on screen');
+  // The raster paints ONCE, into boxes we freeze to px below (inlineComputedStyles). If a face decodes
+  // AFTER that single paint, a box sized under the on-screen face gets painted with a different-width
+  // fallback and text clips (notably the right-flush date stamp). So settle the fonts FIRST — embed the
+  // data-URI'd raster faces, decode them + the page faces — THEN measure and snapshot.
+  const fontCss = await invoiceFontFaceCss();   // embed the real Saira/Geist faces — a foreignObject has no page @font-face
+  try { if (document.fonts) { if (fontCss) await ensureEmbeddedFacesReady(fontCss); if (document.fonts.ready) await document.fonts.ready; } } catch (e) {}
   const rect = doc.getBoundingClientRect();
   const W = Math.ceil(rect.width), H = Math.ceil(rect.height);
   const clone = doc.cloneNode(true);
-  inlineComputedStyles(doc, clone);   // resolve classes + CSS vars to concrete values
-  await inlineDocImages(clone);       // <img src> → data: so drawImage doesn't taint the canvas
-  const fontCss = await invoiceFontFaceCss();   // embed the real Saira/Geist faces — a foreignObject has no page @font-face
+  inlineComputedStyles(doc, clone);      // resolve classes + CSS vars to concrete values (index-aligned walk — must precede any clone mutation)
+  normalizeCloneForRaster(doc, clone);   // a foreignObject drops ::before/::after — materialize them as real nodes so the ' · ' separators survive; strip screen-only edit affordances
+  await inlineDocImages(clone);          // <img src> → data: so drawImage doesn't taint the canvas
   if (fontCss) { const st = document.createElement('style'); st.textContent = fontCss; clone.insertBefore(st, clone.firstChild); }
-  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0'; clone.style.margin = '0'; clone.style.maxWidth = 'none'; clone.style.width = W + 'px';
+  clone.style.boxShadow = 'none'; clone.style.borderRadius = '0'; clone.style.margin = '0'; clone.style.maxWidth = 'none'; clone.style.width = W + 'px'; clone.style.height = H + 'px';
   clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
   const xhtml = new XMLSerializer().serializeToString(clone);
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}"><foreignObject x="0" y="0" width="${W}" height="${H}">${xhtml}</foreignObject></svg>`;
@@ -21425,6 +21431,34 @@ function inlineComputedStyles(src, dst) {
   dst.setAttribute('style', s);
   const sc = src.children, dc = dst.children;
   for (let i = 0; i < sc.length; i++) if (dc[i]) inlineComputedStyles(sc[i], dc[i]);
+}
+// Prep a cloned .pr-doc for rasterization. A <foreignObject> renders as a DISCONNECTED image with no
+// page stylesheet and no ::before/::after — so (1) materialize each pseudo-element's generated content
+// (the ' · ' card/line separators, style.css) as a REAL inline span, or it vanishes and adjacent text
+// glues together ("JUN 16"+"1 DAY" → "JUN 161 DAY"); and (2) strip the screen-only edit affordances
+// (the ↗ source link, the PO "Edit" pill) that shouldn't ride into a shared/emailed image. Reads
+// computed styles from the LIVE src (a detached clone reports none); mutates ONLY the clone, so the
+// on-screen sheet and the print doc are untouched. Runs right after inlineComputedStyles, while src and
+// clone still share shape (the pseudo-walk is index-aligned); the affordance strip runs after the walk.
+function normalizeCloneForRaster(src, clone) {
+  const inserts = [];   // defer insertion so the index-aligned parallel walk can't desync mid-walk
+  const walk = (s, c) => {
+    if (!s || !c) return;
+    for (const which of ['::before', '::after']) {
+      const cs = getComputedStyle(s, which);
+      const m = cs.content && /^["'](.*)["']$/.exec(cs.content);   // only simple string content (every .pr-doc pseudo is a text separator)
+      if (!m || m[1] === '') continue;
+      const sp = document.createElement('span');
+      sp.textContent = m[1];
+      sp.style.cssText = `font:${cs.font};color:${cs.color};letter-spacing:${cs.letterSpacing};white-space:pre;`;   // carry the pseudo's own text styling; pre keeps the separator's spaces
+      inserts.push([c, sp, which === '::before']);
+    }
+    const sc = s.children, cc = c.children;
+    for (let i = 0; i < sc.length; i++) walk(sc[i], cc[i]);
+  };
+  walk(src, clone);
+  for (const [parent, node, first] of inserts) parent.insertBefore(node, first ? parent.firstChild : null);   // insertBefore(_, null) === appendChild
+  clone.querySelectorAll('.pr-line-src, .pr-po-edit, .inline-edit, [data-edit]').forEach((n) => n.remove());
 }
 // Same-origin images (logo, customer selfie) → data URIs, so the rasterized canvas isn't tainted
 // (a tainted canvas can't be read back to a blob). An unfetchable image is dropped, not fatal.
@@ -21470,6 +21504,32 @@ function invoiceFontFaceCss() {
   _invFontCssP = p;
   p.then((css) => { if (!css) _invFontCssP = null; }, () => { _invFontCssP = null; });   // cache only a successful, non-empty result; a failed/empty fetch retries next time
   return p;
+}
+// Decode the data-URI'd @font-face blocks we embed for the raster INTO document.fonts before the
+// one-shot SVG paint, so the copied/emailed image paints the real faces instead of a late-decoding
+// fallback (which clips boxes frozen under the real face). Cached per css string so a repeat copy/email
+// doesn't re-register; best-effort — never throws, and a browser without FontFace just skips it.
+let _facesReadyKey = null, _facesReadyP = null;
+function ensureEmbeddedFacesReady(css) {
+  if (_facesReadyKey === css) return _facesReadyP;
+  _facesReadyKey = css;
+  _facesReadyP = (async () => {
+    if (!window.FontFace || !document.fonts) return;
+    const jobs = [];
+    const re = /@font-face\s*{([^}]*)}/g; let m;
+    while ((m = re.exec(css))) {
+      const b = m[1];
+      const fam = (b.match(/font-family:\s*([^;]+);/) || [])[1];
+      const src = (b.match(/src:\s*([^;]+?);\s*(?:}|$)/) || b.match(/src:\s*([^;]+);/) || [])[1];
+      if (!fam || !src) continue;
+      const desc = {};
+      const w = (b.match(/font-weight:\s*([^;]+);/) || [])[1]; if (w) desc.weight = w.trim();
+      const st = (b.match(/font-style:\s*([^;]+);/) || [])[1]; if (st) desc.style = st.trim();
+      try { const ff = new FontFace(fam.replace(/['"]/g, '').trim(), src.trim(), desc); document.fonts.add(ff); jobs.push(ff.load()); } catch (e) {}
+    }
+    try { await Promise.all(jobs); } catch (e) {}
+  })();
+  return _facesReadyP;
 }
 // Raw base64 (no data: prefix) of a blob — for handing an image to the backend email send.
 function blobToBase64(blob) {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26420 lines, 41 chapters
+## app.js — 26422 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -41,14 +41,14 @@
 | APP-31 | 16821–16824 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-32 | 16825–19290 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
 | APP-33 | 19291–20587 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 20588–22118 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+96) |
-| APP-35 | 22119–22601 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 22602–22604 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 22605–23829 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23830–24758 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
-| APP-39 | 24759–24765 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24766–25069 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25070–26420 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-34 | 20588–22120 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+96) |
+| APP-35 | 22121–22603 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 22604–22606 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 22607–23831 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
+| APP-38 | 23832–24760 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
+| APP-39 | 24761–24767 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24768–25071 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25072–26422 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 664 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26360 lines, 41 chapters
+## app.js — 26420 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -41,14 +41,14 @@
 | APP-31 | 16821–16824 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-32 | 16825–19290 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
 | APP-33 | 19291–20587 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 20588–22058 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+93) |
-| APP-35 | 22059–22541 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 22542–22544 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 22545–23769 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23770–24698 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
-| APP-39 | 24699–24705 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24706–25009 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25010–26360 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-34 | 20588–22118 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+96) |
+| APP-35 | 22119–22601 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 22602–22604 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 22605–23829 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
+| APP-38 | 23830–24758 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+70) |
+| APP-39 | 24759–24765 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24766–25069 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25070–26420 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
 ## config.js — 664 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717v" />
+  <link rel="stylesheet" href="style.css?v=20260717w" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717v"></script>
-  <script type="module" src="app.js?v=20260717v"></script>
+  <script src="rule-usage.js?v=20260717w"></script>
+  <script type="module" src="app.js?v=20260717w"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717u" />
+  <link rel="stylesheet" href="style.css?v=20260717v" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717u"></script>
-  <script type="module" src="app.js?v=20260717u"></script>
+  <script src="rule-usage.js?v=20260717v"></script>
+  <script type="module" src="app.js?v=20260717v"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717t" />
+  <link rel="stylesheet" href="style.css?v=20260717u" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717t"></script>
-  <script type="module" src="app.js?v=20260717t"></script>
+  <script src="rule-usage.js?v=20260717u"></script>
+  <script type="module" src="app.js?v=20260717u"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Fixes the copy-as-image / email-PNG fidelity defects Jac reported off a real-device paste. The raster clones `.pr-doc` into a standalone `<svg><foreignObject>`, which renders with **no page stylesheet and no `::before`/`::after`**. Root-caused via a parallel diagnosis and **verified with a headless repro of the exact clone→foreignObject→canvas pipeline** (before/after PNGs).

## Fixes (all in `renderInvoicePng`, via a new `normalizeCloneForRaster` pass — source sheet + print doc untouched)

1. **Missing `·` separators** ✅ *proven (headless before/after)*
   The `·` between a rental card's window/duration/provenance and before each line-item's category/meta is CSS `::before` generated content (`style.css` `.pr-card-m > span + span::before`, `.pr-cat/.pr-mt::before`) — invisible to the disconnected SVG raster, so "JUN 16"+"1 DAY" glued into "JUN 161 DAY". `normalizeCloneForRaster` materializes every `::before`/`::after` in the clone as a **real inline span** (carrying the pseudo's computed font/color), so the separators survive.

2. **Baked-in edit affordances** ✅ *proven*
   The interactive ↗ source link (`.pr-line-src`) and PO "Edit" pill (`.pr-po-edit`) were cloned verbatim into the shared/emailed image. The pass strips `.pr-line-src, .pr-po-edit, .inline-edit, [data-edit]` from the clone. This also fixes the **email** path (`invoiceSheetPng` is forced to build with `interactive:true` to get `data-inv`, so it carried them too).

3. **Right-edge date-stamp clip** ⚠️ *hardened, needs real-device confirmation*
   Ruled out geometry and mobile layout (a headless repro is clean at every width with a *consistent* font). The clip only appears when the one-shot SVG paint uses a **different** font than the on-screen sheet was measured under — a font-readiness race, since boxes are frozen to px under the on-screen face. Now: embed + decode the data-URI faces (`ensureEmbeddedFacesReady`) and `await document.fonts.ready` **before** measuring/snapshotting, and pin the clone height. **Could not be reproduced in the cloud sandbox** (the Google Fonts CDN is blocked here), so this one needs a real-device re-test to confirm.

## What's untouched
`invoiceDocHtml`, `style.css`, and the print doc are byte-identical — the pass mutates only the raster clone. No `data-r`/`WINDOW_CATALOG` changes (the stamped `.pr-line-src` is stripped from the *clone*, not the source).

## Verification
- `node --check` ✓; `gen-code-map --check` ✓, `gen-rule-usage --check` ✓, `check-window-catalog` ✓ (47 kinds).
- Headless repro of the real pipeline: before shows the glued text + baked affordances; after shows restored `·` separators and no affordances.
- Deployed to staging (slot 2) for a real-device copy test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXi9B7frNncgefhZU4ZyGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXi9B7frNncgefhZU4ZyGg)_