### PR TITLE
MEMORY: userSync #685 shipped live + sendBeacon/duplicate-feature gotchas

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,7 +6,7 @@
 > Keep it lean; the first ~200 lines are what a session actually leans on.
 
 ## Decisions
-- **2026-07-17 — Cross-device user sync SHIPPED LIVE (`userSync` ON, PRs #692+#702, `?v=20260717y`).**
+- **2026-07-17 — Cross-device user sync SHIPPED LIVE (`userSync` ON, PRs #692+#702+#685, `?v=20260717ab`).**
   A logged-in PERSON's prefs / saved Views / dispatcher route state / comms state / resume-column
   follow them across devices, keyed on `personId` **resolved SERVER-SIDE from the session token**
   (never a client value — the operator-isolation review held 0 findings). Hybrid store: additive
@@ -16,7 +16,10 @@
   role-shared AI-history leak). CLIENT design = **per-section dirty flush** (only changed top-level
   buckets are sent), which is structurally immune to the "whole-doc last-write-wins clobbers a bucket
   a device lacks" class the concurrent #685 implementation wrestled with — so #692's client won and
-  **#685 was superseded**. `syncMirrorGuard` is the SINGLE tag-guarded wipe point (shared-device
+  **#685's whole-doc client was superseded** — but its branch was then repurposed to ship a small
+  robustness pass on top of #692: a `navigator.sendBeacon` tab-close flush (#692's flush was a plain
+  fetch, which the browser ABORTS on a real close) + a one-time cutover toast (`?v=20260717ab`).
+  `syncMirrorGuard` is the SINGLE tag-guarded wipe point (shared-device
   Blocker 1). Backend shipped additive via `/clasp` (v112, editor deploy). Team-chat/comment
   attribution re-key DEFERRED (spec §13 — see Open threads). Spec:
   `docs/superpowers/specs/2026-07-17-cross-device-user-sync-design.md`.
@@ -178,6 +181,21 @@
   tag-guarded function the SINGLE wipe point (grep-prove it has exactly one caller), and wipe ONLY for
   a KNOWN DIFFERENT person (`prev && prev !== tag`), never on first-adopt or same-person. Review the
   ACTIVATION path of a flag-gated feature, not just the diff.
+- **A plain `fetch` started during page unload is ABORTED — use `navigator.sendBeacon` for tab-close
+  flushes (2026-07-17, #685).** A debounced sync had a plain-fetch flush wired to `visibilitychange`/
+  `pagehide`; on a real tab close the browser kills the in-flight fetch, so an edit in the last debounce
+  window (~1.2s) was silently lost. `sendBeacon(url, new Blob([json], {type:'text/plain;charset=utf-8'}))`
+  is queued by the browser and delivered AFTER the page is gone; `text/plain` keeps it CORS-safe (no
+  preflight) against a GAS endpoint. Check its BOOLEAN return — `false` = payload over the ~64KB / pending-
+  queue limit → re-mark dirty and fall back to a best-effort fetch so nothing is dropped. Match the normal
+  handler's auth fields + body shape exactly, since there's no response to inspect.
+- **Two concurrent sessions built the SAME feature end-to-end (2026-07-17, #685 vs #692 cross-device sync).**
+  Both implemented per-person sync independently (whole-doc vs per-section-dirty client); #692 merged first
+  and won on design, #685's client was superseded but its branch was salvaged into a robustness pass. Cost:
+  a duplicated build + a near-miss where #685 was briefly (wrongly) judged buggy from grepping for its OWN
+  function names against #692's code. LESSON: before building a sizable feature, scan open PRs/branches
+  (`list_pull_requests`, `git ls-remote`) for a concurrent duplicate; if found, reconcile to ONE canonical
+  impl early and repurpose the other branch (don't rebuild), and never assess impl A by grepping impl B's symbols.
 - **A concurrent session may have already deployed the backend — pull-inspect-idempotency before a
   `/clasp` push (2026-07-17).** The cross-device `clasp push` found `getUserPrefs`/`setUserPrefs`
   ALREADY on live HEAD (a parallel session's compatible version), so only the additive group-order/
@@ -372,7 +390,7 @@
   **staging drive** (real Chrome), not headless screenshots.
 
 ## Open threads
-- **Cross-device user sync — SHIPPED LIVE + PROMOTED (2026-07-17, PRs #692+#702, `?v=20260717y`, flag
+- **Cross-device user sync — SHIPPED LIVE + PROMOTED (2026-07-17, PRs #692+#702+#685, `?v=20260717ab`, flag
   `userSync` ON).** Prefs/Views/dispatch/comms/resume-column follow the PERSON across devices (see
   the Decisions entry for the design). Verified by a 4-lens adversarial workflow (operator-isolation
   held 0 findings) + two fresh-context reviews that each caught + fixed a real data-loss bug on the
@@ -382,7 +400,8 @@
   `chatCanSee_` is `by === me` and creators aren't in `members`, so flipping the key hides every
   pre-cutover chat from its creator), a `personId → name` DISPLAY lookup (raw ids otherwise render in
   the comms rail), and a `seen`/`by` migration. Parked tracker: branch `parked/team-chat-attribution-rekey`
-  (draft PR). (2) **#685** (the concurrent whole-doc implementation) is SUPERSEDED — close its PR. (3)
+  (draft PR). (2) **#685** — its whole-doc client was superseded, but the branch shipped LIVE as a
+  robustness pass on #692 (a `sendBeacon` tab-close flush + one-time cutover toast, `?v=20260717ab`); DONE. (3)
   **two-device functional test** (spec §9) is Jac's — the round-trip can't be driven headlessly here.
 - **QR scan-to-log — SHIPPED LIVE + PROMOTED (2026-07-17, PRs #660/#694/#697, `?v=20260717u`, flag `qrScanLog` ON).**
   A `#u=<unitId>` decal scan opens a focused capture screen, records ONE video, and files it to the


### PR DESCRIPTION
Docs-only `/end` refresh of the cross-session brain (`MEMORY.md`). No served file changes — ships by `/merge` alone (production untouched).

**Adds/updates:**
- **Decisions + Open-threads** — the cross-device-sync entries now record that **#685 merged + promoted live** (`?v=20260717ab`) as a robustness pass on #692, rather than being dropped/superseded.
- **Gotcha** — a plain `fetch` started during page unload is **aborted**; use `navigator.sendBeacon` (`text/plain` Blob, CORS-safe) for tab-close flushes, and check its boolean return to fall back on a rejected/oversized queue.
- **Gotcha** — the **#685↔#692 concurrent-duplicate-feature** collision: scan open PRs/branches before building a sizable feature; reconcile to one canonical impl and repurpose (don't rebuild) the other; never assess impl A by grepping impl B's symbols.

_From the same session that shipped the #685 robustness pass; captured on `/end`._

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUtcDa1itAL28X2LjVJDDu)_