### PR TITLE
Lift collapsed invoice rows off the card for visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717ab" />
+  <link rel="stylesheet" href="style.css?v=20260717ac" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717ab"></script>
-  <script type="module" src="app.js?v=20260717ab"></script>
+  <script src="rule-usage.js?v=20260717ac"></script>
+  <script type="module" src="app.js?v=20260717ac"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717y" />
+  <link rel="stylesheet" href="style.css?v=20260717z" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717y"></script>
-  <script type="module" src="app.js?v=20260717y"></script>
+  <script src="rule-usage.js?v=20260717z"></script>
+  <script type="module" src="app.js?v=20260717z"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260717x" />
+  <link rel="stylesheet" href="style.css?v=20260717y" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260717x"></script>
-  <script type="module" src="app.js?v=20260717x"></script>
+  <script src="rule-usage.js?v=20260717y"></script>
+  <script type="module" src="app.js?v=20260717y"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -4204,9 +4204,15 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .inv-add-pill.drop-ok { box-shadow: 0 0 0 1px var(--accent-line); }
 .inv-add-pill.drop-hot { border-color: var(--accent) !important; color: var(--accent) !important;
   box-shadow: 0 0 0 2px var(--accent-line), 0 0 26px -4px rgba(255,122,26,.5) !important; }
-/* embedded invoice rows / the expanded invoice as drop targets (they aren't `.row`/`.card`) */
-.inv-row.drop-ok, .inv-open.drop-ok { border-color: var(--accent-line); box-shadow: 0 0 0 1px var(--accent-line); cursor: copy; }
-.inv-row.drop-hot, .inv-open.drop-hot { border-color: var(--accent) !important;
+/* embedded invoice rows / the expanded invoice as drop targets (they aren't `.row`/`.card`).
+   box-shadow isn't additive, so the row states re-list the collapsed-row lift (inset bevel +
+   --chip-shadow) BEFORE the drop ring — otherwise a drop-hovered row would flatten back to the
+   old dark-on-dark look mid-drag. .inv-open has no lift, so its states stay as they were. */
+.inv-row.drop-ok { border-color: var(--accent-line); box-shadow: inset 0 1px 0 rgba(255,255,255,.06), var(--chip-shadow), 0 0 0 1px var(--accent-line); cursor: copy; }
+.inv-open.drop-ok { border-color: var(--accent-line); box-shadow: 0 0 0 1px var(--accent-line); cursor: copy; }
+.inv-row.drop-hot { border-color: var(--accent) !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06), var(--chip-shadow), 0 0 0 2px var(--accent-line), 0 0 26px -4px rgba(255,122,26,.5) !important; }
+.inv-open.drop-hot { border-color: var(--accent) !important;
   box-shadow: 0 0 0 2px var(--accent-line), 0 0 26px -4px rgba(255,122,26,.5) !important; }
 @media (prefers-reduced-motion: reduce) { .inv-row { transition: none; } }
 

--- a/style.css
+++ b/style.css
@@ -4100,10 +4100,16 @@ body { font-variant-numeric: tabular-nums; }
 .soon-sub { font-size: 12px; color: var(--txt-3); line-height: 1.5; }
 .inv-empty { font-size: 12px; padding: 4px 0; }
 
+/* Rows lift one elevation above the card (depth-by-lightness): the surface reads a step
+   lighter than --card, --chip-shadow floats it, and a hairline inset top-highlight gives the
+   brushed-steel bevel — so a collapsed row separates cleanly instead of melting into the card
+   (Jac 2026-07-17: dark-on-dark rows weren't visible). Same bevel technique as the ranch .row. */
 .inv-row { display: flex; align-items: center; gap: 10px; padding: 10px 11px; border: 1px solid var(--line); border-radius: 11px;
-  background: linear-gradient(180deg, var(--card-head), var(--card)); cursor: pointer; position: relative;
-  transition: border-color .12s ease, filter .12s ease; }
-.inv-row:hover { border-color: var(--accent-line); filter: brightness(1.05); }
+  background: linear-gradient(180deg, var(--track), var(--panel-2)); cursor: pointer; position: relative;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06), var(--chip-shadow);
+  transition: border-color .12s ease, filter .12s ease, box-shadow .12s ease; }
+.inv-row:hover { border-color: var(--accent-line); filter: brightness(1.06);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.09), var(--chip-shadow); }
 .inv-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .ir-stat { width: 3px; align-self: stretch; border-radius: 3px; flex: 0 0 auto; margin: -2px 0; background: var(--gray); }
 .ir-stat.due { background: var(--red); } .ir-stat.paid { background: var(--green); } .ir-stat.part { background: var(--yellow); }


### PR DESCRIPTION
## What

Collapsed invoice rows (`.inv-row`) were nearly invisible — they used a `--card-head → --card` gradient almost identical to the customer card behind them, so a row melted into the background instead of reading as its own plate. Jac flagged the poor visibility (2026-07-17).

This lifts each row **one elevation above the card** (Option A — "brushed steel lift", chosen from a 3-treatment mockup):

- **Surface** → `linear-gradient(180deg, var(--track), var(--panel-2))` — a clear step lighter than `--card` (depth-by-lightness, the sanctioned way to lift on dark).
- **Elevation** → `var(--chip-shadow)` — the token defined for lifting chips/rows.
- **Bevel** → a hairline `inset 0 1px 0 rgba(255,255,255,.06)` top-highlight for the brushed-steel read (same technique as the ranch `.row`).
- **Hover** unchanged in intent — keeps the `--accent-line` border, brightens the bevel.

## Design notes

- **Token-pure** — no raw hexes; every surface/shadow value comes from existing `:root` tokens, so it themes for free.
- Structure, spacing, and the status registry (red late / green paid / yellow partial) are untouched — only the row's surface/elevation changed.
- No new `data-r` element type, no new popup → no `rule-usage.js` / `WINDOW_CATALOG` change. Applies to both the invoice list rows and the Transactions-tab rows (shared `.inv-row`).

## Scope

`style.css` only — a 9-line change to the `.inv-row` block.

## Gates

- ✅ `node ci/gen-rule-usage.mjs --check`
- ✅ `node ci/check-window-catalog.mjs`
- ✅ `node tools/gen-code-map.mjs --check`
- `smoke` / `logic-test` (Playwright) run in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuxseKVuuJQWiS9qD6nWqx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuxseKVuuJQWiS9qD6nWqx)_