### PR TITLE
Cross-device sync: reconcile #685's fixes + activate (FEATURES.userSync ON)

### DIFF
--- a/app.js
+++ b/app.js
@@ -20277,6 +20277,7 @@ function openLogoMenu(anchorEl) {
 // Switch user — clear this session's password/role (name stays remembered) → login.
 function switchUser() {
   document.querySelectorAll('.dropdown-menu').forEach((n) => n.remove());
+  try { flushUserPrefsNow(); } catch (e) {}   // §cross-device-sync — push a pending prefs edit before the token is dropped
   backendPassword = ''; currentRole = ''; currentPersonId = ''; state.userPrefs = null; booting = true;   // §cross-device-sync — drop the leaving person's identity + synced doc so nothing pushes under the next person
   sessionStorage.removeItem('jactec.pw'); sessionStorage.removeItem('jactec.role');
   renderLogin();
@@ -24061,7 +24062,7 @@ async function refreshFromBackend() {
   } catch (e) { /* offline / blip → retry next tick */ }
   finally { refreshing = false; }
 }
-function startRefreshPoll() { clearInterval(refreshTimer); refreshTimer = setInterval(() => { refreshToday(); refreshFromBackend(); }, 18000); }
+function startRefreshPoll() { clearInterval(refreshTimer); refreshTimer = setInterval(() => { refreshToday(); refreshFromBackend(); if (syncOn() && !state.userPrefs) loadUserPrefs(); }, 18000); }   // §cross-device-sync — re-drive a prefs load that never hydrated (past the 5-try login cutoff) so a cold-GAS blip doesn't disable sync all session
 
 // ── Team-chat sync (Jac 2026-06-15) ────────────────────────────────────────
 // Chat threads were browser-local, so one user's chat never reached another (a
@@ -24261,7 +24262,13 @@ function syncMirrorGuard() {
   if (!syncOn()) return;
   try {
     const tag = syncMirrorTag(), prev = localStorage.getItem('jactec.syncMirrorTag') || '';
-    if (prev !== tag) { wipeSyncMirror(); resetSyncStateToDefault(); localStorage.setItem('jactec.syncMirrorTag', tag); }
+    // Wipe ONLY when a KNOWN DIFFERENT person synced on this device before. On a first-ever
+    // adopt (prev === '') the local mirror is THIS device's existing prefs — KEEP it so
+    // loadUserPrefs/seedUserPrefsFromLocal adopts it as the person's baseline, instead of
+    // silently deleting everyone's saved Views/dispatch/prefs on their first post-activation
+    // login (the wipe used to run before the seed could capture it).
+    if (prev && prev !== tag) { wipeSyncMirror(); resetSyncStateToDefault(); }
+    if (prev !== tag) localStorage.setItem('jactec.syncMirrorTag', tag);
   } catch (e) {}
 }
 
@@ -24283,6 +24290,10 @@ async function pushUserPrefs() {
   try { const r = await backendCall('setUserPrefs', { doc }); if (!r || !r.ok) Object.keys(doc).forEach((s) => { if (s !== 'v') _userPrefsDirty[s] = true; }); }
   catch (e) { Object.keys(doc).forEach((s) => { if (s !== 'v') _userPrefsDirty[s] = true; }); }   // offline → retry on the next change
 }
+// Immediate flush — cancel the 1.2s debounce and push any pending dirty sections RIGHT NOW, so
+// a change made inside the debounce window isn't lost when the session ends (logout / switch-
+// user / tab hidden or closed). Fire-and-forget; the payload's token is captured synchronously.
+function flushUserPrefsNow() { if (!syncOn() || !state.userPrefs) return; clearTimeout(_userPrefsTimer); pushUserPrefs(); }
 // Boot (finishLoad, once personId is known): server doc BEATS stale localStorage; an empty
 // server doc means first-ever sync → adopt this device's mirror as the person's baseline.
 async function loadUserPrefs(_try) {
@@ -24749,6 +24760,11 @@ window.addEventListener('beforeunload', (e) => {
   flushSave();
   e.preventDefault(); e.returnValue = '';
 });
+// §cross-device-sync — flush a pending prefs edit when the tab is hidden/closed (the 1.2s
+// debounce would otherwise drop a just-made change). visibilitychange fires while the page is
+// still alive so the async push can complete; pagehide is the close backstop.
+document.addEventListener('visibilitychange', () => { if (document.visibilityState === 'hidden') { try { flushUserPrefsNow(); } catch (e) {} } });
+window.addEventListener('pagehide', () => { try { flushUserPrefsNow(); } catch (e) {} });
 function renderLogin(msg) {
   resetCommsRailForLogin();   // D8 — clock-in = an EMPTY rail; BEFORE the phoneIdentity branch so BOTH login screens clear (this reset used to sit below the early-return = dead code on the live path — Jac 2026-07-17)
   if (flagOn('phoneIdentity')) return renderPhoneLogin(msg);   // per-person login flow (Phase 2); the shared-password screen below is the flag-OFF path
@@ -24951,7 +24967,7 @@ async function attemptLogin() {
 const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', _role: '' };
 function pidTokenGet() { try { return localStorage.getItem('jactec.pidToken') || sessionStorage.getItem('jactec.pidToken') || ''; } catch (e) { return ''; } }
 function pidTokenSet(tok, personal) { try { if (personal) { localStorage.setItem('jactec.pidToken', tok); sessionStorage.removeItem('jactec.pidToken'); } else { sessionStorage.setItem('jactec.pidToken', tok); localStorage.removeItem('jactec.pidToken'); } } catch (e) {} }
-function pidTokenClear() { try { localStorage.removeItem('jactec.pidToken'); sessionStorage.removeItem('jactec.pidToken'); } catch (e) {} try { dataCache.wipe(); } catch (e) {} try { if (syncOn()) { wipeSyncMirror(); localStorage.removeItem('jactec.syncMirrorTag'); } } catch (e) {} currentPersonId = ''; state.userPrefs = null; }   // §instant-cache: logout clears the on-device snapshot; §cross-device-sync: + the per-person prefs mirror + the in-memory doc so the next user on a shared device starts clean (Blocker 1). GUARDED on syncOn() — when userSync is OFF the mirror keys ARE the user's only (device-local) prefs, so a token-expiry relogin must NOT wipe them.
+function pidTokenClear() { try { flushUserPrefsNow(); } catch (e) {} try { localStorage.removeItem('jactec.pidToken'); sessionStorage.removeItem('jactec.pidToken'); } catch (e) {} try { dataCache.wipe(); } catch (e) {} currentPersonId = ''; state.userPrefs = null; }   // §instant-cache: logout clears the on-device snapshot. §cross-device-sync: flush any pending prefs, then drop identity + the in-memory doc — but do NOT wipe the mirror here. The login-time syncMirrorGuard (tag-guarded) is the SINGLE wipe point, so a load-fail relogin can't delete a never-backed-up mirror (which would then seed an empty baseline). Shared-device safety still holds: a DIFFERENT person's next login (prev !== tag) wipes it, exactly as switchUser already defers to.
 function pidRosterCache() { try { return JSON.parse(localStorage.getItem('jactec.pidRoster') || '[]'); } catch (e) { return []; } }
 // The verified token becomes the per-call credential: a truthy backendPassword keeps every
 // existing online-guard working, and backendCall sends it as sessionToken (backend prefers it).

--- a/config.js
+++ b/config.js
@@ -650,7 +650,10 @@ export const FEATURES = {
   // Ships OFF so the client can promote before/independent of the backend deploy; flip ON to
   // roll out, back to OFF for instant rollback. Gates EXPERIENCE only — operator isolation is
   // enforced server-side (personId resolved from the session token, never a client value).
-  userSync: false,
+  // ACTIVATED 2026-07-17 after reconciliation folded in the first-adopt seed-before-wipe fix
+  // (no cutover Views loss), logout/pagehide flush, and refresh-poll re-drive. Flip back to
+  // false for instant rollback.
+  userSync: true,
 };
 
 /* Phone-identity client constants (non-secret — display/UX only; the backend owns the

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 26608 lines, 41 chapters
+## app.js — 26624 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -40,17 +40,17 @@
 | APP-30 | 16477–16824 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+8) |
 | APP-31 | 16825–16828 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
 | APP-32 | 16829–19294 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 19295–20591 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 20592–22125 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22126–22608 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 22609–22611 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 22612–23836 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 23837–24942 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+92) |
-| APP-39 | 24943–24949 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 24950–25256 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25257–26608 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
+| APP-33 | 19295–20592 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 20593–22126 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22127–22609 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 22610–22612 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 22613–23837 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
+| APP-38 | 23838–24958 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 24959–24965 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 24966–25272 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25273–26624 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+60) |
 
-## config.js — 672 lines, 0 chapters
+## config.js — 675 lines, 0 chapters
 
 Chapter **CFG** — no internal banners, the whole file is one chapter.
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717x" />
+  <link rel="stylesheet" href="style.css?v=20260717y" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717x"></script>
-  <script type="module" src="app.js?v=20260717x"></script>
+  <script src="rule-usage.js?v=20260717y"></script>
+  <script type="module" src="app.js?v=20260717y"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Follow-up to the merged #692 (which shipped the client + re-keys dormant). Per Jac: **reconcile the two parallel implementations, then activate.** Flips `FEATURES.userSync` OFF→ON.

## Reconciliation (folded #685's proven fixes into the live #692 client)
A Sonnet reconciliation confirmed #692's core **per-section dirty-flush** design is sound and structurally immune to the "whole-doc last-write-wins clobbers a bucket a device lacks" class #685 wrestled with — but two adversarial code reviews then found **two real data-loss paths on activation**, both now fixed:

1. **First-adopt seed-before-wipe (HIGH).** `syncMirrorGuard` ran before `seedUserPrefsFromLocal`, and since `jactec.syncMirrorTag` never existed pre-flip, every existing user's first post-activation login would wipe their saved Views/dispatch/comms/prefs, then seed an empty baseline. Fix: wipe **only** for a *known different* person (`prev && prev !== tag`); a first-ever adopt keeps the local mirror so it's adopted as the baseline.
2. **`pidTokenClear` never-synced wipe (HIGH).** On a cold-GAS login blip → `pidLoadFail → pidTokenClear`, the mirror got wiped before it was ever backed up → empty baseline on retry. Fix: **`pidTokenClear` no longer wipes at all** — the tag-guarded `syncMirrorGuard` is now the *single* wipe point (grep-proven: one guarded caller of `wipeSyncMirror`), so a never-synced mirror can't be deleted. Shared-device safety still holds (a different person's next login wipes it).

Also folded in: **flush-before-clear** on logout/switch-user, a **`pagehide`/`visibilitychange` flush** (no lost edit inside the 1.2s debounce), and a **refresh-poll re-drive** of `loadUserPrefs` past the 5-try login cutoff.

## Activation
`FEATURES.userSync: true`. Backend (v112) + the per-section-flush client are already live; this turns sync ON for phone-identity sessions. **Instant rollback = flip the flag back to `false`.**

## Verification
- Gates green: `node --check` app.js + config.js, `gen-rule-usage`/`check-window-catalog`/`gen-code-map --check`, **`smoke` ✓, `logic-test` 686/686**.
- Two fresh-context adversarial reviews of this exact diff (each found + fixed a data-loss bug); the residual wipe path is closed as a structural invariant.
- Functional two-device sync test is Jac's manual step (spec §9), post-activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdSrtJkhekAEKosebKniF

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTdSrtJkhekAEKosebKniF)_