### PR TITLE
Cache-bust: bump ?v= to 20260718c for the funnel promote

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260718b" />
+  <link rel="stylesheet" href="style.css?v=20260718c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260718b"></script>
-  <script type="module" src="app.js?v=20260718b"></script>
+  <script src="rule-usage.js?v=20260718c"></script>
+  <script type="module" src="app.js?v=20260718c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
The funnel squash (#693) landed on trunk carrying `?v=20260718b` — the **same token production already serves** (from #711), but with different `app.js` bytes. Fast-forwarding production as-is would swap `app.js` without changing the token, so browser caches wouldn't bust.

This bumps the shared `?v=` to a fresh `20260718c` so the funnel go-live busts caches immediately. `index.html` only — no logic change. Staging slot 1 was re-deployed and verified serving `20260718c` with trunk's funnel bytes, so the `/promote` freshness gate now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oRTXJzNA6qMjepSLLJomC

---
_Generated by [Claude Code](https://claude.ai/code/session_015oRTXJzNA6qMjepSLLJomC)_