### PR TITLE
a11y(mobile): obey iOS Dynamic Type — root on -apple-system-body, px→rem

### DIFF
--- a/app.js
+++ b/app.js
@@ -612,7 +612,7 @@ function heldSignBlock(o, custRec, d) {
   const p = (custRec && custRec.pendingCapture) || {};   // §7.1c pre-card held pieces (saddle onto the first card)
   return `<div class="ag-capcap" style="margin:16px 2px 8px">Signed agreement</div>
     ${capProgress([{ label: 'Card', done: false }, { label: 'Selfie', done: !!p.selfie }, { label: 'Signature', done: !!p.signature }])}
-    <p class="muted" style="font-size:11px;margin:2px 2px 0">Selfie &amp; signature save now and saddle onto the first card you add; On-Rent &amp; delivery unlock once that card is complete.</p>
+    <p class="muted" style="font-size:0.6471rem;margin:2px 2px 0">Selfie &amp; signature save now and saddle onto the first card you add; On-Rent &amp; delivery unlock once that card is complete.</p>
     ${agCaptureBlock(o, ag, 'account')}`;
 }
 /* Move an account-level HELD signing onto a freshly-added card — the draft's FROZEN
@@ -870,7 +870,7 @@ function cardTabBody(c) {
       ${k.isDefault ? badge('Default', 'blue') : actionPill('commit', 'Make default', { js: 'js-card-default', data: { rec: c.customerId, card: k.id } })}
       <button class="x js-card-remove" data-rec="${c.customerId}" data-card="${k.id}" data-tip="Remove card">${I.x}</button>
     </div>`;
-  }).join('') : '<span class="muted" style="font-size:12px">No cards on file.</span>';
+  }).join('') : '<span class="muted" style="font-size:0.7059rem">No cards on file.</span>';
   return `<div class="cards-list">${rows}</div>
     ${canMoney() ? `<div style="margin-top:10px">${addBtn('Card', { link: true, js: 'js-add-card', data: { rec: c.customerId } })}</div>` : ''}`;
 }
@@ -883,11 +883,11 @@ function achTabBody(c) {
       ${k.verified ? badge('Verified', 'green') : actionPill('commit', 'Verify', { js: 'js-bank-verify', data: { rec: c.customerId, bank: k.id } })}
       ${k.isDefault ? badge('Default', 'blue') : actionPill('commit', 'Make default', { js: 'js-bank-default', data: { rec: c.customerId, bank: k.id } })}
       <button class="x js-bank-remove" data-rec="${c.customerId}" data-bank="${k.id}" data-tip="Remove bank account">${I.x}</button>
-    </div>`).join('') : '<span class="muted" style="font-size:12px">No bank accounts on file.</span>';
+    </div>`).join('') : '<span class="muted" style="font-size:0.7059rem">No bank accounts on file.</span>';
   return `<div class="cards-list">${rows}</div>
     ${!canMoney() ? ''
       : consent ? `<div style="margin-top:10px">${addBtn('ACH', { link: true, js: 'js-add-ach', data: { rec: c.customerId } })}</div>`
-                : '<span class="muted" style="font-size:11px">Capture a selfie + signature (Edit account) before adding a bank account.</span>'}`;
+                : '<span class="muted" style="font-size:0.6471rem">Capture a selfie + signature (Edit account) before adding a bank account.</span>'}`;
 }
 
 /* §19 stable-key migration: give every existing invoice line a `lid` and remap
@@ -1678,15 +1678,15 @@ function transportEditorHtml() {
   const live = mapsReady();
   const who = u ? esc(u.name) + ' · ' : '';
   return `<div class="tedit sec" data-r="R5b">
-    <div class="tedit-head"><span class="stamp">Set ${te.leg === 'recovery' ? 'recovery' : 'delivery'} site</span><span class="muted" style="font-size:10.5px">${who}drag the pin for the exact driver drop</span></div>
+    <div class="tedit-head"><span class="stamp">Set ${te.leg === 'recovery' ? 'recovery' : 'delivery'} site</span><span class="muted" style="font-size:0.6176rem">${who}drag the pin for the exact driver drop</span></div>
     <div class="tedit-map js-tmap${live ? '' : ' ph'}">${live ? '' : (((GOOGLE_MAPS_KEY || _mapsKey) && !te.mapFailed)
       ? `<span class="map-spin" aria-hidden="true"></span><span class="map-tag">Loading dispatch map…</span>`
-      : `<span class="map-pin" aria-hidden="true">${ICO_PIN}</span><span class="map-tag stamp" style="font-size:11px;color:var(--accent)">${te.mapFailed ? 'Live map unavailable' : 'Offline'} · city-tier pricing</span><span class="map-sub">${te.mapFailed ? 'Type the site address below — pricing falls back to city tiers. Reopen the editor to retry the live map.' : 'Type the site address below — the live map &amp; exact mileage come online once the dispatch key is set.'}</span>`)}</div>
+      : `<span class="map-pin" aria-hidden="true">${ICO_PIN}</span><span class="map-tag stamp" style="font-size:0.6471rem;color:var(--accent)">${te.mapFailed ? 'Live map unavailable' : 'Offline'} · city-tier pricing</span><span class="map-sub">${te.mapFailed ? 'Type the site address below — pricing falls back to city tiers. Reopen the editor to retry the live map.' : 'Type the site address below — the live map &amp; exact mileage come online once the dispatch key is set.'}</span>`)}</div>
     <input class="lf-in js-taddr" placeholder="Site address — start typing…" value="${esc(te.addr || '')}" autocomplete="off" spellcheck="false" aria-label="Site address">
     <div class="js-tsug tedit-sug" role="listbox"></div>
     <div class="tedit-foot">
       <span class="muted tedit-hint">↑↓ choose · Tab/Enter set · Esc cancel</span>
-      <span class="muted js-te-dist" style="font-size:10.5px;margin-left:8px"></span>
+      <span class="muted js-te-dist" style="font-size:0.6176rem;margin-left:8px"></span>
       <span class="spacer"></span>
       ${ghostPill('Cancel', { js: 'js-tedit-cancel' })}
       ${actionPill('commit', 'Set address', { js: 'js-tedit-save' })}
@@ -2110,7 +2110,7 @@ function salePricingAutoApply() {
    the generic sync). Volume of asks per category feeds purchasing/fleet-spread decisions. */
 function lostDemandBtn(c) {
   const n = (c.lostDemand || []).length;
-  return `<button class="catr-slot js-lost-demand" data-r="R5b" data-cat="${esc(c.categoryId)}" data-tip="A customer wanted one and none were free — log the lost ask${n ? ` (${n} logged)` : ''}"><span class="add-field anchor" style="height:20px;font-size:10px">+Lost${n ? ` ${n}` : ''}</span></button>`;
+  return `<button class="catr-slot js-lost-demand" data-r="R5b" data-cat="${esc(c.categoryId)}" data-tip="A customer wanted one and none were free — log the lost ask${n ? ` (${n} logged)` : ''}"><span class="add-field anchor" style="height:20px;font-size:0.5882rem">+Lost${n ? ` ${n}` : ''}</span></button>`;
 }
 function categoryAvailableCount(catId, startISO, endISO, selfId) {
   return DATA.units.filter((u) => u.categoryId === catId && isUnitAvailableFor(u, startISO, endISO, selfId)).length;
@@ -5055,12 +5055,12 @@ function settingsFlagsPane(o) {
       const off = !!oo.off;
       const sevCtl = segCtl(['red', 'yellow', 'green'].map((sv) => ({ label: sv === 'red' ? 'R' : sv === 'yellow' ? 'Y' : 'G', js: 'js-flag-sev', data: { ent, id: f.id, sev: sv }, on: (!off && sev === sv) ? sv : null })));
       const onCtl = segCtl([{ label: 'On', js: 'js-flag-ov', data: { ent, id: f.id, val: 'on' }, on: !off ? 'green' : null }, { label: 'Off', js: 'js-flag-ov', data: { ent, id: f.id, val: 'off' }, on: off ? 'red' : null }]);
-      const changed = oo.off || oo.severity ? `<span class="muted" style="font-size:10px">edited</span>` : '';
+      const changed = oo.off || oo.severity ? `<span class="muted" style="font-size:0.5882rem">edited</span>` : '';
       return `<div class="set-row" style="gap:9px;align-items:center"><span style="flex:1;min-width:150px;${off ? 'opacity:.45' : ''}">${flagEl(f.label, sev)} ${esc(f.label)}</span>${sevCtl}${onCtl}${changed}</div>`;
     }).join('');
     return `<div class="set-sec"><h4 class="set-h">${esc(ENT_LBL[ent] || ent)}</h4>${items}</div>`;
   }).join('');
-  return `<div class="set-pane"><div class="muted" style="font-size:11.5px;margin-bottom:9px">Every flag is owner-tunable — Off hides it everywhere; R/Y/G overrides its severity. Defaults return by flipping back. Disabling a money/credit flag is audited.</div>${rows}</div>`;
+  return `<div class="set-pane"><div class="muted" style="font-size:0.6765rem;margin-bottom:9px">Every flag is owner-tunable — Off hides it everywhere; R/Y/G overrides its severity. Defaults return by flipping back. Disabling a money/credit flag is audited.</div>${rows}</div>`;
 }
 /* ── Settings → Team Roster (spec hr-compliance trimmed scope, Jac 2026-06-29) ──────
    The employee list — name · role · phone · note. Deliberately NO credentials/medical/
@@ -5098,7 +5098,7 @@ function settingsTeamPane(o) {
     <div class="emp-welcome-lbl">Crew welcome text</div>
     <textarea class="emp-welcome-ta" data-emp-welcome rows="3" placeholder="${esc(welcomeDefault)}" data-tip="Sent to a hand when they're added or their number changes">${esc(welcomeVal)}</textarea>
     <div class="emp-welcome-foot"><span class="emp-welcome-tok">Tokens <em>{name}</em> and <em>{link}</em> (the app link) fill in when it sends — no login code, they get that in the app.</span><button type="button" class="emp-act js-emp-welcome-reset" data-tip="Restore the default welcome wording">Reset to default</button></div></div>` : '';
-  return `<div class="set-pane"><div class="muted" style="font-size:11.5px;margin-bottom:9px">${esc(note)}</div>${rows || '<div class="muted" style="font-size:12px">No hands on the roster yet.</div>'}${welcomeBlock}<div class="kv pillrow" style="margin-top:9px">${addBtn('Employee', { link: true, js: 'js-emp-add' })}${showAuth ? `<button type="button" class="emp-act js-emp-blast" data-tip="Text the whole roster the app link + welcome">Round up the crew</button>` : ''}</div></div>`;
+  return `<div class="set-pane"><div class="muted" style="font-size:0.6765rem;margin-bottom:9px">${esc(note)}</div>${rows || '<div class="muted" style="font-size:0.7059rem">No hands on the roster yet.</div>'}${welcomeBlock}<div class="kv pillrow" style="margin-top:9px">${addBtn('Employee', { link: true, js: 'js-emp-add' })}${showAuth ? `<button type="button" class="emp-act js-emp-blast" data-tip="Text the whole roster the app link + welcome">Round up the crew</button>` : ''}</div></div>`;
 }
 /* ── Settings → Notifications (Phase A control center — design spec
    docs/superpowers/specs/2026-07-14-notifications-pane-design.md) ────────────────────
@@ -6119,12 +6119,12 @@ function svcPartPanelEl(u, task, pr, idx) {
       <div class="svc-ref-head" style="margin-top:14px">Vendor</div>
       <div class="svc-vendor-block">
         <div class="svc-vendor-name">${esc(vendor.name || '')}</div>
-        ${vendor.primaryContact ? `<div class="muted" style="font-size:11.5px">${esc(vendor.primaryContact)}</div>` : ''}
+        ${vendor.primaryContact ? `<div class="muted" style="font-size:0.6765rem">${esc(vendor.primaryContact)}</div>` : ''}
         ${vendor.phone ? linkName(vendor.phone, { js: 'js-open-link', data: { url: 'tel:' + String(vendor.phone).replace(/[^\d+]/g, '') } }) : ''}
         ${vendor.email ? linkName(vendor.email, { js: 'js-open-link', data: { url: 'mailto:' + vendor.email } }) : ''}
         ${vendor.website ? linkName(vendor.website, { js: 'js-open-link', data: { url: webUrl(vendor.website) } }) : ''}
       </div>` : (enriched ? '' : `
-      <p class="muted" style="font-size:12px;margin-top:8px">Not in the parts catalog yet.</p>
+      <p class="muted" style="font-size:0.7059rem;margin-top:8px">Not in the parts catalog yet.</p>
       <div class="svc-part-row">${linkName('Search this part number ↗', { js: 'js-open-link', data: { url: 'https://www.google.com/search?q=' + encodeURIComponent(pr.oem || pr.name || '') } })}</div>`);
   const pp = el('div', 'popup svc-part-popup'); pp.style.width = '300px';
   pp.innerHTML = popupShell({
@@ -6133,7 +6133,7 @@ function svcPartPanelEl(u, task, pr, idx) {
     closeJs: 'js-svc-part-close',
     body: `
       ${img ? `<img class="insp-thumb" src="${esc(img)}" alt="${esc(pr.name || 'part')}">` : ''}
-      <div class="muted" style="font-size:11px;margin-bottom:8px">OEM ${esc(pr.oem || '—')}${catalogPart ? ` · Catalog ${esc(catalogPart.productNumber || '')}` : ''}</div>
+      <div class="muted" style="font-size:0.6471rem;margin-bottom:8px">OEM ${esc(pr.oem || '—')}${catalogPart ? ` · Catalog ${esc(catalogPart.productNumber || '')}` : ''}</div>
       ${cost != null ? kv(money(cost), { pfx: 'Cost', derived: pr.cost == null }) : ''}
       ${catalogPart && catalogPart.qtyOnHand != null ? kv(catalogPart.qtyOnHand + ' on hand', { pfx: 'Stock', derived: true }) : ''}
       ${url ? `<div class="svc-part-row">${linkName(url.length > 30 ? 'Order / info ↗' : url, { js: 'js-open-link', data: { url: webUrl(url) } })}</div>` : ''}
@@ -6417,7 +6417,7 @@ function runCtxAction(act) {
 }
 /** R17: forward-action pills — commit (blue) / money (green) / danger (solid red). */
 function actionPill(kind, label, { js, data, h } = {}) {
-  return `<button class="pill c-${kind}${js ? ' ' + js : ''}" data-r="R17"${dataAttrs(data)}${h ? ` style="height:${h}px;font-size:11px"` : ''}>${esc(label)}</button>`;
+  return `<button class="pill c-${kind}${js ? ' ' + js : ''}" data-r="R17"${dataAttrs(data)}${h ? ` style="height:${h}px;font-size:0.6471rem"` : ''}>${esc(label)}</button>`;
 }
 /** R18: the ONE quiet/neutral action — Cancel, Close, secondary tools.
  *  `disabled` greys it (is-disabled) and drops the js hook so it's inert; pair with `tip`
@@ -6522,16 +6522,16 @@ const RB_FOUNDATION = {
   // ── TYPE ──
   'type-display': ['Aa', 'Display · stamped', "'Saira Condensed' · 600–800 · UPPERCASE · +1–2px tracking",
     'The yard “stamped-steel” voice: wordmark, column tabs, KPI labels, section headers, ignition buttons.',
-    `<span style="font-family:'Saira Condensed',sans-serif;text-transform:uppercase;letter-spacing:1.6px;font-weight:800;font-size:23px;color:var(--txt)">Clock In · Wrangle</span>`],
+    `<span style="font-family:'Saira Condensed',sans-serif;text-transform:uppercase;letter-spacing:1.6px;font-weight:800;font-size:1.3529rem;color:var(--txt)">Clock In · Wrangle</span>`],
   'type-body': ['Aa', 'Body', "'Geist' (var(--font)) · 400–700",
     'Everything you read: row text, field values, descriptions. Quiet, legible, never stamped.',
-    `<span style="font-size:14px;color:var(--txt)">Rugged equipment, rented right — the body face carries the content.</span>`],
+    `<span style="font-size:0.8235rem;color:var(--txt)">Rugged equipment, rented right — the body face carries the content.</span>`],
   'type-mono': ['‹›', 'Mono', 'ui-monospace · 10–12px · txt-3',
     'Code + debug references only: the Inspector tag and rulebook builder names.',
-    `<code style="font-family:ui-monospace,monospace;font-size:12px;color:var(--txt-3)">UNITS › INSPECTION › “Passed”</code>`],
+    `<code style="font-family:ui-monospace,monospace;font-size:0.7059rem;color:var(--txt-3)">UNITS › INSPECTION › “Passed”</code>`],
   'type-scale': ['#', 'Size scale', '28 · 15 · 13 · 12 · 11 · 10 · 9.5px',
     'Bigger = identity/value (28 KPI · 15 popup title). 12–13 = content. ≤11 = stamped micro-labels & counters. ONE size (11px) for every status badge.',
-    `<span style="display:flex;align-items:baseline;gap:13px;flex-wrap:wrap;color:var(--txt)"><span style="font-size:28px;font-weight:800">28</span><span style="font-size:15px;font-weight:700">15</span><span style="font-size:13px">13</span><span style="font-size:12px">12</span><span style="font-family:'Saira Condensed';text-transform:uppercase;letter-spacing:1px;font-size:11px;font-weight:700">11 label</span><span style="font-size:9.5px;color:var(--txt-3)">9.5</span></span>`],
+    `<span style="display:flex;align-items:baseline;gap:13px;flex-wrap:wrap;color:var(--txt)"><span style="font-size:1.6471rem;font-weight:800">28</span><span style="font-size:0.8824rem;font-weight:700">15</span><span style="font-size:0.7647rem">13</span><span style="font-size:0.7059rem">12</span><span style="font-family:'Saira Condensed';text-transform:uppercase;letter-spacing:1px;font-size:0.6471rem;font-weight:700">11 label</span><span style="font-size:0.5588rem;color:var(--txt-3)">9.5</span></span>`],
   'type-weight': ['B', 'Weight', '800 · 700 · 600 · 400',
     '800 stamped identity · 700 titles & labels · 600 strong body · 400 body.',
     `<span style="display:flex;gap:16px;align-items:baseline;color:var(--txt)"><span style="font-weight:800">800</span><span style="font-weight:700">700</span><span style="font-weight:600">600</span><span style="font-weight:400">400</span></span>`],
@@ -6553,7 +6553,7 @@ const RB_FOUNDATION = {
     rbSw('var(--tan,#c2925a)', 'Tan', 'saddle-stitch', '#1a1205')],
   'color-ec-red': ['⚠', 'ec-red · flagging glow', 'fill: color-mix(--red 65%, white) · shadow: 0 0 3px --red, 0 0 7px (--red 60%+transparent)',
     'Official treatment for EVERY flagging-red signal — text names/pills/flags/headers, borders, dots/bars. Three knobs in style.css .ec-red group: fill % (65), inner glow (3px), outer halo (7px / 60%). Never use pure --red alone on flagging text.',
-    `<span style="-webkit-text-fill-color:color-mix(in srgb,var(--red) 65%,white);text-shadow:0 0 3px var(--red),0 0 7px color-mix(in srgb,var(--red) 60%,transparent);font-weight:700;font-size:13px;letter-spacing:.5px">TUCKER FONTENOT · No Card · $0.30 overdue</span>`],
+    `<span style="-webkit-text-fill-color:color-mix(in srgb,var(--red) 65%,white);text-shadow:0 0 3px var(--red),0 0 7px color-mix(in srgb,var(--red) 60%,transparent);font-weight:700;font-size:0.7647rem;letter-spacing:.5px">TUCKER FONTENOT · No Card · $0.30 overdue</span>`],
   // ── FORM ──
   'radius': ['◳', 'Radius', '--radius 14–16 · --chip-radius 11–12 · 8–10 controls · 999 pills',
     'Cards/popups softest · chips medium · controls tight · pills & counters full-round · rings/avatars circles.',
@@ -6563,7 +6563,7 @@ const RB_FOUNDATION = {
     `<span style="display:flex;gap:12px"><span class="rb-surf" style="box-shadow:var(--shadow)">float</span><span class="rb-surf" style="box-shadow:var(--chip-shadow)">chip</span><span class="rb-surf" style="box-shadow:0 0 0 2px var(--accent-line),0 0 22px -8px var(--accent)">glow</span></span>`],
   'spacing': ['▦', 'Spacing', 'grid 12 · list 7 · section pad 12 · row pad 9–11',
     'Tight, dense yard data — generous enough to scan, never airy.',
-    `<span style="display:flex;align-items:center;color:var(--txt-3);font-size:11px;gap:8px"><span style="display:flex;gap:12px"><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span></span>12px gap</span>`],
+    `<span style="display:flex;align-items:center;color:var(--txt-3);font-size:0.6471rem;gap:8px"><span style="display:flex;gap:12px"><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span></span>12px gap</span>`],
   'motion': ['↻', 'Motion', '.12s controls · .15s surfaces · .5s rings/timeline',
     'Fast, functional. Keyframes: attnGlow (flash) · plateIn (login) · flagPulse · rwLint. prefers-reduced-motion respected everywhere.',
     `<span class="pill c-blue" style="animation:attnGlow 1.1s ease-in-out infinite;border-radius:10px"><span class="t">flash</span></span>`],
@@ -6593,23 +6593,23 @@ const RB_FOUNDATION = {
   // ── HEADERS / CONTAINERS ──
   'header-section': ['▭', 'Section header', '.section>h4 · centered · 11px UPPER',
     'Centered stamped label; right-side flags pin absolutely so the title stays true-center.',
-    `<span style="display:block;text-align:center;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--txt-3)">Inspection</span>`],
+    `<span style="display:block;text-align:center;font-size:0.6471rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--txt-3)">Inspection</span>`],
   'header-popup': ['▭', 'Popup header', '.popup-head · icon + h3(15) + ✕',
     'Every overlay leads with an accent icon, a 15px title, and the close on the right.',
-    `<span style="display:flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:9px;padding:7px 10px;background:var(--panel)"><span style="color:var(--accent);display:inline-flex">${I.doc || ''}</span><b style="font-size:14px">Popup title</b></span>`],
+    `<span style="display:flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:9px;padding:7px 10px;background:var(--panel)"><span style="color:var(--accent);display:inline-flex">${I.doc || ''}</span><b style="font-size:0.8235rem">Popup title</b></span>`],
   'overlay-popup': ['◳', 'Pop-up / overlay', '.overlay scrim + .popup',
     'Centered modal: 50%-black scrim · panel with the orange border + glow halo · max 92vw/86vh · internal scroll.',
     `<span class="rb-surf" style="background:var(--panel);border:1px solid var(--accent);box-shadow:0 0 0 2px var(--accent-line),0 0 20px -6px var(--accent);width:130px;height:42px;border-radius:12px">modal</span>`],
   'menu-dropdown': ['▾', 'Menu', '.dropdown-menu / .ctx-menu',
     'Floating orange-ringed lists: the sort/filter dropdowns and the R20 right-click menu.',
-    `<span style="display:inline-block;background:var(--panel);border:1px solid var(--accent);border-radius:11px;box-shadow:0 0 0 2px var(--accent-line);padding:5px;min-width:128px"><span style="display:block;padding:5px 9px;border-radius:8px;font-size:12px;color:var(--txt-2)">Sort · Name</span><span style="display:block;padding:5px 9px;border-radius:8px;font-size:12px;color:var(--accent);background:var(--panel-2)">Sort · Status</span></span>`],
+    `<span style="display:inline-block;background:var(--panel);border:1px solid var(--accent);border-radius:11px;box-shadow:0 0 0 2px var(--accent-line);padding:5px;min-width:128px"><span style="display:block;padding:5px 9px;border-radius:8px;font-size:0.7059rem;color:var(--txt-2)">Sort · Name</span><span style="display:block;padding:5px 9px;border-radius:8px;font-size:0.7059rem;color:var(--accent);background:var(--panel-2)">Sort · Status</span></span>`],
   'grid': ['▥', 'Yard grid', '.grid · 3 equal cols · 12px gap',
     'The fixed 3-column layout (Units · Rentals · Customers). Reflows 3→2→1 by width on phones (M0–M3); never squishes below the desktop floor.',
     `<span style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px;width:150px"><span class="rb-surf" style="height:30px"></span><span class="rb-surf" style="height:30px"></span><span class="rb-surf" style="height:30px"></span></span>`],
   // ── DATA VIZ ──
   'data-kpi': ['◎', 'KPI rings', '.kpi-ring · concentric progress',
     'The header rings: Apple-style progress, each colored by its value band, number + stamped role label below.',
-    `<span style="display:inline-grid;place-items:center;width:38px;height:38px;border-radius:50%;background:conic-gradient(var(--green) 72%,var(--track) 0)"><span style="display:grid;place-items:center;width:27px;height:27px;border-radius:50%;background:var(--bg);font-size:10px;font-weight:800;color:var(--txt)">9</span></span>`],
+    `<span style="display:inline-grid;place-items:center;width:38px;height:38px;border-radius:50%;background:conic-gradient(var(--green) 72%,var(--track) 0)"><span style="display:grid;place-items:center;width:27px;height:27px;border-radius:50%;background:var(--bg);font-size:0.5882rem;font-weight:800;color:var(--txt)">9</span></span>`],
   'data-gauge': ['▰', 'Activity gauge', '.active-bar.bipolar · steel data-plate',
     'A bipolar −100…+100 track (customer health); a hazard overlay marks the deep-danger end.',
     `<span style="display:inline-block;width:140px;height:14px;border-radius:7px;overflow:hidden;background:var(--track)"><span style="display:block;height:100%;width:64%;background:linear-gradient(90deg,var(--red),var(--orange),var(--yellow),var(--green))"></span></span>`],
@@ -7264,10 +7264,10 @@ const ROWS = {
     const driverChip = multi
       ? (t.driverId
         ? `<button class="catr-slot js-trip-driver" data-id="${esc(t.id)}" data-day="${esc(t.day)}" data-tip="Driver on this trip (${t.stops.length} stops) — tap to change">${badge(driverName(t.driverId), 'navy')}</button>`
-        : (driverRoster().length ? `<button class="catr-slot js-trip-driver" data-r="R5b" data-id="${esc(t.id)}" data-day="${esc(t.day)}" data-tip="Assign a driver to this trip"><span class="add-field anchor" data-r="R5b" style="height:20px;font-size:10px">+Driver</span></button>` : ''))
+        : (driverRoster().length ? `<button class="catr-slot js-trip-driver" data-r="R5b" data-id="${esc(t.id)}" data-day="${esc(t.day)}" data-tip="Assign a driver to this trip"><span class="add-field anchor" data-r="R5b" style="height:20px;font-size:0.5882rem">+Driver</span></button>` : ''))
       : (t.driverId
         ? `<button class="catr-slot js-stop-driver" data-id="${esc(t.id)}" data-rec="${esc(t.rentalId)}" data-unit="${esc(t.unitId || '')}" data-task="${esc(t.task)}" data-tip="Driver on this leg — tap to change">${badge(driverName(t.driverId), 'navy')}</button>`
-        : (driverRoster().length ? `<button class="catr-slot js-stop-driver" data-r="R5b" data-id="${esc(t.id)}" data-rec="${esc(t.rentalId)}" data-unit="${esc(t.unitId || '')}" data-task="${esc(t.task)}" data-tip="Assign a driver to this leg"><span class="add-field anchor" data-r="R5b" style="height:20px;font-size:10px">+Driver</span></button>` : ''));
+        : (driverRoster().length ? `<button class="catr-slot js-stop-driver" data-r="R5b" data-id="${esc(t.id)}" data-rec="${esc(t.rentalId)}" data-unit="${esc(t.unitId || '')}" data-task="${esc(t.task)}" data-tip="Assign a driver to this leg"><span class="add-field anchor" data-r="R5b" style="height:20px;font-size:0.5882rem">+Driver</span></button>` : ''));
     // §2.3 row-2 — one unit pill per stop; a merged trip numbers the sequence (the
     // implicit array order IS the run order — spec §2.3, within-trip drag-reorder
     // skipped as a documented nice-to-have).
@@ -7955,11 +7955,11 @@ function woExpandedHtml(w) {
     + `<div class="wo-open-body">`
     + `<div class="kv" style="justify-content:flex-end;gap:6px">${flagsStack([typeFlag, dateFlag], 22)}</div>`
     + `<div class="wototals">${addBtn('Part/Task', { anchor: true, js: 'js-add-part', h: 26, data: { rec: w.woId } })}<span class="derived">${money(parts)} parts + ${hrs} hrs</span></div>`
-    + `${lines || '<div class="kv"><span class="muted" style="font-size:12px">No line items yet</span></div>'}`
+    + `${lines || '<div class="kv"><span class="muted" style="font-size:0.7059rem">No line items yet</span></div>'}`
     + `<div class="wofoot"><span class="derived">Parts ${money(Math.max(0, billed - laborBilled))} + Hrs ${money(laborBilled)} = ${money(billed)}</span>`
     + (w.cancelled
-        ? `<span class="pill c-gray" style="height:26px;font-size:11px" data-tip="This work order is cancelled">Cancelled</span>${actionPill('commit', 'Reopen WO', { js: 'js-wo-reopen', h: 26, data: { rec: w.woId } })}`
-        : `${addBtn('Invoice', { link: true, icon: CARD_ICON.invoices, js: 'js-bill-wo', h: 26, data: { rec: w.woId } })}<button class="pill ghost js-wo-cancel" data-r="R18" data-rec="${esc(w.woId)}" style="height:26px;font-size:11px">Cancel WO</button>${actionPill('commit', 'Complete WO', { js: `js-wo-complete ramp${bn.color === 'green' ? ' ready' : ''}`, h: 26, data: { rec: w.woId } })}`)
+        ? `<span class="pill c-gray" style="height:26px;font-size:0.6471rem" data-tip="This work order is cancelled">Cancelled</span>${actionPill('commit', 'Reopen WO', { js: 'js-wo-reopen', h: 26, data: { rec: w.woId } })}`
+        : `${addBtn('Invoice', { link: true, icon: CARD_ICON.invoices, js: 'js-bill-wo', h: 26, data: { rec: w.woId } })}<button class="pill ghost js-wo-cancel" data-r="R18" data-rec="${esc(w.woId)}" style="height:26px;font-size:0.6471rem">Cancel WO</button>${actionPill('commit', 'Complete WO', { js: `js-wo-complete ramp${bn.color === 'green' ? ' ready' : ''}`, h: 26, data: { rec: w.woId } })}`)
     + `</div>`
     + `</div>`
     + `</div>`;
@@ -8155,7 +8155,7 @@ function miniJourneyHtml(r2, eu) {
   if (te && te.rentalId === r2.rentalId && (te.unitId || null) === (eu ? eu.unitId : null)) return transportEditorHtml();
   const type = (T.transportType && T.transportType !== 'Self') ? T.transportType : null;
   if (!type) {
-    return `<div class="kv" style="justify-content:center;gap:9px"><span class="muted" style="font-size:10.5px">Self pickup · no transport</span><button class="add-field anchor js-tedit-open" data-r="R5b" data-rec="${esc(r2.rentalId)}"${du} data-leg="delivery" style="height:24px;font-size:11px">+Transport</button></div>`;
+    return `<div class="kv" style="justify-content:center;gap:9px"><span class="muted" style="font-size:0.6176rem">Self pickup · no transport</span><button class="add-field anchor js-tedit-open" data-r="R5b" data-rec="${esc(r2.rentalId)}"${du} data-leg="delivery" style="height:24px;font-size:0.6471rem">+Transport</button></div>`;
   }
   const sd = !!T.startCapture, ed = !!T.endCapture;
   const delAddr = T.deliveryAddress ? esc(T.deliveryAddress) : '+Address';
@@ -8389,7 +8389,7 @@ const DETAIL = {
             ${stallRouteHtml(r, eu)}
           </div>`;
         }).join('')
-      : `<div class="stall stall-empty rd-unit rd-unit-empty">${pickUnitBtn}<span class="muted" style="font-size:12px">drag a unit on, or cancel the quote</span></div>`;
+      : `<div class="stall stall-empty rd-unit rd-unit-empty">${pickUnitBtn}<span class="muted" style="font-size:0.7059rem">drag a unit on, or cancel the quote</span></div>`;
 
     /* Footer: field call only. The Complete/Cancel Rental buttons are RETIRED
        (Jac 2026-07-03) — terminal gates on every unit ARE the completion; the
@@ -8459,13 +8459,13 @@ const DETAIL = {
     const gpsSeen = gpsM ? gpsRelTime(gpsM.lastSeen) : '';
     const gpsBody = `<div class="fieldstack">
       ${kvPills((gsUnit ? statusPill('gpsStatus', gsUnit.status, { focal: true }) : badge('No GPS')) + (gpsMapped ? '' : addBtn('Connect GPS', { link: true, js: 'js-gps-connect', data: { rec: u.unitId } })))}
-      ${gpsStale ? `<div class="kv" style="justify-content:center"><span class="muted" style="font-size:11px">Last known — live link down</span></div>` : ''}
+      ${gpsStale ? `<div class="kv" style="justify-content:center"><span class="muted" style="font-size:0.6471rem">Last known — live link down</span></div>` : ''}
       ${gpsM ? `<div class="kv" style="justify-content:center;gap:8px;flex-wrap:wrap">
-        ${gpsSeen ? `<span class="muted" style="font-size:11px">Last seen ${esc(gpsSeen)}</span>` : ''}
+        ${gpsSeen ? `<span class="muted" style="font-size:0.6471rem">Last seen ${esc(gpsSeen)}</span>` : ''}
         ${gpsMapHref ? `<a class="gps-maplink" href="${gpsMapHref}" target="_blank" rel="noopener">${esc(gpsM.address || 'View on map')}</a>` : ''}
         ${badge(gpsM.engineOn ? 'Engine On' : 'Engine Off', gpsM.engineOn ? 'green' : 'gray')}
       </div>` : ''}
-      ${gpsMapped ? `<div class="kv"><span class="v muted" style="font-size:11px">${esc(u.gpsProvider)} · ${esc(u.gpsDeviceId)}</span>${ghostPill('Reconnect', { js: 'js-gps-connect', data: { rec: u.unitId } })}</div>` : ''}
+      ${gpsMapped ? `<div class="kv"><span class="v muted" style="font-size:0.6471rem">${esc(u.gpsProvider)} · ${esc(u.gpsDeviceId)}</span>${ghostPill('Reconnect', { js: 'js-gps-connect', data: { rec: u.unitId } })}</div>` : ''}
       ${efld('units', u, 'unitId', 'gpsType', 'GPS unit/type')}
       ${efld('units', u, 'unitId', 'gpsPlacement', 'Placement')}
       ${gpsShutdownControl(u, gpsM)}
@@ -8566,7 +8566,7 @@ const DETAIL = {
           ])}
         </div>
         <div class="kv" style="justify-content:center">${washBtn(u)}</div>
-        ${li2?.description ? `<div class="kv" style="justify-content:center"><span class="muted">Latest:</span> <span style="font-size:12.5px">${esc(li2.description)}</span></div>` : ''}
+        ${li2?.description ? `<div class="kv" style="justify-content:center"><span class="muted">Latest:</span> <span style="font-size:0.7353rem">${esc(li2.description)}</span></div>` : ''}
       </div>
     </div>`;
     const svcSec = serviceTasksHtml(u);   // Shop retirement (Jac 2026-07-07): services live ON the unit
@@ -8655,7 +8655,7 @@ const DETAIL = {
         ${ghostPill('Cancel', { js: 'js-rp-cancel' })}${actionPill('commit', 'Link', { js: 'js-rp-save', data: { rec: x.expenseId } })}
       </div>` : kvPills(addBtn('Part', { line: true, js: 'js-rcpt-addpart', h: 26, data: { rec: x.expenseId } }));
     const reconcile = `<div class="section"><h4>Reconcile — Parts</h4><div class="fieldstack">
-      ${partRows ? `<div class="hlog">${partRows}</div>` : '<span class="muted" style="font-size:12px">No parts linked yet.</span>'}
+      ${partRows ? `<div class="hlog">${partRows}</div>` : '<span class="muted" style="font-size:0.7059rem">No parts linked yet.</span>'}
       ${partForm}
       ${kv(money(lineTotal), { pfx: 'Line Total', derived: true })}
       ${kv(`<span style="color:var(--${unColor})">${(un < 0 ? '-' : '') + money(Math.abs(un))}</span>`, { pfx: 'Unaccounted', derived: true, html: true })}
@@ -8804,13 +8804,13 @@ const DETAIL = {
     const dupSrc = cs?.dupFrom ? IDX.model.get(cs.dupFrom) : null;
     const addModelRow = cs?.addingModel
       ? `<div class="kv pillrow" style="gap:7px">
-          ${dupSrc ? `<span class="muted" style="font-size:11px;width:100%">Duplicating ${esc(dupSrc.name)} — rename below</span>` : ''}
+          ${dupSrc ? `<span class="muted" style="font-size:0.6471rem;width:100%">Duplicating ${esc(dupSrc.name)} — rename below</span>` : ''}
           <input class="lf-in js-am-name" placeholder="Model name" style="flex:1" value="${dupSrc ? esc(dupSrc.name + ' copy') : ''}">
           ${ghostPill('Cancel', { js: 'js-am-cancel' })}${actionPill('commit', 'Add', { js: 'js-am-save', data: { rec: c.categoryId } })}
         </div>`
       : kvPills(addBtn('Model', { line: true, js: 'js-add-model', h: 26, data: { rec: c.categoryId } }));
     const models = `<div class="section"><h4>Models</h4><div class="fieldstack">
-      ${modelRows || '<span class="muted" style="font-size:12px">No models yet — units in this category use the generic service schedule.</span>'}
+      ${modelRows || '<span class="muted" style="font-size:0.7059rem">No models yet — units in this category use the generic service schedule.</span>'}
       ${addModelRow}
     </div></div>`;
     // every unit in the category — R2 linked pill + R4 derived status pill (Jac 2026-06-12)
@@ -8839,7 +8839,7 @@ const DETAIL = {
           ${efld('categories', c, 'categoryId', 'endOfLifeYears', 'End of life (yrs)', { type: 'number', admin: true, fmt: (v) => v + ' YRS', sfx: 'end of life' })}
           ${c.usefulLifeHours > 0 && c.endOfLifeYears > 0 ? kv(`${num(Math.round(c.usefulLifeHours / (c.endOfLifeYears * 12)))} HRS/MO`, { sfx: 'expected pace', derived: true }) : ''}
         </div>
-        <div class="side r">${unitRows || '<span class="muted" style="font-size:12px">No units</span>'}</div>
+        <div class="side r">${unitRows || '<span class="muted" style="font-size:0.7059rem">No units</span>'}</div>
       </div></div>`;
     const notes = notesSection('categories', c, 'categoryId');
     return `<div class="detail">
@@ -8893,7 +8893,7 @@ const DETAIL = {
           ? `${badge('Refunded')}${actionPill('commit', 'Details', { js: 'js-pay-invoice', data: { rec: i.invoiceId } })}`
           : t.balance <= 0 && t.paid > 0
             ? `${badge(`Paid${i.paymentMethod ? ' · ' + i.paymentMethod : ''}`, 'green')}${actionPill('danger', 'Refund', { js: 'js-pay-invoice', data: { rec: i.invoiceId } })}`
-            : `${actionPill('money', hasCardOnFile(cust) ? (t.paid > 0 ? 'Pay balance ' : 'Pay ') + money2(t.balance) : 'Take payment', { js: 'js-pay-invoice', data: { rec: i.invoiceId } })}${hasCardOnFile(cust) ? `<span class="muted" style="font-size:11px">${esc(cardLabel(cust))}</span>` : ''}`)
+            : `${actionPill('money', hasCardOnFile(cust) ? (t.paid > 0 ? 'Pay balance ' : 'Pay ') + money2(t.balance) : 'Take payment', { js: 'js-pay-invoice', data: { rec: i.invoiceId } })}${hasCardOnFile(cust) ? `<span class="muted" style="font-size:0.6471rem">${esc(cardLabel(cust))}</span>` : ''}`)
       : '') + colCell;
     // Void (Jac 2026-07-09): an UNPAID invoice ($0 assigned) can be voided — unlinks its rental
     // so the slot frees to re-invoice and retires this to a $0 auditable record (no hard-delete).
@@ -8902,17 +8902,17 @@ const DETAIL = {
     const voidCell = (canMoney()
       ? invoiceVoidable(i)
         ? actionPill('danger', 'Void invoice', { js: 'js-void-invoice', h: 26, data: { rec: i.invoiceId } })
-        : (t.paid > 0.005 && !i.refunded && !i.voided ? `<span class="muted" style="font-size:11px" data-tip="A payment is assigned — refund it first, then you can void this invoice.">Refund to void</span>` : '')
+        : (t.paid > 0.005 && !i.refunded && !i.voided ? `<span class="muted" style="font-size:0.6471rem" data-tip="A payment is assigned — refund it first, then you can void this invoice.">Refund to void</span>` : '')
       : '');
     const lineForm = `<div class="lineform"><input class="lf-in js-lf-label" placeholder="Custom line description" /><div class="lineform-row"><input class="lf-in js-lf-amt" type="number" min="0" placeholder="Amount $" /></div><div class="pillrow" style="justify-content:flex-end">${ghostPill('Cancel', { js: 'js-line-cancel' })}${actionPill('commit', 'Add line', { js: 'js-line-save', data: { rec: i.invoiceId } })}</div></div>`;
     // Merge (#64): a customer's other UNPAID invoices can fold into this one. Money-safe
     // by construction — only $0-paid, unlocked, un-refunded bills qualify (invoiceMergeable).
     const mergeables = (canMoney() && invoiceMergeable(i)) ? DATA.invoices.filter((o) => o.invoiceId !== i.invoiceId && o.customerId === i.customerId && invoiceMergeable(o)) : [];
-    const mergePicker = `<div class="lineform mergeform"><div class="muted" style="font-size:12px;margin-bottom:7px">Fold another unpaid invoice for ${esc(cust ? cust.name : 'this customer')} into ${esc(i.invoiceId)} — its lines move over and the original is removed.</div>${mergeables.map((o) => { const ot = invoiceTotals(o); const n = (o.lineItems || []).length; return `<div class="hitem"><b class="derived">${esc(invoiceShort(o.invoiceId))}</b><span class="muted" style="font-size:11px">${n} line${n === 1 ? '' : 's'} · ${money2(ot.total)}</span><span class="spacer"></span>${actionPill('commit', 'Merge in', { js: 'js-merge-pick', h: 24, data: { keep: i.invoiceId, rec: o.invoiceId } })}</div>`; }).join('')}<div class="pillrow" style="justify-content:flex-end;margin-top:7px">${ghostPill('Done', { js: 'js-merge-cancel' })}</div></div>`;
+    const mergePicker = `<div class="lineform mergeform"><div class="muted" style="font-size:0.7059rem;margin-bottom:7px">Fold another unpaid invoice for ${esc(cust ? cust.name : 'this customer')} into ${esc(i.invoiceId)} — its lines move over and the original is removed.</div>${mergeables.map((o) => { const ot = invoiceTotals(o); const n = (o.lineItems || []).length; return `<div class="hitem"><b class="derived">${esc(invoiceShort(o.invoiceId))}</b><span class="muted" style="font-size:0.6471rem">${n} line${n === 1 ? '' : 's'} · ${money2(ot.total)}</span><span class="spacer"></span>${actionPill('commit', 'Merge in', { js: 'js-merge-pick', h: 24, data: { keep: i.invoiceId, rec: o.invoiceId } })}</div>`; }).join('')}<div class="pillrow" style="justify-content:flex-end;margin-top:7px">${ghostPill('Done', { js: 'js-merge-cancel' })}</div></div>`;
     const manageRow = state.invLineForm === i.invoiceId ? lineForm
       : (state.invMergePick === i.invoiceId && mergeables.length) ? mergePicker
       : locked
-        ? `<div class="pillrow"><span class="muted" style="font-size:12px">🔒 Pricing locked.</span>${canMoney() ? actionPill('commit', 'Unlock to edit', { js: 'js-unlock-invoice', data: { rec: i.invoiceId } }) : ''}</div>`
+        ? `<div class="pillrow"><span class="muted" style="font-size:0.7059rem">🔒 Pricing locked.</span>${canMoney() ? actionPill('commit', 'Unlock to edit', { js: 'js-unlock-invoice', data: { rec: i.invoiceId } }) : ''}</div>`
         : `<div class="pillrow pillcol">${addBtn('Rental', { line: true, js: 'js-add-line', h: 26, data: { rec: i.invoiceId, kind: 'Rental' } })}${addBtn('WO', { line: true, js: 'js-add-line', h: 26, data: { rec: i.invoiceId, kind: 'WO' } })}${addBtn('Custom', { line: true, js: 'js-add-line', h: 26, data: { rec: i.invoiceId, kind: 'Custom' } })}</div>${canMoney() && (i.lineItems || []).length ? `<div class="pillrow pillcol">${actionPill('commit', '🔒 Lock price', { js: 'js-lock-invoice', data: { rec: i.invoiceId } })}</div>` : ''}${mergeables.length ? `<div class="pillrow pillcol">${addBtn('Merge invoice', { line: true, js: 'js-merge-open', h: 26, data: { rec: i.invoiceId } })}</div>` : ''}`;
     const invoiceSec = `<div class="section"><h4>Invoice</h4>
       <div class="inv-split">
@@ -8922,7 +8922,7 @@ const DETAIL = {
           ${manageRow}
         </div>
         <div class="inv-data">
-          ${lines || '<span class="muted" style="font-size:12px">No line items yet</span>'}
+          ${lines || '<span class="muted" style="font-size:0.7059rem">No line items yet</span>'}
           ${(i.lineItems || []).length ? '<div class="inv-div"></div>' : ''}
           ${subRows}
           ${ledgerRow('Subtotal', money2(t.subtotal))}
@@ -8930,7 +8930,7 @@ const DETAIL = {
           ${ledgerRow('Total', money2(t.total), 'big')}
           ${ledgerRow('Paid', `${money2(t.paid)} / ${money2(t.total)}`)}
           ${ledgerRow(`Due${i.dueDate ? ' · ' + fmtShortDate(i.dueDate) : ''}`, money2(t.balance), 'due')}
-          ${!locked ? `<div class="kv" style="justify-content:flex-end;align-items:center;gap:7px;margin-top:2px"><span class="derived" style="font-size:11px">Set due date</span><input type="date" class="js-due-date" data-rec="${esc(i.invoiceId)}" value="${esc(i.dueDate || '')}" style="font-size:11px;color:var(--txt);background:var(--panel-2);border:1px solid var(--line);border-radius:6px;padding:3px 7px;color-scheme:dark"></div>` : ''}
+          ${!locked ? `<div class="kv" style="justify-content:flex-end;align-items:center;gap:7px;margin-top:2px"><span class="derived" style="font-size:0.6471rem">Set due date</span><input type="date" class="js-due-date" data-rec="${esc(i.invoiceId)}" value="${esc(i.dueDate || '')}" style="font-size:0.6471rem;color:var(--txt);background:var(--panel-2);border:1px solid var(--line);border-radius:6px;padding:3px 7px;color-scheme:dark"></div>` : ''}
           ${(payCell || voidCell) ? `<div class="pillrow" style="justify-content:flex-end;margin-top:9px">${payCell}${voidCell}</div>` : ''}
           <div class="pillrow" style="justify-content:flex-end;margin-top:9px">${ghostPill('🖨 Print', { js: 'js-print-invoice', data: { rec: i.invoiceId }, tip: 'Edge-to-edge already. For a fully clean page, turn off “Headers & footers” in the print dialog (Chrome remembers it).' })}${ghostPill('✉ Send Email', { js: 'js-send-email', data: { rec: i.invoiceId }, disabled: !cust || !cust.email, tip: !cust ? 'No customer on file' : !cust.email ? 'No email on file' : '' })}${ghostPill('💬 Send Text', { js: 'js-send-text', data: { rec: i.invoiceId }, disabled: !cust || !cust.phone, tip: !cust ? 'No customer on file' : !cust.phone ? 'No phone on file' : '' })}</div>
         </div>
@@ -8969,7 +8969,7 @@ const DETAIL = {
       <div class="pillrow"><button class="pill c-green js-part-save" data-rec="${w.woId}">Add line</button><button class="pill c-gray js-part-cancel">Cancel</button></div>
     </div>`;
     const journeySec = `<div class="section"><h4>Journey</h4>
-      <div class="hlog">${journey || '<span class="muted" style="font-size:12px">No line items</span>'}</div>
+      <div class="hlog">${journey || '<span class="muted" style="font-size:0.7059rem">No line items</span>'}</div>
       ${state.woPartForm === w.woId ? partForm : `<div class="pillrow" style="margin-top:8px">${addBtn('Part/Task', { anchor: true, js: 'js-add-part', h: 26, data: { rec: w.woId } })}${billBtn}</div>`}
     </div>`;
     const billToggle = gatePillRaw(`Bill customer: ${w.billCustomer === 'Yes' ? 'Yes' : 'No'}`, w.billCustomer === 'Yes' ? 'orange' : 'gray', 'js-wo-bill', { rec: w.woId }, true);
@@ -9010,7 +9010,7 @@ const DETAIL = {
     const headTop = top ? (top.washRequested ? `<span class="pill c-blue">Wash Requested</span>` : `<span class="pill c-${top.color}">${esc(getStatus('serviceStatus', top.status).label)}</span>`) : '';
     const notes = notesSection('units', u, 'unitId');
     return `<div class="detail">
-      <div class="detail-head">${unitPill(u.unitId)}<span class="muted" style="font-size:13px;font-weight:600">${num(u.currentHours)} HRS</span>${ar ? statusPill('rentalStatus', rentalDisplayStatus(ar), { card: 'rentals', recId: ar.rentalId }) : ''}${headTop}</div>
+      <div class="detail-head">${unitPill(u.unitId)}<span class="muted" style="font-size:0.7647rem;font-weight:600">${num(u.currentHours)} HRS</span>${ar ? statusPill('rentalStatus', rentalDisplayStatus(ar), { card: 'rentals', recId: ar.rentalId }) : ''}${headTop}</div>
       ${notes.top}
       ${tasks}
       ${notes.bottom}
@@ -9049,7 +9049,7 @@ const DETAIL = {
     </div></div>`;
     const notes = notesSection('inspections', n, 'inspectionId');
     return `<div class="detail">
-      <div class="detail-head">${unit ? unitPill(unit.unitId) : '<span class="d-title">Inspection</span>'}${resultPill}<span class="muted" style="font-size:12px;margin-left:auto">${esc(fmtShortDate(n.date))}</span></div>
+      <div class="detail-head">${unit ? unitPill(unit.unitId) : '<span class="d-title">Inspection</span>'}${resultPill}<span class="muted" style="font-size:0.7059rem;margin-left:auto">${esc(fmtShortDate(n.date))}</span></div>
       ${notes.top}
       ${report}
       ${notes.bottom}
@@ -9074,7 +9074,7 @@ function historySection(card, rec, cs, chips) {
   const items = q ? base.filter((h) => (h.search || `${h.when} ${h.text}`).toLowerCase().includes(q)) : base;
   const log = items.length
     ? items.map((h) => `<div class="hitem"><span class="htime">${esc(h.when)}</span>${h.pill || ''}<span>${esc(histText(h.text))}</span>${h.by ? `<span class="hby">${esc(h.by)}</span>` : ''}</div>`).join('')
-    : `<div class="muted" style="font-size:12px">${q || chip ? 'No matching history.' : 'No history yet.'}</div>`;
+    : `<div class="muted" style="font-size:0.7059rem">${q || chip ? 'No matching history.' : 'No history yet.'}</div>`;
   const chipBar = chips?.length
     ? `<div class="hvals">${chips.map((c) => `<button class="hv ${c.cls || ''} ${cs?.histKind === c.kind ? 'on' : ''} js-hchip" data-card="${esc(card)}" data-kind="${esc(c.kind)}">${esc(c.label)}</button>`).join('')}</div>` : '';
   // History Search (§0.6) — appears once the log has some depth.
@@ -9556,7 +9556,7 @@ function calendarCardEl(session) {
     const gmaps = dest ? `<span class="trips-gmaps">${linkName('Open in Google Maps', { href: `https://www.google.com/maps/dir/?api=1&destination=${dest}`, ext: true })}</span>` : '';
     panel.innerHTML = live
       ? `<div class="dispm js-dispmount" data-day="${esc(state.dispatchDay || TODAY_ISO)}">${mapsReady() ? '' : '<span class="map-spin" aria-hidden="true"></span><span class="map-tag">Loading dispatch map…</span>'}</div>${gmaps}`
-      : `<div class="trips-map-ph"><span class="map-pin" aria-hidden="true">${ICO_PIN}</span><span class="map-tag stamp" style="font-size:11px;color:var(--accent)">Map offline</span><span class="map-sub">The run below still drives the day.</span></div>${gmaps}`;
+      : `<div class="trips-map-ph"><span class="map-pin" aria-hidden="true">${ICO_PIN}</span><span class="map-tag stamp" style="font-size:0.6471rem;color:var(--accent)">Map offline</span><span class="map-sub">The run below still drives the day.</span></div>${gmaps}`;
     body.appendChild(panel);
   }
   let trips = tripsFor();
@@ -10190,7 +10190,7 @@ function toolsMenuRows() {
   // (Developer/Admin) render only when unlocked, exactly as before.
   const fam = (name, rows) => `<details class="dd-fam"><summary class="dd-fam-h">${esc(name)}<span class="dd-fam-chev">${I.chev}</span></summary><div class="dd-fam-body">${rows}</div></details>`;
   // General — the everyday tools + the manual cache-buster (force the newest build past a stale mobile cache, Jac 2026-07-16).
-  const general = `<button class="dd-item js-app-update"><span class="mi-ico" style="display:inline-flex;color:var(--accent)">${STATUS_ICONS.refresh}</span>Check for updates<span style="margin-left:auto;color:var(--txt-3);font-size:11px;letter-spacing:.3px">v${esc(appVersion())}</span></button>`
+  const general = `<button class="dd-item js-app-update"><span class="mi-ico" style="display:inline-flex;color:var(--accent)">${STATUS_ICONS.refresh}</span>Check for updates<span style="margin-left:auto;color:var(--txt-3);font-size:0.6471rem;letter-spacing:.3px">v${esc(appVersion())}</span></button>`
     + item('js-qr', I.qr, 'Share session (QR)')
     + item('js-previews', state.previewsOn ? I.eye : I.eyeOff, state.previewsOn ? 'Hover previews: on' : 'Hover previews: off', state.previewsOn)
     + item('js-hotkeys', I.mouse, 'Mouse & keyboard shortcuts');
@@ -10633,7 +10633,7 @@ function wranglerDockEl() {
   const chip = rec ? `<span class="wr-chip">${CARD_ICON[entityCardOf(o.card, o.recType)] || ''}${esc(detailTitle(entityCardOf(o.card, o.recType), rec))}</span>` : '';
   return `
     <div class="wr-dock-head">
-      <span style="font-size:18px">🤠</span>
+      <span style="font-size:1.0588rem">🤠</span>
       <span class="wr-dock-title">Mr. Wrangler</span>
       ${chip}
       <span class="spacer"></span>
@@ -12967,8 +12967,8 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: I.qr, title: o.title || 'Share session', tag: 'Share · this session', body: `
       <div style="text-align:center">
         <img class="qr-img" alt="QR code" src="https://api.qrserver.com/v1/create-qr-code/?size=240x240&margin=8&bgcolor=15171c&color=ff7a1a&data=${encodeURIComponent(url)}" width="220" height="220" style="border-radius:12px;background:var(--panel-2)" />
-        <p class="muted" style="margin-top:10px;font-size:12px;word-break:break-all">${esc(url)}</p>
-        <p class="muted" style="margin-top:6px;font-size:11px">${esc(o.caption || 'Scan to open this session on another device (single shared login — §1/§4.2).')}</p>
+        <p class="muted" style="margin-top:10px;font-size:0.7059rem;word-break:break-all">${esc(url)}</p>
+        <p class="muted" style="margin-top:6px;font-size:0.6471rem">${esc(o.caption || 'Scan to open this session on another device (single shared login — §1/§4.2).')}</p>
       </div>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'migrateUnits') {
@@ -12978,16 +12978,16 @@ function buildPopupEl(o, overlay, opts = {}) {
     const rentals = o.plan.reduce((n, p) => n + p.count, 0);
     const rows = o.plan.map((p) => `<tr style="border-top:1px solid rgba(255,255,255,.06)">
         <td style="padding:5px 8px">${esc(p.name)}</td>
-        <td style="padding:5px 8px"><span class="pill ${p.action === 'create' ? 'c-commit' : 'ref'}" style="height:20px;font-size:10px">${p.action === 'create' ? 'New · ' + p.unitId : 'Link · ' + p.unitId}</span></td>
+        <td style="padding:5px 8px"><span class="pill ${p.action === 'create' ? 'c-commit' : 'ref'}" style="height:20px;font-size:0.5882rem">${p.action === 'create' ? 'New · ' + p.unitId : 'Link · ' + p.unitId}</span></td>
         <td style="padding:5px 8px;color:var(--muted)">${esc(IDX.category.get(p.categoryId)?.name || p.categoryId || '—')}</td>
         <td style="padding:5px 8px;color:var(--muted);text-align:right">${p.count}</td></tr>`).join('');
     const pop = el('div', 'popup'); pop.style.width = '560px';
     pop.innerHTML = popupShell({ icon: CARD_ICON.units || '', title: 'Round up missing units', tag: 'Units · migrate',
       foot: `<button class="pill ghost js-close" data-r="R18">Cancel</button><button class="pill ignition js-migrate-go" data-r="R17">Create &amp; link ${o.plan.length}</button>`,
       body: `
-        <p style="font-size:13px;margin-bottom:10px"><b>${o.plan.length}</b> unit${o.plan.length === 1 ? '' : 's'} were referenced on rentals but never recorded. This will <b>create ${creates}</b> new record${creates === 1 ? '' : 's'}${links ? ` and <b>link ${links}</b> to existing units` : ''}, then connect <b>${rentals}</b> rental${rentals === 1 ? '' : 's'} (and their customers, categories &amp; invoices) to them.</p>
+        <p style="font-size:0.7647rem;margin-bottom:10px"><b>${o.plan.length}</b> unit${o.plan.length === 1 ? '' : 's'} were referenced on rentals but never recorded. This will <b>create ${creates}</b> new record${creates === 1 ? '' : 's'}${links ? ` and <b>link ${links}</b> to existing units` : ''}, then connect <b>${rentals}</b> rental${rentals === 1 ? '' : 's'} (and their customers, categories &amp; invoices) to them.</p>
         <div style="max-height:46vh;overflow:auto;border:1px solid rgba(255,255,255,.1);border-radius:8px">
-          <table style="width:100%;border-collapse:collapse;font-size:12px">
+          <table style="width:100%;border-collapse:collapse;font-size:0.7059rem">
             <thead><tr style="position:sticky;top:0;background:var(--panel-2)"><th style="text-align:left;padding:6px 8px">Unit</th><th style="text-align:left;padding:6px 8px">Action</th><th style="text-align:left;padding:6px 8px">Category</th><th style="text-align:right;padding:6px 8px">Rentals</th></tr></thead>
             <tbody>${rows}</tbody>
           </table>
@@ -13073,7 +13073,7 @@ function buildPopupEl(o, overlay, opts = {}) {
         ${o.devicesLoading ? `<div class="set-loading" style="min-height:140px"><div class="set-loading-bar" aria-hidden="true"></div><div class="set-loading-lbl">Rounding up ${esc(o.provider)} machines…</div></div>`
           : o.devicesError ? `<p class="set-err" style="text-align:left">${esc(o.devicesError)}</p>`
           : list.length ? `<div class="gps-dev-list">${rows}</div>`
-          : `<p class="muted" style="font-size:12px">No ${q ? 'matching' : 'authorized'} machines${q ? ` for “${esc(o.deviceQuery)}”` : ' on this account yet'}.</p>`}`;
+          : `<p class="muted" style="font-size:0.7059rem">No ${q ? 'matching' : 'authorized'} machines${q ? ` for “${esc(o.deviceQuery)}”` : ' on this account yet'}.</p>`}`;
       foot = ghostPill('Back', { js: 'js-gps-back' });
     } else {   // 'poll' — the live first-contact confirmation (§5a step 3)
       const UI = {
@@ -13291,7 +13291,7 @@ function buildPopupEl(o, overlay, opts = {}) {
         <span class="gps-poll-ic c-${UI.color}">${UI.icon}</span>
         <div class="gpsru-poll-txt">
           <div class="gpsru-poll-lbl">${esc(UI.label)}</div>
-          <div class="muted" style="font-size:11px">${o.pollState === 'timeout' ? 'It may just be catching up — try again, or confirm from the last-known data above.' : `Attempt ${o.pollAttempt || 0} of ${o.pollMax || 8}`}</div>
+          <div class="muted" style="font-size:0.6471rem">${o.pollState === 'timeout' ? 'It may just be catching up — try again, or confirm from the last-known data above.' : `Attempt ${o.pollAttempt || 0} of ${o.pollMax || 8}`}</div>
         </div>
         ${o.pollState === 'timeout' ? ghostPill('Try again', { js: 'js-gpsru-poll-start', data: { rec: o.pollUnitId } }) : ''}
       </div>`;
@@ -13310,14 +13310,14 @@ function buildPopupEl(o, overlay, opts = {}) {
       return `<div class="gpsru-detail">
         ${segCtl(GPS_PROVIDERS.map((p) => ({ label: p, js: 'js-gpsru-swap-provider', data: { rec: r.unitId, val: p }, on: provider === p ? 'orange' : '' })))}
         <div class="bv-searchwrap" style="width:100%;margin:9px 0"><span class="s-icon">${I.search}</span><input class="bv-query js-gpsru-swap-search" placeholder="Search ${esc(provider)} devices…" value="${esc(o.swapQuery || '')}"></div>
-        ${devRows ? `<div class="gps-dev-list">${devRows}</div>` : `<p class="muted" style="font-size:12px">No ${sq ? 'matching' : 'available'} ${esc(provider)} devices${(o.devices || []).length ? '' : ' — scan first'}.</p>`}
+        ${devRows ? `<div class="gps-dev-list">${devRows}</div>` : `<p class="muted" style="font-size:0.7059rem">No ${sq ? 'matching' : 'available'} ${esc(provider)} devices${(o.devices || []).length ? '' : ' — scan first'}.</p>`}
         <div class="gpsru-detail-actions"><span class="spacer"></span>${ghostPill('Cancel', { js: 'js-gpsru-swap-cancel' })}</div>
       </div>`;
     };
     const expandHtml = (r) => {
       if (o.expandedMode === 'swap') return swapHtml(r);
       if (!r.deviceId) return `<div class="gpsru-detail">
-        <p class="muted" style="font-size:12.5px">No tracker picked yet for this unit.</p>
+        <p class="muted" style="font-size:0.7353rem">No tracker picked yet for this unit.</p>
         <div class="gpsru-detail-actions">${ghostPill('Pick a device', { js: 'js-gpsru-swap-open', data: { rec: r.unitId } })}</div>
       </div>`;
       const u = IDX.unit.get(r.unitId);
@@ -13562,9 +13562,9 @@ function buildPopupEl(o, overlay, opts = {}) {
       R8: '<span class="derived">$2,610 · 7-Day×1 + 1-Day×3</span>',
       R9: flagsStack([flagEl('Passed', 'green', { icon: CARD_ICON.inspections }), flagEl('ETA Jun 18', 'yellow', { icon: CARD_ICON.workOrders })]),
       R10: '<span class="c-titlecard"><span class="c-icon">' + CARD_ICON.units + '</span><span class="c-title">Beacon</span></span>',
-      R11: '<span style="display:inline-block;border:1px solid color-mix(in srgb, var(--green) 45%, transparent);border-radius:9px;padding:4px 14px;font-size:10px;font-weight:700;letter-spacing:.5px;color:var(--green)">INSPECTION</span>',
-      R12: '<span class="add-field" data-r="R5c" style="height:24px;font-size:11px">+Notes</span><span class="muted" style="font-size:11px"> (boxless line)</span>',
-      R13: '<button class="hv g on" style="font-size:11px;font-weight:700;border:1px solid var(--accent);border-radius:99px;padding:2px 8px;background:none;color:var(--accent)">12 Inspections</button>',
+      R11: '<span style="display:inline-block;border:1px solid color-mix(in srgb, var(--green) 45%, transparent);border-radius:9px;padding:4px 14px;font-size:0.5882rem;font-weight:700;letter-spacing:.5px;color:var(--green)">INSPECTION</span>',
+      R12: '<span class="add-field" data-r="R5c" style="height:24px;font-size:0.6471rem">+Notes</span><span class="muted" style="font-size:0.6471rem"> (boxless line)</span>',
+      R13: '<button class="hv g on" style="font-size:0.6471rem;font-weight:700;border:1px solid var(--accent);border-radius:99px;padding:2px 8px;background:none;color:var(--accent)">12 Inspections</button>',
       R14: segCtl([{ label: '✓ Pass', on: 'green' }, { label: 'Not Ready' }, { label: '✕ Fail' }]),
       R15: '<span style="display:inline-grid;place-items:center;width:26px;height:26px;border-radius:8px;background:#fff;color:#16181d">' + I.video + '</span><span style="border-top:2px dotted var(--line);width:34px;display:inline-block;vertical-align:middle;margin:0 4px"></span><span style="display:inline-grid;place-items:center;width:26px;height:26px;border-radius:8px;background:var(--green-bg);color:var(--green)">✓</span>',
       R16: '<span style="display:inline-flex;height:22px;width:120px;border:1px solid var(--line);border-radius:7px;overflow:hidden"><span style="flex:1;background:var(--green-bg);border-right:1px dashed var(--line-soft)"></span><span style="flex:1;background:var(--green-bg);border-right:1px dashed var(--line-soft)"></span><span style="flex:1;border-right:1px dashed var(--line-soft)"></span><span style="flex:1"></span></span>',
@@ -13580,7 +13580,7 @@ function buildPopupEl(o, overlay, opts = {}) {
       R23: '<span class="pill c-gray" data-tip="The one styled tip"><span class="t">hover me</span></span>',
     };
     EX.R21 = fileDrop('Add File', { icon: I.box });
-    EX.R25 = '<span style="position:relative;display:inline-flex;align-items:center;gap:9px;padding:8px 12px;background:var(--panel);border:1px solid var(--line);border-radius:9px;overflow:hidden;max-width:360px"><span style="position:absolute;top:0;left:0;right:0;height:3px;background:repeating-linear-gradient(135deg,var(--red) 0 13px,#14181d 13px 26px)"></span><span style="font-family:\'Saira Condensed\',system-ui,sans-serif;text-transform:uppercase;letter-spacing:1.4px;font-weight:800;font-size:12px;color:var(--red);white-space:nowrap">⚠ Not saving</span><span style="font-size:11px;color:var(--txt-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">changes held, retrying…</span></span>';
+    EX.R25 = '<span style="position:relative;display:inline-flex;align-items:center;gap:9px;padding:8px 12px;background:var(--panel);border:1px solid var(--line);border-radius:9px;overflow:hidden;max-width:360px"><span style="position:absolute;top:0;left:0;right:0;height:3px;background:repeating-linear-gradient(135deg,var(--red) 0 13px,#14181d 13px 26px)"></span><span style="font-family:\'Saira Condensed\',system-ui,sans-serif;text-transform:uppercase;letter-spacing:1.4px;font-weight:800;font-size:0.7059rem;color:var(--red);white-space:nowrap">⚠ Not saving</span><span style="font-size:0.6471rem;color:var(--txt-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">changes held, retrying…</span></span>';
     // ── tabbed render — a row builder per kind, then just the active tab's items ──
     const ruleRow = (r) => {
       const m = RULE_META[r]; if (!m) return '';
@@ -13593,7 +13593,7 @@ function buildPopupEl(o, overlay, opts = {}) {
       return `<div class="rb-row">
         <span class="rb-id">${r}</span>
         <div class="rb-ex">${EX[r] || '<span class="muted">—</span>'}</div>
-        <div class="rb-info"><b>${esc(m[0])}</b> · <code>${esc(m[1])}</code><div class="muted" style="font-size:11px">${esc(m[2])}</div>${idxHtml}</div>
+        <div class="rb-info"><b>${esc(m[0])}</b> · <code>${esc(m[1])}</code><div class="muted" style="font-size:0.6471rem">${esc(m[2])}</div>${idxHtml}</div>
       </div>`;
     };
     const foundRow = (key) => {
@@ -13602,7 +13602,7 @@ function buildPopupEl(o, overlay, opts = {}) {
         <span class="rb-id found">${esc(f[0])}</span>
         <div class="rb-found-body">
           <div class="rb-ex">${f[4]}</div>
-          <div class="rb-info"><b>${esc(f[1])}</b> · <code>${esc(f[2])}</code><div class="muted" style="font-size:11px">${esc(f[3])}</div></div>
+          <div class="rb-info"><b>${esc(f[1])}</b> · <code>${esc(f[2])}</code><div class="muted" style="font-size:0.6471rem">${esc(f[3])}</div></div>
         </div>
       </div>`;
     };
@@ -13701,16 +13701,16 @@ function buildPopupEl(o, overlay, opts = {}) {
       foot: `${ghostPill('Cancel', { js: 'js-close' })}${actionPill('commit', rec ? 'Save' : (forTask ? 'Add part' : 'Add line'), { js: 'js-pf2-save' })}`,
       body: `
         ${fileDrop(state.partPhoto || rec?.photo ? '✓ photo attached' : 'Add Photo (not required)', { js: 'js-pf2-file', capture: 'environment', done: !!(state.partPhoto || rec?.photo), icon: I.camera })}
-        ${forTask ? '' : `<p class="muted" style="text-align:center;font-size:11.5px;margin:7px 0 10px">✨ Mr. Wrangler will add the parts for you!</p>`}
+        ${forTask ? '' : `<p class="muted" style="text-align:center;font-size:0.6765rem;margin:7px 0 10px">✨ Mr. Wrangler will add the parts for you!</p>`}
         <input class="lf-in js-pf2-desc" placeholder="Part/Task Name" value="${esc((forTask ? pr?.name : li?.part) || '')}" style="width:100%;margin-bottom:7px">
-        ${forTask && pr?.oem ? `<div class="muted" style="font-size:11px;margin:-3px 0 7px">OEM ${esc(pr.oem)} · from the manufacturer manual</div>` : ''}
+        ${forTask && pr?.oem ? `<div class="muted" style="font-size:0.6471rem;margin:-3px 0 7px">OEM ${esc(pr.oem)} · from the manufacturer manual</div>` : ''}
         <div style="display:flex;gap:7px;margin-bottom:7px">
           <input class="lf-in js-pf2-cost" type="number" min="0" placeholder="$Cost" value="${(forTask ? pr?.cost : li?.cost) ?? ''}" style="flex:1">
           ${forTask ? '' : `<input class="lf-in js-pf2-hours" type="number" min="0" step="0.5" placeholder="Hours" value="${li?.hours ?? ''}" style="flex:1">`}
         </div>
         <input class="lf-in js-pf2-url" placeholder="URL link" value="${esc((forTask ? pr?.url : li?.url) || '')}" style="width:100%;margin-bottom:7px">
         <input class="lf-in js-pf2-vendor" placeholder="Vendor" value="${esc(ven?.name || '')}" style="width:100%;margin-bottom:4px">
-        ${forTask ? '' : `<p class="muted" style="font-size:11px;margin:4px 0 4px">✨ Empty fields are filled by Mr. Wrangler after saving: the photo is reviewed for the description/cost/url, and hours are estimated from the category + industry standards.</p>`}` });
+        ${forTask ? '' : `<p class="muted" style="font-size:0.6471rem;margin:4px 0 4px">✨ Empty fields are filled by Mr. Wrangler after saving: the photo is reviewed for the description/cost/url, and hours are estimated from the category + industry standards.</p>`}` });
     overlay.appendChild(pop);
   } else if (o.kind === 'modelSchedule') {
     // A model's real maintenance schedule (Jac 2026-07-07) — replaces the generic
@@ -13728,7 +13728,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.workOrders, title: mo?.name || 'Model schedule', tag: 'Category · model',
       foot: `${ghostPill('Close', { js: 'js-close' })}`,
       body: `
-        ${rows || '<p class="muted" style="font-size:12.5px;text-align:center;margin:6px 0 12px">No tasks yet — this model falls back to the generic schedule until you add some.</p>'}
+        ${rows || '<p class="muted" style="font-size:0.7353rem;text-align:center;margin:6px 0 12px">No tasks yet — this model falls back to the generic schedule until you add some.</p>'}
         <div class="wototals">${addBtn('Task', { anchor: true, js: 'js-add-svctask', h: 26, data: { rec: o.modelId } })}</div>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'svctaskform') {
@@ -13760,7 +13760,7 @@ function buildPopupEl(o, overlay, opts = {}) {
           ${dateField('date', o.date)}
         </div>
         <input class="lf-in js-rf-part" placeholder="Part Name" value="" style="width:100%;margin-bottom:4px">
-        <p class="muted" style="font-size:11px;margin:4px 0 4px">✨ Empty fields are filled by Mr. Wrangler after saving: the photo is read for the vendor, amount, date and category.</p>` });
+        <p class="muted" style="font-size:0.6471rem;margin:4px 0 4px">✨ Empty fields are filled by Mr. Wrangler after saving: the photo is read for the vendor, amount, date and category.</p>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'wodone') {
     // v2: Complete WO with open line items → warn, don't hard-block
@@ -13770,8 +13770,8 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.workOrders, title: 'Complete this Work Order?', tag: 'Work order · confirm', danger: true,
       foot: `${ghostPill('Cancel', { js: 'js-close' })}${actionPill('danger', 'Complete WO', { js: 'js-wodone-confirm', data: { rec: o.woId } })}`,
       body: `
-        <p style="font-size:13px;margin-bottom:6px">Are you sure? Not all items are completed.</p>
-        <p class="muted" style="font-size:12px;margin-bottom:4px">Still open: ${open.map((l) => `“${esc(l.part)} · ${esc(getStatus('woPhase', l.phase).label)}”`).join(' · ') || '—'}</p>` });
+        <p style="font-size:0.7647rem;margin-bottom:6px">Are you sure? Not all items are completed.</p>
+        <p class="muted" style="font-size:0.7059rem;margin-bottom:4px">Still open: ${open.map((l) => `“${esc(l.part)} · ${esc(getStatus('woPhase', l.phase).label)}”`).join(' · ') || '—'}</p>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'role') {
     const role = ROLES.find((r) => r.id === o.role);
@@ -13781,7 +13781,7 @@ function buildPopupEl(o, overlay, opts = {}) {
       const raw = vals[i];
       const b = bandColor(raw == null ? 0 : raw);
       const valTxt = raw == null ? '<span class="muted">Coming soon</span>' : `<span style="color:var(--${b.color})">${raw}%</span>`;
-      return `<div class="kpi-line" data-tip="${esc(KPI_HELP[k] || '')}"><span class="ring-no" style="border-color:var(--${raw == null ? 'line' : b.color});color:var(--${raw == null ? 'txt-3' : b.color})">${i + 1}</span><span class="k-name">${esc(k)}<span class="muted" style="font-size:10px;margin-left:6px">${ringTag[i]}</span></span><span class="k-val">${valTxt}</span></div>`;
+      return `<div class="kpi-line" data-tip="${esc(KPI_HELP[k] || '')}"><span class="ring-no" style="border-color:var(--${raw == null ? 'line' : b.color});color:var(--${raw == null ? 'txt-3' : b.color})">${i + 1}</span><span class="k-name">${esc(k)}<span class="muted" style="font-size:0.5882rem;margin-left:6px">${ringTag[i]}</span></span><span class="k-val">${valTxt}</span></div>`;
     }).join('');
     const pop = el('div', 'popup kpi-popup');
     pop.innerHTML = popupShell({ icon: RING_ICON[role.id], title: `${role.label} KPIs`, tag: 'Role · scorecard', body: `
@@ -13904,7 +13904,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     const pop = el('div', 'popup hk-popup');
     pop.innerHTML = popupShell({ icon: I.mouse, title: 'Mouse shortcuts', tag: 'Operator · controls', bodyClass: 'hk-body', body: `
         ${rows.map((r) => `<div class="hk-row"><div class="hk-demo hk-${r.d}">${hkDemoInner(r.d)}</div><div class="hk-text"><div class="hk-name">${esc(r.n)}</div><div class="hk-desc">${esc(r.t)}</div></div></div>`).join('')}
-        <p class="muted" style="font-size:11px;margin:6px 2px 0">These work on a list row or anywhere on a card.</p>` });
+        <p class="muted" style="font-size:0.6471rem;margin:6px 2px 0">These work on a list row or anywhere on a card.</p>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'roadmap') {
     // §M2 — "Coming 2026" roadmap (the morale window behind the blurred rings).
@@ -14084,7 +14084,7 @@ function buildPopupEl(o, overlay, opts = {}) {
             <div class="ag-pcell"><div class="ag-pcap">Selfie</div>${signingSelfieSrc(sg) ? `<img class="ag-selfie" src="${esc(signingSelfieSrc(sg))}" alt="selfie on file" />` : '<div class="ag-selfie empty">—</div>'}</div>
             <div class="ag-pcell"><div class="ag-pcap">Signature</div>${signingSignatureSrc(sg) ? `<img class="ag-sigthumb" src="${esc(signingSignatureSrc(sg))}" alt="signature on file" />` : '<div class="ag-sigthumb"></div>'}</div>
           </div>
-          <p class="muted" style="font-size:11px;margin:12px 2px 0">🔒 Locked — the exact agreement accepted on this card. Re-signing happens only on a new card or an account-type change.</p>`;
+          <p class="muted" style="font-size:0.6471rem;margin:12px 2px 0">🔒 Locked — the exact agreement accepted on this card. Re-signing happens only on a new card or an account-type change.</p>`;
       } else {
         const key = requiredAgreementKey(custRec); const ag = AGREEMENTS[key];
         body = `
@@ -14222,14 +14222,14 @@ function buildPopupEl(o, overlay, opts = {}) {
         <div class="kv" style="justify-content:center">${kv(money2(t.balance), { sfx: `balance handed over · ${daysPast} days past` })}</div>
         <label class="pay-field"><span>Reason</span><select class="lf-in js-col-reason"><option>Uncollectable in-house</option><option>Customer unresponsive</option><option>Disputed — exhausted</option><option>Business closed</option><option>Other</option></select></label>
         <label class="pay-field"><span>Note</span><input class="lf-in js-col-note" placeholder="Optional note for the record" /></label>
-        <div class="muted" style="font-size:11.5px;margin-top:8px">This queues the debt for the collections agency and takes it off active aging. <b>It also blacklists the account</b> (blocks new rentals). A Recall reverses both.</div>` });
+        <div class="muted" style="font-size:0.6765rem;margin-top:8px">This queues the debt for the collections agency and takes it off active aging. <b>It also blacklists the account</b> (blocks new rentals). A Recall reverses both.</div>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'installNudge') {
     // A1 — one-time Add-to-Home-Screen sheet (spec frontend-performance P1 / mobile-remote D3).
     const pop = el('div', 'popup nc-popup');
     pop.innerHTML = popupShell({ icon: CARD_ICON.units || '', title: 'Saddle Up — Add to Home Screen', tag: 'App · install',
       foot: `<button class="pill ghost js-install-later" data-r="R18">Not now</button><button class="pill ignition js-install-go" data-r="R17">Add it</button>`,
-      body: `<div class="muted" style="font-size:12.5px;line-height:1.5">Pin Rental Wrangler to your home screen — full-screen, one tap from the yard, no browser chrome. You can always do it later from the browser menu.</div>` });
+      body: `<div class="muted" style="font-size:0.7353rem;line-height:1.5">Pin Rental Wrangler to your home screen — full-screen, one tap from the yard, no browser chrome. You can always do it later from the browser menu.</div>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'checklist') {
     // Required-checklist takeover (Settings → Inspections): replaces the sheet until completed;
@@ -14305,7 +14305,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.inspections, title: `${passed ? 'Inspection' : 'Failure report'} — ${unit?.name || '—'}`, tag: `Inspection · ${passed ? 'passed' : 'failure'}`, danger: !passed,
       foot: `<button class="pill ignition js-close" data-r="R17">Done</button>`,
       body: `
-        <div class="pillrow" style="margin-bottom:12px">${unit ? unitPill(unit.unitId) : ''}<span class="pill c-${ir.color}">${esc(ir.label)}</span>${n.woId ? refPill('workOrders', n.woId, 'Work Order') : ''}<span class="muted" style="font-size:12px;margin-left:auto">${esc(fmtShortDate(n.date))}</span></div>
+        <div class="pillrow" style="margin-bottom:12px">${unit ? unitPill(unit.unitId) : ''}<span class="pill c-${ir.color}">${esc(ir.label)}</span>${n.woId ? refPill('workOrders', n.woId, 'Work Order') : ''}<span class="muted" style="font-size:0.7059rem;margin-left:auto">${esc(fmtShortDate(n.date))}</span></div>
         ${media}
         <textarea class="insp-desc js-insp-desc" data-rec="${n.inspectionId}" placeholder="${esc(descPh)}">${esc(n.description || '')}</textarea>
         ${passed ? '' : `<div class="insp-gate" style="margin-top:12px"><span class="insp-gate-lbl">Charge the customer?</span>${segCtl([
@@ -14327,7 +14327,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.serviceOrders || '', title: `Complete service — ${u.name}`, tag: 'Service · complete',
       foot: `<button class="pill ignition js-svc-save" data-r="R17" data-unit="${u.unitId}" data-task="${task.taskId}">Record completion</button>`,
       body: `
-        <div class="pillrow" style="margin-bottom:12px">${unitPill(u.unitId)}<span class="pill c-${task.color}">${esc(task.name)}</span><span class="muted" style="font-size:12px;margin-left:auto">${esc(svcText(task))}</span></div>
+        <div class="pillrow" style="margin-bottom:12px">${unitPill(u.unitId)}<span class="pill c-${task.color}">${esc(task.name)}</span><span class="muted" style="font-size:0.7059rem;margin-left:auto">${esc(svcText(task))}</span></div>
         <div class="svc-ref"><div class="svc-ref-head">What you need${sourceLinkBtn(task.sourceUrl, task.source)}</div><div class="svc-ref-body">${svcNeedHtml(u, task)}</div></div>
         <label class="svc-field"><span>Hours at completion</span><input type="number" class="js-svc-hours" value="${num(u.currentHours)}"></label>
         <label class="svc-field"><span>Date completed</span><input type="date" class="js-svc-date" value="${TODAY_ISO}"></label>
@@ -14405,7 +14405,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.rentals, title: `Different dates — ${u.name}`, tag: 'Rental · split window',
       foot: `<button class="pill ghost js-close" data-r="R18">Cancel</button><button class="pill ignition js-split-go" data-r="R17">Make separate rental</button>`,
       body: `
-        <p style="font-size:12.5px;margin-bottom:12px">The other machines stay on <b>${esc(fmtWindow(r.startDate, r.endDate) || 'this window')}</b>. This makes a <b>separate rental</b> for ${esc(u.name)}${inv ? ` on the same invoice (${esc(invoiceShort(inv.invoiceId))})` : ''}, moving its journey + lines over.</p>
+        <p style="font-size:0.7353rem;margin-bottom:12px">The other machines stay on <b>${esc(fmtWindow(r.startDate, r.endDate) || 'this window')}</b>. This makes a <b>separate rental</b> for ${esc(u.name)}${inv ? ` on the same invoice (${esc(invoiceShort(inv.invoiceId))})` : ''}, moving its journey + lines over.</p>
         <label class="svc-field"><span>Start</span>${dateField('splitStart', o.splitStart)}</label>
         <label class="svc-field" style="margin-top:8px"><span>End</span>${dateField('splitEnd', o.splitEnd)}</label>` });
     overlay.appendChild(pop);
@@ -14417,11 +14417,11 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.customers || '', title: `Add card — ${c.name}`, tag: 'Customer · card on file',
       foot: `<button class="pill ghost js-close" data-r="R18">Cancel</button><button class="pill ignition js-card-save" data-r="R17">Save card</button>`,
       body: `
-        <p class="muted" style="font-size:11px;margin:0 0 10px">Saved cards can be charged right away. Capture the selfie + signature below to authorize On-Rent &amp; deliveries — or just save the card and sign it later.</p>
+        <p class="muted" style="font-size:0.6471rem;margin:0 0 10px">Saved cards can be charged right away. Capture the selfie + signature below to authorize On-Rent &amp; deliveries — or just save the card and sign it later.</p>
         <div class="pay-cap">Card number</div>
         <div class="pay-card-field" id="sl-card-element"></div>
         <div class="pay-err" id="sl-card-error"></div>
-        <p class="muted" style="font-size:11px;margin:10px 0 0">Entered securely via Stripe. We store only the brand + last 4 digits — never the full number.</p>
+        <p class="muted" style="font-size:0.6471rem;margin:10px 0 0">Entered securely via Stripe. We store only the brand + last 4 digits — never the full number.</p>
         <div class="ag-cardsplit"></div>
         ${heldSignBlock(o, c, {})}` });
     overlay.appendChild(pop);
@@ -14447,7 +14447,7 @@ function buildPopupEl(o, overlay, opts = {}) {
           <div class="ach-col"><div class="pay-cap">Holder type</div><select class="lf-in" id="sl-ach-holdertype"><option value="individual">Individual</option><option value="company">Company</option></select></div>
         </div>
         <div class="pay-err" id="sl-ach-error"></div>
-        <p class="muted" style="font-size:11px;margin:10px 0 0">Entered securely via Stripe. We store only the bank name + last 4 digits — never the full routing or account number. The signature + selfie on file authorize ACH debits. The account must be verified before it can be charged.</p>` });
+        <p class="muted" style="font-size:0.6471rem;margin:10px 0 0">Entered securely via Stripe. We store only the bank name + last 4 digits — never the full routing or account number. The signature + selfie on file authorize ACH debits. The account must be verified before it can be charged.</p>` });
     overlay.appendChild(pop);
   } else if (o.kind === 'verifyAch') {
     // §14b verify a pending ACH via the micro-deposit descriptor code the customer
@@ -14459,7 +14459,7 @@ function buildPopupEl(o, overlay, opts = {}) {
     pop.innerHTML = popupShell({ icon: CARD_ICON.customers || '', title: `Verify ${k.bankName || 'bank'} ••${k.last4}`, tag: 'Customer · verify ACH',
       foot: `<button class="pill ghost js-close" data-r="R18">Cancel</button><button class="pill ignition js-ach-verify-save" data-r="R17">Verify account</button>`,
       body: `
-        <p class="muted" style="font-size:12px;margin:0 0 12px">Stripe sent a small deposit (about $0.01) to this account. Once it lands (1–2 business days), the customer sees a 6-character code on their statement starting with <b>SM</b>. Enter it here to verify the account for charging.</p>
+        <p class="muted" style="font-size:0.7059rem;margin:0 0 12px">Stripe sent a small deposit (about $0.01) to this account. Once it lands (1–2 business days), the customer sees a 6-character code on their statement starting with <b>SM</b>. Enter it here to verify the account for charging.</p>
         <div class="pay-cap">Verification code</div>
         <input class="lf-in" id="sl-vach-code" autocomplete="off" maxlength="6" placeholder="SM____" style="text-transform:uppercase;letter-spacing:2px">
         <div class="pay-err" id="sl-vach-error"></div>` });
@@ -20713,7 +20713,7 @@ function openLogoMenu(anchorEl) {
   const team = `<div class="menu-sep"></div><div class="menu-team"><div class="menu-team-head">Team KPIs</div><div class="menu-team-ring">${ringsSVG(roleScores, ROLES.map((r) => r.color), { size: 104 })}</div><div class="kpi-list"><div class="kpi-line"><span class="k-name">Sulphur Team</span><span class="k-val" style="color:var(--${tbd.color})">${teamScore}%</span></div></div></div>`;
   const userLine = `<div class="menu-user"><span class="mu-name">${esc(currentUser || 'Signed in')}</span>${currentRole ? `<span class="mu-role">${esc(currentRole)}</span>` : ''}</div>
     <button class="dd-item js-switch-user"><span class="mi-ico" style="display:inline-flex;color:var(--accent)">${I.back}</span>Switch user</button>
-    <button class="dd-item js-open-settings"><span class="mi-ico" style="display:inline-flex;color:var(--accent)">${I.grid}</span>Settings${adminUnlocked() ? '' : ' <span class="muted" style="font-size:10px;margin-left:2px">Admin</span>'}</button>
+    <button class="dd-item js-open-settings"><span class="mi-ico" style="display:inline-flex;color:var(--accent)">${I.grid}</span>Settings${adminUnlocked() ? '' : ' <span class="muted" style="font-size:0.5882rem;margin-left:2px">Admin</span>'}</button>
     <button class="dd-item js-ru-open"><span class="mi-ico" style="display:inline-flex;color:var(--accent)">${I.graph}</span>Reports</button>
     <div class="menu-sep"></div>`;
   openDropdown(anchorEl, userLine + boards + team);

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260718d" />
+  <link rel="stylesheet" href="style.css?v=20260718e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260718d"></script>
-  <script type="module" src="app.js?v=20260718d"></script>
+  <script src="rule-usage.js?v=20260718e"></script>
+  <script type="module" src="app.js?v=20260718e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -60,12 +60,28 @@
 html {
   height: 100%; overflow-x: auto; overflow-y: hidden;
   background: var(--bg);
+  /* §M-a11y — Dynamic Type opt-in. This is the `rem` anchor for the whole app:
+     17px so every (Npx/17)rem font size (see the px→rem migration) renders
+     byte-identical at the iOS DEFAULT Text Size and on every desktop browser.
+     text-size-adjust:100% keeps Safari from auto-inflating text on rotate — we
+     own the scaling now. */
+  font-size: 17px;
+  -webkit-text-size-adjust: 100%; text-size-adjust: 100%;
+}
+/* On TOUCH devices only (iPhone/iPad), bind the rem anchor to the system body
+   text style so the accessibility Text-Size slider actually resizes the app.
+   Scoped to (hover:none)+(pointer:coarse) so desktop keeps the flat 17px base —
+   notably macOS Safari, where -apple-system-body is a FIXED ~13px and would
+   otherwise shrink the whole app. Non-Apple touch browsers drop the invalid
+   keyword and fall back to the 17px above. */
+@media (hover: none) and (pointer: coarse) {
+  html { font: -apple-system-body; font-family: var(--font); }
 }
 body {
   height: 100%; overflow: hidden;            /* body fills the 1180px floor; html scrolls it */
   min-width: 1180px;                         /* §4.4 desktop floor — below this you side-scroll instead of squishing */
   background: var(--bg); color: var(--txt);
-  font-family: var(--font); font-size: 14px; line-height: 1.4;
+  font-family: var(--font); font-size: 0.8235rem; line-height: 1.4;
   -webkit-font-smoothing: antialiased;
 }
 button { font-family: inherit; color: inherit; cursor: pointer; border: none; background: none; }
@@ -102,7 +118,7 @@ input { font-family: inherit; }
 .bb-utils { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; }
 .bb-utils .fab { width: 40px; height: 40px; }
 .bb-utils .fab svg { width: 19px; height: 19px; }
-.hello-name { margin-left: auto; align-self: center; font-size: 24px; font-weight: 800; color: var(--txt); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 46%; letter-spacing: .2px; line-height: 1; padding-right: 4px; }
+.hello-name { margin-left: auto; align-self: center; font-size: 1.4118rem; font-weight: 800; color: var(--txt); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 46%; letter-spacing: .2px; line-height: 1; padding-right: 4px; }
 .toolbar { display: flex; align-items: center; gap: 10px; }
 .toolbar .closeall { flex: 0 0 auto; }
 .toolbar .searchwrap { flex: 1 1 auto; min-width: 0; }
@@ -131,7 +147,7 @@ input { font-family: inherit; }
 @keyframes ringScoreFlash { 0%, 100% { filter: none; } 50% { stroke: var(--green); filter: drop-shadow(0 0 5px var(--green)); } }
 .ring-fill.ring-score-flash { animation: ringScoreFlash .22s ease-in-out 3; }
 @keyframes scorePopFloat { 0% { transform: translate(-50%, 2px); opacity: 0; } 18% { opacity: 1; } 100% { transform: translate(-50%, -26px); opacity: 0; } }
-.score-pop { position: absolute; left: 50%; top: 2px; transform: translate(-50%, 2px); font-weight: 800; font-size: 13.5px;
+.score-pop { position: absolute; left: 50%; top: 2px; transform: translate(-50%, 2px); font-weight: 800; font-size: 0.7941rem;
   color: var(--green); white-space: nowrap; pointer-events: none; z-index: 60; text-shadow: 0 1px 3px rgba(0, 0, 0, .5);
   animation: scorePopFloat .72s ease-out forwards; }
 .kpi-ring:hover { background: var(--panel); border-color: var(--line); }
@@ -144,8 +160,8 @@ input { font-family: inherit; }
 .ring-fill { transition: stroke-dashoffset .5s ease; }
 .ring-fill.ring-glow { filter: drop-shadow(0 0 1.2px var(--green)) drop-shadow(0 0 2.4px var(--green)); }   /* toned 40%, then another 20% */
 .big-ring .ring-fill.ring-glow { filter: drop-shadow(0 0 2.4px var(--green)) drop-shadow(0 0 5.2px var(--green)); }
-.kpi-ring .ring-label { font-size: 10px; color: var(--txt-3); font-weight: 600; text-transform: uppercase; letter-spacing: .3px; }
-.kpi-ring .ring-pct { font-size: 28px; font-weight: 700; fill: var(--txt); }   /* big popup ring only */
+.kpi-ring .ring-label { font-size: 0.5882rem; color: var(--txt-3); font-weight: 600; text-transform: uppercase; letter-spacing: .3px; }
+.kpi-ring .ring-pct { font-size: 1.6471rem; font-weight: 700; fill: var(--txt); }   /* big popup ring only */
 
 /* ── COMING 2026 — floats free over the blurred rings (Jac 2026-06-23) ──────────
    No card backing: just the stamped "COMING 2026" floating over the dimmed gauges,
@@ -159,7 +175,7 @@ input { font-family: inherit; }
 }
 .coming-plate:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: var(--chip-radius); }
 .cp-stamp { position: relative; overflow: hidden; line-height: 1;
-  font-size: 18px; font-weight: 800; letter-spacing: 2.5px; text-transform: uppercase;
+  font-size: 1.0588rem; font-weight: 800; letter-spacing: 2.5px; text-transform: uppercase;
   color: var(--txt); text-shadow: 0 1px 6px rgba(0,0,0,.55); transition: filter .15s; }
 .cp-stamp b { color: var(--yellow); font-weight: 800; }
 .coming-plate:hover .cp-stamp { filter: brightness(1.15); }
@@ -170,25 +186,25 @@ input { font-family: inherit; }
   transform: translateX(-140%); animation: cpGleam 15s ease-in-out infinite;
 }
 @keyframes cpGleam { 0%, 90% { transform: translateX(-140%); } 97%, 100% { transform: translateX(140%); } }
-.is-phone .cp-stamp { font-size: 13px; letter-spacing: 1.4px; }
+.is-phone .cp-stamp { font-size: 0.7647rem; letter-spacing: 1.4px; }
 @media (prefers-reduced-motion: reduce) { .cp-stamp::after { display: none; } }
 
 /* ── COMING 2026 roadmap popup — the docket + the whole territory ── */
 .rm-popup { width: 460px; max-width: 94vw; }
-.rm-intro { margin: 0 2px 12px; font-size: 12.5px; line-height: 1.45; color: var(--txt-2); }
+.rm-intro { margin: 0 2px 12px; font-size: 0.7353rem; line-height: 1.45; color: var(--txt-2); }
 .rm-list { display: flex; flex-direction: column; }
 .rm-row { display: grid; grid-template-columns: 80px 1fr auto; align-items: center; gap: 10px;
   padding: 7px 2px; border-bottom: 1px solid var(--line-soft); }
 .rm-row:last-child { border-bottom: 0; }
 .rm-badge { display: flex; }
-.rm-name { font-size: 13px; font-weight: 600; color: var(--txt); }
-.rm-area { font-family: 'Saira Condensed', sans-serif; font-size: 10px; text-transform: uppercase; letter-spacing: 1px; color: var(--txt-3); white-space: nowrap; }
+.rm-name { font-size: 0.7647rem; font-weight: 600; color: var(--txt); }
+.rm-area { font-family: 'Saira Condensed', sans-serif; font-size: 0.5882rem; text-transform: uppercase; letter-spacing: 1px; color: var(--txt-3); white-space: nowrap; }
 .rm-stitch { margin: 15px 0; border-top: 1.5px dashed var(--tan, #c2925a); opacity: .6; }   /* saddle-stitch — the ranch seasoning */
-.rm-terr-h { margin-bottom: 9px; text-align: center; font-family: 'Saira Condensed', sans-serif; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px; color: var(--txt-3); }
+.rm-terr-h { margin-bottom: 9px; text-align: center; font-family: 'Saira Condensed', sans-serif; font-size: 0.6471rem; font-weight: 700; text-transform: uppercase; letter-spacing: 1.5px; color: var(--txt-3); }
 .rm-chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .rm-chip { padding: 3px 10px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel-2);
-  font-family: 'Saira Condensed', sans-serif; font-size: 11px; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-2); }
-.rm-foot { margin: 14px 2px 0; font-size: 11.5px; line-height: 1.4; color: var(--txt-3); }
+  font-family: 'Saira Condensed', sans-serif; font-size: 0.6471rem; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-2); }
+.rm-foot { margin: 14px 2px 0; font-size: 0.6765rem; line-height: 1.4; color: var(--txt-3); }
 
 /* tab strip — ONE row, scrolls horizontally if many; sits above the toolbar */
 .tabstrip { display: flex; gap: 6px; overflow-x: auto; max-width: 100%; padding-bottom: 0; }
@@ -216,7 +232,7 @@ input { font-family: inherit; }
    fixed 3-column grid (name | nums | actions) never gains a 4th, wrapping child. */
 .woline-acts { display: inline-flex; align-items: center; gap: 6px; }
 /* cascade chip — the anchor's cascade made visible + clearable at the front of a cascaded card's search bar */
-.casc-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 4px 2px 8px; border-radius: 8px; background: var(--accent-soft); border: 1px solid var(--accent-line); color: var(--accent); font-size: 11.5px; font-weight: 700; white-space: nowrap; flex-shrink: 0; }
+.casc-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 4px 2px 8px; border-radius: 8px; background: var(--accent-soft); border: 1px solid var(--accent-line); color: var(--accent); font-size: 0.6765rem; font-weight: 700; white-space: nowrap; flex-shrink: 0; }
 .casc-chip .cc-name { max-width: 130px; overflow: hidden; text-overflow: ellipsis; }
 .casc-chip .close-x { width: 15px; height: 15px; }
 /* active item tab — solid orange + white, matching the .coltab.on card toggle */
@@ -226,14 +242,14 @@ input { font-family: inherit; }
 .tab.active .pill .dot { background: var(--on-orange); }
 .tab .tab-ico { display: inline-flex; align-items: center; }   /* rule 2: entity icon on item tabs */
 .tab .tab-ico svg { width: 14px; height: 14px; }
-.tab .tab-name { font-size: 12px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }
+.tab .tab-name { font-size: 0.7059rem; font-weight: 700; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }
 .tab .pill { flex: 0 0 auto; }
 
 /* row-2 buttons + search */
 .iconbtn {
   display: inline-flex; align-items: center; justify-content: center; gap: 7px;
   height: 34px; padding: 0 13px; border-radius: 10px;
-  background: var(--panel); border: 1px solid var(--line); font-size: 13px; font-weight: 600;
+  background: var(--panel); border: 1px solid var(--line); font-size: 0.7647rem; font-weight: 600;
   transition: background .12s, border-color .12s, color .12s;
 }
 .iconbtn:hover { background: var(--panel-2); border-color: var(--accent-line); }
@@ -265,7 +281,7 @@ input { font-family: inherit; }
 .searchwrap .filt-term:first-of-type { margin-left: 2px; }
 .search {
   flex: 1 1 64px; min-width: 48px; width: auto; height: 100%; padding: 0;
-  background: transparent; border: none; color: var(--txt); font-size: 13px;
+  background: transparent; border: none; color: var(--txt); font-size: 0.7647rem;
 }
 .search:focus { outline: none; box-shadow: none; }
 .search-tools { position: absolute; right: 8px; display: flex; align-items: center; gap: 4px; }
@@ -273,11 +289,11 @@ input { font-family: inherit; }
 .search-tool:hover { background: var(--panel-2); color: var(--txt); }
 .search-tool svg { width: 15px; height: 15px; }
 /* §5.4 search filter bar — AND-narrowing term builder (type + Enter) */
-.filt-term { display: inline-flex; align-items: center; gap: 5px; height: 28px; padding: 0 11px 0 5px; border-radius: 999px; background: var(--green-bg); border: 1px solid color-mix(in srgb, var(--green) 30%, transparent); color: var(--green); font-size: 12px; font-weight: 700; cursor: pointer; transition: filter .12s; }
+.filt-term { display: inline-flex; align-items: center; gap: 5px; height: 28px; padding: 0 11px 0 5px; border-radius: 999px; background: var(--green-bg); border: 1px solid color-mix(in srgb, var(--green) 30%, transparent); color: var(--green); font-size: 0.7059rem; font-weight: 700; cursor: pointer; transition: filter .12s; }
 .filt-term:hover { filter: brightness(1.12); }
 .filt-term .lbl { pointer-events: none; }
 /* leading ○ → red − "NOT" toggle inside each filter-term pill */
-.ft-neg { flex: 0 0 auto; width: 16px; height: 16px; padding: 0; border-radius: 50%; border: 1.6px solid currentColor; background: transparent; color: inherit; display: inline-flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 900; line-height: 1; cursor: pointer; opacity: .7; }
+.ft-neg { flex: 0 0 auto; width: 16px; height: 16px; padding: 0; border-radius: 50%; border: 1.6px solid currentColor; background: transparent; color: inherit; display: inline-flex; align-items: center; justify-content: center; font-size: 0.7647rem; font-weight: 900; line-height: 1; cursor: pointer; opacity: .7; }
 .ft-neg:hover { opacity: 1; }
 .filt-term.neg { background: var(--red-bg); color: var(--red); border-color: color-mix(in srgb, var(--red) 32%, transparent); }
 .filt-term.neg .ft-neg { background: var(--red); border-color: var(--red); opacity: 1; }
@@ -286,7 +302,7 @@ input { font-family: inherit; }
 .mini-searchwrap { flex: 1; min-width: 0; display: flex; align-items: center; flex-wrap: wrap; gap: 5px; padding: 4px 6px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); box-shadow: var(--chip-shadow); }
 .mini-searchwrap:focus-within, .mini-searchwrap.has-query { border-color: var(--accent-line); box-shadow: var(--chip-shadow), 0 0 0 3px var(--accent-soft); }
 .listbar .mini-searchwrap .mini-search { flex: 1; min-width: 70px; height: 24px; padding: 0 5px; border: none; background: transparent; box-shadow: none; }
-.mini-searchwrap .filt-term { height: 23px; max-width: 140px; font-size: 11px; }
+.mini-searchwrap .filt-term { height: 23px; max-width: 140px; font-size: 0.6471rem; }
 .mini-searchwrap .filt-term .lbl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mini-searchwrap .ft-neg { width: 14px; height: 14px; }
 .mini-searchwrap .filt-term.neg .ft-neg::before { width: 7px; }
@@ -352,7 +368,7 @@ input { font-family: inherit; }
 .mcard-tog { display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto; min-height: 44px; min-width: 44px; justify-content: center;
   padding: 0 9px; border: none; background: none; cursor: pointer; border-radius: 9px; color: var(--txt-2); transition: background .12s, color .12s; }
 .mcard-tog .mct-ico { display: inline-flex; } .mcard-tog .mct-ico svg { width: 19px; height: 19px; }
-.mcard-tog .mct-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 13px; white-space: nowrap; min-width: 0; overflow: hidden; text-overflow: ellipsis; }   /* long label ellipsis-truncates instead of clipping the ⅓-width bar (#552-r14) */
+.mcard-tog .mct-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 0.7647rem; white-space: nowrap; min-width: 0; overflow: hidden; text-overflow: ellipsis; }   /* long label ellipsis-truncates instead of clipping the ⅓-width bar (#552-r14) */
 .mcard-tog.on { background: var(--accent); color: var(--on-orange, #1a1205); }   /* selected = ignition orange + dark ink */
 /* Fill the bar (Jac 2026-06-24): the icon toggles share the leftover width evenly so
    there's no dead space, while the selected (labelled) toggle keeps its natural size. */
@@ -405,7 +421,7 @@ body.is-phone { touch-action: manipulation; }
 /* §M-touch — iOS Safari auto-zooms when you FOCUS an input whose font-size is < 16px,
    independent of the viewport scale lock. Force every phone input to 16px so tapping a
    field (card search, line-item fields, chat compose, login) never zooms the screen. */
-.is-phone input, .is-phone textarea, .is-phone select { font-size: 16px !important; }
+.is-phone input, .is-phone textarea, .is-phone select { font-size: 0.9412rem !important; }
 /* ── §M3 — overlays & the winpicker become bottom SHEETS on phones: full-width,
    pinned to the bottom edge, rounded top, slide up. Popups keep their ✕ and the
    backdrop closes on tap; the winpicker gets its own tap-to-close backdrop + Esc. ── */
@@ -426,8 +442,8 @@ body.is-phone { touch-action: manipulation; }
 .is-phone.sheet-open .card-body { overflow: hidden; }   /* §M3 lock the column scroll behind an open sheet */
 /* the calendar (both the window picker AND the R22 single-date picker reuse .wp-*):
    on a full-width sheet the day cells get room, so make them tappable too */
-.is-phone .winpicker .wp-day { height: 42px; font-size: 14px; }                 /* was 30 */
-.is-phone .winpicker .wp-dow { font-size: 11px; }
+.is-phone .winpicker .wp-day { height: 42px; font-size: 0.8235rem; }                 /* was 30 */
+.is-phone .winpicker .wp-dow { font-size: 0.6471rem; }
 .is-phone .winpicker .wp-nav button { min-width: 40px; min-height: 40px; }
 .is-phone .winpicker .wp-time input[type="time"] { height: 40px; }
 @keyframes sheetUp { from { transform: translateY(100%); } to { transform: none; } }
@@ -439,7 +455,7 @@ body.is-phone { touch-action: manipulation; }
 .is-phone .kpis { order: 1; flex: 1 1 auto; min-width: 0; display: flex; justify-content: space-around; gap: 2px; }   /* logo + rings share a row, below the tool bar */
 .is-phone .kpi-ring { min-width: 0; flex: 0 1 auto; padding: 1px 0 0; }
 .is-phone .ring-wrap svg { width: 52px; height: 52px; }
-.is-phone .kpi-ring .ring-label { font-size: 8.5px; letter-spacing: .1px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.is-phone .kpi-ring .ring-label { font-size: 0.5rem; letter-spacing: .1px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .is-phone .header-right { order: 2; flex: 1 1 100%; min-width: 0; }   /* global search on its own full-width row */
 /* the tool bar ACROSS THE TOP, ABOVE the logo/rings (phone only) — its own full-width row */
 .top-toolbar { display: none; }
@@ -495,11 +511,11 @@ body.is-phone { touch-action: manipulation; }
 .is-phone .mobile-toolbar .mtile .mtile-ico svg { width: 34px; height: 34px; }   /* icon-only tiles — glyph fills the chip (Jac 2026-07-17) */
 .is-phone .mobile-toolbar .mtile.on .mtile-ico svg { color: var(--on-orange); }
 .is-phone .mobile-toolbar .mtile .mtile-lbl { font-family: "Saira Condensed", sans-serif; text-transform: uppercase;
-  letter-spacing: .3px; font-size: 9.5px; font-weight: 800; font-stretch: condensed; color: var(--txt-2);
+  letter-spacing: .3px; font-size: 0.5588rem; font-weight: 800; font-stretch: condensed; color: var(--txt-2);
   max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .is-phone .mobile-toolbar .mtile.on .mtile-lbl { color: var(--on-orange); }
 .is-phone .mobile-toolbar .mtile .mtile-mode { font-family: "Saira Condensed", sans-serif; text-transform: uppercase;
-  letter-spacing: .6px; font-size: 8.5px; font-weight: 800; margin-top: -3px; color: var(--txt-3); }
+  letter-spacing: .6px; font-size: 0.5rem; font-weight: 800; margin-top: -3px; color: var(--txt-3); }
 .is-phone .mobile-toolbar .mtile.on .mtile-mode { color: var(--on-orange); opacity: .72; }
 .is-phone .mobile-toolbar .mtile .mtile-dot { position: absolute; top: 8px; right: 10px; width: 9px; height: 9px;
   border-radius: 50%; box-shadow: 0 0 0 2px var(--panel-2); }
@@ -532,13 +548,13 @@ body.is-phone { touch-action: manipulation; }
 .is-phone .mcomms .cp-cap { display: none; }
 /* inbox */
 .is-phone .mcomms-inbox .cp-head { padding: calc(env(safe-area-inset-top) + 12px) 14px 10px; }
-.is-phone .mcomms-inbox .cp-cat { font-size: 20px; }
+.is-phone .mcomms-inbox .cp-cat { font-size: 1.1765rem; }
 .is-phone .mcomms-inbox .cp-feed.cp-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding-bottom: env(safe-area-inset-bottom); }
 .is-phone .mcomms-inbox .cm-row { padding: 13px 14px; }
-.is-phone .mcomms-inbox .cm-who { font-size: 15px; white-space: normal; }
+.is-phone .mcomms-inbox .cm-who { font-size: 0.8824rem; white-space: normal; }
 .is-phone .mcomms-inbox .comms-chan { margin: 10px 14px 6px; }
 /* thread */
-.is-phone .mcomms-back { display: flex; align-items: center; gap: 4px; flex: 0 0 auto; color: var(--accent); font-weight: 700; font-size: 15px;
+.is-phone .mcomms-back { display: flex; align-items: center; gap: 4px; flex: 0 0 auto; color: var(--accent); font-weight: 700; font-size: 0.8824rem;
   padding: calc(env(safe-area-inset-top) + 12px) 12px 4px; }
 .is-phone .mcomms-back svg { width: 26px; height: 26px; stroke-width: 2.4; }
 .is-phone .mcomms-thread .cp-head { padding: 2px 14px 10px; }
@@ -608,7 +624,7 @@ body.is-phone { touch-action: manipulation; }
 .coltab {
   display: inline-flex; align-items: center; gap: 7px; padding: 7px 13px; border-radius: 10px; min-width: 0;
   background: transparent; border: none; color: var(--txt-3);
-  font-weight: 700; font-size: 13px; line-height: 1; white-space: nowrap; transition: color .12s, background .12s;
+  font-weight: 700; font-size: 0.7647rem; line-height: 1; white-space: nowrap; transition: color .12s, background .12s;
 }
 .coltab:hover { color: var(--txt); }
 .coltab.on { background: var(--accent); color: var(--on-orange); }   /* selected = solid orange + DARK ink (rule 2) */
@@ -622,7 +638,7 @@ body.is-phone { touch-action: manipulation; }
 .coltab.on .ct-lbl { max-width: none; overflow: visible; }
 .coltab:not(.on) { flex: 0 1 auto; }
 .coltab .ct-ico { display: inline-flex; flex: 0 0 auto; } .coltab .ct-ico svg { width: 16px; height: 16px; }
-.coltab .ct-n { font-size: 11px; font-weight: 700; color: var(--txt-3); background: var(--bg-2); padding: 1px 8px; border-radius: 999px; }
+.coltab .ct-n { font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); background: var(--bg-2); padding: 1px 8px; border-radius: 999px; }
 .coltab.on .ct-n { color: var(--on-orange); background: rgba(0,0,0,.16); }
 /* red "needs work" alert on a Shop tab (pending inspections / open WOs / overdue service) */
 .coltab.alert:not(.on) { color: var(--txt); background: var(--bg-2); box-shadow: inset 0 0 0 1px var(--red), 0 0 5px color-mix(in srgb, var(--red) 30%, transparent); }   /* rule 1: red border + red icon + light ink + dark bg */
@@ -633,7 +649,7 @@ body.is-phone { touch-action: manipulation; }
    exact transparent neon-blue dashed add-field.anchor language — NO fill (Jac 2026-06-13). */
 .bigbtn { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; padding: 13px 16px;
   border-radius: 12px; background: transparent; border: 1px dashed rgba(24, 182, 255, .55); color: #18b6ff;
-  font-weight: 700; font-size: 14px; transition: border-color .12s; }
+  font-weight: 700; font-size: 0.8235rem; transition: border-color .12s; }
 .bigbtn:hover { border-color: #18b6ff; }
 .bigbtn svg { width: 16px; height: 16px; }
 .empty-new { display: flex; flex-direction: column; gap: 12px; padding: 18px 6px; align-items: stretch; text-align: center; }
@@ -641,13 +657,13 @@ body.is-phone { touch-action: manipulation; }
 /* §14 cards-on-file list + payment card picker */
 .cards-list { display: flex; flex-direction: column; gap: 7px; }
 .card-row { display: flex; align-items: center; gap: 9px; padding: 8px 11px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); }
-.card-row .cr-brand { font-weight: 700; font-size: 13px; }
-.card-row .cr-exp { font-size: 11px; color: var(--txt-3); } .card-row .cr-exp.warn { color: var(--yellow); } .card-row .cr-exp.bad { color: var(--red); }
-.card-row .cr-nick { font-size: 12px; color: var(--txt-2); }
+.card-row .cr-brand { font-weight: 700; font-size: 0.7647rem; }
+.card-row .cr-exp { font-size: 0.6471rem; color: var(--txt-3); } .card-row .cr-exp.warn { color: var(--yellow); } .card-row .cr-exp.bad { color: var(--red); }
+.card-row .cr-nick { font-size: 0.7059rem; color: var(--txt-2); }
 .card-row .x { margin-left: auto; color: var(--txt-3); } .card-row .x:hover { color: var(--red); }
 /* §14b Payment Methods — Cards | ACH tabs + the ACH form */
 .pm-tabs { display: flex; gap: 5px; margin: 0 0 10px; }
-.pm-tab { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 11px; font-weight: 700; color: var(--txt-3); background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 5px 13px; cursor: pointer; }
+.pm-tab { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 5px 13px; cursor: pointer; }
 .pm-tab:hover { color: var(--txt-2); border-color: var(--accent-line); }
 .pm-tab.on { color: var(--on-orange); background: var(--accent); border-color: var(--accent); }
 .pm-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -656,12 +672,12 @@ body.is-phone { touch-action: manipulation; }
 .ach-col .pay-cap { margin-bottom: 5px; }
 select.lf-in { appearance: none; cursor: pointer; }
 .pay-cards { display: flex; flex-direction: column; gap: 6px; margin: 4px 0; }
-.pay-card { display: flex; align-items: center; gap: 6px; padding: 9px 12px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); font-size: 13px; font-weight: 600; text-align: left; }
+.pay-card { display: flex; align-items: center; gap: 6px; padding: 9px 12px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); font-size: 0.7647rem; font-weight: 600; text-align: left; }
 .pay-card.on { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
-.pay-pm-note { font-size: 11.5px; color: var(--txt-3); margin: 6px 0 0; padding: 6px 10px; border: 1px dashed var(--line); border-radius: 8px; }
+.pay-pm-note { font-size: 0.6765rem; color: var(--txt-3); margin: 6px 0 0; padding: 6px 10px; border: 1px dashed var(--line); border-radius: 8px; }
 /* #109 payment-method selector — Cash / Check / Card (selected = orange detent, like .pay-card.on) */
 .pay-methods { display: flex; gap: 6px; margin: 4px 0 10px; }
-.pay-method { flex: 1 1 0; display: flex; align-items: center; justify-content: center; gap: 5px; padding: 9px 8px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); font-size: 12.5px; font-weight: 600; }
+.pay-method { flex: 1 1 0; display: flex; align-items: center; justify-content: center; gap: 5px; padding: 9px 8px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); font-size: 0.7353rem; font-weight: 600; }
 .pay-method:hover:not(:disabled) { border-color: var(--accent-line); }
 .pay-method.on { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
 .pay-method:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -669,22 +685,22 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* §15 feedback popup */
 .fb-types { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; }
 .fb-types .nc-pill { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; padding: 7px 12px; line-height: 1.15; }
-.fb-types .fb-hint { font-size: 9.5px; font-weight: 600; opacity: .7; text-transform: none; }
+.fb-types .fb-hint { font-size: 0.5588rem; font-weight: 600; opacity: .7; text-transform: none; }
 .fb-attach { display: flex; align-items: center; justify-content: center; gap: 6px; margin-top: 10px; padding: 11px; border-radius: 10px;
-  border: 1px dashed var(--accent-line); color: var(--accent); font-size: 13px; font-weight: 600; cursor: pointer; }
+  border: 1px dashed var(--accent-line); color: var(--accent); font-size: 0.7647rem; font-weight: 600; cursor: pointer; }
 .fb-attach:hover { background: var(--accent-soft); }
 .fb-attach svg { width: 15px; height: 15px; }
 .fb-shot { position: relative; margin-top: 10px; }
 .fb-shot img { width: 100%; max-height: 220px; object-fit: contain; border-radius: 10px; border: 1px solid var(--line); background: var(--panel); }
 .fb-shot-x { position: absolute; top: 6px; right: 6px; width: 26px; height: 26px; border-radius: 50%; background: rgba(0,0,0,.6); color: #fff; }
-.fb-ctx { font-size: 11px; margin-top: 10px; }
+.fb-ctx { font-size: 0.6471rem; margin-top: 10px; }
 
 /* Mouse-shortcuts popup — animated gesture demos */
 .hk-popup { width: 470px; }
 .hk-body { display: flex; flex-direction: column; gap: 10px; }
 .hk-row { display: flex; align-items: center; gap: 14px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
-.hk-name { font-size: 13px; font-weight: 800; color: var(--txt); }
-.hk-desc { font-size: 11.5px; color: var(--txt-3); margin-top: 2px; }
+.hk-name { font-size: 0.7647rem; font-weight: 800; color: var(--txt); }
+.hk-desc { font-size: 0.6765rem; color: var(--txt-3); margin-top: 2px; }
 /* animated gesture demos: mock cards/rows + cursor/mouse + expanding click rings */
 .hk-demo { position: relative; width: 94px; height: 54px; flex: 0 0 auto; border-radius: 10px; background: var(--bg-2); border: 1px solid var(--line); overflow: hidden; }
 /* one mock card (click / ctrl) */
@@ -717,7 +733,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* ctrl: a new-tab chip slides in + a "Ctrl" key */
 .hk-newtab { position: absolute; left: 28px; top: 6px; width: 18px; height: 7px; border-radius: 3px 3px 0 0; background: var(--accent); opacity: 0; animation: hkTab 2.1s ease-in-out infinite; }
 @keyframes hkTab { 0%,50% { opacity: 0; transform: translateY(-3px) } 62%,100% { opacity: 1; transform: none } }
-.hk-key { position: absolute; left: 5px; bottom: 4px; font-size: 8.5px; font-weight: 800; color: var(--accent); background: var(--accent-soft); border-radius: 4px; padding: 1px 5px; }
+.hk-key { position: absolute; left: 5px; bottom: 4px; font-size: 0.5rem; font-weight: 800; color: var(--accent); background: var(--accent-soft); border-radius: 4px; padding: 1px 5px; }
 /* right-click: a full card morphs into multiple rows + a mouse w/ the right button lit */
 .hk-morph { position: absolute; left: 22px; right: 34px; top: 9px; bottom: 9px; border-radius: 5px; background: var(--panel-2); border: 1px solid var(--line); }
 .hk-morph::before, .hk-morph::after { content: ''; position: absolute; left: 5px; right: 5px; height: 4px; border-radius: 2px; background: var(--line); opacity: 0; animation: hkRows 2.4s ease-in-out infinite; }
@@ -730,7 +746,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 @keyframes hkRight { 0%,46% { background: transparent } 56%,78% { background: #18b6ff } 90%,100% { background: transparent } }
 
 /* active fleet-bar filter chip on the Units list */
-.fleet-chip { display: flex; align-items: center; gap: 6px; margin: 0 0 9px; padding: 6px 10px; font-size: 12px; background: var(--panel); border: 1px solid var(--accent-line); border-radius: 9px; color: var(--txt-2); }
+.fleet-chip { display: flex; align-items: center; gap: 6px; margin: 0 0 9px; padding: 6px 10px; font-size: 0.7059rem; background: var(--panel); border: 1px solid var(--accent-line); border-radius: 9px; color: var(--txt-2); }
 .fleet-chip b { color: var(--txt); }
 /* clickable pills highlight on hover (#1.1) */
 .pill[data-pill-card], .pill.ref { cursor: pointer; }
@@ -745,64 +761,64 @@ select.lf-in { appearance: none; cursor: pointer; }
 .hover-preview .detail { gap: 10px; }
 /* Flag-color-system §5: active flags listed below the preview content. */
 .prev-flags { margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); display: flex; flex-direction: column; align-items: flex-start; gap: 5px; }
-.prev-flags .pf-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.1px; font-size: 9px; font-weight: 700; color: var(--txt-3); }
+.prev-flags .pf-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.1px; font-size: 0.5294rem; font-weight: 700; color: var(--txt-3); }
 .prev-flags .flags { display: flex; flex-wrap: wrap; gap: 5px; }
 /* Trips (née Calendar/dispatch grid) inside the middle column */
 .cal-body { padding: 0; display: flex; flex-direction: column; min-height: 0; }
 /* §2.3 dispatch — the daily driver timeline (Phase 6) */
 .disp-head { display: flex; align-items: center; gap: 8px; padding: 10px 12px; border-bottom: 1px solid var(--line); flex: 0 0 auto; }
-.disp-nav { width: 30px; height: 30px; flex: 0 0 auto; border-radius: 8px; border: 1px solid var(--line); background: var(--bg-2, var(--panel)); color: var(--txt); font-size: 17px; cursor: pointer; line-height: 1; }
+.disp-nav { width: 30px; height: 30px; flex: 0 0 auto; border-radius: 8px; border: 1px solid var(--line); background: var(--bg-2, var(--panel)); color: var(--txt); font-size: 1rem; cursor: pointer; line-height: 1; }
 .disp-nav:hover { border-color: var(--accent-line); }
-.disp-date { display: flex; align-items: center; gap: 8px; font-size: 14px; }
+.disp-date { display: flex; align-items: center; gap: 8px; font-size: 0.8235rem; }
 .disp-date b { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; }
-.disp-today { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .6px; color: var(--accent); background: var(--accent-soft); padding: 2px 7px; border-radius: 99px; }
-.disp-jump { font-size: 11px; color: var(--accent); background: none; border: none; cursor: pointer; text-decoration: underline; }
-.disp-count { font-size: 11px; color: var(--txt-3); white-space: nowrap; }
+.disp-today { font-size: 0.5882rem; font-weight: 700; text-transform: uppercase; letter-spacing: .6px; color: var(--accent); background: var(--accent-soft); padding: 2px 7px; border-radius: 99px; }
+.disp-jump { font-size: 0.6471rem; color: var(--accent); background: none; border: none; cursor: pointer; text-decoration: underline; }
+.disp-count { font-size: 0.6471rem; color: var(--txt-3); white-space: nowrap; }
 .disp-empty { padding: 40px 24px; text-align: center; color: var(--txt-3); }
 .disp-empty svg { width: 30px; height: 30px; opacity: .5; }
-.disp-empty p { font-size: 14px; color: var(--txt-2); margin: 10px 0 4px; }
-.disp-empty span { font-size: 12px; }
+.disp-empty p { font-size: 0.8235rem; color: var(--txt-2); margin: 10px 0 4px; }
+.disp-empty span { font-size: 0.7059rem; }
 .disp-route { position: relative; padding: 6px 12px 18px 34px; overflow-y: auto; }
 .disp-stop { position: relative; display: flex; align-items: center; gap: 9px; }
 .js-disp-stop { background: linear-gradient(180deg, var(--card-head), var(--card)); border: 1px solid var(--line); border-radius: 11px; padding: 9px 11px; margin: 7px 0; cursor: pointer; }
 .js-disp-stop:hover { border-color: var(--accent-line); }
 .js-disp-stop.disp-dragging { opacity: .4; }
 /* directional route arrow between stops */
-.js-disp-stop:not(:last-child)::after, .disp-home:not(:last-child)::after { content: '▼'; position: absolute; left: 26px; bottom: -14px; font-size: 10px; color: var(--accent); opacity: .65; z-index: 1; }
-.disp-grip { color: var(--txt-3); cursor: grab; font-size: 13px; flex: 0 0 auto; }
-.disp-seq { font-size: 10px; font-weight: 800; color: var(--txt-3); width: 12px; text-align: center; flex: 0 0 auto; }
-.disp-time { width: 50px; flex: 0 0 auto; height: 28px; text-align: center; border: 1px solid var(--line); border-radius: 7px; background: var(--bg-2, var(--panel)); color: var(--txt); font: inherit; font-size: 12px; font-weight: 700; }
+.js-disp-stop:not(:last-child)::after, .disp-home:not(:last-child)::after { content: '▼'; position: absolute; left: 26px; bottom: -14px; font-size: 0.5882rem; color: var(--accent); opacity: .65; z-index: 1; }
+.disp-grip { color: var(--txt-3); cursor: grab; font-size: 0.7647rem; flex: 0 0 auto; }
+.disp-seq { font-size: 0.5882rem; font-weight: 800; color: var(--txt-3); width: 12px; text-align: center; flex: 0 0 auto; }
+.disp-time { width: 50px; flex: 0 0 auto; height: 28px; text-align: center; border: 1px solid var(--line); border-radius: 7px; background: var(--bg-2, var(--panel)); color: var(--txt); font: inherit; font-size: 0.7059rem; font-weight: 700; }
 .disp-time:focus { border-color: var(--accent-line); outline: none; }
-.disp-ico { width: 30px; height: 30px; flex: 0 0 auto; border-radius: 50%; display: grid; place-items: center; font-weight: 800; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 14px; color: #fff; }
+.disp-ico { width: 30px; height: 30px; flex: 0 0 auto; border-radius: 50%; display: grid; place-items: center; font-weight: 800; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.8235rem; color: #fff; }
 /* the D/R letter must stay white on the colored disc — beat the generic .c-blue/.c-brown text color (style.css §pills) */
 .disp-ico.c-blue { background: var(--blue); color: #fff; } .disp-ico.c-brown { background: var(--brown, #9a6a3a); color: #fff; }
-.disp-ico.home { background: var(--bg-2, var(--panel)); border: 1px solid var(--line); font-size: 15px; }
+.disp-ico.home { background: var(--bg-2, var(--panel)); border: 1px solid var(--line); font-size: 0.8824rem; }
 .disp-bd { flex: 1; min-width: 0; }
-.disp-unit { font-weight: 700; font-size: 13.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.disp-task { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-left: 4px; }
-.disp-sub { font-size: 11.5px; color: var(--txt-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.disp-unit { font-weight: 700; font-size: 0.7941rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.disp-task { font-size: 0.5882rem; font-weight: 600; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-left: 4px; }
+.disp-sub { font-size: 0.6765rem; color: var(--txt-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .disp-addr { color: var(--blue); text-decoration: underline; cursor: pointer; }
-.disp-deadline { flex: 0 0 auto; font-size: 10.5px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .4px; }
+.disp-deadline { flex: 0 0 auto; font-size: 0.6176rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .4px; }
 .disp-deadline.today { color: var(--accent); }
 .disp-deadline.over { color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .disp-home { padding: 4px 11px; }
-.disp-home .disp-unit { font-size: 12px; color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; }
-.disp-home .disp-sub { font-size: 10.5px; }
+.disp-home .disp-unit { font-size: 0.7059rem; color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; }
+.disp-home .disp-sub { font-size: 0.6176rem; }
 /* Trips empty state (spec §2.2) — a small stamped plate, not a void. */
 .trip-empty { padding: 22px 14px; text-align: center; border: 1px dashed var(--line); border-radius: 12px; margin: 4px 8px; }
-.trip-empty-label { display: block; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 12px; color: var(--txt-2); }
-.trip-empty-hint { display: block; margin-top: 4px; font-size: 11.5px; color: var(--txt-3); }
+.trip-empty-label { display: block; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 0.7059rem; color: var(--txt-2); }
+.trip-empty-hint { display: block; margin-top: 4px; font-size: 0.6765rem; color: var(--txt-3); }
 /* ── §2.3 free-form route arrows: click an icon to start a leg, click another to land it ── */
 .js-disp-arrowpt { cursor: pointer; transition: box-shadow .12s, transform .12s; }
 .js-disp-arrowpt:hover { box-shadow: 0 0 0 2px var(--accent-line); }
 .js-disp-arrowpt:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .disp-route.arming .js-disp-arrowpt { box-shadow: 0 0 0 1px var(--accent-line); }   /* every icon is a target while drawing */
 .js-disp-arrowpt.armed { box-shadow: 0 0 0 2px var(--accent), 0 0 9px var(--accent); transform: scale(1.06); }
-.disp-arm { display: flex; align-items: center; gap: 7px; margin: 0 12px 4px; padding: 7px 10px; font-size: 11.5px; color: var(--accent);
+.disp-arm { display: flex; align-items: center; gap: 7px; margin: 0 12px 4px; padding: 7px 10px; font-size: 0.6765rem; color: var(--accent);
   background: var(--accent-soft); border: 1px solid var(--accent-line); border-radius: 9px; }
 .disp-arm svg { width: 15px; height: 15px; flex: 0 0 auto; }
-.disp-arm-x { margin-left: auto; font-size: 11px; font-weight: 700; color: var(--txt-2); background: none; border: none; cursor: pointer; text-decoration: underline; }
-.disp-clearleg { display: inline-flex; align-items: center; gap: 3px; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px;
+.disp-arm-x { margin-left: auto; font-size: 0.6471rem; font-weight: 700; color: var(--txt-2); background: none; border: none; cursor: pointer; text-decoration: underline; }
+.disp-clearleg { display: inline-flex; align-items: center; gap: 3px; font-size: 0.6176rem; font-weight: 700; text-transform: uppercase; letter-spacing: .4px;
   color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-line); border-radius: 99px; padding: 2px 8px; cursor: pointer; white-space: nowrap; }
 .disp-clearleg svg { width: 11px; height: 11px; }
 .disp-clearleg:hover { border-color: var(--accent); }
@@ -825,20 +841,20 @@ select.lf-in { appearance: none; cursor: pointer; }
   background: repeating-linear-gradient(135deg, rgba(245,197,66,.05) 0 13px, rgba(20,24,29,.5) 13px 26px), radial-gradient(circle at 50% 40%, rgba(255,122,26,.10), transparent 62%), var(--panel-2); }
 /* §2.2b Google Maps handoff — rides the panel (map or plate) when a trip is focused */
 .trips-gmaps { position: absolute; right: 8px; bottom: 8px; z-index: 4; display: inline-flex; align-items: center; background: var(--panel-2); border: 1px solid var(--line); border-radius: 999px; padding: 4px 11px; box-shadow: var(--chip-shadow); }
-.trips-gmaps .linkname { font-size: 11.5px; white-space: nowrap; display: inline-flex; align-items: center; }
+.trips-gmaps .linkname { font-size: 0.6765rem; white-space: nowrap; display: inline-flex; align-items: center; }
 .is-phone .trips-gmaps .linkname { min-height: 36px; }   /* §M-touch: the ANCHOR is the tap target (the chip's padding tops it up past 44) */
 
 /* ── Trips card — day-grouped trip rows (spec 2026-07-09 §2.2 + §2.2b, Phase 1/1b) ──
    Rows route through the universal .row/.row-1/.row-2 template (APP-14); only the
    time input (reused verbatim from the retired lane rail) + the §2.2b driver taps
    (town / call / log / cab sheet) need their own rules. Tokens only — no new hex. */
-.dt-time { width: 72px; flex: 0 0 auto; font-size: 13px; font-weight: 800; color: var(--txt); font-family: inherit; background: transparent; border: 1px solid transparent; border-radius: 6px; padding: 3px 4px; }   /* 72px fits "12:00 PM" — 56px clipped it (review, 2026-07-09) */
+.dt-time { width: 72px; flex: 0 0 auto; font-size: 0.7647rem; font-weight: 800; color: var(--txt); font-family: inherit; background: transparent; border: 1px solid transparent; border-radius: 6px; padding: 3px 4px; }   /* 72px fits "12:00 PM" — 56px clipped it (review, 2026-07-09) */
 .dt-time::placeholder { color: var(--txt-3); font-weight: 600; }
 .dt-time:hover { border-color: var(--line); }
 .dt-time:focus { border-color: var(--accent-line); background: var(--bg-2); outline: none; }
 /* §2.2b destination = the TOWN; tap jumps the live map to the trip. Blue = link voice;
    yellow ⚠ when the site has no pin yet (same signal the address line carried). */
-.trip-town { background: none; border: 0; padding: 0; font: inherit; font-size: 11.5px; color: var(--blue); cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 0 1 auto; min-width: 0; text-align: left; }
+.trip-town { background: none; border: 0; padding: 0; font: inherit; font-size: 0.6765rem; color: var(--blue); cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 0 1 auto; min-width: 0; text-align: left; }
 .trip-town.nopin { color: var(--yellow); }
 .trip-town:hover { filter: brightness(1.15); }
 .trip-town:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
@@ -869,7 +885,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .is-phone .row[data-card="calendar"] .dt-time { min-height: 44px; }
 /* §2.3 Phase 3 — the ⋯ Merge/Split menu trigger. A real <button>, always visible (no
    hover-reveal state to keep in sync with the phone rule); ≥44px on phones. */
-.row[data-card="calendar"] .trip-more { display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; width: 22px; height: 22px; border-radius: 8px; background: none; border: none; color: var(--txt-2); font-size: 15px; font-weight: 800; letter-spacing: 1px; line-height: 1; cursor: pointer; }
+.row[data-card="calendar"] .trip-more { display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; width: 22px; height: 22px; border-radius: 8px; background: none; border: none; color: var(--txt-2); font-size: 0.8824rem; font-weight: 800; letter-spacing: 1px; line-height: 1; cursor: pointer; }
 .row[data-card="calendar"] .trip-more:hover { background: var(--panel-2); color: var(--accent); }
 .row[data-card="calendar"] .trip-more:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .is-phone .row[data-card="calendar"] .trip-more { width: 44px; height: 44px; }
@@ -885,7 +901,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .grp-hd .pill.c-commit:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }   /* same gap — AUTO-RUN had no focus ring */
 /* §2.3 Phase 3 — a merged trip's stop sequence number (row-2 + the cab sheet): the
    array order IS the run order. Plain R3b-adjacent fact chip, not a status pill. */
-.row[data-card="calendar"] .trip-seq-n { display: inline-flex; align-items: center; justify-content: center; min-width: 15px; height: 15px; padding: 0 3px; border-radius: 999px; background: var(--panel-2); color: var(--txt-3); font-size: 9.5px; font-weight: 800; flex: 0 0 auto; }
+.row[data-card="calendar"] .trip-seq-n { display: inline-flex; align-items: center; justify-content: center; min-width: 15px; height: 15px; padding: 0 3px; border-radius: 999px; background: var(--panel-2); color: var(--txt-3); font-size: 0.5588rem; font-weight: 800; flex: 0 0 auto; }
 /* §2.3 Phase 3 — drag one trip row onto another to merge (desktop; the ⋯ menu is the
    touch-parity path). Blue = commit-intent (R17 language), never orange (R2/selected). */
 .row[data-card="calendar"].trip-dragging { opacity: .4; }
@@ -894,7 +910,7 @@ select.lf-in { appearance: none; cursor: pointer; }
    ("Offline — cached") unless a real getTrips/setTrip round-trip has actually succeeded this
    session (Phase 4, tripsSyncFooter in app.js), in which case the dot/text go --green and the
    text names the highest synced rev — never a claim the app can't back up. */
-.disp-foot { flex: 0 0 auto; display: flex; align-items: center; gap: 7px; padding: 7px 12px; border-top: 1px solid var(--line); font-size: 10.5px; color: var(--txt-3); }
+.disp-foot { flex: 0 0 auto; display: flex; align-items: center; gap: 7px; padding: 7px 12px; border-top: 1px solid var(--line); font-size: 0.6176rem; color: var(--txt-3); }
 .disp-offline { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; }
 .disp-offline.on { color: var(--green); }
 .disp-offdot { width: 8px; height: 8px; border-radius: 50%; background: var(--txt-3); flex: 0 0 auto; }
@@ -934,8 +950,8 @@ select.lf-in { appearance: none; cursor: pointer; }
 .c-titlecard:hover { border-color: var(--accent-line); }
 .c-titlecard .c-icon { display: inline-flex; color: var(--accent); }
 .c-titlecard .c-icon svg { width: 14px; height: 14px; }
-.c-titlecard .c-title { font-size: 13.5px; font-weight: 800; letter-spacing: .2px; color: var(--txt); }
-.c-titlecard .c-count { font-size: 11px; font-weight: 700; color: var(--txt-3); }
+.c-titlecard .c-title { font-size: 0.7941rem; font-weight: 800; letter-spacing: .2px; color: var(--txt); }
+.c-titlecard .c-count { font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); }
 /* Back + ⊞/+ live together on the right of the header */
 .c-head-right { margin-left: auto; display: inline-flex; align-items: center; gap: 8px; }
 .c-actions {
@@ -993,20 +1009,20 @@ select.lf-in { appearance: none; cursor: pointer; }
    columnEl) so the card-body scrollbar runs only through the list below it — no
    gutter gap beside the search strip. */
 .card > .listbar { flex: 0 0 auto; position: static; background: var(--card); }
-.listbar .mini-search { flex: 1; min-width: 0; height: 32px; padding: 0 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 12px; box-shadow: var(--chip-shadow); }
+.listbar .mini-search { flex: 1; min-width: 0; height: 32px; padding: 0 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 0.7059rem; box-shadow: var(--chip-shadow); }
 .listbar .mini-search:focus { outline: none; border-color: var(--accent-line); }
 /* §12 sort control — ONE unified chip: [field ⌄ │ ▲▼]. The two segments share a
    single steel chip (no second box, no extra horizontal space) split by a
    saddle-stitch seam, matching the .card-jog stepper (recognition over recall). */
 .sort { display: inline-flex; align-items: stretch; height: 32px; border-radius: var(--chip-radius); overflow: hidden; background: var(--panel); border: 1px solid var(--line); box-shadow: var(--chip-shadow); }
 .sort:hover, .sort:has(.sortbtn.viewing) { border-color: var(--accent-line); }
-.sortbtn { display: inline-flex; align-items: center; gap: 5px; height: 100%; padding: 0 9px; border: 0; background: transparent; color: var(--txt-2); font-size: 11px; font-weight: 600; white-space: nowrap; }
+.sortbtn { display: inline-flex; align-items: center; gap: 5px; height: 100%; padding: 0 9px; border: 0; background: transparent; color: var(--txt-2); font-size: 0.6471rem; font-weight: 600; white-space: nowrap; }
 .sortbtn:hover { color: var(--txt); }
 .sortbtn.viewing { color: var(--accent); }
 .sortbtn .chev { width: 12px; height: 12px; opacity: .6; }
 .sort .dir { display: flex; flex-direction: column; width: 22px; height: 100%; border: 0; border-left: 1px dashed rgba(194,146,90,.55); background: transparent; align-items: center; justify-content: center; }   /* saddle-stitch seam (same as .card-jog) */
 .sort .dir:hover { background: var(--accent-soft); }
-.sort .dir span { font-size: 9px; line-height: 1.05; color: var(--txt-3); }
+.sort .dir span { font-size: 0.5294rem; line-height: 1.05; color: var(--txt-3); }
 .sort .dir span.on { color: var(--accent); }
 .sort > button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
@@ -1015,22 +1031,22 @@ select.lf-in { appearance: none; cursor: pointer; }
 .dropdown-menu { position: fixed; z-index: 9100; width: max-content; min-width: 150px; max-width: min(92vw, 340px); padding: 6px; background: var(--panel); border: 1px solid var(--line); border-radius: var(--chip-radius); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); }   /* width:max-content hugs the widest item label; min/max keep it from getting awkwardly narrow or stretching wide */
 .dropdown-menu:not(.gt) { position: fixed; overflow: hidden; padding-left: 14px; }
 .dropdown-menu:not(.gt)::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 6px; background: repeating-linear-gradient(180deg, var(--yellow) 0 11px, #14181d 11px 22px); }
-.dropdown-menu .dd-item { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border-radius: 9px; font-size: 12px; font-weight: 600; text-align: left; color: var(--txt-2); }
+.dropdown-menu .dd-item { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border-radius: 9px; font-size: 0.7059rem; font-weight: 600; text-align: left; color: var(--txt-2); }
 .dropdown-menu .dd-item:hover { background: var(--panel-2); color: var(--txt); }
 .dropdown-menu .dd-item.on { color: var(--accent); }
 .dropdown-menu .dd-item .tick { margin-left: auto; opacity: 0; }
 .dropdown-menu .dd-item.on .tick { opacity: 1; }
 /* §5.5 Views menu: section headers + a per-view delete ✕ */
-.dropdown-menu .dd-sec { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.1px; color: var(--txt-3); padding: 8px 10px 3px; }
+.dropdown-menu .dd-sec { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.5882rem; font-weight: 700; text-transform: uppercase; letter-spacing: 1.1px; color: var(--txt-3); padding: 8px 10px 3px; }
 .dropdown-menu .dd-item.js-applyview.on .tick { margin-left: 0; }
 /* §313 — Close-all confirm popover: the two action pills sit on one calm row */
 .dropdown-menu .dd-confirm { display: flex; gap: 8px; padding: 6px 10px 8px; }
 .closeall-slot { flex-shrink: 0; display: inline-flex; align-items: center; }
-.dropdown-menu .dd-item .x { margin-left: auto; opacity: .45; font-size: 12px; padding: 0 2px; }
+.dropdown-menu .dd-item .x { margin-left: auto; opacity: .45; font-size: 0.7059rem; padding: 0 2px; }
 .dropdown-menu .dd-item .x:hover { opacity: 1; color: var(--red); }
 /* Tools-menu collapsible FAMILIES — native <details>, all closed on open (Jac 2026-07-17) ── */
 .dropdown-menu .dd-fam-h { display: flex; align-items: center; gap: 8px; padding: 7px 10px; border-radius: 9px; cursor: pointer; user-select: none; list-style: none;
-  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 10.5px; font-weight: 700; color: var(--txt-3); }
+  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 0.6176rem; font-weight: 700; color: var(--txt-3); }
 .dropdown-menu .dd-fam-h::-webkit-details-marker { display: none; }
 .dropdown-menu .dd-fam-h:hover { background: var(--panel-2); color: var(--txt-2); }
 .dropdown-menu .dd-fam[open] > .dd-fam-h { color: var(--txt); }
@@ -1043,7 +1059,7 @@ select.lf-in { appearance: none; cursor: pointer; }
    hazard rail, NO orange halo (that stays for dialogs); monochrome progress states ── */
 .dropdown-menu.gt { width: max-content; min-width: 180px; max-width: 92vw; padding: 0; overflow: hidden; position: fixed; border: 1px solid var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); }   /* MUST be position:fixed (a fixed box still anchors the absolute rail/connectors). `relative` here overrode the base .dropdown-menu's fixed → openDropdown's top/left measured from page flow, dumping the menu ~1 viewport below the fold (the "opens far below screen" bug). `width:max-content` hugs the widest row's label (the menu was a fixed 244px regardless of content); the max-width clamp keeps the width:100% rows from stretching it to the viewport. */
 .gt-haz { position: absolute; left: 0; top: 0; bottom: 0; width: 7px; background: repeating-linear-gradient(180deg, var(--yellow) 0 11px, #14181d 11px 22px); }
-.gt-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 10px; color: var(--txt-3); padding: 10px 12px 4px 20px; }
+.gt-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); padding: 10px 12px 4px 20px; }
 .gt-body { padding: 2px 10px 9px 18px; }
 .gt-row { position: relative; display: flex; align-items: center; gap: 11px; width: 100%; min-height: 40px; padding: 0 4px; text-align: left; background: none; border: 0; cursor: pointer; color: var(--txt-2); }
 .gt-row:hover { background: rgba(255,255,255,.04); border-radius: 8px; }
@@ -1058,7 +1074,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .gt-dash { position: absolute; left: 17px; top: 50%; height: 100%; border-left: 2px dashed var(--line); }
 .gt-node { position: relative; z-index: 1; width: 28px; height: 28px; flex: 0 0 auto; border-radius: 50%; display: flex; align-items: center; justify-content: center; background: var(--panel-2); box-shadow: inset 0 0 0 1.5px var(--line); }
 .gt-node svg { width: 15px; height: 15px; }
-.gt-lbl { font-size: 12.5px; font-weight: 600; }
+.gt-lbl { font-size: 0.7353rem; font-weight: 600; }
 .gt-chk { display: inline-flex; vertical-align: -2px; margin-right: 3px; }
 .gt-chk svg { width: 11px; height: 11px; color: #5fc98a; }
 .gt-d .gt-node { color: #7fd49a; background: #15231a; box-shadow: inset 0 0 0 1.5px #2f6b3e; }
@@ -1068,7 +1084,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .gt-s .gt-node { color: #5b636f; background: var(--panel); box-shadow: inset 0 0 0 1.5px var(--line-soft); }
 .gt-s .gt-lbl { color: var(--txt-3); font-style: italic; }
 .gt-a .gt-node { color: var(--on-orange); background: linear-gradient(180deg, #ff9038, var(--accent)); box-shadow: 0 0 0 3px var(--accent-soft); }
-.gt-a .gt-lbl { color: var(--accent); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 800; font-size: 13.5px; }
+.gt-a .gt-lbl { color: var(--accent); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 800; font-size: 0.7941rem; }
 
 /* ── §6.2 Item rows are cards/chips ──────────────────────────────────────── */
 .list { padding: 4px 8px 8px; display: flex; flex-direction: column; gap: 10px; }   /* +50% row rhythm (Jac 2026-07-17; was 7px) */
@@ -1086,8 +1102,8 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* §6.2 #2 — HARD two-row limit: Row 1 (title + fields) and Row 2 (pills only),
    both single-line; overflow clips rather than spilling to a third row. */
 .row-1 { display: flex; align-items: center; gap: 8px; min-width: 0; }
-.row-1 .r-title { font-size: 19.5px; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }   /* +50% (Jac 2026-07-17; was 13px) */
-.row-1 .r-fields { display: flex; gap: 10px; color: var(--txt-2); font-size: 18px; min-width: 0; overflow: hidden; flex: 0 1 auto; }   /* +50% (Jac 2026-07-17; was 12px) */
+.row-1 .r-title { font-size: 1.1471rem; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 0 1 auto; min-width: 0; }   /* +50% (Jac 2026-07-17; was 13px) */
+.row-1 .r-fields { display: flex; gap: 10px; color: var(--txt-2); font-size: 1.0588rem; min-width: 0; overflow: hidden; flex: 0 1 auto; }   /* +50% (Jac 2026-07-17; was 12px) */
 .row-1 .r-fields span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 /* Customers: the name truncates first so the phone number stays fully visible */
 .card[data-card="customers"] .row-1 .r-fields { flex: 0 0 auto; }
@@ -1108,8 +1124,8 @@ select.lf-in { appearance: none; cursor: pointer; }
 .rbtn:hover { background: var(--panel-2); color: var(--accent); }
 .rbtn svg { width: 14px; height: 14px; }
 
-.empty { padding: 22px 14px; text-align: center; color: var(--txt-3); font-size: 12px; display: flex; flex-direction: column; align-items: center; gap: 9px; }
-.showmore { display: block; width: 100%; margin: 6px 0 2px; padding: 9px 12px; border-radius: 9px; background: var(--accent-soft); border: 1px solid var(--accent-line); color: var(--accent); font-size: 12px; font-weight: 700; cursor: pointer; text-align: center; transition: background .12s ease; }
+.empty { padding: 22px 14px; text-align: center; color: var(--txt-3); font-size: 0.7059rem; display: flex; flex-direction: column; align-items: center; gap: 9px; }
+.showmore { display: block; width: 100%; margin: 6px 0 2px; padding: 9px 12px; border-radius: 9px; background: var(--accent-soft); border: 1px solid var(--accent-line); color: var(--accent); font-size: 0.7059rem; font-weight: 700; cursor: pointer; text-align: center; transition: background .12s ease; }
 .showmore:hover { background: var(--accent-line); }
 /* contextual "+New" at the top of a list (e.g. add a rental for an anchored customer) */
 
@@ -1117,7 +1133,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .pill {
   display: inline-flex; align-items: center; justify-content: center; gap: 5px; height: 19px; padding: 0 9px;
   line-height: 1;   /* tight line box so UPPERCASE caps optically center (1.4× leading made them ride high) */
-  border-radius: 999px; font-size: 10px; font-weight: 700; letter-spacing: .2px; white-space: nowrap;
+  border-radius: 999px; font-size: 0.5882rem; font-weight: 700; letter-spacing: .2px; white-space: nowrap;
   box-shadow: 0 1px 2px rgba(0,0,0,.25); border: 1px solid transparent; cursor: pointer;
 }
 .pill .dot { width: 6px; height: 6px; border-radius: 50%; }
@@ -1134,7 +1150,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .pill.ghost.icon-only { width: 19px; padding: 0; }                                                            /* R18 icon-only — circular chip, matches a row badge's height */
 .pill.ghost.icon-only:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .pill.locked { opacity: .55; cursor: not-allowed; }                                                          /* R17 locked-gate state (no inline hacks) */
-.req { display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 13px; border-radius: 10px; background: #fff; color: #16181d; border: 1px solid #fff; font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; }  /* rule 15/16/22: required-until-entered = white bg + dark ink */
+.req { display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 13px; border-radius: 10px; background: #fff; color: #16181d; border: 1px solid #fff; font: inherit; font-size: 0.7059rem; font-weight: 700; cursor: pointer; }  /* rule 15/16/22: required-until-entered = white bg + dark ink */
 .req svg { width: 15px; height: 15px; }
 /* rule 8: notes carry a 3-color dot tag (white/red/green), picked while entering */
 .nd-white { background: #e9edf4; }
@@ -1146,7 +1162,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .dotpick .dp { width: 15px; height: 15px; border-radius: 50%; border: 1px solid var(--line); cursor: pointer; }
 .dotpick .dp.on { box-shadow: 0 0 0 2px var(--accent); }
 /* rule 25 (v2): hyperlinks = blue · italic · NOT bold · 12px · PERMANENT underline */
-.linkname, .inv-line-link { color: var(--blue); font-weight: 400; font-style: italic; font-size: 12px; text-decoration: underline; cursor: pointer; }
+.linkname, .inv-line-link { color: var(--blue); font-weight: 400; font-style: italic; font-size: 0.7059rem; text-decoration: underline; cursor: pointer; }
 .linkname:hover, .inv-line-link:hover { filter: brightness(1.15); }
 .pill[data-badge]:hover { filter: brightness(1.16); }                                                        /* rule 3: status badge hover highlight */
 .pill[data-badge]:hover .t { text-decoration: underline; }
@@ -1154,14 +1170,14 @@ select.lf-in { appearance: none; cursor: pointer; }
 .pill .x { margin-left: 2px; opacity: .6; font-weight: 800; }
 .pill .x:hover { opacity: 1; color: var(--red); }
 .pill svg { width: 12px; height: 12px; flex: 0 0 auto; }
-.badge { display: inline-flex; align-items: center; height: 19px; padding: 0 8px; border-radius: 999px; font-size: 10px; font-weight: 700; background: var(--panel-2); border: 1px solid var(--line); color: var(--txt-2); }
+.badge { display: inline-flex; align-items: center; height: 19px; padding: 0 8px; border-radius: 999px; font-size: 0.5882rem; font-weight: 700; background: var(--panel-2); border: 1px solid var(--line); color: var(--txt-2); }
 
 /* status color helper classes (set by registry color token) */
 .c-green  { background: var(--green-bg);  color: var(--green);  border-color: color-mix(in srgb, var(--green) 30%, transparent); }
 .c-yellow { background: var(--yellow-bg); color: var(--yellow); border-color: color-mix(in srgb, var(--yellow) 30%, transparent); }
 /* R34 wash cycle button — one pressable status-tone pill (registry green/yellow/gray), reuses .c-* fills. */
 .washbtn { cursor: pointer; display: inline-flex; align-items: center; gap: 6px; height: 28px; padding: 0 15px;
-  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .8px; font-weight: 700; font-size: 11px; }
+  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .8px; font-weight: 700; font-size: 0.6471rem; }
 .washbtn:hover { filter: brightness(1.08); }
 .washbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .c-red    { background: var(--red-bg);    color: var(--red);    border-color: color-mix(in srgb, var(--red) 30%, transparent); }
@@ -1182,7 +1198,7 @@ select.lf-in { appearance: none; cursor: pointer; }
   text-transform: uppercase;
   letter-spacing: .8px;
   font-weight: 700;
-  font-size: 11px;
+  font-size: 0.6471rem;
   height: 22px;
 }
 
@@ -1216,7 +1232,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* ── Standard mode (§0.2 / §12) ──────────────────────────────────────────── */
 .detail { padding: 12px; display: flex; flex-direction: column; gap: 12px; }
 .detail-head { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
-.detail-head .d-title { font-size: 16px; font-weight: 700; }
+.detail-head .d-title { font-size: 0.9412rem; font-weight: 700; }
 /* §0.6 — the open record's title lives in the card header, so hide the in-body
    title; collapse the head entirely when only the title was there. */
 .card .detail-head .d-title { display: none; }
@@ -1245,10 +1261,10 @@ select.lf-in { appearance: none; cursor: pointer; }
 }
 /* section headers CENTERED (v2 build); right-side flags pin absolutely so the
    title stays true-center */
-.section > h4 { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 8px; display: flex; align-items: center; justify-content: center; gap: 7px; position: relative; }
+.section > h4 { font-size: 0.6471rem; font-weight: 700; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 8px; display: flex; align-items: center; justify-content: center; gap: 7px; position: relative; }
 .section > h4 .right { position: absolute; right: 0; top: 50%; transform: translateY(-50%); display: inline-flex; align-items: center; gap: 6px; text-transform: none; letter-spacing: 0; }
 .section > h4 .hmuted { text-transform: none; letter-spacing: 0; color: var(--txt-3); font-weight: 600; }
-.section > h4.h-name { text-transform: none; letter-spacing: 0; font-size: 13px; }   /* R11: record-NAME headers (WO: <name>) */
+.section > h4.h-name { text-transform: none; letter-spacing: 0; font-size: 0.7647rem; }   /* R11: record-NAME headers (WO: <name>) */
 /* inside the anchored main card: dark-gray section cards (normal light text) —
    NO orange border (the card's orange border + glow is the anchor signal). */
 /* anchored cards keep the DEFAULT section background (no special gray fill) */
@@ -1262,12 +1278,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 
 /* label-free stacked fields (§6.2 #3 — prefix/suffix, no field titles) */
 .fieldstack { display: flex; flex-direction: column; gap: 8px; }
-.kv { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; min-width: 0; font-size: 13px; line-height: 1.35; }
+.kv { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; min-width: 0; font-size: 0.7647rem; line-height: 1.35; }
 .kv > .v { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
 .kv.wrap > .v { white-space: normal; }
-.kv .sfx { color: var(--txt-3); font-size: 12px; font-weight: 500; }     /* trailing qualifier: /one-way, due, HRS */
-.kv .pfx { color: var(--txt-3); font-size: 12px; font-weight: 600; }     /* leading qualifier: Start, Return */
-.kv .v.big { font-size: 15px; }
+.kv .sfx { color: var(--txt-3); font-size: 0.7059rem; font-weight: 500; }     /* trailing qualifier: /one-way, due, HRS */
+.kv .pfx { color: var(--txt-3); font-size: 0.7059rem; font-weight: 600; }     /* leading qualifier: Start, Return */
+.kv .v.big { font-size: 0.8824rem; }
 .kv .v.muted { color: var(--txt-3); font-weight: 500; }
 .kv.derived > .v, .kv.derived .sfx, .derived { font-style: italic; }   /* rule 13/20/21/27: derived/formulaic values italic */
 .detail-badges { gap: 7px; }
@@ -1280,7 +1296,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .ca-panel::before { content:''; position:absolute; top:0; left:0; right:0; height:4px; border-bottom:1px solid #000;
   background: repeating-linear-gradient(135deg, var(--yellow) 0 8px, #14181d 8px 16px); }
 .ca-stage { position:absolute; top:13px; left:13px; z-index:8; font-family:'Saira Condensed',system-ui,sans-serif;
-  text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:12px; padding:4px 11px; border-radius:7px;
+  text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:0.7059rem; padding:4px 11px; border-radius:7px;
   color:var(--on-orange); background:linear-gradient(180deg,#ff9038,var(--accent));
   box-shadow: inset 0 1px 0 rgba(255,255,255,.32), 0 3px 9px -3px rgba(255,122,26,.5); }
 .ca-stage.c-green { background:linear-gradient(180deg,#4ce0a8,var(--green)); color:#06231a; }
@@ -1291,12 +1307,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 .ca-chart { position:relative; height:170px; margin-top:6px; }
 .ca-svg { display:block; width:100%; height:150px; }
 .ca-lbls { position:absolute; left:0; right:0; top:151px; height:12px;
-  font-family:'Saira Condensed',system-ui,sans-serif; text-transform:uppercase; letter-spacing:.4px; font-size:8px; color:var(--txt-3); }
+  font-family:'Saira Condensed',system-ui,sans-serif; text-transform:uppercase; letter-spacing:.4px; font-size:0.4706rem; color:var(--txt-3); }
 .ca-lbls span { position:absolute; transform:translateX(-50%); }
 .ca-dot { position:absolute; width:5px; height:5px; border-radius:50%; background:var(--accent); border:1.5px solid #0c0e11; transform:translate(-50%,-50%); z-index:4; }
 .ca-dot.big { width:8px; height:8px; box-shadow:0 0 0 2px rgba(255,122,26,.3); }
 .ca-dot.d { width:4px; height:4px; background:#c2925a; }
-.ca-legend { position:absolute; top:6px; right:10px; display:flex; gap:11px; font-size:10px; color:var(--txt-3); z-index:5; pointer-events:none; }
+.ca-legend { position:absolute; top:6px; right:10px; display:flex; gap:11px; font-size:0.5882rem; color:var(--txt-3); z-index:5; pointer-events:none; }
 .ca-legend i { display:inline-block; width:9px; height:2px; vertical-align:middle; margin-right:4px; border-radius:1px; }
 .ca-legend .ca-leg-r { display:inline-flex; align-items:center; gap:3px; }
 .ca-legend .ca-leg-r svg { width:11px; height:11px; fill:var(--accent); stroke:none; }
@@ -1308,22 +1324,22 @@ select.lf-in { appearance: none; cursor: pointer; }
 .ca-scrub.on { opacity:1; }
 .ca-tip { position:absolute; top:24px; transform:translateX(-50%); background:#14181d; border:1px solid rgba(255,255,255,.16); border-radius:7px; padding:4px 9px; display:flex; flex-direction:column; gap:1px; line-height:1.3; opacity:0; pointer-events:none; z-index:6; white-space:nowrap; box-shadow:0 4px 14px rgba(0,0,0,.5); }
 .ca-tip.on { opacity:1; }
-.ca-tip b { font-family:'Saira Condensed',sans-serif; font-size:11px; letter-spacing:.5px; text-transform:uppercase; }
-.ca-tip .ca-tip-s { color:var(--accent); font-size:12px; font-weight:600; }
-.ca-tip .ca-tip-d { color:#c2925a; font-size:11px; }
-.ca-tip .ca-tip-r { color:var(--accent); font-size:11px; font-weight:600; }
+.ca-tip b { font-family:'Saira Condensed',sans-serif; font-size:0.6471rem; letter-spacing:.5px; text-transform:uppercase; }
+.ca-tip .ca-tip-s { color:var(--accent); font-size:0.7059rem; font-weight:600; }
+.ca-tip .ca-tip-d { color:#c2925a; font-size:0.6471rem; }
+.ca-tip .ca-tip-r { color:var(--accent); font-size:0.6471rem; font-weight:600; }
 .ca-co { position:absolute; transform:translateX(-50%); z-index:6; white-space:nowrap; display:flex; align-items:center; gap:6px; }
-.ca-bag { width:26px; height:26px; border-radius:50%; display:grid; place-items:center; font-size:13px; background:#0c0f14; border:1px solid #2a313b; flex:0 0 auto; }
+.ca-bag { width:26px; height:26px; border-radius:50%; display:grid; place-items:center; font-size:0.7647rem; background:#0c0f14; border:1px solid #2a313b; flex:0 0 auto; }
 .ca-cc { background:#12161c; border:1px solid #2a313b; border-radius:8px; padding:4px 8px; box-shadow:0 8px 18px -8px rgba(0,0,0,.7); }
-.ca-cv { font-family:'Saira Condensed',system-ui,sans-serif; font-weight:800; font-size:13px; line-height:1; color:var(--txt); }
-.ca-cl { display:block; font-family:'Saira Condensed',system-ui,sans-serif; text-transform:uppercase; letter-spacing:.6px; font-size:7.5px; color:var(--txt-3); margin-top:1px; }
+.ca-cv { font-family:'Saira Condensed',system-ui,sans-serif; font-weight:800; font-size:0.7647rem; line-height:1; color:var(--txt); }
+.ca-cl { display:block; font-family:'Saira Condensed',system-ui,sans-serif; text-transform:uppercase; letter-spacing:.6px; font-size:0.4412rem; color:var(--txt-3); margin-top:1px; }
 /* the cadence markers on the timeline — Today (stage-colored) + Next Expected (dashed) */
 .ca-vline { position:absolute; top:6px; height:142px; width:2px; transform:translateX(-1px); z-index:5; }
 .ca-vline.ca-exp { width:0; background:none; border-left:2px dashed rgba(255,255,255,.5); }
 .ca-band { position:absolute; top:6px; height:142px; z-index:2; border-radius:3px; }
 /* the dates caption under the chart */
 .ca-cap { display:flex; justify-content:space-between; gap:8px; margin-top:9px;
-  font-family:'Saira Condensed',system-ui,sans-serif; text-transform:uppercase; letter-spacing:.5px; font-size:10px; color:var(--txt-3); }
+  font-family:'Saira Condensed',system-ui,sans-serif; text-transform:uppercase; letter-spacing:.5px; font-size:0.5882rem; color:var(--txt-3); }
 .ca-cap b { color:var(--txt-2); font-weight:700; }
 .ca-cap .ca-exp { display:inline-flex; align-items:center; gap:3px; color:var(--txt-2); }
 .ca-cap .ca-exp b { color:var(--accent); }
@@ -1356,33 +1372,33 @@ select.lf-in { appearance: none; cursor: pointer; }
 .cmt-dot.on { opacity: 1; transform: scale(1.12); box-shadow: 0 0 0 3px rgba(255,255,255,.6), 0 0 13px 2px currentColor; }   /* glowing ring on the selected dot (IMG_1899) */
 .cmt-card .x { color: var(--cmt-ink); opacity: .5; } .cmt-card .x:hover { opacity: .85; }
 .cmt-input { display: block; width: 100%; min-height: 118px; border: none; background: transparent; resize: none; outline: none;
-  color: var(--cmt-ink); font: inherit; font-size: 15px; line-height: 1.45; padding: 4px 18px 14px; }
+  color: var(--cmt-ink); font: inherit; font-size: 0.8824rem; line-height: 1.45; padding: 4px 18px 14px; }
 .cmt-input::placeholder { color: var(--cmt-ink); opacity: .5; }
 .cmt-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 6px 14px 15px; }
-.cmt-hint { font-size: 11px; font-weight: 700; color: var(--cmt-ink); opacity: .62; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cmt-hint { font-size: 0.6471rem; font-weight: 700; color: var(--cmt-ink); opacity: .62; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmt-post { border: none; cursor: pointer; background: rgba(0,0,0,.18); color: var(--cmt-ink); border-radius: 9px; padding: 8px 18px;
-  font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 12.5px; }
+  font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 0.7353rem; }
 .cmt-post:hover { background: rgba(0,0,0,.28); }
 
 /* §18 MR. WRANGLER — the in-app AI chat overlay (Claude via the backend). */
 .wr-pop { display: flex; flex-direction: column; max-height: min(80vh, 640px); }
-.wr-pop .popup-head .wr-chip { display: inline-flex; align-items: center; gap: 5px; margin-left: 9px; padding: 3px 9px; border-radius: 99px; background: var(--panel); border: 1px solid var(--line); font-size: 11px; font-weight: 700; color: var(--txt-2); max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wr-pop .popup-head .wr-chip { display: inline-flex; align-items: center; gap: 5px; margin-left: 9px; padding: 3px 9px; border-radius: 99px; background: var(--panel); border: 1px solid var(--line); font-size: 0.6471rem; font-weight: 700; color: var(--txt-2); max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wr-pop .popup-head .wr-chip svg { width: 13px; height: 13px; flex: 0 0 auto; }
 .wr-pop .popup-head .wr-chip.muted { color: var(--txt-3); }
 .wr-feed { flex: 1 1 auto; overflow-y: auto; padding: 14px 16px; display: flex; flex-direction: column; gap: 12px; min-height: 150px; }
-.wr-empty { color: var(--txt-3); font-size: 13px; text-align: center; padding: 30px 14px; line-height: 1.55; }
+.wr-empty { color: var(--txt-3); font-size: 0.7647rem; text-align: center; padding: 30px 14px; line-height: 1.55; }
 .wr-msg { display: flex; gap: 8px; align-items: flex-start; max-width: 92%; }
 .wr-msg.user { align-self: flex-end; }
 .wr-msg.assistant { align-self: flex-start; }
-.wr-av { flex: 0 0 auto; font-size: 19px; line-height: 1; margin-top: 3px; }
-.wr-bub { padding: 9px 13px; border-radius: 13px; font-size: 13.5px; line-height: 1.5; word-wrap: break-word; }
+.wr-av { flex: 0 0 auto; font-size: 1.1176rem; line-height: 1; margin-top: 3px; }
+.wr-bub { padding: 9px 13px; border-radius: 13px; font-size: 0.7941rem; line-height: 1.5; word-wrap: break-word; }
 .wr-msg.assistant .wr-bub { background: #232c37; color: var(--txt); border-bottom-left-radius: 4px; }
 .wr-msg.user .wr-bub { background: var(--accent); color: #1a1205; font-weight: 500; border-bottom-right-radius: 4px; }
 .wr-bub.wr-think { color: var(--txt-3); font-style: italic; }
 .wr-bub-wrap { display: flex; flex-direction: column; gap: 3px; min-width: 0; align-items: flex-start; }
 .wr-msg.user .wr-bub-wrap { align-items: flex-end; }
-.wr-time { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; font-size: 9.5px; font-weight: 700; color: var(--txt-3); padding: 0 3px; }
-.wr-err { color: var(--red); font-size: 12px; padding: 0 16px 6px; }
+.wr-time { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; font-size: 0.5588rem; font-weight: 700; color: var(--txt-3); padding: 0 3px; }
+.wr-err { color: var(--red); font-size: 0.7059rem; padding: 0 16px 6px; }
 /* R28 — Wrangler Ops PAUSED plate (§18h): a Developer-tier operator took the wheel
    (live jump-in from Wrangler Ops), so the dock/rail window is read-only until
    released. Red hazard stripe (danger variant of the app's signature motif) on a
@@ -1391,14 +1407,14 @@ select.lf-in { appearance: none; cursor: pointer; }
    body-level fixed band like R25/R27 — this is a per-conversation state, not global. */
 .wr-paused { position: relative; display: flex; flex-direction: column; gap: 1px; padding: 8px 14px 8px 22px; background: var(--red-bg); border-bottom: 1px solid var(--red); flex: 0 0 auto; }
 .wr-paused::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 8px; background: repeating-linear-gradient(135deg, var(--red) 0 7px, #14181d 7px 14px); }
-.wr-paused-ttl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 70%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 55%, transparent); }
-.wr-paused-sub { font-size: 11.5px; color: var(--txt-2); }
+.wr-paused-ttl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 0.7647rem; color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 70%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 55%, transparent); }
+.wr-paused-sub { font-size: 0.6765rem; color: var(--txt-2); }
 .wr-attach.is-disabled { opacity: .45; cursor: not-allowed; pointer-events: none; }
 .wr-compose { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--line); }
 /* §18d attach/paste images — paperclip stamp + pending thumbnails + sent-in-bubble.
    The chat takes a paste or a dropped file, Claude-style. */
 .wr-attach { width: 38px; height: 38px; flex: 0 0 auto; border-radius: 10px; cursor: pointer;
-  display: inline-flex; align-items: center; justify-content: center; font-size: 17px;
+  display: inline-flex; align-items: center; justify-content: center; font-size: 1rem;
   background: var(--bg-2, var(--panel)); border: 1px solid var(--line); color: var(--txt-2, var(--txt)); }
 .wr-attach:hover { border-color: color-mix(in srgb, #c2925a 60%, var(--line)); color: var(--txt); }
 .wr-attach svg { width: 18px; height: 18px; }
@@ -1406,13 +1422,13 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-thumb { position: relative; width: 54px; height: 54px; border-radius: 8px; overflow: hidden; border: 1px solid var(--line); }
 .wr-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .wr-thumb-x { position: absolute; top: 2px; right: 2px; width: 18px; height: 18px; border: none; border-radius: 50%;
-  background: rgba(12, 14, 17, .82); color: #fff; font-size: 13px; line-height: 1; cursor: pointer; display: grid; place-items: center; }
+  background: rgba(12, 14, 17, .82); color: #fff; font-size: 0.7647rem; line-height: 1; cursor: pointer; display: grid; place-items: center; }
 .wr-bub-imgs { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 6px; }
 .wr-bub-imgs:last-child { margin-bottom: 0; }
 .wr-bub-imgs img { max-width: 160px; max-height: 160px; border-radius: 8px; display: block; }
 /* §18d CSV/text attachment chips — pending (compose) + sent (bubble) */
 .wr-fileatt { position: relative; display: inline-flex; align-items: center; max-width: 180px; padding: 6px 9px; border-radius: 8px; background: var(--panel); border: 1px solid var(--line); }
-.wr-fileatt-n, .wr-file-chip { display: inline-flex; align-items: center; gap: 5px; min-width: 0; font-size: 11px; font-weight: 700; color: var(--txt-2); }
+.wr-fileatt-n, .wr-file-chip { display: inline-flex; align-items: center; gap: 5px; min-width: 0; font-size: 0.6471rem; font-weight: 700; color: var(--txt-2); }
 .wr-fileatt-n svg, .wr-file-chip svg { width: 13px; height: 13px; flex: 0 0 auto; color: var(--tan, #c2925a); }
 .wr-file-n { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wr-fileatt-x.wr-thumb-x { position: static; margin-left: 6px; flex: 0 0 auto; }
@@ -1420,7 +1436,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-bub-files:last-child { margin-bottom: 0; }
 .wr-bub-files .wr-file-chip { max-width: 200px; padding: 4px 9px; border-radius: 99px; background: var(--bg-2, var(--panel)); border: 1px solid var(--line); }
 .wr-pop.wr-drag { outline: 2px dashed var(--accent, #ff7a1a); outline-offset: -6px; }
-.wr-in { flex: 1; height: 38px; border-radius: 10px; background: var(--bg-2, var(--panel)); border: 1px solid var(--line); color: var(--txt); padding: 0 13px; font: inherit; font-size: 13.5px; outline: none; }
+.wr-in { flex: 1; height: 38px; border-radius: 10px; background: var(--bg-2, var(--panel)); border: 1px solid var(--line); color: var(--txt); padding: 0 13px; font: inherit; font-size: 0.7941rem; outline: none; }
 .wr-in:focus { border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
 .wr-send { width: 38px; height: 38px; flex: 0 0 auto; border-radius: 10px; border: none; cursor: pointer; background: var(--accent); color: #1a1205; display: inline-flex; align-items: center; justify-content: center; }
 .wr-send:disabled { opacity: .5; cursor: default; }
@@ -1431,7 +1447,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-actbtn { display: inline-flex; align-items: center; gap: 6px; margin-top: 9px; cursor: pointer;
   height: 30px; padding: 0 13px; border: none; border-radius: 8px;
   background: linear-gradient(180deg, #ff9038, var(--accent)); color: #1a1205;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 11.5px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 0.6765rem;
   letter-spacing: 1.1px; text-transform: uppercase; white-space: nowrap;
   box-shadow: 0 1px 0 rgba(0, 0, 0, .35), inset 0 1px 0 rgba(255, 255, 255, .25); }
 .wr-actbtn:hover { filter: brightness(1.06); }
@@ -1444,21 +1460,21 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wr-ask { margin-top: 9px; display: flex; flex-wrap: wrap; gap: 7px; }
 .wr-askbtn { cursor: pointer; min-height: 30px; padding: 5px 12px; border-radius: 8px;
   border: 1.5px solid var(--accent-line, #ff7a1a); background: rgba(255, 122, 26, .08); color: var(--txt);
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 11.5px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 0.6765rem;
   letter-spacing: 1.1px; text-transform: uppercase; white-space: normal; text-align: left; }
 .wr-askbtn:hover { background: linear-gradient(180deg, #ff9038, var(--accent)); color: #1a1205; border-color: transparent; }
 .wr-askbtn:active { transform: translateY(1px); }
 .wr-askbtn:focus-visible { outline: 2px solid var(--accent-line, #ff7a1a); outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) { .wr-askbtn:active { transform: none; } }
 .wr-apply { margin-top: 9px; display: flex; flex-direction: column; gap: 6px; align-items: flex-start; }
-.wr-apply-sum { font-size: 12px; font-weight: 700; color: var(--txt); }
-.wr-apply-skip { font-size: 10.5px; color: var(--yellow); }
-.wr-apply-none { font-size: 11.5px; color: var(--txt-3); font-style: italic; }
-.wr-actdone { display: inline-block; margin-top: 8px; font-size: 11.5px; font-weight: 600;
+.wr-apply-sum { font-size: 0.7059rem; font-weight: 700; color: var(--txt); }
+.wr-apply-skip { font-size: 0.6176rem; color: var(--yellow); }
+.wr-apply-none { font-size: 0.6765rem; color: var(--txt-3); font-style: italic; }
+.wr-actdone { display: inline-block; margin-top: 8px; font-size: 0.6765rem; font-weight: 600;
   color: var(--green, #46c46a); letter-spacing: .3px; }
 /* the clickable "Open <record> →" link Wrangler shows after it acts (Jac: bring me to it) */
 .wr-goto { display: inline-block; margin: 6px 0 0 8px; padding: 0; background: none; border: none;
-  font: inherit; font-size: 11.5px; font-weight: 700; color: var(--accent, #ff7a1a); cursor: pointer;
+  font: inherit; font-size: 0.6765rem; font-weight: 700; color: var(--accent, #ff7a1a); cursor: pointer;
   text-decoration: underline; text-underline-offset: 2px; }
 .wr-goto:hover { filter: brightness(1.12); }
 .wr-goto:focus-visible { outline: 2px solid var(--accent-line, #ff7a1a); outline-offset: 2px; border-radius: 4px; }
@@ -1467,17 +1483,17 @@ select.lf-in { appearance: none; cursor: pointer; }
 .req-wrap { max-height: 70vh; overflow-y: auto; display: flex; flex-direction: column; gap: 10px; padding: 14px 16px; }
 .req-card { background: linear-gradient(180deg, var(--card-head), var(--card)); border: 1px solid var(--line); border-radius: 12px; padding: 12px 14px; }
 .req-head { display: flex; align-items: baseline; gap: 8px; }
-.req-num { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 12px; color: var(--accent); flex: 0 0 auto; }
-.req-title { font-weight: 700; font-size: 13.5px; color: var(--txt); }
-.req-text { font-size: 12px; color: var(--txt-2, var(--txt-3)); line-height: 1.45; margin: 7px 0 10px; }
+.req-num { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 0.7059rem; color: var(--accent); flex: 0 0 auto; }
+.req-title { font-weight: 700; font-size: 0.7941rem; color: var(--txt); }
+.req-text { font-size: 0.7059rem; color: var(--txt-2, var(--txt-3)); line-height: 1.45; margin: 7px 0 10px; }
 .req-acts { display: flex; align-items: center; gap: 8px; }
-.req-acts .pill { height: 28px; font-size: 12px; }
-.req-await { font-size: 11.5px; color: var(--txt-3); font-style: italic; }
-.req-link { margin-left: auto; font-size: 11px; color: var(--blue); text-decoration: underline; }
+.req-acts .pill { height: 28px; font-size: 0.7059rem; }
+.req-await { font-size: 0.6765rem; color: var(--txt-3); font-style: italic; }
+.req-link { margin-left: auto; font-size: 0.6471rem; color: var(--blue); text-decoration: underline; }
 .req-empty { padding: 40px 22px; text-align: center; color: var(--txt-3); }
-.req-empty-ic { font-size: 30px; }
-.req-empty p { font-size: 14px; color: var(--txt-2); margin: 8px 0 4px; }
-.req-empty span { font-size: 12px; }
+.req-empty-ic { font-size: 1.7647rem; }
+.req-empty p { font-size: 0.8235rem; color: var(--txt-2); margin: 8px 0 4px; }
+.req-empty span { font-size: 0.7059rem; }
 /* §18e richer request card — the ask + photos + the filed conversation */
 .req-acts { flex-wrap: wrap; }
 .req-acts .spacer { flex: 1 1 auto; }
@@ -1485,25 +1501,25 @@ select.lf-in { appearance: none; cursor: pointer; }
 .req-photo { width: 72px; height: 72px; object-fit: cover; border-radius: 8px; border: 1px solid var(--line); cursor: zoom-in; }
 .req-convo { display: flex; flex-direction: column; gap: 7px; margin: 0 0 11px; padding: 9px 11px; border-radius: 10px; background: var(--bg-2); border: 1px solid var(--line-soft); max-height: 210px; overflow-y: auto; }
 .req-line { display: flex; flex-direction: column; gap: 1px; }
-.req-who { font-size: 9.5px; font-weight: 800; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); }
+.req-who { font-size: 0.5588rem; font-weight: 800; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); }
 .req-line.wr .req-who { color: var(--accent); }
-.req-msg { font-size: 12px; color: var(--txt-2); line-height: 1.42; }
+.req-msg { font-size: 0.7059rem; color: var(--txt-2); line-height: 1.42; }
 /* the request bar inside the Mr. Wrangler chat (continuing a filed request) */
 /* The request header on the dock — a small stacked plate: stamp + status on top, the FULL
    ask wrapping below (never truncated — that was the bug), actions on their own row. */
 .wr-reqbar { display: flex; flex-direction: column; gap: 7px; padding: 9px 14px; background: var(--accent-soft); border-bottom: 1px solid var(--accent-line); }
 .wr-reqbar-head { display: flex; align-items: center; gap: 8px; }
-.wr-reqnum { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 12px; color: var(--accent); letter-spacing: .5px; flex: 0 0 auto; text-transform: uppercase; }
+.wr-reqnum { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 0.7059rem; color: var(--accent); letter-spacing: .5px; flex: 0 0 auto; text-transform: uppercase; }
 .wr-reqbar-head .spacer { flex: 1 1 auto; }
-.wr-reqttl { font-size: 13px; line-height: 1.4; color: var(--txt); font-weight: 600; white-space: normal; overflow-wrap: anywhere; }
-.wr-reqlink { font-size: 11px; color: var(--blue); text-decoration: none; flex: 0 0 auto; font-weight: 600; }
+.wr-reqttl { font-size: 0.7647rem; line-height: 1.4; color: var(--txt); font-weight: 600; white-space: normal; overflow-wrap: anywhere; }
+.wr-reqlink { font-size: 0.6471rem; color: var(--blue); text-decoration: none; flex: 0 0 auto; font-weight: 600; }
 .wr-reqlink:hover { text-decoration: underline; }
 .wr-reqlink:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
 .wr-reqacts { display: flex; align-items: center; gap: 8px; }
-.wr-reqbar .pill { height: 26px; font-size: 11.5px; }
+.wr-reqbar .pill { height: 26px; font-size: 0.6765rem; }
 /* request lifecycle state (Needs your OK / Needs your answer / Building) */
 .req-head .spacer { flex: 1 1 auto; }
-.req-state { height: 20px; font-size: 9.5px; letter-spacing: .3px; flex: 0 0 auto; align-self: center; }
+.req-state { height: 20px; font-size: 0.5588rem; letter-spacing: .3px; flex: 0 0 auto; align-self: center; }
 .req-card.req-needs { border-color: var(--red); box-shadow: 0 0 0 1px color-mix(in srgb, var(--red) 50%, transparent), 0 0 7px color-mix(in srgb, var(--red) 30%, transparent); }
 
 /* §18e/f the round bell + Requests inbox — now ride the right of the bottom comms band
@@ -1515,7 +1531,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .fab:focus-visible { outline: 2px solid var(--accent-line); outline-offset: 2px; }
 .fab svg { width: 21px; height: 21px; }
 .fab-badge { position: absolute; top: -3px; right: -3px; min-width: 18px; height: 18px; padding: 0 5px; border-radius: 99px;
-  background: var(--accent); color: #1a1205; font-size: 11px; font-weight: 800; display: grid; place-items: center; box-shadow: 0 0 0 2px var(--bg); }
+  background: var(--accent); color: #1a1205; font-size: 0.6471rem; font-weight: 800; display: grid; place-items: center; box-shadow: 0 0 0 2px var(--bg); }
 @media (prefers-reduced-motion: reduce) { .fab:hover { transform: none; } }
 /* §18g/§17 — the bottom COMMS RAIL: channels grouped + stamped, each conversation its
    OWN data-plate tab. Fills the band's middle and scrolls horizontally; the toolbar
@@ -1526,11 +1542,11 @@ select.lf-in { appearance: none; cursor: pointer; }
 .comms-rail::-webkit-scrollbar { height: 0; width: 0; }
 .crail-group { flex: 0 0 auto; display: flex; align-items: center; gap: 7px; }
 .crail-div { flex: 0 0 auto; width: 1px; align-self: stretch; margin: 5px 2px; background: var(--line); }
-.crail-empty { color: var(--txt-3); font-size: 12px; font-style: italic; white-space: nowrap; }
+.crail-empty { color: var(--txt-3); font-size: 0.7059rem; font-style: italic; white-space: nowrap; }
 .crail-tab { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; max-width: 190px; padding: 6px 12px;
   border-radius: var(--chip-radius, 11px); cursor: pointer; border: 1px solid var(--line); color: var(--txt-2, var(--txt));
   background: linear-gradient(180deg, var(--card-head), var(--card));
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.06); font: inherit; font-size: 12.5px; font-weight: 600;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06); font: inherit; font-size: 0.7353rem; font-weight: 600;
   transition: transform .1s, border-color .1s, background .12s, color .12s; }
 .crail-tab:hover { border-color: var(--accent-line); color: var(--txt); transform: translateY(-1px); }
 .crail-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -1539,7 +1555,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* the × to REMOVE a chat tab (closing the dock only snapshots it back) — quiet, reveals on
    hover; always reachable on touch (no hover); reddens on hover to read as a remove. */
 .crail-x { flex: 0 0 auto; margin: 0 -4px 0 1px; width: 16px; height: 16px; display: inline-flex;
-  align-items: center; justify-content: center; border-radius: 50%; font-size: 14px; line-height: 1;
+  align-items: center; justify-content: center; border-radius: 50%; font-size: 0.8235rem; line-height: 1;
   color: var(--txt-3); opacity: 0; transition: opacity .1s, color .1s, background .1s; }
 .crail-tab:hover .crail-x { opacity: .75; }
 .crail-x:hover { opacity: 1; color: var(--red); background: color-mix(in srgb, var(--red) 18%, transparent); }
@@ -1584,7 +1600,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .crail-tab.comms-tab.st-gray, .crail-tab.comms-tab.is-active.st-gray { border-left-color: var(--txt-3); }
 /* the ALL tab — dashed, blue, stamped; FIRST (leftmost) in every session */
 .crail-tab.comms-all { border-style: dashed; border-color: color-mix(in srgb, var(--blue) 55%, var(--line)); color: var(--blue); }
-.crail-tab.comms-all .crail-t { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 800; font-size: 11px; }
+.crail-tab.comms-all .crail-t { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 800; font-size: 0.6471rem; }
 .crail-tab.comms-all.is-active { background: var(--blue); border-style: solid; border-color: var(--blue); color: #fff; }   /* solid-blue ink matches .pill.c-commit */
 /* ── the windows (Messenger metaphor: each above its OWN tab, several at once) ── */
 .comms-pops { position: fixed; inset: 0; z-index: 58; pointer-events: none; }
@@ -1595,36 +1611,36 @@ select.lf-in { appearance: none; cursor: pointer; }
 .cp-cap { flex: 0 0 auto; height: 5px; background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 13px, #14181d 13px 26px); }   /* the hazard cap — plate chrome */
 .cp-head { display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-bottom: 1px solid var(--line); background: var(--card-head); flex: 0 0 auto; }
 .cp-head .spacer { flex: 1 1 auto; }
-.cp-head .pill { height: 22px; font-size: 10.5px; }
+.cp-head .pill { height: 22px; font-size: 0.6176rem; }
 .cp-dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; background: var(--txt-3); }
 .cp-dot.c-green { background: var(--green); } .cp-dot.c-yellow { background: var(--yellow); } .cp-dot.c-red { background: var(--red); } .cp-dot.c-gray { background: var(--txt-3); }
-.cp-cat { flex: 0 0 auto; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-size: 10px; font-weight: 800; color: var(--txt-3); }
-.cp-who { min-width: 0; font-weight: 700; font-size: 13px; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cp-cat { flex: 0 0 auto; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-size: 0.5882rem; font-weight: 800; color: var(--txt-3); }
+.cp-who { min-width: 0; font-weight: 700; font-size: 0.7647rem; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cp-x { flex: 0 0 auto; width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; color: var(--txt-3); }
 .cp-x:hover { color: var(--txt); background: var(--panel-2); }
 .cp-x svg { width: 13px; height: 13px; }
 .cp-feed { flex: 1 1 auto; overflow-y: auto; padding: 10px; display: flex; flex-direction: column; gap: 7px; min-height: 110px; }
-.cp-empty { color: var(--txt-3); font-size: 12px; font-style: italic; text-align: center; padding: 22px 12px; line-height: 1.5; }
+.cp-empty { color: var(--txt-3); font-size: 0.7059rem; font-style: italic; text-align: center; padding: 22px 12px; line-height: 1.5; }
 .cp-row { display: flex; } .cp-row.me { justify-content: flex-end; }
 .cp-cell { max-width: 84%; display: flex; flex-direction: column; gap: 2px; }
 .cp-row.me .cp-cell { align-items: flex-end; }
 /* bubbles — 16px radius with the Apple corner-notch (tight corner on the sender side) */
-.cp-bub { padding: 7px 12px; border-radius: 16px; border-bottom-left-radius: 5px; background: var(--bub-them); border: 1px solid var(--bub-them-line); color: var(--txt); font-size: 12.5px; line-height: 1.4; overflow-wrap: break-word; }
+.cp-bub { padding: 7px 12px; border-radius: 16px; border-bottom-left-radius: 5px; background: var(--bub-them); border: 1px solid var(--bub-them-line); color: var(--txt); font-size: 0.7353rem; line-height: 1.4; overflow-wrap: break-word; }
 .cp-bub.me { background: var(--bub-me); border-color: var(--bub-me); color: var(--on-bub-me); border-radius: 16px; border-bottom-right-radius: 5px; }
 .cp-bub.failed { border-color: var(--red); box-shadow: 0 0 0 1px color-mix(in srgb, var(--red) 45%, transparent); }
-.cp-meta { font-size: 9.5px; color: var(--txt-3); padding: 0 4px; }
+.cp-meta { font-size: 0.5588rem; color: var(--txt-3); padding: 0 4px; }
 /* D7 FROM picker chip — email only, >1 connected alias */
 .cp-fromrow { padding: 7px 10px 0; border-top: 1px solid var(--line); flex: 0 0 auto; }
-.cp-from { display: inline-flex; align-items: center; gap: 5px; max-width: 100%; padding: 3px 9px; border-radius: 999px; border: 1px dashed var(--line); background: var(--bg-2); color: var(--txt-2); font-size: 11px; overflow: hidden; }
+.cp-from { display: inline-flex; align-items: center; gap: 5px; max-width: 100%; padding: 3px 9px; border-radius: 999px; border: 1px dashed var(--line); background: var(--bg-2); color: var(--txt-2); font-size: 0.6471rem; overflow: hidden; }
 .cp-from:hover { border-color: var(--accent-line); color: var(--txt); }
 .cp-from svg.chev { width: 12px; height: 12px; flex: 0 0 auto; }
 .cp-compose { display: flex; gap: 7px; padding: 9px 10px; border-top: 1px solid var(--line); flex: 0 0 auto; }
 .cp-fromrow + .cp-compose { border-top: none; padding-top: 7px; }
-.cp-in { flex: 1; min-width: 0; height: 32px; border-radius: 9px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); padding: 0 10px; font: inherit; font-size: 12.5px; outline: none; }
+.cp-in { flex: 1; min-width: 0; height: 32px; border-radius: 9px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); padding: 0 10px; font: inherit; font-size: 0.7353rem; outline: none; }
 .cp-in:focus { border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
 /* the ignition Send — stamped, orange, dark ink (the ONE primary beat per window) */
 .cp-send { flex: 0 0 auto; height: 32px; padding: 0 14px; border-radius: 999px; border: none;
-  font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 11px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 0.6471rem;
   background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 78%, #ffd9b0), var(--accent)); color: var(--on-orange, #1a1205); }
 .cp-send:hover { filter: brightness(1.05); }
 .cp-send:disabled { opacity: .6; cursor: default; }
@@ -1633,12 +1649,12 @@ select.lf-in { appearance: none; cursor: pointer; }
 .cm-row { display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-bottom: 1px solid var(--line-soft); }
 .cm-row:last-child { border-bottom: none; }
 .cm-row .pill { flex: 0 0 auto; }
-.cm-who { flex: 0 0 auto; font-weight: 700; font-size: 12.5px; white-space: nowrap; }
-.cm-snip { flex: 1 1 auto; min-width: 0; color: var(--txt-2); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cm-who { flex: 0 0 auto; font-weight: 700; font-size: 0.7353rem; white-space: nowrap; }
+.cm-snip { flex: 1 1 auto; min-width: 0; color: var(--txt-2); font-size: 0.6471rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 /* D8 merged Customer menu — the Text/Email channel toggle riding the menu head (comms-local,
    not the R14 .seg family). Active channel = ignition orange + dark ink. */
 .comms-chan { display: flex; gap: 4px; margin: 8px 10px 4px; padding: 4px; background: var(--bg-2); border: 1px solid var(--line); border-radius: 12px; }
-.comms-chan-b { flex: 1 1 0; display: flex; align-items: center; justify-content: center; gap: 7px; height: 38px; border-radius: 9px; color: var(--txt-2); font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 800; font-size: 12.5px; }
+.comms-chan-b { flex: 1 1 0; display: flex; align-items: center; justify-content: center; gap: 7px; height: 38px; border-radius: 9px; color: var(--txt-2); font-family: "Saira Condensed", sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 800; font-size: 0.7353rem; }
 .comms-chan-b svg { width: 17px; height: 17px; }
 .comms-chan-b.on { background: var(--accent); color: var(--on-orange); box-shadow: var(--chip-shadow); }
 .comms-chan-b:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -1646,7 +1662,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* customer profile — the compact Comms section (one row per channel with history) */
 .comms-sec .comms-line { display: flex; align-items: center; gap: 8px; flex-wrap: nowrap; }
 .comms-sec .comms-line .pill { flex: 0 0 auto; }
-.comms-sec .comms-snip { flex: 1 1 auto; min-width: 0; color: var(--txt-2); font-size: 11.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.comms-sec .comms-snip { flex: 1 1 auto; min-width: 0; color: var(--txt-2); font-size: 0.6765rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .comms-chip:focus-visible, .cp-x:focus-visible, .cp-from:focus-visible, .cp-send:focus-visible, .cp-in:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 /* ── D9 — Team + Mr. Wrangler windows on the rail (their docks are phone-only now).
    The window reuses each dock's INNER classes verbatim (the machinery's selectors),
@@ -1667,36 +1683,36 @@ select.lf-in { appearance: none; cursor: pointer; }
 /* §17 INTERNAL TEAM DOCK (Jac, Phase 7) — headerless: tagged-element pill rail on top,
    chat bubbles, role tab-bar at the bottom. Floats bottom-right. Yard data-plate steel. */
 .bottombar .iconbtn { position: relative; }
-.bb-badge { position: absolute; top: 1px; right: 1px; min-width: 15px; height: 15px; padding: 0 3px; border-radius: 8px; background: var(--accent); color: #1a1205; font-size: 9px; font-weight: 800; display: inline-flex; align-items: center; justify-content: center; }
+.bb-badge { position: absolute; top: 1px; right: 1px; min-width: 15px; height: 15px; padding: 0 3px; border-radius: 8px; background: var(--accent); color: #1a1205; font-size: 0.5294rem; font-weight: 800; display: inline-flex; align-items: center; justify-content: center; }
 .chat-dock { position: fixed; right: 14px; bottom: 60px; width: 366px; max-height: min(74dvh, 660px); z-index: 60;
   display: flex; flex-direction: column; border-radius: 16px; overflow: hidden;
   background: linear-gradient(180deg,#1b2129,#0c0e11); border: 1px solid var(--line); box-shadow: 0 26px 64px -18px rgba(0,0,0,.72); }
 /* ─ tagged-element rail (the signature: a row of colored context plates) ─ */
 .chat-rail { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 10px 10px 9px; border-bottom: 1px solid var(--line); background: rgba(0,0,0,.22); flex: 0 0 auto; }
-.chat-rail-hint { font-size: 11px; color: var(--txt-3); font-style: italic; padding: 2px 2px; }
+.chat-rail-hint { font-size: 0.6471rem; color: var(--txt-3); font-style: italic; padding: 2px 2px; }
 .rail-sp { flex: 1 1 auto; }
 .rail-ico { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border: none; background: none; color: var(--txt-3); cursor: pointer; padding: 0; border-radius: 6px; }
 .rail-ico svg { width: 15px; height: 15px; } .rail-ico:hover { color: var(--txt); background: rgba(255,255,255,.06); }
 /* ─ thread ─ */
 .chat-feed { flex: 1 1 auto; overflow-y: auto; padding: 12px 11px; display: flex; flex-direction: column; gap: 10px; min-height: 120px; }
-.chat-empty { color: var(--txt-3); font-size: 12.5px; text-align: center; padding: 30px 14px; line-height: 1.5; }
+.chat-empty { color: var(--txt-3); font-size: 0.7353rem; text-align: center; padding: 30px 14px; line-height: 1.5; }
 .cbub-row { display: flex; align-items: flex-end; gap: 7px; max-width: 88%; }
 .cbub-row.me { align-self: flex-end; }
-.cav { flex: 0 0 auto; width: 26px; height: 26px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 11px; color: #0c0e11; background: var(--av, var(--accent)); }
+.cav { flex: 0 0 auto; width: 26px; height: 26px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 0.6471rem; color: #0c0e11; background: var(--av, var(--accent)); }
 .cbub-wrap { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.cbub-name { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 10px; font-weight: 700; color: var(--txt-3); padding-left: 2px; }
-.cbub { padding: 8px 11px; border-radius: 13px; border-bottom-left-radius: 4px; background: #232c37; color: var(--txt); font-size: 13px; line-height: 1.38; word-wrap: break-word; }
+.cbub-name { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); padding-left: 2px; }
+.cbub { padding: 8px 11px; border-radius: 13px; border-bottom-left-radius: 4px; background: #232c37; color: var(--txt); font-size: 0.7647rem; line-height: 1.38; word-wrap: break-word; }
 .cbub.me { border-radius: 13px; border-bottom-right-radius: 4px; background: var(--accent); color: #1a1205; font-weight: 500; }
 /* a flagged comment, threaded in as a system/context line */
 .cflag { display: flex; gap: 8px; align-items: flex-start; align-self: stretch; text-align: left; background: rgba(0,0,0,.22); border: 1px solid var(--line); border-radius: 10px; padding: 8px 10px; cursor: pointer; }
 .cflag:hover { border-color: var(--accent-line); }
 .cflag .cmt-marker { margin-top: 2px; flex: 0 0 auto; }
 .cflag-b { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.cflag-t { font-size: 12.5px; color: var(--txt); line-height: 1.35; }
-.cflag-m { font-size: 10px; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); font-weight: 700; }
+.cflag-t { font-size: 0.7353rem; color: var(--txt); line-height: 1.35; }
+.cflag-m { font-size: 0.5882rem; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); font-weight: 700; }
 /* ─ compose ─ */
 .chat-compose { display: flex; gap: 8px; padding: 9px 10px; border-top: 1px solid var(--line); flex: 0 0 auto; }
-.chat-input { flex: 1; height: 36px; border-radius: 10px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); padding: 0 12px; font: inherit; font-size: 13px; outline: none; }
+.chat-input { flex: 1; height: 36px; border-radius: 10px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); padding: 0 12px; font: inherit; font-size: 0.7647rem; outline: none; }
 .chat-input:focus { border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
 .chat-send { width: 36px; height: 36px; flex: 0 0 auto; border-radius: 10px; border: none; cursor: pointer; background: var(--accent); color: #1a1205; display: inline-flex; align-items: center; justify-content: center; }
 .chat-send:hover { filter: brightness(1.06); } .chat-send svg { width: 18px; height: 18px; transform: rotate(-90deg); }
@@ -1704,37 +1720,37 @@ select.lf-in { appearance: none; cursor: pointer; }
 .chat-rolebar { display: flex; gap: 2px; padding: 6px 6px 8px; border-top: 1px solid var(--line); background: rgba(0,0,0,.28); flex: 0 0 auto; }
 .rtab { flex: 1 1 0; display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 6px 2px 4px; border: none; background: none; cursor: pointer; border-radius: 8px; min-width: 0; }
 .rtab-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--rc); opacity: .35; transition: opacity .15s, box-shadow .15s; }
-.rtab-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .4px; font-size: 10px; font-weight: 700; color: var(--txt-3); overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.rtab-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .4px; font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
 .rtab.on .rtab-dot { opacity: 1; box-shadow: 0 0 9px 0 var(--rc); }
 .rtab.on .rtab-l { color: var(--rc); }
 .rtab:hover { background: rgba(255,255,255,.05); }
 /* ── Team chat 2026-07-08 rail spec: editable title · member rail · pasted chips ── */
 .chat-title-in { flex: 1 1 auto; min-width: 0; background: transparent; border: none; color: var(--txt);
-  font-family: var(--font); font-weight: 700; font-size: 13px; padding: 3px 5px; border-radius: 6px;
+  font-family: var(--font); font-weight: 700; font-size: 0.7647rem; padding: 3px 5px; border-radius: 6px;
   overflow: hidden; text-overflow: ellipsis; }
 .chat-title-in::placeholder { color: var(--txt-3); font-weight: 600; font-style: italic; }
 .chat-title-in:hover { background: rgba(255,255,255,.05); }
 .chat-title-in:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; background: rgba(0,0,0,.25); }
 .chat-titlebar { padding: 8px 10px; }
-.cp-head .chat-title-in { font-size: 13px; }
+.cp-head .chat-title-in { font-size: 0.7647rem; }
 /* member rail — roster people grouped under their role heading; default none */
 .chat-memberbar { flex-wrap: wrap; gap: 7px 12px; align-items: flex-start; padding: 7px 9px 9px; }
 .chat-memberbar .mrole-grp { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .chat-memberbar .mrole-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase;
-  letter-spacing: 1px; font-size: 9px; font-weight: 800; color: var(--txt-3); padding: 0 2px; }
+  letter-spacing: 1px; font-size: 0.5294rem; font-weight: 800; color: var(--txt-3); padding: 0 2px; }
 .chat-memberbar .mrole-chips { display: flex; flex-wrap: wrap; gap: 4px; }
 .chat-memberbar .rtab { flex: 0 0 auto; flex-direction: row; gap: 5px; padding: 4px 10px 4px 8px;
   border: 1px solid var(--line); border-radius: 999px; }
-.chat-memberbar .rtab .rtab-l { max-width: 132px; font-size: 10.5px; }
+.chat-memberbar .rtab .rtab-l { max-width: 132px; font-size: 0.6176rem; }
 .chat-memberbar .rtab.on { border-color: var(--rc); background: rgba(255,255,255,.05); }
-.mbar-hint { font-size: 11px; color: var(--txt-3); font-style: italic; padding: 4px 4px; }
+.mbar-hint { font-size: 0.6471rem; color: var(--txt-3); font-style: italic; padding: 4px 4px; }
 /* read-only member view (non-creator): static chips + a Leave */
 .chat-memberbar-ro { align-items: center; }
 .chat-memberbar-ro .rtab.is-static { cursor: default; border: 1px solid var(--line); border-radius: 999px;
   flex: 0 0 auto; flex-direction: row; gap: 5px; padding: 4px 10px 4px 8px; }
 .chat-memberbar-ro .rtab.is-static .rtab-dot { opacity: 1; }
-.chat-memberbar-ro .rtab.is-static .rtab-l { color: var(--txt-2); max-width: 132px; font-size: 10.5px; }
-.chat-title-ro { flex: 1 1 auto; min-width: 0; font-weight: 700; font-size: 13px; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 3px 5px; }
+.chat-memberbar-ro .rtab.is-static .rtab-l { color: var(--txt-2); max-width: 132px; font-size: 0.6176rem; }
+.chat-title-ro { flex: 1 1 auto; min-width: 0; font-weight: 700; font-size: 0.7647rem; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 3px 5px; }
 /* the gear (chat settings) button in the window header */
 .cp-gear { display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; flex: 0 0 auto;
   border: none; background: none; color: var(--txt-3); cursor: pointer; border-radius: 7px; }
@@ -1754,7 +1770,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .chip-ref .cr-i, .chip-ref .cr-go { display: inline-flex; flex: 0 0 auto; }
 .chip-ref .cr-i { color: var(--accent); } .cbub.me .chip-ref .cr-i { color: #1a1205; }
 .chip-ref .cr-i svg { width: 15px; height: 15px; }
-.chip-ref .cr-t { font-weight: 700; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chip-ref .cr-t { font-weight: 700; font-size: 0.7059rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .chip-ref .cr-go { margin-left: auto; opacity: .55; } .chip-ref .cr-go svg { width: 13px; height: 13px; }
 .chip-ref:hover { border-color: var(--accent); }
 .chip-ref:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -1764,7 +1780,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .chat-compose .held-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 6px 4px 9px; border-radius: 999px;
   border: 1px dashed var(--tan); background: rgba(194,146,90,.14); color: var(--txt-2); flex: 0 0 auto; max-width: 48%; align-self: center; }
 .held-chip .hc-i { flex: 0 0 auto; color: var(--tan); display: inline-flex; } .held-chip .hc-i svg { width: 14px; height: 14px; }
-.held-chip .hc-t { font-size: 11px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.held-chip .hc-t { font-size: 0.6471rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .held-chip .hc-x { display: inline-flex; align-items: center; border: none; background: none; color: var(--txt-3); cursor: pointer; padding: 0; }
 .held-chip .hc-x:hover { color: var(--red); } .held-chip .hc-x svg { width: 12px; height: 12px; }
 .held-chip .hc-x:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
@@ -1774,7 +1790,7 @@ select.lf-in { appearance: none; cursor: pointer; }
   border: 1px solid var(--accent); background: rgba(255,122,26,.1); color: var(--txt-2); }
 .wr-focus-chip.chip-gone { border-style: dashed; border-color: var(--line); color: var(--txt-3); }
 .wr-focus-chip .wf-i { display: inline-flex; color: var(--accent); } .wr-focus-chip .wf-i svg { width: 14px; height: 14px; }
-.wr-focus-chip .wf-t { font-size: 11px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 150px; }
+.wr-focus-chip .wf-t { font-size: 0.6471rem; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 150px; }
 .wr-focus-chip .wf-x { display: inline-flex; align-items: center; border: none; background: none; color: var(--txt-3); cursor: pointer; padding: 0; }
 .wr-focus-chip .wf-x:hover { color: var(--red); } .wr-focus-chip .wf-x svg { width: 12px; height: 12px; }
 .wr-focus-chip .wf-x:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
@@ -1792,7 +1808,7 @@ select.lf-in { appearance: none; cursor: pointer; }
 .chat-drop .cd-inner { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 10px 12px; text-align: center; color: #e7ebf0; transition: color .12s ease; }
 .chat-drop.hot .cd-inner { color: var(--accent, #ff7a1a); }
 .chat-drop .cd-ico { width: 30px; height: 30px; }
-.chat-drop .cd-label { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 13px; font-weight: 800; letter-spacing: 1.3px; text-transform: uppercase; line-height: 1.1; max-width: 140px; }
+.chat-drop .cd-label { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.7647rem; font-weight: 800; letter-spacing: 1.3px; text-transform: uppercase; line-height: 1.1; max-width: 140px; }
 .drag-ghost.chatel-ghost { color: var(--txt); }
 .drag-ghost .dg-dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; background: var(--txt-3); }
 .drag-ghost .dg-dot.c-red { background: var(--red); } .drag-ghost .dg-dot.c-yellow { background: var(--yellow); } .drag-ghost .dg-dot.c-green { background: var(--green); }
@@ -1805,7 +1821,7 @@ select.lf-in { appearance: none; cursor: pointer; }
   background: linear-gradient(180deg,#1b2129,#0c0e11); border: 1px solid var(--line); box-shadow: 0 26px 64px -18px rgba(0,0,0,.72); }
 .wrangler-dock.wr-beside-chat { right: 394px; }
 .wr-dock-head { display: flex; align-items: center; gap: 8px; padding: 10px 12px 10px 14px; border-bottom: 1px solid var(--line); flex: 0 0 auto; background: rgba(0,0,0,.22); }
-.wr-dock-title { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--txt); }
+.wr-dock-title { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.8235rem; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--txt); }
 .wrangler-dock .wr-feed { flex: 1 1 auto; overflow-y: auto; min-height: 80px; }
 .wrangler-dock .wr-compose { flex: 0 0 auto; }
 .wrangler-dock.wr-drag { outline: 2px dashed var(--accent); outline-offset: -4px; }
@@ -1830,7 +1846,7 @@ select.lf-in { appearance: none; cursor: pointer; }
    composer), Developer-tier gated (devUnlocked()). Tokens only, so dark/light/ranch themes
    are free. Reuses .wr-msg/.wr-bub for the transcript pane (same renderer as the dock). */
 .wrops-body { padding: 0; }
-.wrops-empty { color: var(--txt-3); font-size: 13px; text-align: center; padding: 30px 16px; line-height: 1.5; }
+.wrops-empty { color: var(--txt-3); font-size: 0.7647rem; text-align: center; padding: 30px 16px; line-height: 1.5; }
 .wrops-wrap { display: grid; grid-template-columns: 280px 1fr; height: 62vh; min-height: 0; }
 .wrops-list { overflow-y: auto; border-right: 1px solid var(--line); display: flex; flex-direction: column; }
 .wrops-row { display: flex; flex-direction: column; gap: 4px; padding: 10px 13px; border: 0; border-bottom: 1px solid var(--line); background: transparent; text-align: left; cursor: pointer; color: var(--txt); width: 100%; }
@@ -1838,17 +1854,17 @@ select.lf-in { appearance: none; cursor: pointer; }
 .wrops-row.on { background: var(--accent-soft); box-shadow: inset 3px 0 0 var(--accent); }
 .wrops-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .wrops-row-top { display: flex; align-items: center; gap: 7px; min-width: 0; }
-.wrops-row-ttl { font-weight: 600; font-size: 13px; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.wrops-row-role { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 10px; color: var(--txt-3); flex: 0 0 auto; }
-.wrops-row-prev { font-size: 12px; color: var(--txt-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wrops-row-ttl { font-weight: 600; font-size: 0.7647rem; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wrops-row-role { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 0.5882rem; color: var(--txt-3); flex: 0 0 auto; }
+.wrops-row-prev { font-size: 0.7059rem; color: var(--txt-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wrops-row-meta { display: flex; align-items: center; gap: 8px; }
-.wrops-age { font-size: 11px; color: var(--txt-3); margin-left: auto; }
+.wrops-age { font-size: 0.6471rem; color: var(--txt-3); margin-left: auto; }
 .wrops-pane { display: flex; flex-direction: column; min-width: 0; }
 .wrops-detail { display: flex; flex-direction: column; height: 100%; min-height: 0; }
 .wrops-transcript { flex: 1 1 auto; overflow-y: auto; padding: 14px 16px; display: flex; flex-direction: column; gap: 12px; }
 .wrops-driver { display: flex; align-items: center; gap: 8px; padding: 8px 14px; border-top: 1px solid var(--line); }
 .wrops-compose { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--line); }
-.wrops-in { flex: 1 1 auto; height: 38px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); padding: 0 12px; font-size: 13.5px; }
+.wrops-in { flex: 1 1 auto; height: 38px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); padding: 0 12px; font-size: 0.7941rem; }
 .wrops-in:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 @media (max-width: 700px) { .wrops-popup { width: 94vw !important; } .wrops-wrap { grid-template-columns: 1fr; height: 70vh; } .wrops-list { max-height: 38%; border-right: 0; border-bottom: 1px solid var(--line); } }
 
@@ -1873,28 +1889,28 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .mixseg:first-child { border-radius: 7px 0 0 7px; } .mixseg:last-child { border-radius: 0 7px 7px 0; }
 .mixseg:hover { filter: brightness(1.18); }
 .mixseg.on { box-shadow: inset 0 0 0 2px rgba(255,255,255,.55); }
-.mixseg-lbl { font-size: 10px; font-weight: 800; white-space: nowrap; padding: 0 5px; text-shadow: 0 1px 2px rgba(0,0,0,.45); }
+.mixseg-lbl { font-size: 0.5882rem; font-weight: 800; white-space: nowrap; padding: 0 5px; text-shadow: 0 1px 2px rgba(0,0,0,.45); }
 
 /* §12.2 rental status bar (window timeline) */
 .statusbar { position: relative; height: 46px; border-radius: 12px; overflow: hidden; border: 1px solid var(--line); cursor: pointer; }
 /* §12.2 rental-window picker — a trigger bar that opens a single calendar popup */
 .statusbar.draftwin.wintrigger { width: 100%; box-sizing: border-box; height: 46px; cursor: pointer; padding: 0 12px; display: flex; align-items: center; justify-content: space-between; gap: 10px; background: var(--panel); border-style: dashed; border-color: var(--accent-line); color: var(--accent); }
-.statusbar.draftwin.wintrigger .wt-label { flex: 1; text-align: center; font-size: 13px; font-weight: 700; }
+.statusbar.draftwin.wintrigger .wt-label { flex: 1; text-align: center; font-size: 0.7647rem; font-weight: 700; }
 .statusbar.draftwin.wintrigger:hover { background: var(--accent-soft); }
 .statusbar.js-open-winpicker { cursor: pointer; }
 .winpicker-float, .datesearch-float { position: fixed; z-index: 60; width: 300px; }
 .winpicker { border: 1px solid var(--accent); border-radius: 12px; background: var(--panel); padding: 10px; box-shadow: 0 22px 48px -18px rgba(0,0,0,.7), 0 0 0 2px var(--accent-line), 0 0 26px -4px rgba(255,122,26,.5); }
 .winpicker .wp-time { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 9px; padding-bottom: 9px; border-bottom: 1px solid var(--line-soft); }
-.winpicker .wp-time label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); }
-.winpicker .wp-time input[type="time"] { height: 30px; border-radius: 8px; border: 1px solid #fff; background: #fff; color: #16181d; font: inherit; font-size: 13px; padding: 0 8px; color-scheme: light; }   /* rule 16: required input = white until entered */
+.winpicker .wp-time label { font-size: 0.5882rem; font-weight: 800; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); }
+.winpicker .wp-time input[type="time"] { height: 30px; border-radius: 8px; border: 1px solid #fff; background: #fff; color: #16181d; font: inherit; font-size: 0.7647rem; padding: 0 8px; color-scheme: light; }   /* rule 16: required input = white until entered */
 .winpicker .wp-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 7px; }
-.winpicker .wp-month { font-size: 13px; font-weight: 800; }
+.winpicker .wp-month { font-size: 0.7647rem; font-weight: 800; }
 .winpicker .wp-nav { display: flex; gap: 4px; }
-.winpicker .wp-nav button { width: 26px; height: 26px; border-radius: 7px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); font-size: 15px; line-height: 1; cursor: pointer; }
+.winpicker .wp-nav button { width: 26px; height: 26px; border-radius: 7px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); font-size: 0.8824rem; line-height: 1; cursor: pointer; }
 .winpicker .wp-nav button:hover { border-color: var(--accent-line); color: var(--accent); }
 .winpicker .wp-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
-.winpicker .wp-dow { font-size: 10px; font-weight: 700; color: var(--txt-3); text-align: center; padding: 3px 0; }
-.winpicker .wp-day { height: 30px; border: none; background: transparent; color: var(--txt); font: inherit; font-size: 12px; border-radius: 7px; cursor: pointer; }
+.winpicker .wp-dow { font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); text-align: center; padding: 3px 0; }
+.winpicker .wp-day { height: 30px; border: none; background: transparent; color: var(--txt); font: inherit; font-size: 0.7059rem; border-radius: 7px; cursor: pointer; }
 .winpicker .wp-day:hover { background: var(--bg-2); }
 .winpicker .wp-day.empty { visibility: hidden; cursor: default; }
 .winpicker .wp-day.wp-blocked { color: var(--txt-3); opacity: .4; text-decoration: line-through; cursor: not-allowed; }
@@ -1902,7 +1918,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 /* overbooking allowed → the blocked day is still flagged (greyed/struck) but selectable */
 .winpicker .wp-day.wp-blocked.wp-soft { opacity: .6; cursor: pointer; }
 .winpicker .wp-day.wp-blocked.wp-soft:hover { background: var(--red-bg); }
-.winpicker .wp-blocknote { font-size: 10.5px; color: var(--txt-3); text-align: center; margin: 6px 2px 0; }
+.winpicker .wp-blocknote { font-size: 0.6176rem; color: var(--txt-3); text-align: center; margin: 6px 2px 0; }
 .winpicker .wp-day.today { box-shadow: inset 0 0 0 1px var(--accent-line); }
 .winpicker .wp-day.in-range { background: var(--accent-soft); border-radius: 0; }
 .winpicker .wp-day.range-start { background: var(--accent); color: #fff; border-radius: 7px 0 0 7px; }
@@ -1923,7 +1939,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
   background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid var(--accent); border-radius: 12px;
   box-shadow: inset 0 0 0 1px var(--accent-line); padding: 10px 11px; }
 @media (prefers-reduced-motion: no-preference) { .wp-confirm { animation: plateIn .15s ease-out; } }
-.wp-confirm-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 11px; color: var(--txt); margin-bottom: 6px; }
+.wp-confirm-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 0.6471rem; color: var(--txt); margin-bottom: 6px; }
 .wp-confirm .wp-ext { margin-top: 0; padding-top: 0; border-top: none; }
 .wp-confirm-foot { display: flex; gap: 7px; justify-content: flex-end; margin-top: 9px; }
 /* §ext — extension preview plate: shown when a lengthened fragile-rental window adds a
@@ -1931,21 +1947,21 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
    "rebill" readout; the new balance owed reads in the app's danger-red balance color. */
 .winpicker .wp-ext { margin-top: 9px; padding-top: 9px; border-top: 1px dashed color-mix(in srgb, var(--tan, #c2925a) 60%, transparent); display: flex; flex-direction: column; gap: 3px; }
 .winpicker .wp-ext-cap { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 2px; }
-.winpicker .wp-ext-kick { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 10px; color: var(--tan, #c2925a); }
-.winpicker .wp-ext-days { font-size: 11px; font-weight: 700; color: var(--txt-2); }
-.winpicker .wp-ext-row { display: flex; align-items: center; justify-content: space-between; font-size: 12px; color: var(--txt-2); }
+.winpicker .wp-ext-kick { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 0.5882rem; color: var(--tan, #c2925a); }
+.winpicker .wp-ext-days { font-size: 0.6471rem; font-weight: 700; color: var(--txt-2); }
+.winpicker .wp-ext-row { display: flex; align-items: center; justify-content: space-between; font-size: 0.7059rem; color: var(--txt-2); }
 .winpicker .wp-ext-row b { color: var(--txt); font-weight: 700; }
-.winpicker .wp-ext-row.wp-ext-bal { margin-top: 2px; padding-top: 4px; border-top: 1px solid var(--line-soft); font-size: 12.5px; }
+.winpicker .wp-ext-row.wp-ext-bal { margin-top: 2px; padding-top: 4px; border-top: 1px solid var(--line-soft); font-size: 0.7353rem; }
 .winpicker .wp-ext-row.wp-ext-bal b { color: var(--red); }
-.winpicker .wp-ext-basis { font-size: 10px; color: var(--txt-3); margin-top: 3px; font-style: italic; }
+.winpicker .wp-ext-basis { font-size: 0.5882rem; color: var(--txt-3); margin-top: 3px; font-style: italic; }
 .winpicker .wp-ext.wp-ext-down .wp-ext-kick { color: var(--green); }   /* a reduction is good news */
 .winpicker .wp-ext.wp-ext-down .wp-ext-row:first-of-type b { color: var(--green); }
 /* §5.4d — DATE SEARCH picker: reuses the winpicker shell; a stamped kicker + a live
    selection readout sit above the grid. The date chips it pins carry a tan saddle-
    stitch underline so they read as editable (click re-opens the picker). */
 .winpicker.datesearch .ds-cap { display: flex; flex-direction: column; gap: 1px; margin-bottom: 8px; padding-bottom: 8px; border-bottom: 1px solid var(--line-soft); }
-.winpicker.datesearch .ds-kicker { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
-.winpicker.datesearch .ds-sel { font-size: 13px; font-weight: 700; color: var(--txt); }
+.winpicker.datesearch .ds-kicker { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); }
+.winpicker.datesearch .ds-sel { font-size: 0.7647rem; font-weight: 700; color: var(--txt); }
 .filt-term.is-date .lbl { border-bottom: 1px dashed color-mix(in srgb, var(--tan, #c2925a) 65%, transparent); padding-bottom: 1px; }
 /* (Wave 2) pickbar + pick-target CSS removed with pick mode */
 
@@ -1953,11 +1969,11 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 /* inline add-line / add-part forms (replace OS prompts) */
 .lineform { margin-top: 8px; display: flex; flex-direction: column; gap: 7px; padding: 9px; border: 1px solid var(--accent-line); border-radius: 10px; background: var(--accent-soft); }
 .lineform-row { display: flex; gap: 7px; }
-.lineform .lf-in { width: 100%; height: 32px; border-radius: 8px; border: 1px solid var(--line); background: var(--panel); color: var(--txt); font: inherit; font-size: 12px; padding: 0 9px; }
+.lineform .lf-in { width: 100%; height: 32px; border-radius: 8px; border: 1px solid var(--line); background: var(--panel); color: var(--txt); font: inherit; font-size: 0.7059rem; padding: 0 9px; }
 .lineform .lf-in:focus { outline: none; border-color: var(--accent-line); }
 /* §7.11 — the partform/receiptform popups + the in-detail part-link row use bare .lf-in
    inputs/selects (no .lineform wrapper): give them the same chrome. */
-.popup .lf-in { height: 32px; border-radius: 8px; border: 1px solid var(--line); background: var(--panel); color: var(--txt); font: inherit; font-size: 12px; padding: 0 9px; }
+.popup .lf-in { height: 32px; border-radius: 8px; border: 1px solid var(--line); background: var(--panel); color: var(--txt); font: inherit; font-size: 0.7059rem; padding: 0 9px; }
 .popup .lf-in:focus { outline: none; border-color: var(--accent-line); }
 .lineform .pill { cursor: pointer; }
 /* Merge/fold picker (#482): the actions column is flex-shrink:0, so the long
@@ -1968,14 +1984,14 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 
 /* §0.6 History section — dotted separator + background shift, pinned bottom */
 .history { border-top: 2px dotted var(--line); background: var(--bg-2); border-radius: 0 0 12px 12px; padding: 12px; }
-.history > h4 { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 8px; display: flex; align-items: center; gap: 6px; }
-.history .js-history-search { width: 100%; height: 32px; margin-bottom: 8px; padding: 0 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 12px; box-shadow: var(--chip-shadow); }
+.history > h4 { font-size: 0.6471rem; font-weight: 700; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 8px; display: flex; align-items: center; gap: 6px; }
+.history .js-history-search { width: 100%; height: 32px; margin-bottom: 8px; padding: 0 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 0.7059rem; box-shadow: var(--chip-shadow); }
 .history .js-history-search:focus { outline: none; border-color: var(--accent-line); }
 .hlog { display: flex; flex-direction: column; gap: 6px; }
-.hitem { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--txt-2); flex-wrap: wrap; }
-.hitem .htime { color: var(--txt-3); font-size: 11px; min-width: 92px; flex: 0 0 auto; }
-.hitem .hby { margin-left: auto; flex: 0 0 auto; font-size: 10px; font-weight: 700; color: var(--txt-3); background: var(--panel-2); border: 1px solid var(--line); border-radius: 999px; padding: 1px 7px; }
-.hitem .line-x { cursor: pointer; opacity: .45; font-weight: 800; font-size: 11px; margin-left: 4px; flex: 0 0 auto; }
+.hitem { display: flex; align-items: center; gap: 8px; font-size: 0.7059rem; color: var(--txt-2); flex-wrap: wrap; }
+.hitem .htime { color: var(--txt-3); font-size: 0.6471rem; min-width: 92px; flex: 0 0 auto; }
+.hitem .hby { margin-left: auto; flex: 0 0 auto; font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); background: var(--panel-2); border: 1px solid var(--line); border-radius: 999px; padding: 1px 7px; }
+.hitem .line-x { cursor: pointer; opacity: .45; font-weight: 800; font-size: 0.6471rem; margin-left: 4px; flex: 0 0 auto; }
 .hitem .line-x:hover { opacity: 1; color: var(--red); }
 
 /* ── Popups / sheetpops (§0.5, §6.2 #14) ─────────────────────────────────── */
@@ -1991,7 +2007,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .overlay .popup.is-dragging { cursor: grabbing; user-select: none; }
 .overlay .popup.is-dragging .popup-head { cursor: grabbing; }
 .is-phone .overlay .popup-head { cursor: default; touch-action: auto; }
-.popup-head h3 { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 800; font-size: 16px; color: var(--txt); line-height: 1.05; }
+.popup-head h3 { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 800; font-size: 0.9412rem; color: var(--txt); line-height: 1.05; }
 .popup-head .x { margin-left: auto; width: 30px; height: 30px; flex: 0 0 auto; border-radius: 9px; display: inline-flex; align-items: center; justify-content: center; color: var(--txt-2); }
 .popup-head .x:hover { background: var(--panel-2); color: var(--txt); }
 .popup-body { padding: 16px; overflow: auto; }
@@ -2007,7 +2023,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
   color: var(--on-orange); background: linear-gradient(180deg, #ff9038, var(--accent)); box-shadow: inset 0 1px 0 rgba(255,255,255,.4); }   /* the ignition chip */
 .pl-ic svg { width: 17px; height: 17px; }
 .pl-title { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-.pl-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 600; font-size: 9.5px; color: var(--txt-3); }
+.pl-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 600; font-size: 0.5588rem; color: var(--txt-3); }
 .popup-foot { display: flex; align-items: center; justify-content: flex-end; gap: 9px; flex: 0 0 auto; padding: 11px 16px; border-top: 1px solid var(--line); background: var(--bg-2); }
 .pill.ignition { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; color: var(--on-orange); border-color: transparent;   /* the plate's ONE ignition/primary action (rule 3) */
   background: linear-gradient(180deg, #ff9038, var(--accent)); box-shadow: 0 6px 16px -6px var(--accent), inset 0 1px 0 rgba(255,255,255,.4); }
@@ -2017,7 +2033,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 
 /* back-office board popups (§0.4 / §7.9–7.12) — simple spreadsheet */
 .board-popup { width: 86vw; height: 80vh; }
-.board-popup .popup-head .c-count { font-size: 11px; font-weight: 700; color: var(--txt-3); background: var(--panel-2); padding: 1px 8px; border-radius: 999px; }
+.board-popup .popup-head .c-count { font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); background: var(--panel-2); padding: 1px 8px; border-radius: 999px; }
 /* ── Tier 2 WORK SURFACE (board / boardview) — riveted header rail + 2px orange baseline,
    NO hazard cap: calmer than a dialog because you work IN these, not dismiss them ── */
 .board-popup { border-color: var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.45); }
@@ -2036,13 +2052,13 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .set-loading-bar { width: 220px; height: 8px; border-radius: 99px; overflow: hidden; border: 1px solid var(--line);
   background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 13px, #14181d 13px 26px);
   background-size: 200% 100%; animation: setLoadScan 1.1s linear infinite; }
-.set-loading-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 13px; color: var(--txt-3); }
+.set-loading-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 700; font-size: 0.7647rem; color: var(--txt-3); }
 @keyframes setLoadScan { to { background-position: 200% 0; } }
 @media (prefers-reduced-motion: reduce) { .set-loading-bar { animation: none; } }
 .set-board { display: flex; width: 100%; min-height: 440px; max-height: calc(90vh - 122px); }
 .set-rail { flex: 0 0 188px; display: flex; flex-direction: column; padding: 8px 0; gap: 1px; overflow: auto; background: linear-gradient(180deg, var(--panel-2), var(--panel)); border-right: 1px solid var(--line); }
 .set-tab { display: flex; align-items: center; gap: 9px; width: 100%; padding: 9px 13px; border: 0; border-left: 2px solid transparent; background: transparent; color: var(--txt-2); cursor: pointer; text-align: left; font: inherit; }
-.set-tab-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 12.5px; }
+.set-tab-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 0.7353rem; }
 .set-tab-ic { display: inline-flex; color: var(--txt-3); } .set-tab-ic svg { width: 16px; height: 16px; }
 .set-tab:hover { color: var(--txt); background: var(--accent-soft); }
 .set-tab:hover .set-tab-ic { color: var(--txt-2); }
@@ -2053,20 +2069,20 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .set-tab-dot { margin-left: auto; flex: 0 0 auto; width: 6px; height: 6px; border-radius: 50%; background: var(--tan, #c2925a); box-shadow: 0 0 0 2px var(--panel); }
 .set-pane { flex: 1; min-width: 0; overflow: auto; padding: 16px 18px; }
 .set-pane-head { margin-bottom: 14px; }
-.set-pane-head h4 { margin: 0 0 4px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 15px; color: var(--txt); }
-.set-pane-head p { margin: 0; font-size: 12px; line-height: 1.5; color: var(--txt-2); max-width: 52ch; }
+.set-pane-head h4 { margin: 0 0 4px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 0.8824rem; color: var(--txt); }
+.set-pane-head p { margin: 0; font-size: 0.7059rem; line-height: 1.5; color: var(--txt-2); max-width: 52ch; }
 .set-pane-head em { font-style: normal; font-family: ui-monospace, monospace; color: var(--txt); }
-.set-note { font-size: 10.5px; color: var(--txt-3); margin: 4px 0 0; }
+.set-note { font-size: 0.6176rem; color: var(--txt-3); margin: 4px 0 0; }
 /* Membership pricing group — saddle-stitch divider (ranch seasoning) sets it apart;
    dollar fields grid two-up to keep the Company pane compact. */
 .co-memprice { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 12px; margin-top: 14px; padding-top: 12px; border-top: 1.5px dashed var(--tan, #c2925a); }
 .co-memprice > .kpi-cap { grid-column: 1 / -1; letter-spacing: 2px; }
 /* F7 — membership economics: derived stat rows under a saddle-stitch divider (ranch seasoning). */
 .mem-econ { width: 100%; margin-top: 8px; padding-top: 8px; border-top: 1.5px dashed var(--tan, #c2925a); display: flex; flex-direction: column; gap: 2px; }
-.set-err { align-self: center; color: var(--red); font-size: 12px; font-weight: 600; margin-right: 4px; }
+.set-err { align-self: center; color: var(--red); font-size: 0.7059rem; font-weight: 600; margin-right: 4px; }
 /* Roles & Logins — passwords masked by default; this toggles reveal (stamped, not a native control). */
 .set-reveal-row { display: flex; justify-content: flex-end; margin: -2px 0 8px; }
-.set-reveal { display: inline-flex; align-items: center; gap: 5px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-size: 10px; font-weight: 700; color: var(--txt-3); background: none; border: 1px solid var(--line); border-radius: 8px; padding: 4px 9px; cursor: pointer; transition: color .12s, border-color .12s; }
+.set-reveal { display: inline-flex; align-items: center; gap: 5px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); background: none; border: 1px solid var(--line); border-radius: 8px; padding: 4px 9px; cursor: pointer; transition: color .12s, border-color .12s; }
 .set-reveal:hover { color: var(--txt); border-color: var(--accent-line); }
 .set-reveal:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .set-reveal svg { width: 13px; height: 13px; }
@@ -2076,7 +2092,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 
 /* Statuses & Icons tab */
 .set-picker { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
-.set-pick { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 11px; font-weight: 700; color: var(--txt-3); background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 5px 11px; cursor: pointer; }
+.set-pick { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 5px 11px; cursor: pointer; }
 .set-pick:hover { color: var(--txt-2); border-color: var(--accent-line); }
 .set-pick.on { color: var(--on-orange); background: var(--accent); border-color: var(--accent); }
 .set-pick:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -2085,10 +2101,10 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .so-row.tray-open { border-color: var(--accent-line); }
 .so-prev { flex: 0 0 auto; min-width: 116px; }
 .so-lbl-wrap { display: flex; flex-direction: column; gap: 2px; flex: 1 1 116px; min-width: 104px; cursor: text; }
-.so-lbl-cap { font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: 1px; font-size: 8.5px; font-weight: 700; color: var(--txt-3); }
-.so-lbl { height: 28px; padding: 0 8px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); font-size: 12.5px; font-weight: 600; min-width: 0; }
+.so-lbl-cap { font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: 1px; font-size: 0.5rem; font-weight: 700; color: var(--txt-3); }
+.so-lbl { height: 28px; padding: 0 8px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); font-size: 0.7353rem; font-weight: 600; min-width: 0; }
 .so-lbl:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
-.so-val { display: inline-flex; align-items: center; gap: 4px; font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--txt-3); background: var(--bg-2); border: 1px dashed var(--line); border-radius: 7px; padding: 3px 7px; white-space: nowrap; }
+.so-val { display: inline-flex; align-items: center; gap: 4px; font-family: ui-monospace, monospace; font-size: 0.6176rem; color: var(--txt-3); background: var(--bg-2); border: 1px dashed var(--line); border-radius: 7px; padding: 3px 7px; white-space: nowrap; }
 .so-val svg { width: 11px; height: 11px; opacity: .8; }
 .so-sws { display: flex; flex-wrap: wrap; gap: 4px; }
 .so-sw { width: 19px; height: 19px; border-radius: 5px; border: 1px solid rgba(0,0,0,.45); cursor: pointer; padding: 0; }
@@ -2110,38 +2126,38 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .so-ic-opt:hover { border-color: var(--accent-line); color: var(--txt); }
 .so-ic-opt.on { color: var(--accent); border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
 .so-ic-opt:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.so-ic-def { position: absolute; bottom: -1px; right: -1px; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 6px; font-weight: 800; letter-spacing: .3px; color: var(--txt-3); background: var(--panel); padding: 0 1px; border-radius: 2px; }
+.so-ic-def { position: absolute; bottom: -1px; right: -1px; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.3529rem; font-weight: 800; letter-spacing: .3px; color: var(--txt-3); background: var(--panel); padding: 0 1px; border-radius: 2px; }
 
 /* Planned-tab stub */
 .set-planned { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 8px; padding: 36px 22px; max-width: 44ch; margin: 0 auto; }
 .set-planned-ic { display: inline-flex; color: var(--txt-3); opacity: .7; } .set-planned-ic svg { width: 34px; height: 34px; }
-.set-planned h4 { margin: 4px 0 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 16px; color: var(--txt); }
-.set-planned-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 9.5px; font-weight: 700; color: var(--tan, #c2925a); border: 1px dashed var(--tan, #c2925a); border-radius: 999px; padding: 2px 9px; }
-.set-planned p { margin: 0; font-size: 12.5px; line-height: 1.55; color: var(--txt-2); }
-.set-planned p.set-planned-sub { color: var(--txt-3); font-size: 11px; }   /* #552 audit item 21: scoped to beat .set-planned p's specificity, no !important needed */
+.set-planned h4 { margin: 4px 0 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 0.9412rem; color: var(--txt); }
+.set-planned-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 0.5588rem; font-weight: 700; color: var(--tan, #c2925a); border: 1px dashed var(--tan, #c2925a); border-radius: 999px; padding: 2px 9px; }
+.set-planned p { margin: 0; font-size: 0.7353rem; line-height: 1.55; color: var(--txt-2); }
+.set-planned p.set-planned-sub { color: var(--txt-3); font-size: 0.6471rem; }   /* #552 audit item 21: scoped to beat .set-planned p's specificity, no !important needed */
 
 /* KPIs & Rings tab */
 .kpi-board { display: flex; gap: 16px; align-items: flex-start; }
 .kpi-rows { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 8px; }
 .kpi-row { display: flex; align-items: center; gap: 11px; padding: 9px 11px; background: var(--panel); border: 1px solid var(--line); border-radius: 11px; }
-.kpi-slot { flex: 0 0 auto; writing-mode: vertical-rl; transform: rotate(180deg); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 9px; font-weight: 800; color: var(--txt-3); }
+.kpi-slot { flex: 0 0 auto; writing-mode: vertical-rl; transform: rotate(180deg); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 0.5294rem; font-weight: 800; color: var(--txt-3); }
 .kpi-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
-.kpi-cap { font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: 1px; font-size: 8.5px; font-weight: 700; color: var(--txt-3); }
+.kpi-cap { font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: 1px; font-size: 0.5rem; font-weight: 700; color: var(--txt-3); }
 .kpi-fld { display: flex; flex-direction: column; gap: 2px; }
-.kpi-lbl, .kpi-tgt { height: 28px; padding: 0 8px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); font-size: 12.5px; font-weight: 600; min-width: 0; }
+.kpi-lbl, .kpi-tgt { height: 28px; padding: 0 8px; border-radius: 8px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); font-size: 0.7353rem; font-weight: 600; min-width: 0; }
 .kpi-lbl:focus, .kpi-tgt:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
 .kpi-measure { display: flex; flex-direction: column; gap: 2px; }
-.kpi-measure-t { font-family: ui-monospace, monospace; font-size: 11px; line-height: 1.4; color: var(--txt-2); }
+.kpi-measure-t { font-family: ui-monospace, monospace; font-size: 0.6471rem; line-height: 1.4; color: var(--txt-2); }
 .kpi-measure-t.dsl { color: var(--accent); }
 .kpi-tune { display: flex; gap: 12px; align-items: flex-end; }
 .kpi-fld-sm { flex: 0 0 auto; } .kpi-fld-sm .kpi-tgt { width: 92px; }
 .kpi-val { flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; min-width: 48px; }
-.kpi-val-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 22px; font-weight: 800; line-height: 1; color: var(--txt); }
-.kpi-val-c { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 8px; font-weight: 700; color: var(--txt-3); margin-top: 2px; }
+.kpi-val-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 1.2941rem; font-weight: 800; line-height: 1; color: var(--txt); }
+.kpi-val-c { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 0.4706rem; font-weight: 700; color: var(--txt-3); margin-top: 2px; }
 .kpi-row .js-kpi-refine { flex: 0 0 auto; white-space: nowrap; }
 .kpi-preview { flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 14px 10px 4px; align-self: stretch; }
-.kpi-preview-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 9.5px; font-weight: 700; color: var(--txt-3); }
-.wr-kpi-readback { font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--txt-3); margin: 3px 0 6px; line-height: 1.4; }
+.kpi-preview-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 0.5588rem; font-weight: 700; color: var(--txt-3); }
+.wr-kpi-readback { font-family: ui-monospace, monospace; font-size: 0.6176rem; color: var(--txt-3); margin: 3px 0 6px; line-height: 1.4; }
 /* Settings → Notifications (Phase A control center, spec 2026-07-14) — six stamped
    steel cards; reuses .set-rolecard's panel recipe + .rm-stitch (saddle-stitch, tan) row
    dividers + .kpi-fld/.kpi-cap/.kpi-tgt for numeric + hour-select fields (already themed,
@@ -2153,7 +2169,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .notif-card-body { padding: 3px 14px 13px; display: flex; flex-direction: column; gap: 9px; }
 /* Section header = the collapse control (a full-width button). Collapsed by default so the
    tall pane opens compact; the chevron flips up when the section is open. */
-.notif-card-head { width: 100%; display: flex; align-items: center; gap: 8px; padding: 11px 14px; background: transparent; border: none; cursor: pointer; text-align: left; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12.5px; color: var(--txt); }
+.notif-card-head { width: 100%; display: flex; align-items: center; gap: 8px; padding: 11px 14px; background: transparent; border: none; cursor: pointer; text-align: left; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 0.7353rem; color: var(--txt); }
 .notif-card-head:hover { background: var(--panel); }
 .notif-card-head:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .notif-card-head .nch-t { flex: 1 1 auto; }
@@ -2165,7 +2181,7 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 @media (prefers-reduced-motion: reduce) { .notif-card-head .nch-chev svg { transition: none; } }
 /* ── Return-rating popup — customer-experience stars + tiered follow-ups (2026-07-15) ── */
 .rr-body { display: flex; flex-direction: column; gap: 12px; }
-.rr-intro { font-size: 12.5px; line-height: 1.5; color: var(--txt-2); }
+.rr-intro { font-size: 0.7353rem; line-height: 1.5; color: var(--txt-2); }
 .rr-intro b { color: var(--txt); }
 .rr-stars { display: flex; justify-content: center; gap: 9px; padding: 3px 0 1px; }
 .rr-star { background: none; border: none; cursor: pointer; padding: 4px; line-height: 0; border-radius: 9px; }
@@ -2174,87 +2190,87 @@ select.inline-input:focus-visible { outline: 2px solid var(--accent); outline-of
 .rr-star.on svg { fill: var(--accent); stroke: var(--accent); }
 .rr-star:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) { .rr-star svg { transition: none; } }
-.rr-band { text-align: center; font-size: 12px; font-weight: 600; padding: 7px 10px; border-radius: 10px; line-height: 1.35; }
+.rr-band { text-align: center; font-size: 0.7059rem; font-weight: 600; padding: 7px 10px; border-radius: 10px; line-height: 1.35; }
 .rr-band-none { color: var(--txt-3); font-weight: 500; }
 .rr-band-good { color: var(--green); background: var(--green-bg); }
 .rr-band-mid { color: var(--yellow); background: var(--yellow-bg); }
 .rr-band-low { color: var(--red); background: var(--red-bg); }
 .rr-actions { border: 1px solid var(--line); border-radius: 12px; padding: 10px 12px; display: flex; flex-direction: column; gap: 10px; background: var(--panel-2); }
-.rr-actions-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
+.rr-actions-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); }
 .rr-action { display: flex; align-items: center; gap: 9px; }
 .rr-action-ic { display: inline-flex; flex: 0 0 auto; }
 .rr-action-ic svg { width: 16px; height: 16px; color: var(--txt-2); }
-.rr-action-desc { flex: 1 1 auto; font-size: 12.5px; color: var(--txt); }
+.rr-action-desc { flex: 1 1 auto; font-size: 0.7353rem; color: var(--txt); }
 .rr-action.is-skip .rr-action-desc { color: var(--txt-3); text-decoration: line-through; }
 .rr-action.is-skip .rr-action-ic svg { color: var(--txt-3); }
 .rr-note { width: 100%; margin-top: -2px; }
-.rr-req-note { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--txt-3); }
+.rr-req-note { display: inline-flex; align-items: center; gap: 5px; font-size: 0.6471rem; color: var(--txt-3); }
 .rr-req-note svg { width: 12px; height: 12px; }
 /* Editable rating-message templates in Settings → Notifications → Rating Follow-ups */
-.notif-fld-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 10px; color: var(--txt-3); margin-top: 2px; }
+.notif-fld-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); margin-top: 2px; }
 .notif-msg { width: 100%; resize: vertical; }
 .notif-row { display: flex; align-items: center; gap: 10px; }
-.notif-row .notif-label { flex: 1 1 auto; min-width: 110px; font-size: 12.5px; font-weight: 600; color: var(--txt); }
-.notif-sub { font-size: 11px; line-height: 1.4; color: var(--txt-3); }
-.notif-cadence { font-size: 11px; font-style: italic; color: var(--txt-3); margin-top: -3px; }   /* R8 idiom — italic = a computed readback, not typed */
+.notif-row .notif-label { flex: 1 1 auto; min-width: 110px; font-size: 0.7353rem; font-weight: 600; color: var(--txt); }
+.notif-sub { font-size: 0.6471rem; line-height: 1.4; color: var(--txt-3); }
+.notif-cadence { font-size: 0.6471rem; font-style: italic; color: var(--txt-3); margin-top: -3px; }   /* R8 idiom — italic = a computed readback, not typed */
 .notif-card .rm-stitch { margin: 9px 0; }   /* tighten the saddle-stitch to this card's row rhythm (row pad 9–11) */
 body.is-phone .notif-row { flex-wrap: wrap; }
 /* ── "Text The Crew" broadcast composer (Phase C) ─────────────────────────────
    A manager+ modal: role-grouped roster picker (reuses the team-chat .rtab chips) +
    message box + per-recipient send results. Steel data-plate, no new signature beat —
    the ignition Send in the foot is the one orange note. */
-.cb-intro { font-size: 12px; line-height: 1.45; color: var(--txt-2); margin-bottom: 4px; }
+.cb-intro { font-size: 0.7059rem; line-height: 1.45; color: var(--txt-2); margin-bottom: 4px; }
 .cb-sec-head { display: flex; align-items: baseline; gap: 8px; margin: 4px 0 2px; }
-.cb-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 10.5px; color: var(--txt-3); }
-.cb-count { font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .6px; font-size: 11px; font-weight: 700; color: var(--txt-2); }
+.cb-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 0.6176rem; color: var(--txt-3); }
+.cb-count { font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .6px; font-size: 0.6471rem; font-weight: 700; color: var(--txt-2); }
 .cb-sec-head .spacer { flex: 1; }
 .cb-roster { background: var(--bg-2); border: 1px solid var(--line); border-radius: var(--chip-radius, 12px); max-height: 210px; overflow: auto; }
 .cb-roster .rtab.is-off { opacity: .6; cursor: default; }
 .cb-roster .rtab.is-off:hover { background: none; }
-.cb-off { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; font-size: 9px; font-weight: 700; color: var(--yellow); margin-left: 3px; }
+.cb-off { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; font-size: 0.5294rem; font-weight: 700; color: var(--yellow); margin-left: 3px; }
 .cb-msg { width: 100%; }
 .cb-meta { display: flex; align-items: baseline; gap: 10px; margin-top: 5px; }
-.cb-meta .cb-win { flex: 1; text-align: right; font-size: 10.5px; font-style: italic; color: var(--txt-3); }
+.cb-meta .cb-win { flex: 1; text-align: right; font-size: 0.6176rem; font-style: italic; color: var(--txt-3); }
 .cb-ovr { margin-top: 9px; }
 .cb-results { margin-top: 11px; display: flex; flex-direction: column; gap: 4px; background: var(--bg-2); border: 1px solid var(--line); border-radius: var(--chip-radius, 12px); padding: 8px 10px; }
-.cb-res-row { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.cb-res-row { display: flex; align-items: center; gap: 8px; font-size: 0.7059rem; }
 .cb-res-ic { display: inline-flex; flex: 0 0 auto; }
 .cb-res-ic svg { width: 14px; height: 14px; }
 .cb-res-row.ok .cb-res-ic { color: var(--green); }
 .cb-res-row.bad .cb-res-ic { color: var(--red); }
 .cb-res-nm { flex: 1; min-width: 0; font-weight: 600; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cb-res-meta { flex: 0 0 auto; font-size: 11px; color: var(--txt-3); }
-.cb-empty { font-size: 12px; line-height: 1.5; color: var(--txt-3); background: var(--bg-2); border: 1px dashed var(--line); border-radius: var(--chip-radius, 12px); padding: 14px 15px; text-align: center; }
+.cb-res-meta { flex: 0 0 auto; font-size: 0.6471rem; color: var(--txt-3); }
+.cb-empty { font-size: 0.7059rem; line-height: 1.5; color: var(--txt-3); background: var(--bg-2); border: 1px dashed var(--line); border-radius: var(--chip-radius, 12px); padding: 14px 15px; text-align: center; }
 /* Company tab */
 .co-form { display: flex; flex-direction: column; gap: 12px; max-width: 440px; }
 .co-fld { display: flex; flex-direction: column; gap: 3px; }
-.co-in { height: 34px; padding: 0 11px; border-radius: 9px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); font-size: 13.5px; font-weight: 600; }
+.co-in { height: 34px; padding: 0 11px; border-radius: 9px; background: var(--bg-2); border: 1px solid var(--line); color: var(--txt); font-size: 0.7941rem; font-weight: 600; }
 .co-in:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
 .co-in-area { height: auto; min-height: 168px; padding: 10px 11px; line-height: 1.5; font-weight: 500; font-family: 'Geist', system-ui, sans-serif; resize: vertical; white-space: pre-wrap; }
 .co-goal-wrap { display: flex; align-items: center; gap: 0; background: var(--bg-2); border: 1px solid var(--line); border-radius: 9px; padding-left: 11px; }
 .co-goal-wrap:focus-within { border-color: var(--accent-line); box-shadow: 0 0 0 3px var(--accent-soft); }
-.co-goal-$ { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; color: var(--txt-3); font-size: 15px; }
-.co-in-num { background: transparent; border: 0; box-shadow: none; flex: 1; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 18px; font-weight: 700; letter-spacing: .5px; }
+.co-goal-$ { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; color: var(--txt-3); font-size: 0.8824rem; }
+.co-in-num { background: transparent; border: 0; box-shadow: none; flex: 1; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 1.0588rem; font-weight: 700; letter-spacing: .5px; }
 .co-in-num:focus { box-shadow: none; outline: none; }
-.co-goal-suffix { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; color: var(--txt-3); font-size: 13px; padding-right: 11px; text-transform: uppercase; letter-spacing: 1px; }
-.nc-hint { font-size: 10px; color: var(--txt-3); margin-top: 3px; }
+.co-goal-suffix { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; color: var(--txt-3); font-size: 0.7647rem; padding-right: 11px; text-transform: uppercase; letter-spacing: 1px; }
+.nc-hint { font-size: 0.5882rem; color: var(--txt-3); margin-top: 3px; }
 .co-preview { display: flex; flex-direction: column; gap: 5px; margin-top: 4px; }
 .co-receipt { background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px; text-align: center; }
-.co-receipt-brand { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 18px; color: var(--txt); }
-.co-receipt-sub { font-size: 11px; color: var(--txt-2); margin-top: 2px; }
+.co-receipt-brand { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 1.0588rem; color: var(--txt); }
+.co-receipt-sub { font-size: 0.6471rem; color: var(--txt-2); margin-top: 2px; }
 /* Rental Rules tab */
 .rule-list { display: flex; flex-direction: column; gap: 8px; }
 .rule-row { display: flex; align-items: center; gap: 12px; padding: 11px 13px; background: var(--panel); border: 1px solid var(--line); border-radius: 11px; }
 .rule-row.on { border-color: var(--red); box-shadow: inset 3px 0 0 var(--red); }
 .rule-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
-.rule-label { font-size: 13.5px; font-weight: 700; color: var(--txt); display: inline-flex; align-items: center; gap: 6px; }
+.rule-label { font-size: 0.7941rem; font-weight: 700; color: var(--txt); display: inline-flex; align-items: center; gap: 6px; }
 .rule-label svg { width: 15px; height: 15px; color: var(--txt-3); }
-.rule-desc { font-size: 11.5px; color: var(--txt-2); }
+.rule-desc { font-size: 0.6765rem; color: var(--txt-2); }
 .rule-row .seg { flex: 0 0 auto; }
-.rule-planned-head { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 10px; font-weight: 700; color: var(--txt-3); margin: 16px 0 8px; }
+.rule-planned-head { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); margin: 16px 0 8px; }
 .rule-soon { opacity: .72; }
-.rule-soon-tag { flex: 0 0 auto; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 9px; font-weight: 700; color: var(--tan, #c2925a); border: 1px dashed var(--tan, #c2925a); border-radius: 999px; padding: 2px 8px; }
-.cf-req { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 8.5px; font-weight: 700; color: var(--red); border: 1px solid var(--red); border-radius: 999px; padding: 0 6px; margin-left: 6px; vertical-align: 1px; }
+.rule-soon-tag { flex: 0 0 auto; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 0.5294rem; font-weight: 700; color: var(--tan, #c2925a); border: 1px dashed var(--tan, #c2925a); border-radius: 999px; padding: 2px 8px; }
+.cf-req { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 0.5rem; font-weight: 700; color: var(--red); border: 1px solid var(--red); border-radius: 999px; padding: 0 6px; margin-left: 6px; vertical-align: 1px; }
 .cf-add { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 14px; padding-top: 12px; border-top: 1px dashed var(--line); }
 /* Inline edit-item panel — attached under the row being edited, not a bottom add-row */
 .cf-edit { margin: 6px 0 10px; padding: 10px; border-top: none; border-left: 3px solid var(--accent); background: var(--accent-soft); border-radius: 9px; }
@@ -2265,14 +2281,14 @@ body.is-phone .notif-row { flex-wrap: wrap; }
 .ck-popup { width: 520px; max-width: 95vw; }
 .ck-body { display: flex; flex-direction: column; gap: 8px; padding: 14px 16px; max-height: 64vh; overflow: auto; }
 .ck-row { display: flex; align-items: center; gap: 12px; padding: 9px 12px; background: var(--panel); border: 1px solid var(--line); border-radius: 11px; }
-.ck-label { flex: 1; min-width: 0; font-size: 13.5px; font-weight: 600; color: var(--txt); }
+.ck-label { flex: 1; min-width: 0; font-size: 0.7941rem; font-weight: 600; color: var(--txt); }
 .ck-row .seg { flex: 0 0 auto; }
 .ck-row .co-in { max-width: 180px; flex: 0 0 auto; }
 .ck-row .datefield { flex: 0 0 auto; }
 .ck-row .insp-photo { flex: 0 0 auto; min-height: 64px; width: 120px; margin-bottom: 0; }
 /* Per-item photo evidence strip under a checklist item (Jac 2026-06-26) */
 .ck-evrow { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; padding: 2px 12px 2px 12px; }
-.ck-evadd { display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; border: 1px dashed var(--accent-line); border-radius: 9px; background: var(--accent-soft); color: var(--accent); font-size: 12px; font-weight: 700; cursor: pointer; }
+.ck-evadd { display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; border: 1px dashed var(--accent-line); border-radius: 9px; background: var(--accent-soft); color: var(--accent); font-size: 0.7059rem; font-weight: 700; cursor: pointer; }
 .ck-evadd svg { width: 15px; height: 15px; }
 .ck-evrow.req .ck-evadd { border-color: var(--yellow, #f5c542); color: var(--yellow, #f5c542); background: rgba(245, 197, 66, .08); }
 .ck-evthumb { position: relative; width: 44px; height: 44px; border-radius: 8px; overflow: hidden; border: 1px solid var(--line); flex: 0 0 auto; }
@@ -2282,14 +2298,14 @@ body.is-phone .notif-row { flex-wrap: wrap; }
 /* Unit-level walkaround capture band at the top of the takeover */
 .ck-walk { display: flex; flex-direction: column; gap: 7px; padding: 9px 12px; background: var(--panel); border: 1px solid var(--line); border-radius: 11px; }
 .ck-walk.req { border-color: var(--yellow, #f5c542); }
-.ck-walk-lbl { display: inline-flex; align-items: center; gap: 6px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 12px; font-weight: 700; color: var(--muted, #9aa3ad); }
+.ck-walk-lbl { display: inline-flex; align-items: center; gap: 6px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 0.7059rem; font-weight: 700; color: var(--muted, #9aa3ad); }
 .ck-walk-lbl svg { width: 15px; height: 15px; }
 .ck-walk .ck-evrow { padding: 0; }
 .ck-walk .ck-evthumb video { width: 100%; height: 100%; object-fit: cover; display: block; }
 /* Dropdown options well in the Inspections builder add-row */
 .insp-opt-well { width: 100%; border-left: 3px solid var(--line); background: var(--bg-2); border-radius: 9px; padding: 8px 10px; display: flex; flex-direction: column; gap: 7px; margin-top: 2px; }
 .insp-opt-row { display: flex; align-items: center; gap: 8px; }
-.insp-opt-lbl { flex: 1; min-width: 0; font-size: 13px; font-weight: 600; color: var(--txt); }
+.insp-opt-lbl { flex: 1; min-width: 0; font-size: 0.7647rem; font-weight: 600; color: var(--txt); }
 .insp-opt-well .co-in { flex: 1 1 140px; min-width: 0; }
 /* DISABLED tier (plate .btn.disabled) — checkerboard, muted ink, not-allowed */
 .pill.is-disabled { opacity: 1; color: var(--txt-3); border-color: transparent; cursor: not-allowed;
@@ -2306,14 +2322,14 @@ body.is-phone .set-tab.on { border-left: 0; border-bottom-color: var(--accent); 
 body.is-phone .set-tab-l { flex: 0 0 auto; }
 
 .gv-legend { display: flex; flex-wrap: wrap; gap: 4px 10px; margin-top: 10px; justify-content: center; }
-.gv-leg { font-size: 11px; color: var(--txt-2); display: inline-flex; align-items: center; gap: 5px; }
+.gv-leg { font-size: 0.6471rem; color: var(--txt-2); display: inline-flex; align-items: center; gap: 5px; }
 .gv-leg i { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
 .gv-leg b { color: var(--txt); }
 .gv-bars { display: flex; align-items: flex-end; gap: 8px; height: 120px; }
 .gv-barcol { flex: 1; display: flex; flex-direction: column; align-items: center; height: 100%; min-width: 0; }
-.gv-bar-n { font-size: 10px; color: var(--txt-3); font-weight: 700; height: 14px; }
+.gv-bar-n { font-size: 0.5882rem; color: var(--txt-3); font-weight: 700; height: 14px; }
 .gv-bar-track { flex: 1; width: 70%; display: flex; align-items: flex-end; }
-.gv-bar-x { font-size: 10px; color: var(--txt-3); margin-top: 5px; text-transform: uppercase; letter-spacing: .4px; }
+.gv-bar-x { font-size: 0.5882rem; color: var(--txt-3); margin-top: 5px; text-transform: uppercase; letter-spacing: .4px; }
 /* Shop front-page STACKED bars: each bar's fill is a column of clickable segments
    (Services = overdue/due, Work Orders = woPhase journey). Registry colors per segment;
    a 1.5px gap shows the track behind them as a clean separator. */
@@ -2326,7 +2342,7 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gv-units-scroll { max-height: 240px; overflow-y: auto; border: 1px solid var(--line); border-radius: 10px; }
 .gv-soon { padding: 52px 24px; text-align: center; color: var(--txt-2); }
 .gv-soon-ic { display: inline-flex; width: 40px; height: 40px; color: var(--accent); opacity: .7; }
-.gv-soon p { margin-top: 12px; font-size: 14px; }
+.gv-soon p { margin-top: 12px; font-size: 0.8235rem; }
 @media (max-width: 720px) { .gv-grid { grid-template-columns: repeat(2, 1fr); } .gv-num, .gv-lead, .gv-pie, .gv-wide { grid-column: span 2; } }
 
 /* §13.4 — Graph CAROUSEL: an interactive panel above the list. Selected = orange
@@ -2335,12 +2351,12 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gv-panel { flex: 0 0 auto; padding: 5px 10px 6px; border-bottom: 1px solid var(--line); background: linear-gradient(180deg, var(--card-head), var(--card)); }
 .gv-head { display: flex; align-items: center; gap: 8px; }
 .gv-head-mid { flex: 1; min-width: 0; display: flex; flex-direction: column; align-items: center; gap: 4px; }
-.gv-title { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 12px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.gv-title { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 0.7059rem; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
 .gv-dots { display: flex; gap: 4px; }
 .gv-dots i { width: 5px; height: 5px; border-radius: 50%; background: var(--line); }
 .gv-dots i.on { background: var(--accent); }
 /* §13.4 timeline pill — scopes the time-based graphs to a recent window; active window stamped on it */
-.gv-win { display: inline-flex; align-items: center; gap: 3px; padding: 1px 9px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10px; line-height: 1.7; cursor: pointer; }
+.gv-win { display: inline-flex; align-items: center; gap: 3px; padding: 1px 9px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.5882rem; line-height: 1.7; cursor: pointer; }
 .gv-win svg { width: 11px; height: 11px; }
 .gv-win:hover { color: var(--txt); border-color: var(--accent-line); }
 .gv-win:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -2351,14 +2367,14 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gv-chev:hover { color: var(--txt); border-color: var(--accent-line); }
 .gv-chev:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .gv-view { margin-top: 8px; }
-.gv-empty { color: var(--txt-3); font-size: 12px; padding: 8px 2px; text-align: center; }
+.gv-empty { color: var(--txt-3); font-size: 0.7059rem; padding: 8px 2px; text-align: center; }
 /* clickable donut slices (pie) — the legend chips stay the keyboard path */
 .gv-pie-svg .gv-slice { cursor: pointer; stroke: var(--card); stroke-width: 1.5; }
 .gv-pie-svg .gv-slice:hover { filter: brightness(1.12); }
 .gv-pie-svg .gv-slice.on { stroke: var(--accent); stroke-width: 3; }
 /* clickable legend chips (pie) */
 .gv-legend-click { gap: 6px; }
-.gv-legend-click .gv-leg { cursor: pointer; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-2); font-size: 11px; }
+.gv-legend-click .gv-leg { cursor: pointer; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-2); font-size: 0.6471rem; }
 .gv-legend-click .gv-leg:hover { border-color: var(--accent-line); color: var(--txt); }
 .gv-legend-click .gv-leg.on { background: var(--accent); border-color: var(--accent); color: var(--on-orange); }
 .gv-legend-click .gv-leg.on b { color: var(--on-orange); }
@@ -2381,7 +2397,7 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 /* clickable number tiles */
 .gv-numrow { display: flex; flex-wrap: wrap; gap: 8px; }
 .gv-numtile { flex: 1 1 78px; min-width: 78px; display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 9px 8px; border-radius: 10px; border: 1px solid var(--line); background: linear-gradient(180deg, var(--card-head), var(--card)); cursor: pointer; }
-.gv-numtile .gv-num-v { color: var(--txt); font-size: 26px; }
+.gv-numtile .gv-num-v { color: var(--txt); font-size: 1.5294rem; }
 .gv-numtile .gv-num-l { margin-top: 0; }
 .gv-numtile:hover { border-color: var(--accent-line); }
 .gv-numtile.on { border-color: var(--accent); background: var(--accent-soft); }
@@ -2393,37 +2409,37 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 /* .ru-plate (the old standalone header button) retired 2026-07-10 — the entry
    point is now a "Reports" row in the logo menu (.dd-item js-ru-open). */
 .ru-popup { width: 94vw; height: 90vh; max-width: 1500px; }
-.ru-head .ru-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 11px; color: var(--txt-3); margin-left: 4px; }
+.ru-head .ru-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 0.6471rem; color: var(--txt-3); margin-left: 4px; }
 .ru-body { padding: 0; overflow: hidden; display: flex; }
 .ru-layout { display: grid; grid-template-columns: 158px minmax(0, 1fr); width: 100%; height: 100%; min-height: 0; }
 .ru-spine { display: flex; flex-direction: column; gap: 7px; padding: 16px 12px; border-right: 1px solid var(--line); overflow-y: auto; }
-.ru-per { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 700; font-size: 11.5px; text-align: left; padding: 2px 4px; border: none; background: none; color: var(--txt-3); cursor: pointer; transition: color .12s; white-space: nowrap; }
+.ru-per { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 700; font-size: 0.6765rem; text-align: left; padding: 2px 4px; border: none; background: none; color: var(--txt-3); cursor: pointer; transition: color .12s; white-space: nowrap; }
 .ru-per:hover { color: var(--txt); }
 .ru-per.on { color: var(--accent); }
 .ru-per:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .ru-per-custom { border-top: 1px solid var(--line-soft); margin-top: 4px; padding-top: 9px; overflow: hidden; text-overflow: ellipsis; }
 .ru-custom { margin-top: 6px; padding: 10px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); display: flex; flex-direction: column; gap: 8px; }
 .ru-custom-row { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
-.ru-custom-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 700; font-size: 9.5px; color: var(--txt-3); width: 34px; }
+.ru-custom-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 700; font-size: 0.5588rem; color: var(--txt-3); width: 34px; }
 .ru-main { overflow-y: auto; padding: 16px 18px 28px; min-width: 0; }
 .ru-sec { margin-bottom: 28px; }
-.ru-sec-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 13px; color: var(--txt-2); margin: 0 0 10px; padding-bottom: 6px; border-bottom: 1px solid var(--line); }
+.ru-sec-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 0.7647rem; color: var(--txt-2); margin: 0 0 10px; padding-bottom: 6px; border-bottom: 1px solid var(--line); }
 .ru-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(420px, 1fr)); gap: 14px; }
 .ru-panel { background: linear-gradient(180deg, var(--card-head), var(--card)); border: 1px solid var(--line); border-radius: 12px; padding: 12px 14px; min-width: 0; color: var(--txt-3); }   /* color themes Plot's currentColor axes/ticks */
-.ru-panel-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 11px; color: var(--txt-3); margin-bottom: 8px; }
+.ru-panel-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 0.6471rem; color: var(--txt-3); margin-bottom: 8px; }
 .ru-plotmount svg, .ru-plotmount figure { width: 100%; height: auto; margin: 0; }
 .ru-ph { border-style: dashed; opacity: .75; }
-.ru-ph-note { font-size: 12px; color: var(--txt-3); padding: 18px 4px 22px; }
-.ru-err { color: var(--red); font-size: 12px; padding: 12px 4px; }
-.ru-empty { font-size: 12px; color: var(--txt-3); padding: 18px 4px 22px; }
+.ru-ph-note { font-size: 0.7059rem; color: var(--txt-3); padding: 18px 4px 22px; }
+.ru-err { color: var(--red); font-size: 0.7059rem; padding: 12px 4px; }
+.ru-empty { font-size: 0.7059rem; color: var(--txt-3); padding: 18px 4px 22px; }
 .ru-lead { display: flex; flex-direction: column; width: 100%; }
 .ru-lead-row { display: grid; grid-template-columns: 18px 1fr auto; align-items: center; gap: 10px; padding: 5px 4px; border: none; border-bottom: 1px solid var(--line); background: transparent; color: var(--txt); text-align: left; font: inherit; cursor: pointer; }
 .ru-lead-row:last-child { border-bottom: none; }
 .ru-lead-row:hover { background: var(--panel); }
 .ru-lead-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.ru-lead-n { color: var(--txt-3); font-weight: 700; font-size: 11px; }
-.ru-lead-name { font-weight: 600; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ru-lead-c { font-weight: 800; font-size: 13px; color: var(--txt-2); font-variant-numeric: tabular-nums; }
+.ru-lead-n { color: var(--txt-3); font-weight: 700; font-size: 0.6471rem; }
+.ru-lead-name { font-weight: 600; font-size: 0.7647rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ru-lead-c { font-weight: 800; font-size: 0.7647rem; color: var(--txt-2); font-variant-numeric: tabular-nums; }
 .ru-plotmount .js-ru-nav, .rus-mount .js-ru-nav { cursor: pointer; }
 .ru-plotmount svg .js-ru-nav:hover, .rus-mount svg .js-ru-nav:hover { filter: brightness(1.18); }
 .ru-plotmount svg .js-ru-nav:focus-visible, .rus-mount svg .js-ru-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
@@ -2431,17 +2447,17 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .ru-duo { display: flex; gap: 14px; align-items: stretch; }
 .ru-duo-chart { flex: 1; min-width: 0; }
 .ru-real { width: 92px; flex: none; display: flex; flex-direction: column; justify-content: center; gap: 3px; padding-left: 14px; border-left: 1px dashed var(--tan, #c2925a); }   /* saddle-stitch divider — trend left, "right now" right */
-.ru-real-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 34px; line-height: 1; color: var(--txt); }
-.ru-real-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
+.ru-real-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 2rem; line-height: 1; color: var(--txt); }
+.ru-real-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); }
 .ru-real-bar { display: flex; height: 8px; border-radius: 4px; overflow: hidden; margin-top: 5px; }
 .ru-real-seg { min-width: 3px; }
-.ru-sub-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 10px; color: var(--txt-3); margin: 6px 0 2px; }
+.ru-sub-h { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); margin: 6px 0 2px; }
 .ru-sub-c { text-align: center; }
 .ru-plotmount svg.ru-donut { display: block; max-width: 250px; margin: 0 auto; }
 .ru-donut text { font-family: 'Saira Condensed', system-ui, sans-serif; }
-.ru-donut .ru-slice-n { font-size: 13px; font-weight: 700; }
-.ru-donut .ru-donut-tot { font-size: 27px; font-weight: 800; }
-.ru-donut .ru-donut-sub { font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; }
+.ru-donut .ru-slice-n { font-size: 0.7647rem; font-weight: 700; }
+.ru-donut .ru-donut-tot { font-size: 1.5882rem; font-weight: 800; }
+.ru-donut .ru-donut-sub { font-size: 0.5882rem; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; }
 .ru-donut-pair { display: flex; gap: 10px; justify-content: center; }
 .ru-donut-cell { flex: 1; min-width: 0; }
 .ru-donut-cell svg.ru-donut { max-width: 190px; }
@@ -2449,8 +2465,8 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .ru-tile { display: flex; flex-direction: column; align-items: center; gap: 2px; padding: 14px 8px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); cursor: pointer; }
 .ru-tile:hover { border-color: var(--accent-line); }
 .ru-tile:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.ru-tile-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 30px; line-height: 1; }
-.ru-tile-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10px; color: var(--txt-3); }
+.ru-tile-n { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 1.7647rem; line-height: 1; }
+.ru-tile-l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); }
 @media (max-width: 900px) { .ru-layout { grid-template-columns: 1fr; } .ru-spine { flex-direction: row; flex-wrap: wrap; border-right: none; border-bottom: 1px solid var(--line); padding: 10px 12px; } .ru-grid { grid-template-columns: 1fr; } }
 @media (prefers-reduced-motion: reduce) { .ru-per { transition: none; } }
 
@@ -2459,13 +2475,13 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .is-phone .rus { flex: none; height: 25dvh; }   /* phone: the strip rides inside the scroll column — 25% of the viewport ≈ the column */
 .rus-tabs { display: flex; gap: 2px; padding: 3px 8px 2px; border-bottom: 1px solid var(--line-soft); overflow-x: auto; scrollbar-width: none; justify-content: center; justify-content: safe center; flex: none; }
 .rus-tabs::-webkit-scrollbar { display: none; }
-.rus-tab { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10.5px; padding: 1px 7px; border: none; background: none; color: var(--txt-3); white-space: nowrap; cursor: pointer; transition: color .12s; }
+.rus-tab { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.6176rem; padding: 1px 7px; border: none; background: none; color: var(--txt-3); white-space: nowrap; cursor: pointer; transition: color .12s; }
 .rus-tab:hover { color: var(--txt); }
 .rus-tab.on { color: var(--accent); }
 .rus-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .rus-body { flex: 1; min-height: 0; display: flex; gap: 6px; padding: 2px 8px 5px; }
 .rus-rail { display: flex; flex-direction: column; justify-content: center; gap: 1px; flex: none; min-width: 30px; }
-.rus-per { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 9.5px; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 72px; padding: 0 2px; border: none; background: none; color: var(--txt-3); cursor: pointer; transition: color .12s; }
+.rus-per { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 0.5588rem; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 72px; padding: 0 2px; border: none; background: none; color: var(--txt-3); cursor: pointer; transition: color .12s; }
 .rus-per:hover { color: var(--txt); }
 .rus-per.on { color: var(--accent); }
 .rus-per:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
@@ -2475,8 +2491,8 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .rus-mount .ru-empty { padding: 10px 4px; }
 @media (prefers-reduced-motion: reduce) { .rus-tab, .rus-per { transition: none; } }
 
-.board-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.board-table th { position: sticky; top: 0; z-index: 1; text-align: left; padding: 10px 14px; background: var(--card-head); color: var(--txt-3); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; border-bottom: 1px solid var(--line); white-space: nowrap; }
+.board-table { width: 100%; border-collapse: collapse; font-size: 0.7647rem; }
+.board-table th { position: sticky; top: 0; z-index: 1; text-align: left; padding: 10px 14px; background: var(--card-head); color: var(--txt-3); font-size: 0.6471rem; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; border-bottom: 1px solid var(--line); white-space: nowrap; }
 .board-table td { padding: 9px 14px; border-bottom: 1px solid var(--line-soft); color: var(--txt); vertical-align: middle; }
 .board-table td:first-child { font-weight: 600; }
 .board-table tbody tr:hover { background: var(--panel); }
@@ -2484,7 +2500,7 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 /* §7.10 v2 vendors — clickable board rows + the in-popup record detail */
 .board-table tbody tr.js-board-row { cursor: pointer; }
 /* parts-picker mode (Jac 2026-07-08): the Attach commit pill sits in a right-edge cell */
-.board-pickhint { padding: 9px 14px; font-size: 12px; border-bottom: 1px solid var(--line); }
+.board-pickhint { padding: 9px 14px; font-size: 0.7059rem; border-bottom: 1px solid var(--line); }
 .board-table td.board-pickcell { text-align: right; white-space: nowrap; }
 .board-detail { max-width: 820px; margin: 0 auto; }
 
@@ -2500,24 +2516,24 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .bv-searchwrap { display: flex; align-items: center; gap: 6px; height: 32px; padding: 0 10px; margin-left: 6px;
   border-radius: 9px; background: var(--panel); border: 1px solid var(--line); min-width: 200px; }
 .bv-searchwrap .s-icon { display: inline-flex; color: var(--txt-3); } .bv-searchwrap .s-icon svg { width: 15px; height: 15px; }
-.bv-query { border: none; background: transparent; color: var(--txt); font-size: 13px; width: 100%; outline: none; }
+.bv-query { border: none; background: transparent; color: var(--txt); font-size: 0.7647rem; width: 100%; outline: none; }
 .bv-mini { display: inline-flex; align-items: center; gap: 3px; height: 30px; padding: 0 10px; border-radius: 8px;
-  background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); font-size: 12px; font-weight: 700; }
+  background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); font-size: 0.7059rem; font-weight: 700; }
 .bv-mini:hover { color: var(--accent); border-color: var(--accent-line); }
 .bv-mini svg { width: 13px; height: 13px; }
 .bv-table th.js-bv-sort { cursor: pointer; user-select: none; }
 .bv-table th.js-bv-sort:hover { color: var(--accent); }
 .bv-table th.num, .bv-table td.num { text-align: right; }
-.bv-table .bv-arrow { color: var(--accent); font-size: 10px; }
+.bv-table .bv-arrow { color: var(--accent); font-size: 0.5882rem; }
 .bv-table th.bv-addcol { width: 1%; }
-.bv-table .bv-colname { width: 110px; border: none; background: transparent; color: var(--txt); font-size: 12px; font-weight: 700; outline: none; border-bottom: 1px dashed var(--line); }
+.bv-table .bv-colname { width: 110px; border: none; background: transparent; color: var(--txt); font-size: 0.7059rem; font-weight: 700; outline: none; border-bottom: 1px dashed var(--line); }
 .bv-table .bv-scratch { background: color-mix(in srgb, var(--accent) 5%, transparent); outline: none; min-width: 70px; }
 .bv-table .bv-scratch:focus { background: var(--accent-soft); box-shadow: inset 0 0 0 1px var(--accent-line); }
 .bv-table .bv-scratch.locked { color: var(--txt-3); font-style: italic; background: transparent; }
 .bv-table tfoot .bv-summary { position: sticky; bottom: 0; }
 .bv-table tfoot .bv-summary td { background: var(--card-head); border-top: 2px solid var(--accent-line); font-weight: 700; color: var(--txt); }
 .bv-table tfoot .bv-sumlabel { color: var(--accent); font-weight: 800; }
-.bv-calc { background: var(--panel); color: var(--txt-2); border: 1px solid var(--line); border-radius: 6px; font-size: 11px; padding: 1px 3px; }
+.bv-calc { background: var(--panel); color: var(--txt-2); border: 1px solid var(--line); border-radius: 6px; font-size: 0.6471rem; padding: 1px 3px; }
 .bv-mini.on { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
 
 /* ── GPS CONNECT WIZARD (spec §5a) — device picker rows (step 2, Deere/Yanmar/Bouncie)
@@ -2526,18 +2542,18 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gps-dev-list { display: flex; flex-direction: column; gap: 6px; max-height: 260px; overflow: auto; }
 .gps-dev-row { display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; padding: 9px 12px;
   border-radius: 10px; background: var(--panel); border: 1px solid var(--line); color: var(--txt);
-  font: inherit; font-size: 12.5px; cursor: pointer; transition: border-color .12s, background .12s; }
+  font: inherit; font-size: 0.7353rem; cursor: pointer; transition: border-color .12s, background .12s; }
 .gps-dev-row svg { width: 15px; height: 15px; flex: 0 0 auto; color: var(--txt-3); }
 .gps-dev-row:hover { border-color: var(--accent-line); background: var(--accent-soft); }
 .gps-dev-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .gps-dev-row .gdr-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 700; }
-.gps-dev-row .gdr-sub { flex: 0 0 auto; color: var(--txt-3); font-size: 11px; }
+.gps-dev-row .gdr-sub { flex: 0 0 auto; color: var(--txt-3); font-size: 0.6471rem; }
 .gps-poll-ic { display: inline-flex; align-items: center; justify-content: center; width: 46px; height: 46px;
-  border-radius: 50%; font-size: 20px; font-weight: 800; }
+  border-radius: 50%; font-size: 1.1765rem; font-weight: 800; }
 .gps-poll-ic svg { width: 20px; height: 20px; }
 /* Enriched GPS section (step 4): the external "last seen" map link. External nav, so a
    plain anchor — blue like the registry link tone, never orange. */
-.gps-maplink { color: var(--blue); font-size: 11px; text-decoration: underline; text-underline-offset: 2px; cursor: pointer; }
+.gps-maplink { color: var(--blue); font-size: 0.6471rem; text-decoration: underline; text-underline-offset: 2px; cursor: pointer; }
 .gps-maplink:hover { color: color-mix(in srgb, var(--blue) 82%, var(--txt)); }
 .gps-maplink:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 
@@ -2545,14 +2561,14 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
    unit's GPS section, mirroring the chat-feed language (scrollable, timestamped rows). */
 .gps-feed-wrap { width: 100%; margin-top: 4px; }
 .gps-feed-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
-.gps-feed-head .gfh-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 10.5px; color: var(--txt-3); }
+.gps-feed-head .gfh-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 0.6176rem; color: var(--txt-3); }
 .gps-feed { display: flex; flex-direction: column; gap: 6px; max-height: 190px; overflow-y: auto; padding: 8px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); }
-.gps-feed-empty { color: var(--txt-3); font-size: 11.5px; text-align: center; padding: 14px 8px; }
-.gps-feed-row { display: flex; align-items: center; gap: 8px; font-size: 11.5px; color: var(--txt-2); }
+.gps-feed-empty { color: var(--txt-3); font-size: 0.6765rem; text-align: center; padding: 14px 8px; }
+.gps-feed-row { display: flex; align-items: center; gap: 8px; font-size: 0.6765rem; color: var(--txt-2); }
 .gps-feed-row .gfr-ic { flex: 0 0 auto; display: inline-flex; }
 .gps-feed-row .gfr-ic svg { width: 13px; height: 13px; }
 .gps-feed-row .gfr-txt { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gps-feed-row .gfr-ts { flex: 0 0 auto; color: var(--txt-3); font-size: 10.5px; }
+.gps-feed-row .gfr-ts { flex: 0 0 auto; color: var(--txt-3); font-size: 0.6176rem; }
 
 /* Remote-shutdown hazard control (spec §6/§7) — the ignition-critical action. Borrows
    the cancel-arc's hazard language: caution-yellow stripe cap, red "hot" variant once
@@ -2562,18 +2578,18 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gps-hazard.hot { border-color: color-mix(in srgb, var(--red) 55%, var(--line)); box-shadow: inset 0 0 34px -14px color-mix(in srgb, var(--red) 55%, transparent); }
 .gps-hazard.hot .gh-cap { background: repeating-linear-gradient(135deg, var(--red) 0 13px, #1a0808 13px 26px); }
 .gps-hazard .gh-row { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 10px 10px 6px; }
-.gps-hazard .gh-note { font-size: 10px; color: var(--txt-3); text-align: center; padding: 0 12px 9px; line-height: 1.35; }
+.gps-hazard .gh-note { font-size: 0.5882rem; color: var(--txt-3); text-align: center; padding: 0 12px 9px; line-height: 1.35; }
 .gps-hazard.hot .gh-note { color: color-mix(in srgb, var(--red) 68%, var(--txt-3)); }
 @media (prefers-reduced-motion: no-preference) { .gps-hazard.hot { transition: box-shadow .15s ease, border-color .15s ease; } }
 
 /* ── TRACKER HEALTH roster (Phase 2 M2) — the fleet-wide GPS device list. Quiet steel
    data-plate: a stamped count, a scannable row grid, freshness pinned top. Tokens only. */
 .gpsh-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 10px; }
-.gpsh-counts { font-size: 12px; color: var(--txt-2); }
-.gpsh-counts .gpsh-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 20px; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
+.gpsh-counts { font-size: 0.7059rem; color: var(--txt-2); }
+.gpsh-counts .gpsh-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 1.1765rem; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
 .gpsh-tools { display: flex; align-items: center; gap: 8px; }
 .gpsh-search { width: 200px; margin: 0; }
-.gpsh-banner { font-size: 11.5px; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
+.gpsh-banner { font-size: 0.6765rem; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
   border: 1px solid color-mix(in srgb, var(--yellow) 34%, transparent); border-radius: 10px; padding: 8px 12px; margin-bottom: 10px; }
 .gpsh-bucketrow { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
 .gpsh-list { display: flex; flex-direction: column; gap: 6px; max-height: 52vh; overflow-y: auto; }
@@ -2581,9 +2597,9 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
   padding: 8px 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); }
 .gpsh-row .gpsh-name { min-width: 0; display: flex; flex-direction: column; gap: 1px; font-weight: 700; color: var(--txt);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gpsh-row .gpsh-ser { font-family: ui-monospace, monospace; font-size: 10.5px; font-weight: 500; color: var(--txt-3); letter-spacing: .2px; }
-.gpsh-row .gpsh-seen { font-size: 11px; color: var(--txt-3); white-space: nowrap; text-align: right; }
-.gpsh-empty { color: var(--txt-3); font-size: 12px; text-align: center; padding: 22px 14px; line-height: 1.45; }
+.gpsh-row .gpsh-ser { font-family: ui-monospace, monospace; font-size: 0.6176rem; font-weight: 500; color: var(--txt-3); letter-spacing: .2px; }
+.gpsh-row .gpsh-seen { font-size: 0.6471rem; color: var(--txt-3); white-space: nowrap; text-align: right; }
+.gpsh-empty { color: var(--txt-3); font-size: 0.7059rem; text-align: center; padding: 22px 14px; line-height: 1.45; }
 @media (max-width: 560px) {
   .gpsh-row { grid-template-columns: auto minmax(0, 1fr) auto; row-gap: 6px; }
   .gpsh-row .gpsh-eng, .gpsh-row .gpsh-seen, .gpsh-row .gpsh-map { grid-column: span 3; justify-self: start; }
@@ -2600,11 +2616,11 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gpsfm-popup { width: 92vw; height: 84vh; max-width: 1200px; }
 .gpsfm-body { padding: 0; overflow: hidden; display: flex; flex-direction: column; flex: 1 1 auto; min-height: 0; }
 .gpsfm-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; padding: 12px 16px; border-bottom: 1px solid var(--line); flex: 0 0 auto; }
-.gpsfm-counts { font-size: 12px; color: var(--txt-2); }
-.gpsfm-counts .gpsfm-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 20px; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
+.gpsfm-counts { font-size: 0.7059rem; color: var(--txt-2); }
+.gpsfm-counts .gpsfm-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 1.1765rem; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
 .gpsfm-tools { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .gpsfm-search { width: 180px; margin: 0; }
-.gpsfm-banner { flex: 0 0 auto; font-size: 11.5px; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
+.gpsfm-banner { flex: 0 0 auto; font-size: 0.6765rem; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
   border: 1px solid color-mix(in srgb, var(--yellow) 34%, transparent); border-radius: 10px; padding: 8px 12px; margin: 10px 16px 0; }
 .gpsfm-layout { flex: 1 1 auto; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) 300px; }
 .gpsfm-map { position: relative; min-height: 360px; background: var(--panel-2); }
@@ -2619,12 +2635,12 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gpsfm-row:hover { border-color: var(--accent-line); }
 .gpsfm-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .gpsfm-row.sel { border-color: var(--accent); background: var(--accent-soft); }
-.gpsfm-row .gpsfm-name { min-width: 0; font-weight: 700; font-size: 12.5px; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gpsfm-row .gpsfm-ser { font-family: ui-monospace, monospace; font-size: 10px; font-weight: 500; color: var(--txt-3); letter-spacing: .2px; margin-left: 6px; }
+.gpsfm-row .gpsfm-name { min-width: 0; font-weight: 700; font-size: 0.7353rem; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.gpsfm-row .gpsfm-ser { font-family: ui-monospace, monospace; font-size: 0.5882rem; font-weight: 500; color: var(--txt-3); letter-spacing: .2px; margin-left: 6px; }
 .gpsfm-row-mid { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 .gpsfm-row-bot { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; }
-.gpsfm-seen { font-size: 10.5px; color: var(--txt-3); }
-.gpsfm-empty { color: var(--txt-3); font-size: 12px; text-align: center; padding: 22px 14px; line-height: 1.45; }
+.gpsfm-seen { font-size: 0.6176rem; color: var(--txt-3); }
+.gpsfm-empty { color: var(--txt-3); font-size: 0.7059rem; text-align: center; padding: 22px 14px; line-height: 1.45; }
 @media (max-width: 900px) { .gpsfm-layout { grid-template-columns: minmax(0, 1fr) 250px; } .gpsfm-search { width: 140px; } }
 @media (max-width: 560px) {
   .gpsfm-layout { grid-template-columns: 1fr; grid-template-rows: minmax(220px, 38vh) 1fr; }
@@ -2642,24 +2658,24 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
    decoration. */
 .gpsru-popup { width: 900px; }
 .gpsru-cta { display: flex; flex-direction: column; align-items: center; gap: 14px; text-align: center; padding: 34px 20px; }
-.gpsru-cta-txt { max-width: 440px; font-size: 13px; color: var(--txt-2); line-height: 1.5; }
+.gpsru-cta-txt { max-width: 440px; font-size: 0.7647rem; color: var(--txt-2); line-height: 1.5; }
 .gpsru-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 10px; }
-.gpsru-counts { font-size: 12px; color: var(--txt-2); }
-.gpsru-counts .gpsru-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 20px; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
+.gpsru-counts { font-size: 0.7059rem; color: var(--txt-2); }
+.gpsru-counts .gpsru-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 1.1765rem; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
 .gpsru-tools { display: flex; align-items: center; gap: 8px; }
 .gpsru-search { width: 220px; margin: 0; }
-.gpsru-banner { font-size: 11.5px; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
+.gpsru-banner { font-size: 0.6765rem; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
   border: 1px solid color-mix(in srgb, var(--yellow) 34%, transparent); border-radius: 10px; padding: 8px 12px; margin-bottom: 10px; }
-.gpsru-empty { color: var(--txt-3); font-size: 12px; text-align: center; padding: 30px 14px; line-height: 1.5; }
+.gpsru-empty { color: var(--txt-3); font-size: 0.7059rem; text-align: center; padding: 30px 14px; line-height: 1.5; }
 .gpsru-bucket { margin-bottom: 14px; }
 .gpsru-bucket-head { display: flex; align-items: baseline; gap: 8px; margin: 0 0 7px; padding-bottom: 5px; border-bottom: 1.5px dashed var(--tan, #c2925a); opacity: .96; }   /* saddle-stitch — the ranch seasoning */
-.gpsru-bucket-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.2px; font-weight: 800; font-size: 11.5px; }
+.gpsru-bucket-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.2px; font-weight: 800; font-size: 0.6765rem; }
 .gpsru-bucket-lbl.c-green { color: var(--green); }
 .gpsru-bucket-lbl.c-yellow { color: var(--yellow); }
 .gpsru-bucket-lbl.c-red { color: var(--red); }
 .gpsru-bucket-lbl.c-blue { color: var(--blue); }
 .gpsru-bucket-lbl.c-gray { color: var(--txt-3); }
-.gpsru-bucket-note { font-size: 10.5px; }
+.gpsru-bucket-note { font-size: 0.6176rem; }
 .gpsru-row { border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); margin-bottom: 6px; overflow: hidden; }
 .gpsru-row.conflict { border-color: color-mix(in srgb, var(--red) 40%, var(--line)); }
 .gpsru-row.needsconfirm { border-color: color-mix(in srgb, var(--yellow) 40%, var(--line)); }
@@ -2668,33 +2684,33 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gpsru-check { display: flex; align-items: center; justify-content: center; padding: 4px; margin: -4px; }
 .gpsru-check input { width: 16px; height: 16px; accent-color: var(--accent); cursor: pointer; }
 .gpsru-unit, .gpsru-dev { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
-.gpsru-unit-name, .gpsru-dev-name { font-weight: 700; color: var(--txt); font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gpsru-unit-sub, .gpsru-dev-ser { font-family: ui-monospace, monospace; font-size: 10.5px; color: var(--txt-3); }
-.gpsru-dev-missing { font-size: 12px; }
+.gpsru-unit-name, .gpsru-dev-name { font-weight: 700; color: var(--txt); font-size: 0.7353rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.gpsru-unit-sub, .gpsru-dev-ser { font-family: ui-monospace, monospace; font-size: 0.6176rem; color: var(--txt-3); }
+.gpsru-dev-missing { font-size: 0.7059rem; }
 .gpsru-arrow { color: var(--txt-3); display: flex; align-items: center; justify-content: center; }
 .gpsru-arrow svg { width: 14px; height: 14px; }
 .gpsru-meta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; min-width: 0; }
-.gpsru-reasons { font-size: 10.5px; text-transform: capitalize; }
+.gpsru-reasons { font-size: 0.6176rem; text-transform: capitalize; }
 .gpsru-actions { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
 .gpsru-detail { padding: 12px; border-top: 1px solid var(--line); background: var(--panel-2); }
 .gpsru-confirm-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 10px; }
 .gpsru-plate { padding: 10px 12px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); }
-.gpsru-plate-cap { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.2px; font-size: 10px; font-weight: 700; color: var(--txt-3); margin-bottom: 4px; }
-.gpsru-plate-name { font-weight: 700; font-size: 13px; color: var(--txt); }
-.gpsru-plate-sub { font-size: 11px; margin-top: 2px; }
+.gpsru-plate-cap { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.2px; font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); margin-bottom: 4px; }
+.gpsru-plate-name { font-weight: 700; font-size: 0.7647rem; color: var(--txt); }
+.gpsru-plate-sub { font-size: 0.6471rem; margin-top: 2px; }
 .gpsru-detail-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.gpsru-hazard-note { margin: 9px 0 0; font-size: 10.5px; color: color-mix(in srgb, var(--yellow) 70%, var(--txt-3)); line-height: 1.4; }
+.gpsru-hazard-note { margin: 9px 0 0; font-size: 0.6176rem; color: color-mix(in srgb, var(--yellow) 70%, var(--txt-3)); line-height: 1.4; }
 .gpsru-poll { display: flex; align-items: center; gap: 10px; }
 .gpsru-poll-txt { min-width: 0; }
-.gpsru-poll-lbl { font-weight: 700; font-size: 12.5px; color: var(--txt); }
+.gpsru-poll-lbl { font-weight: 700; font-size: 0.7353rem; color: var(--txt); }
 .gpsru-nomatch-row .gpsru-check { visibility: hidden; }
 .gpsru-nomatch-devs { display: flex; flex-wrap: wrap; gap: 6px; }
-.gpsru-nomatch-dev { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 999px; background: var(--panel); border: 1px solid var(--line); font-size: 11.5px; color: var(--txt-2); }
+.gpsru-nomatch-dev { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 999px; background: var(--panel); border: 1px solid var(--line); font-size: 0.6765rem; color: var(--txt-2); }
 .gpsru-result { border-radius: 10px; padding: 9px 12px; margin-bottom: 12px; background: var(--panel); border: 1px solid var(--line); }
 .gpsru-result.haswarn { border-color: color-mix(in srgb, var(--yellow) 45%, var(--line)); background: var(--yellow-bg); }
 .gpsru-result-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.gpsru-result-stamp { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 11.5px; color: var(--txt); }
-.gpsru-result-list { margin: 8px 0 0; padding-left: 18px; font-size: 11.5px; color: var(--txt-2); line-height: 1.6; }
+.gpsru-result-stamp { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.6765rem; color: var(--txt); }
+.gpsru-result-list { margin: 8px 0 0; padding-left: 18px; font-size: 0.6765rem; color: var(--txt-2); line-height: 1.6; }
 @media (max-width: 940px) { .gpsru-popup { width: 94vw; } }
 @media (max-width: 640px) {
   .gpsru-row-main { grid-template-columns: 20px minmax(0,1fr) auto; row-gap: 6px; }
@@ -2710,21 +2726,21 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
    status pill. Tokens only — red/yellow chip colors come straight off the
    registry (statusPill/badge), never invented here. */
 .gpsi-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 10px; }
-.gpsi-counts { font-size: 12px; color: var(--txt-2); }
-.gpsi-counts .gpsi-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 20px; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
+.gpsi-counts { font-size: 0.7059rem; color: var(--txt-2); }
+.gpsi-counts .gpsi-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 1.1765rem; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
 .gpsi-tools { display: flex; align-items: center; gap: 8px; }
 .gpsi-search { width: 200px; margin: 0; }
-.gpsi-banner { font-size: 11.5px; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
+.gpsi-banner { font-size: 0.6765rem; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
   border: 1px solid color-mix(in srgb, var(--yellow) 34%, transparent); border-radius: 10px; padding: 8px 12px; margin-bottom: 10px; }
 .gpsi-list { display: flex; flex-direction: column; gap: 6px; max-height: 56vh; overflow-y: auto; }
 .gpsi-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto auto; align-items: center; gap: 10px;
   padding: 8px 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); }
 .gpsi-row .gpsi-name { min-width: 0; display: flex; flex-direction: column; gap: 1px; font-weight: 700; color: var(--txt);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gpsi-row .gpsi-ser { font-family: ui-monospace, monospace; font-size: 10.5px; font-weight: 500; color: var(--txt-3); letter-spacing: .2px; }
+.gpsi-row .gpsi-ser { font-family: ui-monospace, monospace; font-size: 0.6176rem; font-weight: 500; color: var(--txt-3); letter-spacing: .2px; }
 .gpsi-row .gpsi-issues { display: flex; flex-wrap: wrap; gap: 5px; }
-.gpsi-row .gpsi-seen { font-size: 11px; color: var(--txt-3); white-space: nowrap; text-align: right; }
-.gpsi-empty { color: var(--txt-3); font-size: 12px; text-align: center; padding: 22px 14px; line-height: 1.45; }
+.gpsi-row .gpsi-seen { font-size: 0.6471rem; color: var(--txt-3); white-space: nowrap; text-align: right; }
+.gpsi-empty { color: var(--txt-3); font-size: 0.7059rem; text-align: center; padding: 22px 14px; line-height: 1.45; }
 @media (max-width: 560px) {
   .gpsi-row { grid-template-columns: auto minmax(0, 1fr) auto; row-gap: 6px; }
   .gpsi-row .gpsi-issues, .gpsi-row .gpsi-seen, .gpsi-row .gpsi-map { grid-column: span 3; justify-self: start; }
@@ -2739,34 +2755,34 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .gpsu-popup { width: 900px; }
 @media (max-width: 940px) { .gpsu-popup { width: 94vw; } }
 .gpsu-cta { display: flex; flex-direction: column; align-items: center; gap: 14px; text-align: center; padding: 34px 20px; }
-.gpsu-cta-txt { max-width: 440px; font-size: 13px; color: var(--txt-2); line-height: 1.5; }
+.gpsu-cta-txt { max-width: 440px; font-size: 0.7647rem; color: var(--txt-2); line-height: 1.5; }
 .gpsu-cta-days { display: flex; justify-content: center; }
-.gpsu-banner { font-size: 11.5px; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
+.gpsu-banner { font-size: 0.6765rem; color: color-mix(in srgb, var(--yellow) 72%, var(--txt)); background: var(--yellow-bg);
   border: 1px solid color-mix(in srgb, var(--yellow) 34%, transparent); border-radius: 10px; padding: 8px 12px; margin-bottom: 10px; }
 .gpsu-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
-.gpsu-counts { font-size: 12px; color: var(--txt-2); }
-.gpsu-counts .gpsu-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 20px; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
+.gpsu-counts { font-size: 0.7059rem; color: var(--txt-2); }
+.gpsu-counts .gpsu-big { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 1.1765rem; letter-spacing: .5px; color: var(--txt); margin-right: 3px; }
 .gpsu-tools { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .gpsu-section { margin-bottom: 16px; }
 .gpsu-section-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.2px;
-  font-weight: 700; font-size: 11px; color: var(--txt-3); margin-bottom: 6px; }
+  font-weight: 700; font-size: 0.6471rem; color: var(--txt-3); margin-bottom: 6px; }
 .gpsu-cat-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; align-items: center; gap: 10px;
   padding: 7px 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); margin-bottom: 5px; }
 .gpsu-cat-name { min-width: 0; font-weight: 700; color: var(--txt); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gpsu-cat-count, .gpsu-cat-avg { font-size: 11px; white-space: nowrap; }
-.gpsu-cat-hrs { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 13px; color: var(--txt); white-space: nowrap; }
+.gpsu-cat-count, .gpsu-cat-avg { font-size: 0.6471rem; white-space: nowrap; }
+.gpsu-cat-hrs { font-family: 'Saira Condensed', var(--font); font-weight: 800; font-size: 0.7647rem; color: var(--txt); white-space: nowrap; }
 .gpsu-table { display: flex; flex-direction: column; gap: 6px; max-height: 42vh; overflow-y: auto; }
 .gpsu-row { display: grid; grid-template-columns: minmax(0, 1.4fr) auto auto auto auto auto; align-items: center; gap: 10px;
   padding: 8px 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); }
 .gpsu-row.failed { opacity: .82; }
 .gpsu-u-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-.gpsu-u-cat { font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.gpsu-u-hrs { font-family: 'Saira Condensed', var(--font); font-weight: 700; font-size: 12.5px; color: var(--txt); white-space: nowrap; text-align: right; }
-.gpsu-u-hpd, .gpsu-u-mi { font-size: 11px; white-space: nowrap; text-align: right; }
+.gpsu-u-cat { font-size: 0.6471rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.gpsu-u-hrs { font-family: 'Saira Condensed', var(--font); font-weight: 700; font-size: 0.7353rem; color: var(--txt); white-space: nowrap; text-align: right; }
+.gpsu-u-hpd, .gpsu-u-mi { font-size: 0.6471rem; white-space: nowrap; text-align: right; }
 .gpsu-u-fail { text-align: right; }
-.gpsu-empty { color: var(--txt-3); font-size: 12px; text-align: center; padding: 22px 14px; line-height: 1.45; }
+.gpsu-empty { color: var(--txt-3); font-size: 0.7059rem; text-align: center; padding: 22px 14px; line-height: 1.45; }
 .gpsu-foot-note { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
-  margin-top: 4px; padding-top: 12px; border-top: 1px dashed var(--line-soft); font-size: 12px; color: var(--txt-2); }
+  margin-top: 4px; padding-top: 12px; border-top: 1px dashed var(--line-soft); font-size: 0.7059rem; color: var(--txt-2); }
 @media (max-width: 560px) {
   .gpsu-cat-row { grid-template-columns: minmax(0, 1fr) auto; row-gap: 4px; }
   .gpsu-cat-row .gpsu-cat-hrs, .gpsu-cat-row .gpsu-cat-avg { grid-column: span 2; justify-self: start; }
@@ -2777,14 +2793,14 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 /* List-rows customiser panel */
 .bv-customize { display: flex; flex-wrap: wrap; gap: 14px 28px; align-items: flex-start; padding: 14px 16px; background: var(--accent-soft); border-bottom: 1px solid var(--accent-line); }
 .bv-pick-group { min-width: 190px; }
-.bv-pick-group h4 { margin: 0 0 8px; font-size: 12px; font-weight: 800; color: var(--txt); text-transform: uppercase; letter-spacing: .4px; }
-.bv-pick { display: flex; align-items: center; gap: 7px; font-size: 13px; color: var(--txt); padding: 3px 0; cursor: pointer; }
+.bv-pick-group h4 { margin: 0 0 8px; font-size: 0.7059rem; font-weight: 800; color: var(--txt); text-transform: uppercase; letter-spacing: .4px; }
+.bv-pick { display: flex; align-items: center; gap: 7px; font-size: 0.7647rem; color: var(--txt); padding: 3px 0; cursor: pointer; }
 .bv-pick.locked { color: var(--txt-3); cursor: default; }
 .bv-pick input { width: 15px; height: 15px; accent-color: var(--accent); }
 .bv-customize .js-bv-resetlayout { align-self: center; }
 /* formula / positional-insert chrome */
-.bv-fieldhint { padding: 8px 14px; font-size: 11.5px; color: var(--txt-2); background: var(--panel); border-bottom: 1px solid var(--line); }
-.bv-fieldhint code { background: var(--panel-2); padding: 1px 5px; border-radius: 5px; color: var(--accent); font-size: 11px; }
+.bv-fieldhint { padding: 8px 14px; font-size: 0.6765rem; color: var(--txt-2); background: var(--panel); border-bottom: 1px solid var(--line); }
+.bv-fieldhint code { background: var(--panel-2); padding: 1px 5px; border-radius: 5px; color: var(--accent); font-size: 0.6471rem; }
 .bv-table th { position: relative; }
 .bv-table th.js-bv-sort, .bv-table th.bv-xcol { padding-right: 22px; }
 .bv-ins { position: absolute; right: 2px; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; display: inline-flex; align-items: center; justify-content: center;
@@ -2802,18 +2818,18 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .bv-rowrm:hover { color: var(--red); background: var(--panel-2); }
 .bv-rowins svg { width: 11px; height: 11px; }
 .bv-comp { font-variant-numeric: tabular-nums; color: var(--accent); font-weight: 600; }
-.bv-err { color: var(--red); font-size: 11px; font-weight: 700; }
+.bv-err { color: var(--red); font-size: 0.6471rem; font-weight: 700; }
 .bv-table tbody .bv-scratch-row td { background: color-mix(in srgb, var(--accent) 4%, transparent); }
 .bv-table tfoot .bv-summary .bv-sumlabel { text-align: center; }
 
 /* logo menu popup (§0.4) */
 /* logo-menu signed-in line + Settings login editor */
 .menu-user { display: flex; align-items: center; gap: 8px; padding: 4px 10px 8px; }
-.menu-user .mu-name { font-weight: 800; font-size: 13px; color: var(--txt); }
-.menu-user .mu-role { font-size: 10px; font-weight: 700; color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-line); border-radius: 999px; padding: 1px 8px; }
+.menu-user .mu-name { font-weight: 800; font-size: 0.7647rem; color: var(--txt); }
+.menu-user .mu-role { font-size: 0.5882rem; font-weight: 700; color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-line); border-radius: 999px; padding: 1px 8px; }
 .set-row { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
-.set-row .set-role { flex: 0 0 84px; font-size: 12px; font-weight: 700; color: var(--txt-2); }
-.set-row .set-input { flex: 1; height: 32px; padding: 0 10px; border-radius: 8px; background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 13px; }
+.set-row .set-role { flex: 0 0 84px; font-size: 0.7059rem; font-weight: 700; color: var(--txt-2); }
+.set-row .set-input { flex: 1; height: 32px; padding: 0 10px; border-radius: 8px; background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 0.7647rem; }
 .set-row .set-input:focus { outline: none; border-color: var(--accent-line); }
 .set-row.set-admin { margin-top: 10px; padding-top: 12px; border-top: 1px dashed var(--line); }
 /* Role cards — one panel per login: label + password + remove, with a tier picker beneath. */
@@ -2823,26 +2839,26 @@ body.is-phone .set-tab-l { flex: 0 0 auto; }
 .set-lock { display: inline-flex; align-items: center; color: var(--txt-3); flex: 0 0 auto; }
 .set-lock svg { width: 14px; height: 14px; }
 .set-tierrow { display: flex; align-items: center; gap: 9px; margin-top: 9px; }
-.set-tiercap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 9.5px; font-weight: 700; color: var(--txt-3); flex: 0 0 auto; }
+.set-tiercap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 0.5588rem; font-weight: 700; color: var(--txt-3); flex: 0 0 auto; }
 .set-tierrow .seg.set-tierseg { margin-left: 0; flex: 1 1 auto; }
-.set-tierrow .seg.set-tierseg button { flex: 1 1 0; justify-content: center; padding: 0 7px; font-size: 10px; }
+.set-tierrow .seg.set-tierseg button { flex: 1 1 0; justify-content: center; padding: 0 7px; font-size: 0.5882rem; }
 /* New Customer onboarding form */
 .nc-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 11px 12px; }
 .nc-field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
 .nc-field.nc-wide { grid-column: 1 / -1; }
-.nc-field > span { font-size: 11px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
-.nc-in { height: 34px; padding: 0 10px; border-radius: 8px; background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 13px; width: 100%; }
+.nc-field > span { font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
+.nc-in { height: 34px; padding: 0 10px; border-radius: 8px; background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 0.7647rem; width: 100%; }
 .nc-in:focus { outline: none; border-color: var(--accent-line); }
 select.nc-in { cursor: pointer; }
 .nc-pills { display: flex; flex-wrap: wrap; gap: 6px; }
-.nc-pill { padding: 7px 13px; border-radius: 999px; background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); font-size: 12px; font-weight: 700; cursor: pointer; transition: background .12s, border-color .12s, color .12s; }
+.nc-pill { padding: 7px 13px; border-radius: 999px; background: var(--panel); border: 1px solid var(--line); color: var(--txt-2); font-size: 0.7059rem; font-weight: 700; cursor: pointer; transition: background .12s, border-color .12s, color .12s; }
 .nc-pill:hover { border-color: var(--accent-line); }
 .nc-pill.on { background: var(--accent-soft); border-color: var(--accent-line); color: var(--accent); }
 /* Notes field sharing its row with a red/gray PO-required toggle */
 .nc-notes-po { display: flex; gap: 8px; align-items: stretch; }
 .nc-notes-po .nc-in { flex: 1; min-width: 0; }
 .nc-po { flex: 0 0 auto; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px;
-  font-weight: 700; font-size: 11px; padding: 0 13px; border-radius: 9px; border: 1px solid var(--line);
+  font-weight: 700; font-size: 0.6471rem; padding: 0 13px; border-radius: 9px; border: 1px solid var(--line);
   background: var(--panel); color: var(--txt-3); cursor: pointer; white-space: nowrap; transition: color .12s, border-color .12s, background .12s; }
 .nc-po:hover { border-color: var(--red); color: var(--txt-2); }
 .nc-po.on { color: var(--red); border-color: var(--red); background: var(--red-bg); }
@@ -2853,14 +2869,14 @@ select.nc-in { cursor: pointer; }
 /* customer account packet — selfie / signature / card */
 .nc-popup { width: 500px; max-height: 88vh; }
 .nc-popup .popup-body { overflow-y: auto; }
-.nc-sec-title { display: flex; align-items: center; gap: 9px; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 11.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.3px; color: var(--txt-2); margin: 17px 0 10px; }
+.nc-sec-title { display: flex; align-items: center; gap: 9px; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.6765rem; font-weight: 700; text-transform: uppercase; letter-spacing: 1.3px; color: var(--txt-2); margin: 17px 0 10px; }
 .nc-sec-title::after { content: ''; flex: 1; height: 1px; background: var(--line); }
-.nc-cap-lbl { font-size: 11px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
+.nc-cap-lbl { font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
 .nc-thumb { width: 100%; height: 84px; object-fit: cover; border-radius: 9px; border: 1px solid var(--line); background: var(--panel); }
 .nc-thumb.sig { object-fit: contain; background: #fff; }
 .nc-sigpad { width: 100%; height: 96px; border-radius: 9px; border: 1px solid var(--accent-line); background: #fff; touch-action: none; cursor: crosshair; }
-.nc-agreement { max-height: 168px; overflow-y: auto; white-space: pre-wrap; font-size: 11.5px; line-height: 1.5; color: var(--txt-2); background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 12px 13px; -webkit-overflow-scrolling: touch; }
-.nc-ag-meta { font-size: 12px; font-weight: 700; color: var(--txt-2); margin: 0 0 9px; }
+.nc-agreement { max-height: 168px; overflow-y: auto; white-space: pre-wrap; font-size: 0.6765rem; line-height: 1.5; color: var(--txt-2); background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 12px 13px; -webkit-overflow-scrolling: touch; }
+.nc-ag-meta { font-size: 0.7059rem; font-weight: 700; color: var(--txt-2); margin: 0 0 9px; }
 .nc-ag-sigline { display: flex; align-items: center; gap: 12px; margin-top: 12px; }
 .nc-ag-sigline .nc-thumb.sig { max-height: 72px; }
 
@@ -2872,7 +2888,7 @@ select.nc-in { cursor: pointer; }
 .ag-tabs { display: flex; align-items: flex-end; gap: 2px; flex: 1; flex-wrap: wrap; min-width: 0; }
 .ag-tab { display: flex; align-items: center; gap: 7px; padding: 9px 13px; margin-bottom: -1px;
   font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700;
-  font-size: 12.5px; color: var(--txt-3); background: transparent; border: none; border-radius: 8px 8px 0 0; cursor: pointer;
+  font-size: 0.7353rem; color: var(--txt-3); background: transparent; border: none; border-radius: 8px 8px 0 0; cursor: pointer;
   position: relative; transition: color .12s; }
 .ag-tab:hover { color: var(--txt-2); }
 .ag-tab.on { color: var(--txt); }
@@ -2890,37 +2906,37 @@ select.nc-in { cursor: pointer; }
 .ag-tab.bad { background: var(--red-bg); color: var(--red); box-shadow: 0 0 6px color-mix(in srgb, var(--red) 25%, transparent); }
 .ag-tab.on.ok, .ag-tab.on.mid, .ag-tab.on.bad { color: var(--txt); }   /* selected: the underline already marks "active" — status still reads via background alone */
 /* short status banner — a thin red hazard rail, calm body */
-.ag-banner { position: relative; padding: 9px 13px 9px 20px; border-radius: 10px; margin: 2px 0 16px; font-size: 12.5px; font-weight: 600; }
+.ag-banner { position: relative; padding: 9px 13px 9px 20px; border-radius: 10px; margin: 2px 0 16px; font-size: 0.7353rem; font-weight: 600; }
 .ag-banner.bad { background: var(--red-bg); border: 1px solid var(--accent-line); border-color: var(--red); color: var(--red); -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); box-shadow: 0 0 6px color-mix(in srgb, var(--red) 25%, transparent); }
 .ag-banner.bad::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 8px; border-radius: 10px 0 0 10px;
   background: repeating-linear-gradient(135deg, var(--red) 0 7px, #14181d 7px 14px); }
 /* per-card meta line + states */
-.ag-meta { display: flex; align-items: center; gap: 9px; margin: 2px 0 14px; font-size: 12.5px; color: var(--txt-2); }
+.ag-meta { display: flex; align-items: center; gap: 9px; margin: 2px 0 14px; font-size: 0.7353rem; color: var(--txt-2); }
 .ag-metasep { margin-left: auto; }
-.ag-gate { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin: 0 0 15px; font-size: 12.5px; }
+.ag-gate { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin: 0 0 15px; font-size: 0.7353rem; }
 .ag-gate .lead { color: var(--red); font-weight: 600; -webkit-text-fill-color: color-mix(in srgb, var(--red) 65%, white); text-shadow: 0 0 3px var(--red), 0 0 7px color-mix(in srgb, var(--red) 60%, transparent); }
 .ag-gate .sub { color: var(--txt-3); }
 .ag-readref { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 10px 13px; border-radius: 10px;
-  background: var(--panel); border: 1px solid var(--line); margin: 0 0 14px; font-size: 13px; color: var(--txt-2); }
+  background: var(--panel); border: 1px solid var(--line); margin: 0 0 14px; font-size: 0.7647rem; color: var(--txt-2); }
 .ag-readref b { font-weight: 600; color: var(--txt); }
 .ag-readbtn { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700;
-  font-size: 11px; color: var(--blue); background: transparent; border: none; cursor: pointer; }
+  font-size: 0.6471rem; color: var(--blue); background: transparent; border: none; cursor: pointer; }
 .ag-readbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .ag-readref + .nc-agreement { margin: -6px 0 14px; }
 .ag-signed { display: flex; align-items: center; gap: 9px; padding: 11px 13px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); }
 .ag-lock { color: var(--green); display: flex; flex: 0 0 auto; }
-.ag-signed .t { font-size: 13px; color: var(--txt-2); }
+.ag-signed .t { font-size: 0.7647rem; color: var(--txt-2); }
 .ag-signed .t b { color: var(--txt); font-weight: 600; }
 .ag-signed .pill { margin-left: auto; }
 /* packet on file: selfie + signature side by side */
 .ag-packet { display: flex; gap: 11px; margin-top: 14px; }
 .ag-pcell { flex: 1; min-width: 0; }
-.ag-pcap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 10px; color: var(--txt-3); margin-bottom: 6px; }
+.ag-pcap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 0.5882rem; color: var(--txt-3); margin-bottom: 6px; }
 .ag-pcell .ag-selfie { width: 100%; height: 96px; object-fit: cover; object-position: center 35%; border: 1px solid var(--line); border-radius: 10px; background: var(--panel-2); }
 .ag-pcell .ag-selfie.empty { display: flex; align-items: center; justify-content: center; color: var(--txt-3); }
 .ag-sigthumb { width: 100%; height: 96px; object-fit: contain; border: 1px solid var(--line); border-radius: 10px; background: #fbfcfd; }
 /* CAPTURE row: selfie tile + the BIG sign pad */
-.ag-capcap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 10.5px; color: var(--txt-3); margin: 0 0 8px; }
+.ag-capcap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-size: 0.6176rem; color: var(--txt-3); margin: 0 0 8px; }
 .ag-caphead { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0 0 8px; }
 .ag-caphead .ag-capcap { margin: 0; }
 .ag-caprow { display: flex; gap: 11px; align-items: stretch; }
@@ -2928,7 +2944,7 @@ select.nc-in { cursor: pointer; }
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; color: var(--txt-3); cursor: pointer; overflow: hidden; }
 .ag-selfiebtn:hover { border-color: var(--accent-line); }
 .ag-selfiebtn:focus-within { outline: 2px solid var(--accent); outline-offset: 2px; }
-.ag-selfiebtn .l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-size: 10.5px; }
+.ag-selfiebtn .l { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px; font-size: 0.6176rem; }
 .ag-selfiebtn .ag-selfie { width: 100%; height: 100%; object-fit: cover; object-position: center 35%; }
 /* live selfie camera — auto-on; one tap snaps the photo (file-input fallback when absent) */
 .ag-selfiebtn { position: relative; }
@@ -2939,7 +2955,7 @@ select.nc-in { cursor: pointer; }
 .ag-selfiebtn.live .ag-cam-fallback { display: none; }
 .ag-cam-cap { position: absolute; left: 0; right: 0; bottom: 0; padding: 4px 6px; text-align: center; background: var(--panel-2);
   border-top: 1px solid var(--line); color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif;
-  text-transform: uppercase; letter-spacing: 1.2px; font-size: 9.5px; }
+  text-transform: uppercase; letter-spacing: 1.2px; font-size: 0.5588rem; }
 .ag-cam-hint { display: none; }
 .ag-selfiebtn.live .ag-cam-hint { display: block; }
 .ag-pad { flex: 1; min-width: 0; height: 160px; width: auto; border: 1.5px dashed var(--line); border-radius: 12px;
@@ -2950,42 +2966,42 @@ select.nc-in { cursor: pointer; }
 /* §7.1c the 3-piece capture progress strip (typographic data-plate, not a pill) + per-piece saved hints */
 .ag-prog { margin: 0 0 14px; padding: 10px 13px; border-radius: 10px; background: var(--panel); border: 1px solid var(--line); }
 .ag-prog-row { display: flex; flex-wrap: wrap; gap: 6px 16px; align-items: center; }
-.ag-prog-item { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 11px; color: var(--txt-3); }
+.ag-prog-item { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 0.6471rem; color: var(--txt-3); }
 .ag-prog-item.done { color: var(--green); }
-.ag-prog-note { margin-top: 7px; font-size: 11px; color: var(--txt-3); }
+.ag-prog-note { margin-top: 7px; font-size: 0.6471rem; color: var(--txt-3); }
 .ag-saverow { display: flex; gap: 16px; margin: 10px 2px 0; }
-.ag-savedhint { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 600; font-size: 9.5px; color: var(--txt-3); }
+.ag-savedhint { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 600; font-size: 0.5588rem; color: var(--txt-3); }
 .ag-savedhint.on { color: var(--green); }
 /* saddle-stitch seam between the card field and the held-agreement capture in the +Card panel */
 .ag-cardsplit { height: 0; margin: 16px 0 4px; border-top: 1.5px dashed var(--tan, #c2925a);
   border-image: repeating-linear-gradient(90deg, var(--tan, #c2925a) 0 7px, transparent 7px 13px) 1; }
 @media (prefers-reduced-motion: reduce) { .ag-tab { transition: none; } }
 /* Stripe payment UI */
-.pay-cap { font-size: 11px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; margin: 0 0 6px; }
+.pay-cap { font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; margin: 0 0 6px; }
 .pay-card-field { padding: 12px 13px; border: 1px solid var(--accent-line); border-radius: 10px; background: var(--panel); }
 .pay-card-field.StripeElement--focus { border-color: var(--accent); }
-.pay-err { color: var(--red, #ff6b6b); font-size: 12px; min-height: 16px; margin-top: 7px; }
+.pay-err { color: var(--red, #ff6b6b); font-size: 0.7059rem; min-height: 16px; margin-top: 7px; }
 .pay-amount { display: flex; align-items: baseline; gap: 8px; margin-bottom: 14px; }
-.pay-amount-num { font-size: 30px; font-weight: 800; color: var(--txt); letter-spacing: -.5px; }
-.pay-amount-sfx { font-size: 12px; color: var(--txt-3); }
-.pay-card-on-file { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--txt-2); padding: 10px 12px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
+.pay-amount-num { font-size: 1.7647rem; font-weight: 800; color: var(--txt); letter-spacing: -.5px; }
+.pay-amount-sfx { font-size: 0.7059rem; color: var(--txt-3); }
+.pay-card-on-file { display: flex; align-items: center; gap: 8px; font-size: 0.7647rem; color: var(--txt-2); padding: 10px 12px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
 .pay-card-on-file.warn { color: var(--yellow); border-color: var(--yellow-bg); }
 .pay-card-on-file.good { color: var(--good, #1a9f57); }
-.pay-status-line { display: flex; align-items: center; gap: 8px; margin: -6px 0 12px; font-size: 12px; }
+.pay-status-line { display: flex; align-items: center; gap: 8px; margin: -6px 0 12px; font-size: 0.7059rem; }
 .pay-field { display: flex; flex-direction: column; gap: 5px; margin-top: 12px; }
-.pay-field > span { font-size: 11px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
-.pay-amt-in { width: 100%; box-sizing: border-box; padding: 9px 11px; border: 1px solid var(--accent-line); border-radius: 9px; background: var(--panel); color: var(--txt); font: inherit; font-size: 15px; }
-.pay-confirm { margin-top: 12px; padding: 10px 12px; border: 1px solid var(--red); border-radius: 9px; background: var(--red-bg); color: var(--txt); font-size: 13px; }
+.pay-field > span { font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
+.pay-amt-in { width: 100%; box-sizing: border-box; padding: 9px 11px; border: 1px solid var(--accent-line); border-radius: 9px; background: var(--panel); color: var(--txt); font: inherit; font-size: 0.8824rem; }
+.pay-confirm { margin-top: 12px; padding: 10px 12px; border: 1px solid var(--red); border-radius: 9px; background: var(--red-bg); color: var(--txt); font-size: 0.7647rem; }
 /* §19 partial-payment allocation rows */
 .alloc-sec { margin-top: 14px; border-top: 1px solid var(--line); padding-top: 12px; }
-.alloc-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; font-size: 11px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
+.alloc-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; font-size: 0.6471rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .3px; }
 .alloc-head .add-field { text-transform: none; }
-.alloc-row { display: flex; align-items: center; gap: 8px; margin: 6px 0; font-size: 12.5px; }
+.alloc-row { display: flex; align-items: center; gap: 8px; margin: 6px 0; font-size: 0.7353rem; }
 .alloc-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--txt-2); }
-.alloc-rem { flex: 0 0 auto; font-size: 11px; color: var(--txt-3); }
+.alloc-rem { flex: 0 0 auto; font-size: 0.6471rem; color: var(--txt-3); }
 .alloc-dollar { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 2px; color: var(--txt-3); }
-.alloc-in { width: 80px; box-sizing: border-box; padding: 6px 8px; border: 1px solid var(--accent-line); border-radius: 8px; background: var(--panel); color: var(--txt); font: inherit; font-size: 13px; text-align: right; }
-.alloc-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 10px; font-size: 12.5px; color: var(--txt-2); }
+.alloc-in { width: 80px; box-sizing: border-box; padding: 6px 8px; border: 1px solid var(--accent-line); border-radius: 8px; background: var(--panel); color: var(--txt); font: inherit; font-size: 0.7647rem; text-align: right; }
+.alloc-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 10px; font-size: 0.7353rem; color: var(--txt-2); }
 .alloc-foot b { color: var(--txt); }
 /* §19b refund-allocation panel + per-line refund display (#125) — calm/muted: the ↩
    marker is a plain fact and the strike carries the "reversed" signal; registry red
@@ -2995,7 +3011,7 @@ select.nc-in { cursor: pointer; }
 .struck { text-decoration: line-through; }
 .inv-line.line-refunded { opacity: .6; }
 .stall.stall-refunded { opacity: .7; }
-.stall-refund { font-size: 11px; font-weight: 600; letter-spacing: .2px; color: var(--txt-3); white-space: nowrap; }
+.stall-refund { font-size: 0.6471rem; font-weight: 600; letter-spacing: .2px; color: var(--txt-3); white-space: nowrap; }
 
 /* role KPI popup */
 .kpi-popup { width: 420px; }
@@ -3003,65 +3019,65 @@ select.nc-in { cursor: pointer; }
 .kpi-popup .big-ring svg { width: 150px; height: 150px; flex: 0 0 auto; }
 /* Team KPI block inside the logo dropdown menu */
 .menu-team { width: 226px; padding: 2px 2px; }
-.menu-team-head { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); padding: 2px 8px 4px; }
+.menu-team-head { font-size: 0.5882rem; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); padding: 2px 8px 4px; }
 .menu-team-ring { display: flex; align-items: center; justify-content: center; padding: 2px 0 10px; }
 .menu-team-ring svg { width: 104px; height: 104px; flex: 0 0 auto; }
 .menu-team .kpi-list { display: flex; flex-direction: column; gap: 5px; }
 .menu-team .kpi-line { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 9px; border-radius: 8px; background: var(--panel-2); }
-.menu-team .kpi-line .k-name { font-size: 12px; font-weight: 600; flex: 1; }
-.menu-team .kpi-line .k-val { font-size: 13px; font-weight: 700; }
+.menu-team .kpi-line .k-name { font-size: 0.7059rem; font-weight: 600; flex: 1; }
+.menu-team .kpi-line .k-val { font-size: 0.7647rem; font-weight: 700; }
 .menu-team .ring-no { width: 14px; height: 14px; }
 .kpi-popup .kpi-list { display: flex; flex-direction: column; gap: 8px; }
 .kpi-popup .kpi-line { display: flex; align-items: center; justify-content: space-between; padding: 9px 11px; border-radius: 10px; background: var(--panel-2); border: 1px solid var(--line); }
 .kpi-popup .kpi-line { gap: 10px; }
-.kpi-popup .kpi-line .k-name { font-size: 13px; font-weight: 600; flex: 1; }
-.kpi-popup .kpi-line .k-val { font-size: 14px; font-weight: 700; }
-.ring-no { display: inline-grid; place-items: center; width: 19px; height: 19px; border-radius: 50%; border: 1.5px solid var(--line); font-size: 10px; font-weight: 800; flex: 0 0 auto; }
+.kpi-popup .kpi-line .k-name { font-size: 0.7647rem; font-weight: 600; flex: 1; }
+.kpi-popup .kpi-line .k-val { font-size: 0.8235rem; font-weight: 700; }
+.ring-no { display: inline-grid; place-items: center; width: 19px; height: 19px; border-radius: 50%; border: 1.5px solid var(--line); font-size: 0.5882rem; font-weight: 800; flex: 0 0 auto; }
 /* §12.8 inspection report popup — photo + gated wash/checklist */
 .insp-popup { width: 380px; }
-.insp-photo { display: flex; align-items: center; justify-content: center; width: 100%; min-height: 120px; border-radius: 12px; border: 1px dashed var(--accent-line); background: var(--accent-soft); color: var(--accent); font-size: 13px; font-weight: 700; cursor: pointer; overflow: hidden; margin-bottom: 4px; position: relative; }
+.insp-photo { display: flex; align-items: center; justify-content: center; width: 100%; min-height: 120px; border-radius: 12px; border: 1px dashed var(--accent-line); background: var(--accent-soft); color: var(--accent); font-size: 0.7647rem; font-weight: 700; cursor: pointer; overflow: hidden; margin-bottom: 4px; position: relative; }
 .insp-photo span { display: inline-flex; align-items: center; gap: 8px; }
 .insp-photo svg { width: 18px; height: 18px; }
 .insp-photo img, .insp-photo video { width: 100%; max-height: 220px; object-fit: cover; display: block; background: #000; }
-.insp-rephoto { position: absolute; right: 8px; bottom: 8px; background: rgba(0,0,0,.6); color: #fff; padding: 4px 10px; border-radius: 8px; font-size: 11px; cursor: pointer; }
+.insp-rephoto { position: absolute; right: 8px; bottom: 8px; background: rgba(0,0,0,.6); color: #fff; padding: 4px 10px; border-radius: 8px; font-size: 0.6471rem; cursor: pointer; }
 .insp-popup .pill { cursor: pointer; }
-.insp-desc { width: 100%; min-height: 84px; margin-top: 12px; resize: vertical; border-radius: 10px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); font: inherit; font-size: 13px; padding: 10px; line-height: 1.4; }
+.insp-desc { width: 100%; min-height: 84px; margin-top: 12px; resize: vertical; border-radius: 10px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); font: inherit; font-size: 0.7647rem; padding: 10px; line-height: 1.4; }
 .insp-desc:focus { outline: none; border-color: var(--accent-line); }
-.svc-field { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 10px; font-size: 12px; font-weight: 700; color: var(--txt-2); }
-.svc-field input { height: 32px; width: 150px; border-radius: 8px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); font: inherit; font-size: 13px; padding: 0 9px; color-scheme: dark; }
+.svc-field { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 10px; font-size: 0.7059rem; font-weight: 700; color: var(--txt-2); }
+.svc-field input { height: 32px; width: 150px; border-radius: 8px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt); font: inherit; font-size: 0.7647rem; padding: 0 9px; color-scheme: dark; }
 .svc-ref { margin-bottom: 12px; padding: 10px; border-radius: 10px; background: var(--panel-2); border: 1px solid var(--line); }
-.svc-ref-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 5px; }
-.svc-ref-body { font-size: 12px; color: var(--txt-2); line-height: 1.5; }
+.svc-ref-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 0.5882rem; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-bottom: 5px; }
+.svc-ref-body { font-size: 0.7059rem; color: var(--txt-2); line-height: 1.5; }
 /* "What you need" (Jac 2026-07-08, service-detail-panel): fluid + parts spec inside
    the service-completion popup's .svc-ref panel — the capacity is what a mechanic
    acts on, so it reads at "big value" weight (matches .kv .v), everything else stays
    at the panel's quiet muted register. */
 .svc-fluid { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; color: var(--txt); }
 .svc-fluid svg { width: 16px; height: 16px; color: var(--accent); flex-shrink: 0; }
-.svc-fluid-txt { font-size: 13px; }
-.svc-fluid-txt b { font-size: 15px; font-weight: 700; }
-.svc-notes { font-size: 11.5px; margin-bottom: 8px; }
-.svc-parts-head { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin: 10px 0 3px; }
+.svc-fluid-txt { font-size: 0.7647rem; }
+.svc-fluid-txt b { font-size: 0.8824rem; font-weight: 700; }
+.svc-notes { font-size: 0.6765rem; margin-bottom: 8px; }
+.svc-parts-head { font-size: 0.5882rem; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin: 10px 0 3px; }
 .svc-editnote { text-transform: none; font-weight: 600; letter-spacing: 0; color: var(--txt-3); opacity: .8; }
 .svc-partadd { margin-top: 6px; display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
 /* the part-detail side panel — a second .popup beside the service popup (cardSub §14
    side-by-side precedent: the .overlay is already flex + gap, so a 2nd child lays out
    beside the 1st with no new layout machinery). */
 .svc-part-popup .popup-body { padding-top: 4px; }
-.svc-part-row { margin: 6px 0; font-size: 12.5px; }
+.svc-part-row { margin: 6px 0; font-size: 0.7353rem; }
 .svc-vendor-block { display: flex; flex-direction: column; gap: 3px; align-items: flex-start; margin-top: 4px; }
-.svc-vendor-name { font-weight: 700; color: var(--txt); font-size: 13px; }
+.svc-vendor-name { font-weight: 700; color: var(--txt); font-size: 0.7647rem; }
 /* §12.7 service task rows (status pill gates the completion popup) */
 .svc-task { padding: 4px 0; border-bottom: 1px solid var(--line-soft); }
 .svc-task:last-child { border-bottom: none; }
-.svc-task-top { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--txt-2); }
+.svc-task-top { display: flex; align-items: center; gap: 8px; font-size: 0.7059rem; color: var(--txt-2); }
 .svc-task-top .svc-name { font-weight: 600; color: var(--txt); }
 .svc-task-top .js-svc-complete { cursor: pointer; }
-.svc-task-sub { font-size: 11px; margin-top: 3px; margin-left: 86px; }
+.svc-task-sub { font-size: 0.6471rem; margin-top: 3px; margin-left: 86px; }
 .insp-thumb { width: 84px; height: 60px; object-fit: cover; border-radius: 8px; cursor: pointer; border: 1px solid var(--line); margin-top: 2px; background: #000; }
 /* inline wash / pass-fail gate (standard mode) */
 .insp-gate { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
-.insp-gate-lbl { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-right: 2px; }
+.insp-gate-lbl { font-size: 0.5882rem; font-weight: 800; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); margin-right: 2px; }
 .insp-gate .pill { cursor: pointer; }
 
 /* pill-styled transport <select> (editable, §7.4) */
@@ -3075,11 +3091,11 @@ select.nc-in { cursor: pointer; }
 .hidden { display: none !important; }
 .spacer { flex: 1; }
 .muted { color: var(--txt-3); }
-.toast { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) scale(.94); z-index: 80; background: var(--accent); border: 1px solid var(--accent); color: #1a1305; padding: 15px 24px; border-radius: 14px; box-shadow: 0 12px 44px rgba(0, 0, 0, .5); font-size: 15px; font-weight: 800; opacity: 0; pointer-events: none; transition: opacity .18s, transform .18s; text-align: center; max-width: 78vw; }
+.toast { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) scale(.94); z-index: 80; background: var(--accent); border: 1px solid var(--accent); color: #1a1305; padding: 15px 24px; border-radius: 14px; box-shadow: 0 12px 44px rgba(0, 0, 0, .5); font-size: 0.8824rem; font-weight: 800; opacity: 0; pointer-events: none; transition: opacity .18s, transform .18s; text-align: center; max-width: 78vw; }
 .toast.show { opacity: 1; transform: translate(-50%, -50%) scale(1); }
 
 /* custom tooltip (app-styled, replaces the native browser title) */
-.tooltip { position: fixed; z-index: 90; max-width: 340px; padding: 6px 10px; background: var(--panel-2); border: 1px solid var(--line); border-radius: 9px; box-shadow: var(--shadow); font-size: 12px; font-weight: 500; color: var(--txt); pointer-events: none; opacity: 0; transition: opacity .12s; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tooltip { position: fixed; z-index: 90; max-width: 340px; padding: 6px 10px; background: var(--panel-2); border: 1px solid var(--line); border-radius: 9px; box-shadow: var(--shadow); font-size: 0.7059rem; font-weight: 500; color: var(--txt); pointer-events: none; opacity: 0; transition: opacity .12s; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .tooltip.show { opacity: 1; }
 
 /* §16 — sign-in screen (shared-password gate for the Sheets backend) */
@@ -3134,22 +3150,22 @@ select.nc-in { cursor: pointer; }
 .login-box .rivet.bl { bottom: 13px; left: 14px; } .login-box .rivet.br { bottom: 13px; right: 14px; }
 .login-plate { display: flex; flex-direction: column; align-items: center; width: 100%; padding: 24px 30px 0; }
 .login-logo { width: 62px; height: 62px; border-radius: 14px; object-fit: cover; box-shadow: 0 5px 16px -5px #000, 0 0 0 1px rgba(255, 255, 255, .06); }
-.login-title { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 31px;
+.login-title { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 1.8235rem;
   letter-spacing: 1.4px; text-transform: uppercase; color: #eef2f6; line-height: 1; margin-top: 13px; }
-.login-sub { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 11px; font-weight: 600;
+.login-sub { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.6471rem; font-weight: 600;
   letter-spacing: 2px; text-transform: uppercase; white-space: nowrap; color: var(--txt-3, #8b94a3); margin: 5px 0 20px; }
 .login-field { width: 100%; }
-.login-lbl { display: block; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 10.5px; font-weight: 600;
+.login-lbl { display: block; font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.6176rem; font-weight: 600;
   letter-spacing: 1.8px; text-transform: uppercase; color: var(--txt-3, #8b94a3); margin: 0 0 5px 2px; }
 .login-input { width: 100%; height: 44px; padding: 0 13px; border-radius: 9px;
-  background: #0e1217; border: 1px solid #2a313b; color: var(--txt, #e8edf2); font-size: 14px;
+  background: #0e1217; border: 1px solid #2a313b; color: var(--txt, #e8edf2); font-size: 0.8235rem;
   transition: border-color .12s, box-shadow .12s; margin-bottom: 13px; }
 .login-input::placeholder { color: #5a6573; }
 .login-input:focus { outline: none; border-color: var(--accent, #ff7a1a); box-shadow: 0 0 0 3px rgba(255, 122, 26, .17); }
 .login-btn {   /* the ignition — hi-vis orange, dark ink */
   width: 100%; height: 47px; border-radius: 9px; border: none; cursor: pointer; margin-top: 5px;
   background: linear-gradient(180deg, #ff9038, var(--accent, #ff7a1a)); color: #1a1205;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 16px; letter-spacing: 2.2px; text-transform: uppercase;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 0.9412rem; letter-spacing: 2.2px; text-transform: uppercase;
   box-shadow: 0 7px 20px -7px rgba(255, 122, 26, .65), inset 0 1px 0 rgba(255, 255, 255, .35);
   transition: filter .12s, transform .04s; }
 .login-btn:hover { filter: brightness(1.06); } .login-btn:active { transform: translateY(1px); }
@@ -3181,7 +3197,7 @@ select.nc-in { cursor: pointer; }
 .login-pw-eye svg { width: 18px; height: 18px; }
 .login-pw-eye:hover { color: #eef2f6; }
 .login-pw-eye:focus-visible { outline: 2px solid var(--accent, #ff7a1a); outline-offset: -3px; border-radius: 7px; color: #eef2f6; }
-.login-err { font-size: 12px; font-weight: 600; color: var(--red, #ff4242); text-align: center; margin-top: 11px; min-height: 14px; }
+.login-err { font-size: 0.7059rem; font-weight: 600; color: var(--red, #ff4242); text-align: center; margin-top: 11px; min-height: 14px; }
 /* ══ SCAN-TO-LOG (QR decal → video) — standalone capture plate; models the .login-box plate ══ */
 .scan-screen {
   min-height: 100vh; min-height: 100dvh;
@@ -3210,34 +3226,34 @@ select.nc-in { cursor: pointer; }
 .scan-box .rivet.bl { bottom: 13px; left: 14px; } .scan-box .rivet.br { bottom: 13px; right: 14px; }
 .scan-plate { display: flex; flex-direction: column; align-items: center; width: 100%; padding: 22px 30px 0; }
 .scan-brand { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; margin-bottom: 20px; }
-.scan-brandtxt { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 18px; letter-spacing: 1.2px; text-transform: uppercase; color: #eef2f6; }
+.scan-brandtxt { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 1.0588rem; letter-spacing: 1.2px; text-transform: uppercase; color: #eef2f6; }
 .scan-brandtxt b { color: inherit; }   /* wordmark stays steel — the RECORD ignition owns the one orange (R3) */
-.scan-tag { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 9.5px; font-weight: 700; letter-spacing: 1.4px; text-transform: uppercase;
+.scan-tag { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.5588rem; font-weight: 700; letter-spacing: 1.4px; text-transform: uppercase;
   color: var(--txt-3, #8b94a3); background: #0e1217; border: 1px solid #2a313b; padding: 3px 7px; border-radius: 5px; }
 .scan-body { display: flex; flex-direction: column; align-items: center; width: 100%; text-align: center; }
-.scan-unit { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 26px; letter-spacing: .4px; text-transform: uppercase; color: #eef2f6; line-height: 1.05; }
-.scan-uid { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 12px; font-weight: 600; letter-spacing: 1.6px; color: var(--txt-3, #8b94a3); margin-top: 3px; }
-.scan-stamp { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 11px; font-weight: 600; letter-spacing: 1.8px; text-transform: uppercase; color: var(--txt-3, #8b94a3); margin: 14px 0 16px; }
+.scan-unit { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 1.5294rem; letter-spacing: .4px; text-transform: uppercase; color: #eef2f6; line-height: 1.05; }
+.scan-uid { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.7059rem; font-weight: 600; letter-spacing: 1.6px; color: var(--txt-3, #8b94a3); margin-top: 3px; }
+.scan-stamp { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.6471rem; font-weight: 600; letter-spacing: 1.8px; text-transform: uppercase; color: var(--txt-3, #8b94a3); margin: 14px 0 16px; }
 .scan-rec {   /* the ignition — hi-vis orange, dark ink; same treatment as the login button */
   display: inline-flex; align-items: center; justify-content: center; gap: 9px; cursor: pointer;
   width: 100%; height: 56px; border-radius: 11px; border: none;
   background: linear-gradient(180deg, #ff9038, var(--accent, #ff7a1a)); color: #1a1205;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 19px; letter-spacing: 2.2px; text-transform: uppercase;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 1.1176rem; letter-spacing: 2.2px; text-transform: uppercase;
   box-shadow: 0 7px 20px -7px rgba(255, 122, 26, .65), inset 0 1px 0 rgba(255, 255, 255, .35);
   transition: filter .12s, transform .04s; }
 .scan-rec svg { width: 22px; height: 22px; }
 .scan-rec:hover { filter: brightness(1.06); } .scan-rec:active { transform: translateY(1px); }
-.scan-hint { font-size: 12px; line-height: 1.5; color: var(--txt-3, #8b94a3); margin: 15px 4px 0; }
-.scan-block { font-size: 13.5px; line-height: 1.5; color: #eef2f6; background: #0e1217; border: 1px solid #2a313b; border-radius: 10px; padding: 13px 14px; margin: 6px 0 16px; }
+.scan-hint { font-size: 0.7059rem; line-height: 1.5; color: var(--txt-3, #8b94a3); margin: 15px 4px 0; }
+.scan-block { font-size: 0.7941rem; line-height: 1.5; color: #eef2f6; background: #0e1217; border: 1px solid #2a313b; border-radius: 10px; padding: 13px 14px; margin: 6px 0 16px; }
 .scan-ghost { background: none; border: 1px solid #2a313b; color: #b9c2cf; cursor: pointer;
   height: 42px; padding: 0 20px; border-radius: 9px;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 13px; letter-spacing: 1.6px; text-transform: uppercase;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 0.7647rem; letter-spacing: 1.6px; text-transform: uppercase;
   transition: border-color .12s, color .12s; }
 .scan-ghost:hover { color: #eef2f6; border-color: #39424e; }
 .scan-rec:focus-visible, .scan-ghost:focus-visible { outline: 2px solid var(--accent, #ff7a1a); outline-offset: 2px; }
 .scan-spin { color: var(--accent, #ff7a1a); margin: 6px 0 4px; animation: scanPulse 1.1s ease-in-out infinite; }
 .scan-spin svg { width: 34px; height: 34px; }
-.scan-ok { color: var(--green, #3ecf6a); line-height: 1; margin-bottom: 8px; font-size: 40px; }
+.scan-ok { color: var(--green, #3ecf6a); line-height: 1; margin-bottom: 8px; font-size: 2.3529rem; }
 .scan-ok svg { width: 40px; height: 40px; }
 @keyframes scanPulse { 0%, 100% { opacity: .45; } 50% { opacity: 1; } }
 @media (prefers-reduced-motion: reduce) { .scan-spin { animation: none; } }
@@ -3247,7 +3263,7 @@ select.nc-in { cursor: pointer; }
 .env-badge {
   position: fixed; z-index: 90; left: 12px; bottom: 12px; pointer-events: none;
   display: inline-flex; align-items: center; gap: 7px;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 11px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 0.6471rem;
   letter-spacing: 2.5px; text-transform: uppercase; color: var(--slot-c);
   padding: 5px 11px 5px 9px; border-radius: 7px;
   background: linear-gradient(180deg, #1b2129, #0c0e11);
@@ -3259,7 +3275,7 @@ select.nc-in { cursor: pointer; }
    so the "1 / 2 / 3" reads instantly. --on-orange is the theme-safe dark ink token. */
 .env-badge-num {
   display: inline-grid; place-items: center; min-width: 15px; height: 15px; padding: 0 3px;
-  margin-left: 1px; border-radius: 4px; letter-spacing: 0; font-size: 12px;
+  margin-left: 1px; border-radius: 4px; letter-spacing: 0; font-size: 0.7059rem;
   background: var(--slot-c); color: var(--on-orange); }
 /* Slot IDENTITY color — one var shared by the badge, its chip, and the top edge bar. The DEFAULT
    is declared FIRST (for both elements) so the bare-class overrides below — equal specificity —
@@ -3292,7 +3308,7 @@ select.nc-in { cursor: pointer; }
 body.rw-refreshing #cache-refreshing {
   position: fixed; z-index: 8800; top: max(64px, calc(env(safe-area-inset-top) + 60px)); left: 50%; transform: translateX(-50%);   /* just below the header band; above all header chrome, below the 9000+ interactive floats (hover 9000 / dropdown 9100 / drag 9400). pointer-events:none, so it never intercepts */
   display: inline-flex; align-items: center; gap: 8px; pointer-events: none;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 11px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 0.6471rem;
   letter-spacing: 2px; text-transform: uppercase; color: var(--txt-2, #b9c2cf);
   padding: 5px 12px 5px 9px; border-radius: 999px;
   background: linear-gradient(180deg, #1b2129, #0c0e11);
@@ -3314,28 +3330,28 @@ body.rw-refreshing #cache-refreshing {
    EXTEND the data-plate vocabulary above: same steel wells (#0e1217 / #2a313b), orange
    ignition (.login-btn), Saira-stamped labels. New: a masked-hint line, the code/PIN
    input, the "shared device?" choice pair, the roster name-pick, and a quiet ghost link. ── */
-.login-hint { font-size: 12.5px; color: var(--txt-2, #b9c2cf); text-align: center; line-height: 1.4; margin: 2px 0 14px; }
-.login-ask { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 12px; font-weight: 700; letter-spacing: 1.6px; text-transform: uppercase; color: var(--txt-3, #8b94a3); text-align: center; margin: 4px 0 10px; }
-.login-otp { text-align: center; font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 23px; letter-spacing: .4em; text-indent: .4em; }   /* text-indent balances the trailing letter-spacing so the digits sit centered */
+.login-hint { font-size: 0.7353rem; color: var(--txt-2, #b9c2cf); text-align: center; line-height: 1.4; margin: 2px 0 14px; }
+.login-ask { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.7059rem; font-weight: 700; letter-spacing: 1.6px; text-transform: uppercase; color: var(--txt-3, #8b94a3); text-align: center; margin: 4px 0 10px; }
+.login-otp { text-align: center; font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 1.3529rem; letter-spacing: .4em; text-indent: .4em; }   /* text-indent balances the trailing letter-spacing so the digits sit centered */
 .login-ghost { width: 100%; margin-top: 11px; background: none; border: none; cursor: pointer;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 600; font-size: 12px; letter-spacing: 1.4px; text-transform: uppercase; color: var(--txt-3, #8b94a3); transition: color .12s; }
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 600; font-size: 0.7059rem; letter-spacing: 1.4px; text-transform: uppercase; color: var(--txt-3, #8b94a3); transition: color .12s; }
 .login-ghost:hover { color: #eef2f6; }
 .login-ghost:focus-visible { outline: 2px solid var(--accent, #ff7a1a); outline-offset: 2px; border-radius: 6px; color: #eef2f6; }
 .login-choice { display: flex; flex-direction: column; gap: 9px; width: 100%; margin-top: 3px; }
 .login-choice-btn { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; width: 100%; padding: 11px 14px; cursor: pointer;
   border-radius: 9px; border: 1px solid #2a313b; background: #0e1217; text-align: left; transition: border-color .12s, box-shadow .12s; }
-.login-choice-btn .lc-t { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 15px; letter-spacing: .6px; text-transform: uppercase; color: var(--txt, #e8edf2); }
-.login-choice-btn .lc-s { font-size: 11.5px; color: var(--txt-3, #8b94a3); }
+.login-choice-btn .lc-t { font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 700; font-size: 0.8824rem; letter-spacing: .6px; text-transform: uppercase; color: var(--txt, #e8edf2); }
+.login-choice-btn .lc-s { font-size: 0.6765rem; color: var(--txt-3, #8b94a3); }
 .login-choice-btn:hover { border-color: #39424e; }
 .login-choice-btn:focus-visible { outline: none; border-color: var(--accent, #ff7a1a); box-shadow: 0 0 0 3px rgba(255, 122, 26, .17); }
 .login-pick { display: flex; flex-direction: column; gap: 7px; width: 100%; max-height: 216px; overflow-y: auto; margin-bottom: 4px; }
 .login-pick-btn { width: 100%; height: 42px; padding: 0 14px; cursor: pointer; text-align: left;
-  border-radius: 9px; border: 1px solid #2a313b; background: #0e1217; color: var(--txt, #e8edf2); font-weight: 700; font-size: 14px; transition: border-color .12s, box-shadow .12s; }
+  border-radius: 9px; border: 1px solid #2a313b; background: #0e1217; color: var(--txt, #e8edf2); font-weight: 700; font-size: 0.8235rem; transition: border-color .12s, box-shadow .12s; }
 .login-pick-btn:hover { border-color: #39424e; }
 .login-pick-btn:focus-visible { outline: none; border-color: var(--accent, #ff7a1a); box-shadow: 0 0 0 3px rgba(255, 122, 26, .17); }
 /* Tier-approval shell (tierAuth popup) — reuses the login pick/OTP shapes so "pick a person +
    enter a texted code" reads the same everywhere; only the popup-context fit lives here. */
-.taz-role { color: var(--txt-3, #8b94a3); font-size: 11.5px; font-weight: 400; }
+.taz-role { color: var(--txt-3, #8b94a3); font-size: 0.6765rem; font-weight: 400; }
 .popup .login-pick { margin: 0; }
 .popup .login-otp { height: 40px; }
 .popup .login-hint { margin: 2px 0 10px; }
@@ -3343,7 +3359,7 @@ body.rw-refreshing #cache-refreshing {
    quiet steel button matching the .set-input wells; not a lint-family element, so no data-r. */
 .emp-act { height: 28px; padding: 0 11px; cursor: pointer; border-radius: 8px;
   border: 1px solid var(--line); background: var(--panel-2, #12161c); color: var(--txt-2);
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 600; font-size: 11px; letter-spacing: 1.2px; text-transform: uppercase;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 600; font-size: 0.6471rem; letter-spacing: 1.2px; text-transform: uppercase;
   transition: border-color .12s, color .12s; }
 .emp-act:hover { color: var(--txt); border-color: var(--accent-line, var(--accent)); }
 .emp-act:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -3351,19 +3367,19 @@ body.rw-refreshing #cache-refreshing {
    saddle-stitch (tan dashed) top rule seasons it as its own wrangler block; the textarea
    matches the .set-input wells. Not a lint-family element, so no data-r. */
 .emp-welcome { margin: 11px 0 3px; padding-top: 11px; border-top: 1px dashed color-mix(in srgb, var(--tan, #c2925a) 62%, transparent); }
-.emp-welcome-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 11.5px; color: var(--txt-2); margin-bottom: 6px; }
+.emp-welcome-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 700; font-size: 0.6765rem; color: var(--txt-2); margin-bottom: 6px; }
 .emp-welcome-ta { width: 100%; min-height: 60px; padding: 8px 10px; border-radius: 8px;
   background: var(--panel); border: 1px solid var(--line); color: var(--txt);
-  font-family: var(--font); font-size: 13px; line-height: 1.45; resize: vertical; }
+  font-family: var(--font); font-size: 0.7647rem; line-height: 1.45; resize: vertical; }
 .emp-welcome-ta::placeholder { color: var(--txt-3); }
 .emp-welcome-ta:focus { outline: none; border-color: var(--accent-line, var(--accent)); }
 .emp-welcome-foot { display: flex; align-items: flex-start; gap: 12px; margin-top: 7px; }
-.emp-welcome-tok { flex: 1; min-width: 0; font-size: 11px; line-height: 1.5; color: var(--txt-3); }
+.emp-welcome-tok { flex: 1; min-width: 0; font-size: 0.6471rem; line-height: 1.5; color: var(--txt-3); }
 .emp-welcome-tok em { font-style: normal; font-family: ui-monospace, monospace; color: var(--txt-2); }
 .emp-welcome-foot .emp-act { flex: 0 0 auto; }
 
 /* §7.1 — R5 ADD affordance: dashed "+Thing" (no word "Add", no space after +) */
-.add-field { color: var(--txt-2); font-weight: 700; border: 1px dashed var(--line); border-radius: 11px; padding: 0 12px; height: 30px; display: inline-flex; align-items: center; background: transparent; font-family: inherit; font-size: 13px; cursor: pointer; }
+.add-field { color: var(--txt-2); font-weight: 700; border: 1px dashed var(--line); border-radius: 11px; padding: 0 12px; height: 30px; display: inline-flex; align-items: center; background: transparent; font-family: inherit; font-size: 0.7647rem; cursor: pointer; }
 .add-field:hover { border-color: var(--accent-line); }
 .add-field.link-ink { color: var(--accent); }            /* R5: orange ink = creates/links a record */
 /* (orange hover on plain adds removed — Jac 2026-06-11: only LINK adds are orange) */
@@ -3391,10 +3407,10 @@ body.rw-lint .seg:not([data-r]) {
 #rw-tip { position: fixed; z-index: 200; display: none; pointer-events: none; max-width: 240px;
   background: var(--card); border: 1px solid var(--accent-line); border-radius: 10px;
   box-shadow: 0 0 0 3px var(--accent-soft), var(--shadow); padding: 6px 10px;
-  font-size: 11px; font-weight: 600; color: var(--txt); }
+  font-size: 0.6471rem; font-weight: 600; color: var(--txt); }
 #rw-tip b { color: var(--accent); font-weight: 800; margin-right: 5px; }
 #rw-tip b.bad { color: var(--red); }
-#rw-tip .rt-b { display: block; font-size: 9.5px; color: var(--txt-3); font-family: ui-monospace, monospace; }
+#rw-tip .rt-b { display: block; font-size: 0.5588rem; color: var(--txt-3); font-family: ui-monospace, monospace; }
 body.rw-inspect .pill, body.rw-inspect .add-field, body.rw-inspect .flag,
 body.rw-inspect .linkname, body.rw-inspect .inv-line-link, body.rw-inspect .req,
 body.rw-inspect .seg, body.rw-inspect .jnode, body.rw-inspect .c-titlecard { cursor: help !important; }
@@ -3405,16 +3421,16 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rb-row { display: grid; grid-template-columns: 44px 200px 1fr; gap: 12px; align-items: center;
   padding: 9px 2px; border-bottom: 1px solid var(--line-soft); }
 .rb-row:last-child { border-bottom: none; }
-.rb-id { font-size: 12px; font-weight: 800; color: var(--accent); background: var(--accent-soft);
+.rb-id { font-size: 0.7059rem; font-weight: 800; color: var(--accent); background: var(--accent-soft);
   border: 1px solid var(--accent-line); border-radius: 8px; padding: 3px 0; text-align: center; }
 .rb-ex { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; min-width: 0; }
-.rb-info { font-size: 12px; min-width: 0; }
-.rb-info code { font-size: 10px; color: var(--txt-3); font-family: ui-monospace, monospace; }
+.rb-info { font-size: 0.7059rem; min-width: 0; }
+.rb-info code { font-size: 0.5882rem; color: var(--txt-3); font-family: ui-monospace, monospace; }
 /* collapsible live index of every element wearing this rule (Jac 2026-06-13) */
-.rb-idx { margin-top: 6px; font-size: 11px; }
+.rb-idx { margin-top: 6px; font-size: 0.6471rem; }
 .rb-idx > summary { cursor: pointer; color: var(--txt-3); font-weight: 700; list-style: none; user-select: none; display: inline-flex; align-items: center; gap: 5px; }
 .rb-idx > summary::-webkit-details-marker { display: none; }
-.rb-idx > summary::before { content: '▸'; font-size: 9px; transition: transform .12s; }
+.rb-idx > summary::before { content: '▸'; font-size: 0.5294rem; transition: transform .12s; }
 .rb-idx[open] > summary::before { transform: rotate(90deg); }
 .rb-idx-row { display: flex; gap: 8px; padding: 2px 0 2px 14px; color: var(--txt-2); }
 .rb-idx-loc { color: var(--accent); font-weight: 700; min-width: 76px; flex-shrink: 0; }
@@ -3424,22 +3440,22 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rb-tabs { position: sticky; top: 0; z-index: 3; display: flex; flex-wrap: wrap; gap: 5px;
   margin: 0 -16px 0; padding: 12px 16px 9px; background: var(--panel); border-bottom: 1px solid var(--line); }
 .rb-tab { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px;
-  font-size: 11.5px; font-weight: 700; color: var(--txt-3); background: var(--bg-2);
+  font-size: 0.6765rem; font-weight: 700; color: var(--txt-3); background: var(--bg-2);
   border: 1px solid var(--line); border-radius: 8px; padding: 5px 10px; transition: color .12s, border-color .12s, background .12s; }
 .rb-tab:hover { color: var(--txt); border-color: var(--accent-line); }
 .rb-tab.on { color: var(--on-orange); background: var(--accent); border-color: transparent; }
-.rb-intro { font-size: 12px; color: var(--txt-2); margin: 11px 2px 13px; line-height: 1.5; }
+.rb-intro { font-size: 0.7059rem; color: var(--txt-2); margin: 11px 2px 13px; line-height: 1.5; }
 /* foundation rows give the live specimen full width (tag · stacked example+info) */
 .rb-row.found { grid-template-columns: 52px 1fr; align-items: start; }
-.rb-id.found { font-size: 15px; line-height: 1.4; background: var(--bg-2); color: var(--txt-2); border-color: var(--line); }
+.rb-id.found { font-size: 0.8824rem; line-height: 1.4; background: var(--bg-2); color: var(--txt-2); border-color: var(--line); }
 .rb-found-body { display: flex; flex-direction: column; gap: 9px; min-width: 0; }
 .rb-found-body > .rb-ex { padding: 3px 0; flex-wrap: wrap; }
 /* color swatch + surface sample chips used inside foundation examples */
 .rb-sw { display: inline-flex; flex-direction: column; justify-content: center; min-width: 56px; height: 38px;
-  padding: 0 11px; border-radius: 8px; font-size: 11px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.09); }
-.rb-sw b { font-weight: 800; } .rb-sw i { font-style: normal; font-weight: 600; opacity: .8; font-size: 9px; }
+  padding: 0 11px; border-radius: 8px; font-size: 0.6471rem; box-shadow: inset 0 0 0 1px rgba(255,255,255,.09); }
+.rb-sw b { font-weight: 800; } .rb-sw i { font-style: normal; font-weight: 600; opacity: .8; font-size: 0.5294rem; }
 .rb-surf { display: inline-flex; align-items: center; justify-content: center; min-width: 52px; height: 34px;
-  padding: 0 11px; border: 1px solid var(--line); border-radius: 10px; font-size: 10.5px; color: var(--txt-3); }
+  padding: 0 11px; border: 1px solid var(--line); border-radius: 10px; font-size: 0.6176rem; color: var(--txt-3); }
 
 /* ── Rulebook → Windows catalog (Jac 2026-06-22): collapsible popup index ── */
 .rb-win { border-bottom: 1px solid var(--line-soft); }
@@ -3451,12 +3467,12 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rb-win-chev { display: inline-flex; flex-shrink: 0; color: var(--txt-3); transition: transform .12s ease; }
 .rb-win-chev svg { width: 15px; height: 15px; }
 .rb-win.open .rb-win-chev { transform: rotate(180deg); color: var(--accent); }
-.rb-win-label { font-size: 13px; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rb-win-label { font-size: 0.7647rem; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .rb-win-tag { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px;
-  font-size: 10px; font-weight: 600; color: var(--txt-3); white-space: nowrap; flex-shrink: 0; }
+  font-size: 0.5882rem; font-weight: 600; color: var(--txt-3); white-space: nowrap; flex-shrink: 0; }
 .rb-win-copy { flex-shrink: 0; align-self: center; display: inline-flex; align-items: center; gap: 5px;
   font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px;
-  font-size: 10px; font-weight: 700; color: var(--txt-3); background: var(--bg-2); border: 1px solid var(--line);
+  font-size: 0.5882rem; font-weight: 700; color: var(--txt-3); background: var(--bg-2); border: 1px solid var(--line);
   border-radius: 8px; padding: 4px 9px; cursor: pointer; transition: color .12s, border-color .12s; }
 .rb-win-copy:hover { color: var(--accent); border-color: var(--accent-line); }
 .rb-win-body { padding: 2px 2px 14px; }
@@ -3465,17 +3481,17 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rb-win-preview .popup { position: static; pointer-events: none; transform: none; box-shadow: var(--chip-shadow); margin: 0; }
 .rb-win-preview .rb-prev-holder { pointer-events: none; display: flex; flex-direction: column; gap: 12px; align-items: center; max-width: 100%; }
 .rb-win-preview::after { content: 'PREVIEW · NOT LIVE'; position: absolute; top: 8px; right: 10px;
-  font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: 1px; font-size: 9px; font-weight: 700;
+  font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: 1px; font-size: 0.5294rem; font-weight: 700;
   color: var(--txt-3); background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 2px 6px; z-index: 2; }
-.rb-win-norec { font-size: 11.5px; color: var(--txt-3); font-style: italic; }
+.rb-win-norec { font-size: 0.6765rem; color: var(--txt-3); font-style: italic; }
 .rb-win-fields { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 11px; align-items: center; }
 .rb-win-fieldlbl { width: 100%; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase;
-  letter-spacing: 1px; font-size: 9.5px; font-weight: 700; color: var(--txt-3); margin-bottom: 1px; }
-.rb-win-field { display: inline-flex; align-items: baseline; gap: 5px; font-size: 11px; color: var(--txt-2);
+  letter-spacing: 1px; font-size: 0.5588rem; font-weight: 700; color: var(--txt-3); margin-bottom: 1px; }
+.rb-win-field { display: inline-flex; align-items: baseline; gap: 5px; font-size: 0.6471rem; color: var(--txt-2);
   background: var(--bg-2); border: 1px solid var(--line-soft); border-radius: 7px; padding: 3px 8px; }
 .rb-win-field b { font-weight: 600; color: var(--txt); }
-.rb-win-field i { font-style: normal; font-size: 9px; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); }
-.rb-win-loc { display: block; margin-top: 11px; font-family: ui-monospace, monospace; font-size: 10.5px;
+.rb-win-field i { font-style: normal; font-size: 0.5294rem; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); }
+.rb-win-loc { display: block; margin-top: 11px; font-family: ui-monospace, monospace; font-size: 0.6176rem;
   color: var(--accent); background: var(--accent-soft); border: 1px solid var(--accent-line); border-radius: 7px;
   padding: 5px 9px; word-break: break-all; }
 .rb-win-toggle:focus-visible, .rb-win-copy:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -3483,7 +3499,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 /* standalone surfaces — forms/dropdowns not in a pop-up; a saddle-stitch tan divider sets them apart */
 .rb-std { margin-top: 16px; padding-top: 13px; border-top: 1px dashed var(--tan, #c2925a); }
 .rb-std-head { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px;
-  font-size: 10.5px; font-weight: 700; color: var(--txt-3); margin-bottom: 4px; }
+  font-size: 0.6176rem; font-weight: 700; color: var(--txt-3); margin-bottom: 4px; }
 /* standalone rows reuse the .rb-win collapsible structure (toggle · body · preview) */
 
 /* ── §13 v2 BUILD: gate pills · derived pills · flags · section colors ·
@@ -3494,7 +3510,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
    chevron. Colors come from the normal .c-* classes; chevron only on real dropdowns. */
 /* Gate matches the status-pill size exactly — Primary / Secondary / Gate are all one
    size (Jac). (Mobile keeps its larger touch target via the .is-phone rule below.) */
-.pill.gate { height: 22px; padding: 0 9px; font-size: 11px; }   /* identical to a status pill; only the leading icon differs (chevron) */
+.pill.gate { height: 22px; padding: 0 9px; font-size: 0.6471rem; }   /* identical to a status pill; only the leading icon differs (chevron) */
 .pill.gate svg { width: 12px; height: 12px; }
 .pill.gate:hover { filter: brightness(1.18); }
 
@@ -3505,7 +3521,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 
 /* TITLE FLAGS — ≤2 stacked 14px mini-rows matching the 30px title chip; no backgrounds */
 .flags { display: flex; flex-direction: column; justify-content: space-between; height: 30px; }
-.flag { display: inline-flex; align-items: center; gap: 3px; height: 14px; padding: 0 2px; font-size: 9px; font-weight: 800; letter-spacing: .2px; white-space: nowrap; cursor: pointer; background: none; border: none; font-family: inherit; }
+.flag { display: inline-flex; align-items: center; gap: 3px; height: 14px; padding: 0 2px; font-size: 0.5294rem; font-weight: 800; letter-spacing: .2px; white-space: nowrap; cursor: pointer; background: none; border: none; font-family: inherit; }
 .flag svg { width: 9px; height: 9px; }
 .flag:hover { text-decoration: underline; }
 .flag.c-green { background: none; color: var(--green); border: none; }
@@ -3551,25 +3567,25 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .jnode.fc:hover .jbox { border-style: solid; }
 .jnode.fc.done .jbox { background: var(--red); border: 1px solid var(--red); color: #fff; }
 .jnode.fc .jlbl { color: var(--red); }
-.jlbl { font-size: 9.5px; font-weight: 700; color: var(--txt-2); }
-.jts { font-size: 8.5px; color: var(--txt-3); font-variant-numeric: tabular-nums; min-height: 10px; }
+.jlbl { font-size: 0.5588rem; font-weight: 700; color: var(--txt-2); }
+.jts { font-size: 0.5rem; color: var(--txt-3); font-variant-numeric: tabular-nums; min-height: 10px; }
 .jts .jscan { color: var(--accent); font-weight: 800; margin-left: 1px; }   /* scan-sourced capture marker — tasteful, tokens-only (jactec-ui) */
 .jseg { flex: 1 1 auto; display: flex; flex-direction: column; align-items: center; gap: 2px; padding-top: 8px; min-width: 0; }
-.jseg .jover { font-size: 9px; font-weight: 700; color: var(--txt-2); white-space: nowrap; display: inline-flex; align-items: center; gap: 3px; min-height: 11px; max-width: 100%; }
+.jseg .jover { font-size: 0.5294rem; font-weight: 700; color: var(--txt-2); white-space: nowrap; display: inline-flex; align-items: center; gap: 3px; min-height: 11px; max-width: 100%; }
 .jseg .jover.loglink { color: var(--txt); font-weight: 800; cursor: pointer; }
 .jseg .jover.loglink:hover { text-decoration: underline; }
 .jseg .jover.done { color: var(--green); cursor: pointer; }
 .jseg .jline2 { width: 100%; border-top: 2px dotted var(--line); }
 .jseg .jline2.on { border-top: 2px solid var(--green); }
-.jseg .junder { font-size: 8.5px; font-weight: 700; color: var(--txt-2); font-variant-numeric: tabular-nums; }
-.jseg .jaddr { font-size: 8.5px; font-weight: 500; font-style: italic; text-decoration: underline; color: var(--blue); cursor: pointer; max-width: 130px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.jseg .junder { font-size: 0.5rem; font-weight: 700; color: var(--txt-2); font-variant-numeric: tabular-nums; }
+.jseg .jaddr { font-size: 0.5rem; font-weight: 500; font-style: italic; text-decoration: underline; color: var(--blue); cursor: pointer; max-width: 130px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .jseg .jaddr:hover { filter: brightness(1.15); }
-.jseg .jkind { font-size: 8px; font-weight: 800; letter-spacing: .4px; text-transform: uppercase; color: var(--txt-3); }
+.jseg .jkind { font-size: 0.4706rem; font-weight: 800; letter-spacing: .4px; text-transform: uppercase; color: var(--txt-3); }
 .journey.mini .jbox { width: 30px; height: 30px; border-radius: 9px; background: var(--panel-2); color: var(--txt-2); border: 1px solid var(--line); }
 .journey.mini .jbox svg { width: 15px; height: 15px; }
 .journey.mini .jbox.site:hover { border-color: var(--accent); color: var(--accent); }
 .journey.mini .jbox.site.set { background: var(--accent-soft); border-color: var(--accent-line); color: var(--accent); }
-.journey.mini .jlbl { font-size: 8.5px; }
+.journey.mini .jlbl { font-size: 0.5rem; }
 .journey.mini .jnode { min-width: 36px; }
 .journey.mini .jseg { padding-top: 2px; }
 /* ── Rentals Stall Board (Jac 2026-06-15): day-timeline blocker · event strip ·
@@ -3577,11 +3593,11 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .tl-over .d1, .tl-over .d2 { position: absolute; top: 50%; transform: translateY(-50%); display: flex; flex-direction: column; line-height: 1.05; z-index: 1; }
 .tl-over .d1 { left: 11px; }
 .tl-over .d2 { right: 11px; align-items: flex-end; }
-.tl-over .dlab { font-weight: 800; font-size: 12.5px; }
+.tl-over .dlab { font-weight: 800; font-size: 0.7353rem; }
 .tl-over .midwrap { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; padding: 0 78px; pointer-events: none; }
 .tl-over .midwrap > * { pointer-events: auto; }
 .rentalsec .timeline { height: 60px; }
-.tl-blocker { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; background: var(--yellow-bg); border: 1px solid color-mix(in srgb, var(--yellow) 38%, transparent); color: var(--yellow); border-radius: 8px; padding: 3px 9px; font-size: 11px; font-weight: 700; cursor: pointer; }
+.tl-blocker { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; background: var(--yellow-bg); border: 1px solid color-mix(in srgb, var(--yellow) 38%, transparent); color: var(--yellow); border-radius: 8px; padding: 3px 9px; font-size: 0.6471rem; font-weight: 700; cursor: pointer; }
 .tl-blocker svg { width: 13px; height: 13px; flex: 0 0 auto; }
 .tl-blocker:hover { filter: brightness(1.12); }
 .estrip { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; margin-top: 11px; }
@@ -3596,10 +3612,10 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .stall-id { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
 .stall-amt { font-weight: 800; color: var(--green); font-variant-numeric: tabular-nums; }
 .stall-right { display: inline-flex; align-items: center; gap: 9px; }
-.stall-split { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; color: var(--txt-3); background: transparent; border: 1px solid var(--line); border-radius: 7px; padding: 2px 7px; cursor: pointer; }
+.stall-split { display: inline-flex; align-items: center; gap: 4px; font-size: 0.6471rem; font-weight: 600; color: var(--txt-3); background: transparent; border: 1px solid var(--line); border-radius: 7px; padding: 2px 7px; cursor: pointer; }
 .stall-split:hover { color: var(--accent); border-color: var(--accent-line); }
 .stall-split svg { flex: 0 0 auto; }
-.stall-sub { font-size: 11.5px; color: var(--txt-3); font-style: italic; margin-top: 6px; }
+.stall-sub { font-size: 0.6765rem; color: var(--txt-3); font-style: italic; margin-top: 6px; }
 .stall-sub.armed { color: var(--accent); font-style: normal; }
 .stall-sub.hint { color: var(--txt-3); font-style: normal; }
 .stall-empty { display: flex; align-items: center; gap: 9px; padding: 11px 2px; }
@@ -3615,12 +3631,12 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rd-units { margin-top: 6px; }
 .rd-unit-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; }
 .rd-unit-id { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
-.rd-unit-rate { display: flex; align-items: center; gap: 5px; font-size: 12px; color: var(--txt-2); white-space: nowrap; flex-shrink: 0; }
+.rd-unit-rate { display: flex; align-items: center; gap: 5px; font-size: 0.7059rem; color: var(--txt-2); white-space: nowrap; flex-shrink: 0; }
 .rd-dur { font-weight: 600; color: var(--txt); }
 /* footer: field call only (Complete/Cancel Rental retired 2026-07-03 — terminal gates complete the rental) */
 .rd-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
 .rd-foot-l { display: flex; align-items: center; gap: 8px; }
-.rd-inv-total { font-size: 15px; font-weight: 800; color: var(--txt); text-decoration: underline; font-variant-numeric: tabular-nums; }
+.rd-inv-total { font-size: 0.8824rem; font-weight: 800; color: var(--txt); text-decoration: underline; font-variant-numeric: tabular-nums; }
 
 /* §20 route rail — linear House(Jac)─Person(Job Site)─House(Jac) stepper; the rail
    itself is the type control (tap two stops). Address rides ABOVE each connector
@@ -3631,7 +3647,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rtgap { height: 0; }
 .rtwell { width: 36px; height: 36px; border-radius: 10px; display: grid; place-items: center; background: var(--panel-2); border: 1px solid var(--line); color: var(--txt-3); transition: color .12s ease, border-color .12s ease, background .12s ease; }
 .rtwell svg { width: 20px; height: 20px; }
-.rtname { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 13px; font-weight: 700; letter-spacing: .4px; line-height: 1; white-space: nowrap; color: var(--txt-2); }
+.rtname { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.7647rem; font-weight: 700; letter-spacing: .4px; line-height: 1; white-space: nowrap; color: var(--txt-2); }
 .rtnode:hover .rtwell { color: var(--txt-2); border-color: var(--accent-line); }
 .rtnode.on .rtwell { background: var(--accent); border-color: var(--accent); color: var(--on-orange); }   /* locked on the run — solid orange + dark ink */
 .rtnode.on .rtname { color: var(--txt); }
@@ -3641,9 +3657,9 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .rtleg { justify-items: stretch; text-align: center; }
 .rtline { height: 0; border-top: 2px dashed var(--line); }
 .rtleg.on .rtline { border-top-style: solid; border-color: var(--accent); }
-.rtaddr { color: var(--tan, #c2925a); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; font-size: 11.5px; line-height: 1; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rtaddr { color: var(--tan, #c2925a); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; font-size: 0.6765rem; line-height: 1; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .rtaddr:hover { filter: brightness(1.12); }
-.rtlog { font-size: 11px; font-weight: 700; line-height: 1; white-space: nowrap; cursor: pointer; }
+.rtlog { font-size: 0.6471rem; font-weight: 700; line-height: 1; white-space: nowrap; cursor: pointer; }
 .rtlog.log { color: var(--txt-2); }
 .rtlog.log:hover { color: var(--txt); text-decoration: underline; }
 .rtlog.done { color: var(--green); }
@@ -3662,15 +3678,15 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 /* HISTORY — centered header; clickable value chips anchored above the search bar */
 .history > h4 { text-align: center; }
 .hvals { display: flex; flex-wrap: wrap; gap: 5px 7px; align-items: center; justify-content: center; margin-bottom: 7px; }
-.hvals .hv { font-size: 11px; font-weight: 700; color: var(--txt-2); cursor: pointer; border-radius: 99px; padding: 2px 8px; border: 1px solid transparent; background: none; font-family: inherit; }
+.hvals .hv { font-size: 0.6471rem; font-weight: 700; color: var(--txt-2); cursor: pointer; border-radius: 99px; padding: 2px 8px; border: 1px solid transparent; background: none; font-family: inherit; }
 .hvals .hv:hover { border-color: var(--accent-line); color: var(--txt); }
 .hvals .hv.on { border-color: var(--accent); color: var(--accent); }
 .hvals .hv.g { color: var(--green); } .hvals .hv.y { color: var(--yellow); }
 .hvals .hv.r { color: var(--red); } .hvals .hv.b { color: var(--blue); }
 
 /* WORK-ORDER section internals */
-.woline { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 9px; font-size: 13px; padding: 3px 0; }
-.woline .nums { display: flex; gap: 10px; font-variant-numeric: tabular-nums; color: var(--txt-2); font-size: 12px; }
+.woline { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 9px; font-size: 0.7647rem; padding: 3px 0; }
+.woline .nums { display: flex; gap: 10px; font-variant-numeric: tabular-nums; color: var(--txt-2); font-size: 0.7059rem; }
 .woline .nums b { color: var(--txt); }
 .wototals { display: flex; justify-content: space-between; align-items: center; gap: 9px; margin-bottom: 5px; }
 .wofoot { display: flex; align-items: center; justify-content: flex-end; gap: 9px; margin-top: 10px; flex-wrap: wrap; }
@@ -3681,21 +3697,21 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .split .side.r { align-items: flex-end; text-align: right; }
 
 /* capture + site popups */
-.cap-drop { border: 1.5px dashed var(--line); border-radius: 12px; min-height: 76px; display: flex; align-items: center; justify-content: center; gap: 8px; color: var(--txt-3); font-size: 12.5px; cursor: pointer; padding: 10px; }
+.cap-drop { border: 1.5px dashed var(--line); border-radius: 12px; min-height: 76px; display: flex; align-items: center; justify-content: center; gap: 8px; color: var(--txt-3); font-size: 0.7353rem; cursor: pointer; padding: 10px; }
 .cap-drop:hover { border-color: var(--accent-line); }
 .cap-drop svg { width: 18px; height: 18px; }
 .site-map { position: relative; border-radius: 12px; border: 1px solid var(--line); overflow: hidden;
   background: repeating-linear-gradient(0deg, transparent 0 34px, rgba(139,148,163,.16) 34px 35px),
               repeating-linear-gradient(90deg, transparent 0 44px, rgba(139,148,163,.16) 44px 45px),
               linear-gradient(135deg, #17251c 0%, #1a2030 55%, #16281f 100%); }
-.site-pin { position: absolute; transform: translate(-50%, -90%); font-size: 20px; transition: .12s; pointer-events: none; }
-.map-tag { position: absolute; right: 8px; bottom: 6px; font-size: 9.5px; color: var(--txt-3); pointer-events: none; }
-.js-site-sug button { all: unset; cursor: pointer; padding: 7px 11px; font-size: 12.5px; color: var(--txt); border-bottom: 1px solid var(--line-soft); border-radius: 0; font-family: inherit; }
+.site-pin { position: absolute; transform: translate(-50%, -90%); font-size: 1.1765rem; transition: .12s; pointer-events: none; }
+.map-tag { position: absolute; right: 8px; bottom: 6px; font-size: 0.5588rem; color: var(--txt-3); pointer-events: none; }
+.js-site-sug button { all: unset; cursor: pointer; padding: 7px 11px; font-size: 0.7353rem; color: var(--txt); border-bottom: 1px solid var(--line-soft); border-radius: 0; font-family: inherit; }
 .js-site-sug button:hover { background: var(--panel-2); }
 
 /* SEGMENTED 3-state toggles (condition · wash) */
 .seg { display: inline-flex; border: 1px solid var(--line); border-radius: 10px; overflow: hidden; background: var(--panel-2); }
-.seg button { font: inherit; font-size: 11px; font-weight: 700; padding: 0 11px; height: 25px; background: transparent; border: none; color: var(--txt-3); cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
+.seg button { font: inherit; font-size: 0.6471rem; font-weight: 700; padding: 0 11px; height: 25px; background: transparent; border: none; color: var(--txt-3); cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
 .seg button svg { width: 11px; height: 11px; }
 .seg button:not(:last-child) { border-right: 1px solid var(--line); }
 .seg button.on-blue { background: var(--blue); color: #fff; }
@@ -3710,7 +3726,7 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
   background: linear-gradient(180deg, var(--panel-2), var(--panel)); border: 1px solid var(--accent-line);
   box-shadow: inset 0 1px 0 rgba(255,255,255,.03), 0 6px 20px rgba(0,0,0,.28); width: 100%; }
 .tedit-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
-.stamp { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 800; font-size: 12px; color: var(--accent); }
+.stamp { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 800; font-size: 0.7059rem; color: var(--accent); }
 .tedit-map { height: 168px; border-radius: 11px; overflow: hidden; position: relative; border: 1px solid var(--line);
   background: repeating-linear-gradient(135deg, rgba(245,197,66,.06) 0 13px, rgba(20,24,29,.45) 13px 26px), var(--panel-2);
   display: grid; place-items: center; }
@@ -3718,30 +3734,30 @@ body.rw-inspect .c-titlecard:hover { outline: 2px solid #18b6ff; outline-offset:
 .tedit-map.ph { gap: 6px; padding: 0 18px; background: repeating-linear-gradient(135deg, rgba(245,197,66,.05) 0 13px, rgba(20,24,29,.5) 13px 26px), radial-gradient(circle at 50% 40%, rgba(255,122,26,.10), transparent 62%), var(--panel-2); }
 .map-pin { color: var(--accent); display: inline-flex; }
 .map-pin svg { width: 30px; height: 30px; }
-.map-sub { font-size: 10.5px; color: var(--txt-3); text-align: center; max-width: 88%; line-height: 1.45; }
+.map-sub { font-size: 0.6176rem; color: var(--txt-3); text-align: center; max-width: 88%; line-height: 1.45; }
 .map-spin { width: 22px; height: 22px; border-radius: 50%; border: 3px solid rgba(255,122,26,.25); border-top-color: var(--accent); animation: mapspin .8s linear infinite; }
 @keyframes mapspin { to { transform: rotate(360deg); } }
-.tedit .lf-in { width: 100%; height: 34px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel); color: var(--txt); font: inherit; font-size: 13px; padding: 0 11px; }
+.tedit .lf-in { width: 100%; height: 34px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel); color: var(--txt); font: inherit; font-size: 0.7647rem; padding: 0 11px; }
 .tedit .lf-in:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 .tedit-sug { display: flex; flex-direction: column; gap: 2px; }
 .tedit-sug:empty { display: none; }
-.tedit-sug .dd-item { display: flex; align-items: center; width: 100%; padding: 8px 11px; border-radius: 9px; font-size: 12.5px; font-weight: 600; text-align: left; color: var(--txt-2); border: 1px solid transparent; }
+.tedit-sug .dd-item { display: flex; align-items: center; width: 100%; padding: 8px 11px; border-radius: 9px; font-size: 0.7353rem; font-weight: 600; text-align: left; color: var(--txt-2); border: 1px solid transparent; }
 .tedit-sug .dd-item:hover { background: var(--panel-2); color: var(--txt); }
 .tedit-sug .dd-item.on { background: var(--accent-soft); border-color: var(--accent-line); color: var(--accent); }
 .tedit-foot { display: flex; align-items: center; gap: 8px; }
 .tedit-foot .spacer { flex: 1; }
-.tedit-hint { font-size: 10px; color: var(--txt-3); letter-spacing: .2px; }
+.tedit-hint { font-size: 0.5882rem; color: var(--txt-3); letter-spacing: .2px; }
 
 /* ── Journey as the transport control (type segs + per-leg price) ── */
 .journeywrap { display: flex; flex-direction: column; gap: 6px; width: 100%; align-items: center; }
 .jtype { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: center; }
-.jtype .seg-ttype button { font-size: 10px; padding: 0 9px; height: 22px; }
-.jprice { font-size: 12px; font-weight: 800; color: var(--accent); font-variant-numeric: tabular-nums; white-space: nowrap; }
-.jprice .sfx { font-size: 9.5px; font-weight: 600; color: var(--txt-3); }
+.jtype .seg-ttype button { font-size: 0.5882rem; padding: 0 9px; height: 22px; }
+.jprice { font-size: 0.7059rem; font-weight: 800; color: var(--accent); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.jprice .sfx { font-size: 0.5588rem; font-weight: 600; color: var(--txt-3); }
 .tsec { display: flex; flex-direction: column; gap: 9px; align-items: center; margin-top: 10px; padding-top: 9px; border-top: 1px dashed var(--line); }
-.tsec-label { font-size: 9.5px; text-transform: uppercase; letter-spacing: .5px; }
+.tsec-label { font-size: 0.5588rem; text-transform: uppercase; letter-spacing: .5px; }
 .tjrow { display: flex; flex-direction: column; gap: 4px; align-items: center; width: 100%; }
-.tjname { font-size: 10px; }
+.tjname { font-size: 0.5882rem; }
 /* ── post-build redlines (Jac 2026-06-11 evening) ── */
 /* full status-color coverage for section borders (RENTAL border = rental status) */
 .section.sec-blue { border-color: color-mix(in srgb, var(--blue) 45%, transparent); }
@@ -3758,7 +3774,7 @@ input[type="number"]::-webkit-inner-spin-button, input[type="number"]::-webkit-o
 input[type="number"] { -moz-appearance: textfield; appearance: textfield; }
 /* money displays: paid/total = blue + NOT italic (consistent number format) */
 .balline { font-variant-numeric: tabular-nums; }
-.balline b { font-weight: 800; font-size: 15px; }
+.balline b { font-weight: 800; font-size: 0.8824rem; }
 .balline .tot { color: var(--txt-2); font-weight: 600; font-style: normal; }
 /* the timeline grew 6px so the gate + rate stack never collide */
 .timeline { height: 56px; }
@@ -3766,7 +3782,7 @@ input[type="number"] { -moz-appearance: textfield; appearance: textfield; }
 /* R20 CONTEXT MENU — right-click on any element. Tier 3 selector-list: steel + left hazard rail. */
 .ctx-menu { position: fixed; z-index: 210; min-width: 190px; overflow: hidden; background: var(--card); border: 1px solid var(--line); border-radius: 12px; box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); padding: 5px 5px 5px 13px; }
 .ctx-menu::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 6px; background: repeating-linear-gradient(180deg, var(--yellow) 0 11px, #14181d 11px 22px); }
-.ctx-menu .dd-item { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 10px; border-radius: 8px; background: none; border: none; color: var(--txt); font: inherit; font-size: 12.5px; font-weight: 600; cursor: pointer; text-align: left; }
+.ctx-menu .dd-item { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 10px; border-radius: 8px; background: none; border: none; color: var(--txt); font: inherit; font-size: 0.7353rem; font-weight: 600; cursor: pointer; text-align: left; }
 .ctx-menu .dd-item:hover { background: var(--panel-2); }
 .ctx-menu .dd-item svg { width: 15px; height: 15px; flex: 0 0 auto; }   /* §17b — library glyphs on the link actions (sized to match the row) */
 .ctx-menu .menu-sep { height: 1px; background: var(--line); margin: 4px 0; }
@@ -3794,7 +3810,7 @@ body { font-variant-numeric: tabular-nums; }
 /* §12.1 rapid action entry: field left, R14 mode toggle right, under the active bar */
 .act-entry { display: flex; gap: 8px; align-items: center; }
 .act-entry .act-in { flex: 1; height: 28px; background: var(--bg-2); border: 1px solid var(--line);
-  border-radius: 8px; color: var(--ink); font: inherit; font-size: 12.5px; padding: 0 10px; }
+  border-radius: 8px; color: var(--ink); font: inherit; font-size: 0.7353rem; padding: 0 10px; }
 .act-entry .act-in:focus { outline: none; border-color: var(--accent-line); }
 .act-entry .act-in::placeholder { color: var(--muted); }
 .hlog.actlog { padding: 0 2px; }
@@ -3814,7 +3830,7 @@ body { font-variant-numeric: tabular-nums; }
 /* R21 FILE DROP (Jac 2026-06-12) — the massive popup add-file zone wearing
    R5b's blue dashed language; .done flips green once a file is attached. */
 .file-drop { border: 1.5px dashed #18b6ff; border-radius: 12px; min-height: 76px; display: flex; align-items: center;
-  justify-content: center; gap: 8px; color: #18b6ff; font-size: 12.5px; cursor: pointer; padding: 10px; }
+  justify-content: center; gap: 8px; color: #18b6ff; font-size: 0.7353rem; cursor: pointer; padding: 10px; }
 .file-drop:hover { filter: brightness(1.25); }
 .file-drop.done { border-style: solid; border-color: var(--green); color: var(--green); }
 .file-drop svg { width: 18px; height: 18px; }
@@ -3827,7 +3843,7 @@ body { font-variant-numeric: tabular-nums; }
 .act-head { display: flex; align-items: flex-end; gap: 10px; }
 .act-half { flex: 1; min-width: 0; display: flex; align-items: flex-end; gap: 8px; }
 .act-half .add-field { flex: 1; justify-content: center; }
-.act-col-lbl { font-size: 13px; font-weight: 700; line-height: 1; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); padding-bottom: 7px; white-space: nowrap; }
+.act-col-lbl { font-size: 0.7647rem; font-weight: 700; line-height: 1; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); padding-bottom: 7px; white-space: nowrap; }
 .act-cols { display: flex; gap: 14px; align-items: flex-start; }
 .act-col { flex: 1; min-width: 0; }
 /* Mr. Wrangler #129: keep each activity row's date in its gutter and let ONLY the
@@ -3849,7 +3865,7 @@ body { font-variant-numeric: tabular-nums; }
 .funnel-hd .fh-rule { flex: 1; border-top: 1.5px dashed var(--tan, #c2925a); opacity: .4; }   /* saddle-stitch flanks (ranch seasoning) */
 .funnel-hd.full { display: block; margin-bottom: 13px; }   /* full-width toggle sitting just above the funnel (Jac 2026-07-17 — matches the mockup) */
 .seg.funnel-full { display: flex; width: 100%; }
-.seg.funnel-full button { flex: 1; justify-content: center; height: 30px; font-size: 12px; }
+.seg.funnel-full button { flex: 1; justify-content: center; height: 30px; font-size: 0.7059rem; }
 .funnel-sec .seg button.on-accent { background: var(--accent); color: var(--on-orange); }     /* selected tab = the ONE orange (rule #3) */
 /* Phase 6 (2026-07-10 dot->background sweep) — next-action urgency reads via the segment's own
    background tint (not a corner dot), same soft-bg + solid-ink treatment as .c-green/.c-yellow/.c-red. */
@@ -3867,7 +3883,7 @@ body { font-variant-numeric: tabular-nums; }
    Two-track detail section (Rental→Member + Equipment) + the R35 ladder + the ONE
    adaptive funnel menu. All tokens theme themselves dark/light; --tan keeps its fallback. */
 .funnel-hd .fh-title { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.4px;
-  font-weight: 800; font-size: 11px; color: var(--txt-2); white-space: nowrap; }
+  font-weight: 800; font-size: 0.6471rem; color: var(--txt-2); white-space: nowrap; }
 .funnel-tracks { display: flex; flex-direction: column; gap: 12px; }
 .ftk { border: 1px solid var(--line); border-radius: 12px; background: var(--panel-2); padding: 11px 12px 12px; }
 .ftk-hd { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
@@ -3875,45 +3891,45 @@ body { font-variant-numeric: tabular-nums; }
 .ftk-dot.a { background: var(--accent); }               /* Track A — Rental → Member (the ignition track) */
 .ftk-dot.b { background: var(--blue); }                 /* Track B — Equipment (separate sales track) */
 .ftk-nm { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px;
-  font-weight: 700; font-size: 11.5px; color: var(--txt); }
+  font-weight: 700; font-size: 0.6765rem; color: var(--txt); }
 .ftk-urg { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; }
 .ftk-urg.due { background: var(--red); box-shadow: 0 0 4px color-mix(in srgb, var(--red) 55%, transparent); }
 .ftk-urg.soon { background: var(--yellow); }
-.ftk-hint { font-size: 10.5px; color: var(--txt-3); font-style: italic; }
+.ftk-hint { font-size: 0.6176rem; color: var(--txt-3); font-style: italic; }
 .ftk-hd .acct-btn { margin-left: auto; }
-.ftk-empty { font-size: 12px; color: var(--txt-3); display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ftk-empty { font-size: 0.7059rem; color: var(--txt-3); display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 
 /* R35 — the funnel LADDER: a row of rungs with chevrons, current lit, auto locked. The
    whole ladder is one press target that opens the funnel menu. Rungs are NOT .pill. */
 .fladder { display: flex; align-items: center; flex-wrap: wrap; gap: 5px 6px; cursor: pointer; padding: 2px; margin: -2px -2px 2px; border-radius: 10px; }
 .fladder:hover { background: rgba(255,255,255,.03); }
 .fladder:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.frung { display: inline-flex; align-items: center; gap: 5px; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600;
+.frung { display: inline-flex; align-items: center; gap: 5px; padding: 4px 10px; border-radius: 999px; font-size: 0.7059rem; font-weight: 600;
   border: 1px solid; white-space: nowrap; }   /* color (bg/ink/border) comes from the generic .c-<registry> class */
 .frung.current { box-shadow: 0 0 0 1px var(--accent), inset 0 0 0 1px var(--accent); border-color: var(--accent); }
 .frung.auto { opacity: .92; }
 .fr-lock { display: inline-flex; opacity: .7; }
 .fr-lock svg { width: 11px; height: 11px; }
-.fl-arw { color: var(--txt-3); font-size: 13px; line-height: 1; }
+.fl-arw { color: var(--txt-3); font-size: 0.7647rem; line-height: 1; }
 
 /* The ONE adaptive funnel menu (shared: detail section + quick-add "Lead?" pill). Steel panel
    + the same vertical hazard rail as the gate timeline, no orange halo (that stays for dialogs). */
 .dropdown-menu.funnelmenu { width: max-content; min-width: 226px; max-width: 92vw; padding: 0 12px 12px 20px; position: fixed;
   border: 1px solid var(--line); box-shadow: var(--shadow), 0 0 0 1px rgba(0,0,0,.4); overflow-y: auto; }
 .funnelmenu .fm-cap { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.3px;
-  font-weight: 700; font-size: 10px; color: var(--txt-3); padding: 10px 0 6px; }
+  font-weight: 700; font-size: 0.5882rem; color: var(--txt-3); padding: 10px 0 6px; }
 .fm-na { display: flex; align-items: center; gap: 7px; padding: 7px 9px; border: 1px dashed var(--line); border-radius: 9px;
-  color: var(--txt-3); font-size: 12px; }
+  color: var(--txt-3); font-size: 0.7059rem; }
 .fm-na.on { border-color: var(--accent-line, color-mix(in srgb, var(--accent) 50%, transparent)); color: var(--txt-2); }
 .fm-sec { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
-  font-size: 9.5px; color: var(--txt-3); margin: 13px 0 7px; display: flex; align-items: center; gap: 7px; }
+  font-size: 0.5588rem; color: var(--txt-3); margin: 13px 0 7px; display: flex; align-items: center; gap: 7px; }
 .fm-sec::after { content: ""; flex: 1; height: 1px; background: var(--line); }
 .fm-sub { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 700;
-  font-size: 9px; color: var(--txt-3); margin: 11px 0 6px; }
+  font-size: 0.5294rem; color: var(--txt-3); margin: 11px 0 6px; }
 .fm-leads { display: flex; gap: 7px; flex-wrap: wrap; }
 .fm-leads.qa { flex-direction: column; }
 .fm-chip { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-2);
-  border-radius: 999px; padding: 6px 13px; font-size: 12.5px; font-weight: 700; cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
+  border-radius: 999px; padding: 6px 13px; font-size: 0.7353rem; font-weight: 700; cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
 .fm-chip:hover { color: var(--txt); border-color: var(--accent-line, color-mix(in srgb, var(--accent) 50%, transparent)); }
 .fm-chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .fm-chip .fm-dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; opacity: .45; }
@@ -3932,12 +3948,12 @@ body { font-variant-numeric: tabular-nums; }
 .fm-sdot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
 .fm-sdot.c-blue { background: var(--blue); } .fm-sdot.c-green { background: var(--green); } .fm-sdot.c-yellow { background: var(--yellow); }
 .fm-sdot.c-purple { background: var(--purple); } .fm-sdot.c-orange { background: var(--orange, #e8873a); } .fm-sdot.c-gray { background: var(--txt-3); }
-.fm-snm { flex: 1; font-size: 13px; font-weight: 600; }
-.fm-lock { display: inline-flex; align-items: center; gap: 3px; font-size: 9.5px; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); }
+.fm-snm { flex: 1; font-size: 0.7647rem; font-weight: 600; }
+.fm-lock { display: inline-flex; align-items: center; gap: 3px; font-size: 0.5588rem; text-transform: uppercase; letter-spacing: .4px; color: var(--txt-3); }
 .fm-lock svg { width: 11px; height: 11px; }
-.fm-tag { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 9px; letter-spacing: .4px; text-transform: uppercase;
+.fm-tag { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 0.5294rem; letter-spacing: .4px; text-transform: uppercase;
   color: var(--txt-3); border: 1px solid var(--line); border-radius: 999px; padding: 1px 6px; }
-.fm-empty { color: var(--txt-3); font-size: 12px; font-style: italic; padding: 4px 2px; }
+.fm-empty { color: var(--txt-3); font-size: 0.7059rem; font-style: italic; padding: 4px 2px; }
 @media (prefers-reduced-motion: reduce) { .fm-chip { transition: none; } }
 
 /* ═══ Dated funnel (Idea D, Jac 2026-07-17) — R35 ═══
@@ -3949,12 +3965,12 @@ body { font-variant-numeric: tabular-nums; }
 .dl:hover { border-color: var(--accent-line, color-mix(in srgb, var(--accent) 50%, transparent)); }
 .dl:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .dl-dot { width: 16px; height: 16px; border-radius: 50%; border: 1.5px solid var(--line-2, var(--line)); display: inline-flex; align-items: center;
-  justify-content: center; font-size: 10px; font-weight: 800; flex: 0 0 auto; color: transparent; }
-.dl-nm { font-weight: 700; font-size: 13px; white-space: nowrap; color: var(--txt); flex: 0 0 auto; }
+  justify-content: center; font-size: 0.5882rem; font-weight: 800; flex: 0 0 auto; color: transparent; }
+.dl-nm { font-weight: 700; font-size: 0.7647rem; white-space: nowrap; color: var(--txt); flex: 0 0 auto; }
 .dl-lock { display: inline-flex; opacity: .55; flex: 0 0 auto; }
 .dl-lock svg { width: 11px; height: 11px; }
-.dl-note { font-size: 11px; color: var(--txt-3); font-style: italic; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1 1 auto; }
-.dl-dt { margin-left: auto; font-size: 11.5px; color: var(--txt-2); font-variant-numeric: tabular-nums; white-space: nowrap; flex: 0 0 auto; }
+.dl-note { font-size: 0.6471rem; color: var(--txt-3); font-style: italic; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1 1 auto; }
+.dl-dt { margin-left: auto; font-size: 0.6765rem; color: var(--txt-2); font-variant-numeric: tabular-nums; white-space: nowrap; flex: 0 0 auto; }
 .dl-dt.up { color: var(--txt-3); font-style: italic; }
 /* REACHED, unarmed → quiet steel history (green is freed to mean "action on track"). */
 .dl.done { background: var(--panel-2); border-color: var(--line); opacity: .8; }
@@ -3962,16 +3978,16 @@ body { font-variant-numeric: tabular-nums; }
 .dl.done.cur { opacity: 1; border-color: var(--accent-line, color-mix(in srgb, var(--accent) 50%, transparent)); }   /* the live position, unarmed */
 .dl.up { opacity: .55; border-style: dashed; }
 .dl.up:hover { opacity: .9; }
-.dl-plan { margin-left: auto; font-size: 10.5px; font-style: italic; color: var(--txt-3); font-family: 'Saira Condensed', var(--font); letter-spacing: .4px; text-transform: uppercase; flex: 0 0 auto; }
-.dl-now { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-size: 9px; font-weight: 800; color: var(--accent); border: 1px solid var(--accent-line, color-mix(in srgb, var(--accent) 50%, transparent)); border-radius: 4px; padding: 1px 5px; }
+.dl-plan { margin-left: auto; font-size: 0.6176rem; font-style: italic; color: var(--txt-3); font-family: 'Saira Condensed', var(--font); letter-spacing: .4px; text-transform: uppercase; flex: 0 0 auto; }
+.dl-now { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-size: 0.5294rem; font-weight: 800; color: var(--accent); border: 1px solid var(--accent-line, color-mix(in srgb, var(--accent) 50%, transparent)); border-radius: 4px; padding: 1px 5px; }
 /* ARMED — the layer carries a dated action: two lines, glowing red / yellow / green by its urgency
    (naUrgency → due/soon/ok, the same thresholds the funnel tabs use). Green now means "on track". */
 .dl.act { flex-direction: column; align-items: stretch; gap: 5px; padding: 9px 12px 10px; }
 .dl-top { display: flex; align-items: center; gap: 9px; }
-.dl.act .dl-nm { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-weight: 800; font-size: 13px; }
+.dl.act .dl-nm { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-weight: 800; font-size: 0.7647rem; }
 .dl-act { display: flex; align-items: center; gap: 8px; padding-left: 25px; }
-.dl-atxt { font-size: 12.5px; color: var(--txt); flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.dl-due { margin-left: auto; flex: 0 0 auto; display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 800; font-family: 'Saira Condensed', var(--font); letter-spacing: .4px; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; white-space: nowrap; }
+.dl-atxt { font-size: 0.7353rem; color: var(--txt); flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.dl-due { margin-left: auto; flex: 0 0 auto; display: inline-flex; align-items: center; gap: 6px; font-size: 0.6471rem; font-weight: 800; font-family: 'Saira Condensed', var(--font); letter-spacing: .4px; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; white-space: nowrap; }
 .dl-due .dd { width: 7px; height: 7px; border-radius: 50%; }
 .dl.act.u-due  { border-color: var(--red); box-shadow: 0 0 0 1px var(--red), 0 0 15px -5px var(--red); background: var(--red-bg); }
 .dl.act.u-due  .dl-dot { border-color: var(--red); background: var(--red); color: #fff; }
@@ -3986,7 +4002,7 @@ body { font-variant-numeric: tabular-nums; }
    near-white stamp reads AA in both themes. */
 .dl.won { border-color: var(--blue); background: color-mix(in srgb, var(--blue) 62%, #05112a);
   box-shadow: 0 0 0 1px var(--blue), 0 0 18px -6px var(--blue); }
-.dl.won .dl-nm { color: #eef4ff; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .7px; font-weight: 800; font-size: 13.5px; }
+.dl.won .dl-nm { color: #eef4ff; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .7px; font-weight: 800; font-size: 0.7941rem; }
 .dl.won .dl-note { color: #cfe0ff; opacity: .9; }
 .dl.won .dl-dt { color: #dce8ff; font-weight: 700; }
 .dl.won .dl-dot { border-color: #eef4ff; background: #eef4ff; color: var(--blue); }
@@ -3995,15 +4011,15 @@ body { font-variant-numeric: tabular-nums; }
   border-radius: 9px; background: color-mix(in srgb, var(--accent) 6%, transparent); cursor: pointer; margin: 1px 0; color: var(--txt-2); font: inherit; }
 .dl-check:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .dl-box { width: 18px; height: 18px; border-radius: 5px; border: 2px solid var(--accent); display: inline-flex; align-items: center; justify-content: center;
-  color: var(--on-orange); font-weight: 900; font-size: 12px; flex: 0 0 auto; }
+  color: var(--on-orange); font-weight: 900; font-size: 0.7059rem; flex: 0 0 auto; }
 .dl-check.on .dl-box { background: var(--accent); }
-.dl-ck-t { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-weight: 800; font-size: 12px; color: var(--txt); }
-.dl-ck-h { margin-left: auto; font-size: 10px; color: var(--txt-3); font-style: italic; }
-.fl-autodate { font-size: 12.5px; color: var(--txt-2); padding: 6px 0; }
+.dl-ck-t { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-weight: 800; font-size: 0.7059rem; color: var(--txt); }
+.dl-ck-h { margin-left: auto; font-size: 0.5882rem; color: var(--txt-3); font-style: italic; }
+.fl-autodate { font-size: 0.7353rem; color: var(--txt-2); padding: 6px 0; }
 /* R28 — the account button: a neutral steel chip, stamped label = the account type */
 .acct-btn { display: inline-flex; align-items: center; gap: 7px; height: 30px; padding: 0 13px; border-radius: 999px;
   border: 1px solid var(--line); background: var(--card); color: var(--txt);
-  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10.5px;
+  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.6176rem;
   cursor: pointer; flex: 0 0 auto; }
 .acct-btn:hover { border-color: var(--accent-line); color: var(--accent); }
 .acct-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -4019,11 +4035,11 @@ body { font-variant-numeric: tabular-nums; }
   background: linear-gradient(180deg, var(--card-head), var(--panel)); }
 .acct-bar:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .acct-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 800;
-  font-size: 11px; color: var(--txt-3); flex: 0 0 auto; }
-.acct-sum { flex: 1; min-width: 0; font-size: 12px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  font-size: 0.6471rem; color: var(--txt-3); flex: 0 0 auto; }
+.acct-sum { flex: 1; min-width: 0; font-size: 0.7059rem; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .acct-sum b { color: var(--txt); font-weight: 700; }
 .acct-dot { color: var(--txt-3); margin: 0 6px; }
-.type-chip { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-size: 9.5px; font-weight: 700;
+.type-chip { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-size: 0.5588rem; font-weight: 700;
   flex: 0 0 auto; padding: 3px 8px; border-radius: 999px; }
 .type-chip.ok { color: var(--green); background: var(--green-bg); }
 .type-chip.warn { color: var(--yellow); background: var(--yellow-bg); }
@@ -4058,7 +4074,7 @@ body { font-variant-numeric: tabular-nums; }
 .wo-open .io-bar-top { cursor: pointer; }
 .wo-open .io-bar-top .inline-edit { cursor: text; }
 .wo-open .type-chip { flex: 0 0 auto; }
-.ir-woreport { color: var(--txt); font-weight: 700; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ir-woreport { color: var(--txt); font-weight: 700; font-size: 0.7059rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wo-open-body { padding: 11px 13px; display: flex; flex-direction: column; gap: 9px; }
 /* +Work Order rides ABOVE the rows as a FULL-WIDTH dashed add-row (Jac — like the
    +Rental / +Invoice add, spanning the width a regular row takes), not a centered pill. */
@@ -4069,21 +4085,21 @@ body { font-variant-numeric: tabular-nums; }
 .acct-fgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 12px; }
 .acct-f { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .acct-f.wide { grid-column: 1 / -1; }
-.acct-f > span { font-size: 9.5px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .4px; font-family: 'Saira Condensed', var(--font); }
-.acct-f .v.inline-edit { font-size: 12px; padding: 6px 9px; background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; display: flex; align-items: center; min-height: 32px; min-width: 0; }
+.acct-f > span { font-size: 0.5588rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; letter-spacing: .4px; font-family: 'Saira Condensed', var(--font); }
+.acct-f .v.inline-edit { font-size: 0.7059rem; padding: 6px 9px; background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; display: flex; align-items: center; min-height: 32px; min-width: 0; }
 .acct-f .v.inline-edit > * { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .acct-f .v.inline-edit:hover { border-color: var(--accent-line); }   /* empty or filled — the whole box invites the tap-to-edit */
 .acct-notesrow { margin-top: 8px; }
 
 /* D22/D23 — NET TERMS · PO · PROTECTION on one line */
 .acct-termsline { display: flex; align-items: center; gap: 7px; margin-top: 10px; flex-wrap: wrap; }
-.acct-cap { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .4px; font-size: 9.5px; font-weight: 700; color: var(--txt-3); flex: 0 0 auto; }
+.acct-cap { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .4px; font-size: 0.5588rem; font-weight: 700; color: var(--txt-3); flex: 0 0 auto; }
 .acct-lock { display: inline-flex; align-items: center; color: var(--txt-3); flex: 0 0 auto; }
 .acct-sep { width: 1px; align-self: stretch; background: var(--line); margin: 1px 3px; flex: 0 0 auto; }
-.acct-prot-note { font-size: 11px; color: var(--txt-3); font-style: italic; margin: 7px 2px 0; }
+.acct-prot-note { font-size: 0.6471rem; color: var(--txt-3); font-style: italic; margin: 7px 2px 0; }
 .acct-prot-note b { color: var(--green); font-style: normal; }
 /* R31 — the single interactive toggle chip (PO / Protection) */
-.chip-toggle { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 10px; font-weight: 700;
+.chip-toggle { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 0.5882rem; font-weight: 700;
   padding: 5px 11px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel-2); color: var(--txt-3); cursor: pointer; }
 .chip-toggle:hover { border-color: var(--accent-line); }
 .chip-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
@@ -4098,7 +4114,7 @@ body { font-variant-numeric: tabular-nums; }
 .inv-kpi-row { display: flex; align-items: center; gap: 9px; margin: -2px 0 12px; }
 .inv-kpi-row .inv-summary { margin: 0; flex: 1; }
 .inv-kpi-row .chip-toggle { flex: 0 0 auto; white-space: nowrap; }
-.kchip .kc-v .arr, .kchip .arr { font-size: 9px; margin-left: 2px; }
+.kchip .kc-v .arr, .kchip .arr { font-size: 0.5294rem; margin-left: 2px; }
 .arr.g { color: var(--green); } .arr.b { color: var(--red); }
 .kchip .kc-l .kc-delta { margin-left: 5px; font-weight: 800; }
 .kc-delta.g { color: var(--green); } .kc-delta.b { color: var(--red); }
@@ -4106,9 +4122,9 @@ body { font-variant-numeric: tabular-nums; }
 /* D16 — Agreements list */
 .ag-divide { border: 0; border-top: 1px dashed var(--tan, #c2925a); opacity: .5; margin: 14px 0 10px; }
 .ag-head { display: flex; align-items: center; justify-content: space-between; margin: 0 2px 8px; }
-.ag-head h5 { margin: 0; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 11px; color: var(--txt-3); font-weight: 700; }
+.ag-head h5 { margin: 0; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 0.6471rem; color: var(--txt-3); font-weight: 700; }
 .ag-scroll { display: flex; flex-direction: column; gap: 6px; margin-top: 6px; }
-.ag-empty { font-size: 12px; padding: 8px 2px; }
+.ag-empty { font-size: 0.7059rem; padding: 8px 2px; }
 
 /* D18 — collapsed agreement row, ONE line */
 .ag-row { display: flex; align-items: center; gap: 9px; padding: 9px 10px; border: 1px solid var(--line); border-radius: 10px;
@@ -4117,22 +4133,22 @@ body { font-variant-numeric: tabular-nums; }
 .ag-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .ag-stat { width: 3px; align-self: stretch; border-radius: 3px; flex: 0 0 auto; margin: -1px 0; background: var(--gray); }
 .ag-stat.ok { background: var(--green); } .ag-stat.warn { background: var(--yellow); } .ag-stat.bad { background: var(--red); } .ag-stat.pend { background: var(--purple); }
-.ag-ttl { font-weight: 800; font-size: 12.5px; letter-spacing: .2px; flex: 0 0 auto; white-space: nowrap; }
-.ag-ttl.status { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .7px; font-size: 12px; font-weight: 800; }
+.ag-ttl { font-weight: 800; font-size: 0.7353rem; letter-spacing: .2px; flex: 0 0 auto; white-space: nowrap; }
+.ag-ttl.status { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .7px; font-size: 0.7059rem; font-weight: 800; }
 .ag-ttl.status.pend { color: var(--purple); } .ag-ttl.status.bad { color: var(--red); } .ag-ttl.status.warn { color: var(--yellow); } .ag-ttl.status.ok { color: var(--green); }
-.ag-sub { flex: 1; min-width: 0; font-size: 11px; color: var(--txt-3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.cind { font-weight: 700; font-size: 11px; letter-spacing: .2px; flex: 0 0 auto; white-space: nowrap; }
+.ag-sub { flex: 1; min-width: 0; font-size: 0.6471rem; color: var(--txt-3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cind { font-weight: 700; font-size: 0.6471rem; letter-spacing: .2px; flex: 0 0 auto; white-space: nowrap; }
 .cind.ok { color: var(--green); } .cind.warn { color: var(--yellow); } .cind.bad { color: var(--red); }
 .rflags { flex: 1; min-width: 0; display: flex; gap: 9px; align-items: center; }
-.rflag { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 9px; font-weight: 700; color: var(--red); white-space: nowrap; }
+.rflag { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 0.5294rem; font-weight: 700; color: var(--red); white-space: nowrap; }
 .ag-chev { color: var(--txt-3); flex: 0 0 auto; display: inline-flex; }
 
 /* expanded agreement row (existing signed OR new-agreement creation) */
 .ag-open { border: 1px solid var(--accent-line); border-radius: 11px; background: var(--card); box-shadow: 0 0 0 1px var(--accent-soft); overflow: hidden; }
 .ao-bar { background: linear-gradient(180deg, var(--card-head), var(--panel-2)); padding: 9px 12px; border-bottom: 1px solid var(--line); display: flex; align-items: center; gap: 9px; }
 .ao-bar.js-ag-collapse { cursor: pointer; }   /* whole header collapses the open agreement (the new-agreement bar keeps its explicit Cancel) */
-.ao-bar .ao-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 11.5px; }
-.ao-bar .unsaved { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .8px; font-size: 9px; font-weight: 700; color: var(--yellow);
+.ao-bar .ao-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 0.6765rem; }
+.ao-bar .unsaved { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .8px; font-size: 0.5294rem; font-weight: 700; color: var(--yellow);
   border: 1px solid color-mix(in srgb, var(--yellow) 45%, transparent); background: var(--yellow-bg); border-radius: 999px; padding: 2px 8px; }
 .ao-bar .sp, .ag-foot .sp, .ao-foot .sp { flex: 1; }
 .ao-collapse { color: var(--txt-3); background: none; border: 0; cursor: pointer; display: inline-flex; }
@@ -4144,46 +4160,46 @@ body { font-variant-numeric: tabular-nums; }
 .ao-body { padding: 12px; display: flex; flex-direction: column; gap: 12px; }
 .ao-row { display: flex; gap: 11px; }
 .ao-cell { flex: 1; display: flex; flex-direction: column; gap: 5px; min-width: 0; }
-.ao-cap { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-size: 10px; color: var(--txt-3); font-weight: 700; }
+.ao-cap { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .6px; font-size: 0.5882rem; color: var(--txt-3); font-weight: 700; }
 .ao-cap-block { display: block; margin-bottom: 5px; }
 .actype-dd { display: flex; align-items: center; justify-content: space-between; gap: 8px; background: var(--panel-2); border: 1px solid var(--accent-line);
   border-radius: 8px; padding: 8px 11px; cursor: pointer; font: inherit; width: 100%; text-align: left; }
-.actype-dd b { font-weight: 800; font-size: 12.5px; color: var(--accent); } .actype-dd .cv { color: var(--txt-3); }
+.actype-dd b { font-weight: 800; font-size: 0.7353rem; color: var(--accent); } .actype-dd .cv { color: var(--txt-3); }
 .actype-dd:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .packet { display: flex; gap: 11px; }
 .packet .pcell { flex: 1; } .packet .pcell .ao-cap { display: block; margin-bottom: 5px; }
 .selfie { height: 74px; border-radius: 8px; border: 1px solid var(--line); background: repeating-linear-gradient(45deg, var(--panel-2) 0 8px, var(--panel) 8px 16px);
-  display: flex; align-items: center; justify-content: center; color: var(--txt-3); font-size: 10px; font-family: 'Saira Condensed', var(--font); letter-spacing: 1px; text-transform: uppercase; }
+  display: flex; align-items: center; justify-content: center; color: var(--txt-3); font-size: 0.5882rem; font-family: 'Saira Condensed', var(--font); letter-spacing: 1px; text-transform: uppercase; }
 .sigpad { height: 74px; border-radius: 8px; border: 1px dashed var(--line); background: var(--panel-2); position: relative; }
 .sigpad .base { position: absolute; left: 12px; right: 12px; bottom: 20px; border-top: 1px solid var(--line); }
-.terms { height: 70px; overflow: auto; border: 1px solid var(--line); border-radius: 8px; background: var(--panel-2); padding: 9px 11px; font-size: 11px; color: var(--txt-2); line-height: 1.5; }
+.terms { height: 70px; overflow: auto; border: 1px solid var(--line); border-radius: 8px; background: var(--panel-2); padding: 9px 11px; font-size: 0.6471rem; color: var(--txt-2); line-height: 1.5; }
 /* Phase 2b — the live account-type toggle-menu, live capture previews, and the enroll tote. */
 .actype-menu { position: relative; margin-top: 4px; display: flex; flex-direction: column; gap: 3px; border: 1px solid var(--line); border-radius: 9px; background: var(--panel); padding: 4px; box-shadow: var(--chip-shadow); }
-.actype-opt { font: inherit; font-size: 12px; text-align: left; padding: 7px 9px; border-radius: 7px; border: 0; background: transparent; color: var(--txt-2); cursor: pointer; }
+.actype-opt { font: inherit; font-size: 0.7059rem; text-align: left; padding: 7px 9px; border-radius: 7px; border: 0; background: transparent; color: var(--txt-2); cursor: pointer; }
 .actype-opt:hover { background: var(--panel-2); } .actype-opt.on { color: var(--accent); font-weight: 700; }
 .selfie-img { width: 100%; height: 74px; object-fit: cover; border-radius: 8px; border: 1px solid var(--line); }
 .picklabel { cursor: pointer; }
 .sigpad.has-sig { display: flex; align-items: center; justify-content: center; padding: 4px; }
 .sig-img { max-width: 100%; max-height: 100%; }
-.sigpad.js-sign-popout { display: flex; align-items: center; justify-content: center; font: inherit; color: var(--txt-3); font-size: 11px; cursor: pointer; }
+.sigpad.js-sign-popout { display: flex; align-items: center; justify-content: center; font: inherit; color: var(--txt-3); font-size: 0.6471rem; cursor: pointer; }
 .sigpad.js-sign-popout:hover { border-color: var(--accent-line); color: var(--accent); }
-.datefield-in { background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 8px 11px; color: var(--txt); font: inherit; font-size: 12.5px; width: 100%; }
+.datefield-in { background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 8px 11px; color: var(--txt); font: inherit; font-size: 0.7353rem; width: 100%; }
 .datefield-in:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .tote { border: 1px solid var(--line); border-radius: 8px; background: var(--panel-2); padding: 9px 11px; display: flex; flex-direction: column; gap: 4px; margin-top: 12px; }
-.tote .ln { display: flex; justify-content: space-between; font-size: 11.5px; color: var(--txt-2); }
+.tote .ln { display: flex; justify-content: space-between; font-size: 0.6765rem; color: var(--txt-2); }
 .tote .ln b { color: var(--txt); font-variant-numeric: tabular-nums; }
-.tote .ln.total { border-top: 1px dashed var(--line); padding-top: 6px; margin-top: 1px; font-size: 13px; } .tote .ln.total b { font-weight: 800; }
-.charge-note { font-size: 11px; color: var(--txt-3); font-style: italic; margin: 8px 0 0; } .charge-note b { color: var(--accent); font-style: normal; }
+.tote .ln.total { border-top: 1px dashed var(--line); padding-top: 6px; margin-top: 1px; font-size: 0.7647rem; } .tote .ln.total b { font-weight: 800; }
+.charge-note { font-size: 0.6471rem; color: var(--txt-3); font-style: italic; margin: 8px 0 0; } .charge-note b { color: var(--accent); font-style: normal; }
 .ao-foot { display: flex; align-items: center; gap: 9px; }
-.ag-meta { display: flex; align-items: center; gap: 8px; font-size: 11.5px; color: var(--txt-3); }
+.ag-meta { display: flex; align-items: center; gap: 8px; font-size: 0.6765rem; color: var(--txt-3); }
 .ag-meta .ag-metasep { width: 1px; height: 12px; background: var(--line); }
-.ag-signed { display: flex; align-items: center; gap: 8px; font-size: 12px; margin-top: 8px; }
+.ag-signed { display: flex; align-items: center; gap: 8px; font-size: 0.7059rem; margin-top: 8px; }
 .ag-signed .ag-lock { color: var(--green); display: inline-flex; flex: 0 0 auto; }
 .ag-packet { display: flex; gap: 11px; margin-top: 10px; }
-.ag-pcell { flex: 1; } .ag-pcap { font-size: 10px; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); font-weight: 700; margin-bottom: 5px; }
+.ag-pcell { flex: 1; } .ag-pcap { font-size: 0.5882rem; text-transform: uppercase; letter-spacing: .5px; color: var(--txt-3); font-weight: 700; margin-bottom: 5px; }
 .ag-selfie, .ag-sigthumb { height: 64px; width: 100%; border-radius: 8px; border: 1px solid var(--line); object-fit: cover; background: var(--panel-2); }
-.ag-selfie.empty { display: flex; align-items: center; justify-content: center; color: var(--txt-3); font-size: 18px; }
-.acct-microcopy { font-size: 11px; color: var(--txt-3); margin: 10px 2px 0; }
+.ag-selfie.empty { display: flex; align-items: center; justify-content: center; color: var(--txt-3); font-size: 1.0588rem; }
+.acct-microcopy { font-size: 0.6471rem; color: var(--txt-3); margin: 10px 2px 0; }
 /* T2.6 — the derived stats folded in from the retired old account section (Total paid / Visits /
    Customer-for / Rents-every / rented categories). Left-aligned here (its old home was a right-
    aligned column; this flat context reads better left-aligned). */
@@ -4200,11 +4216,11 @@ body { font-variant-numeric: tabular-nums; }
 /* Phase 3 (T3.1) — the blockPicker popup: the pick-a-mode row + the invoice-hold checklist. */
 .blockpick-opts { display: flex; flex-direction: column; gap: 8px; }
 .blockpick-list { display: flex; flex-direction: column; gap: 6px; max-height: 220px; overflow-y: auto; }
-.blockpick-row { display: flex; align-items: center; gap: 9px; padding: 8px 10px; border: 1px solid var(--line); border-radius: 9px; background: var(--panel-2); cursor: pointer; font-size: 12.5px; }
+.blockpick-row { display: flex; align-items: center; gap: 9px; padding: 8px 10px; border: 1px solid var(--line); border-radius: 9px; background: var(--panel-2); cursor: pointer; font-size: 0.7353rem; }
 .blockpick-row:hover { border-color: var(--accent-line); }
 .blockpick-row .id { font-weight: 700; color: var(--txt-2); }
 .blockpick-row .amt { margin-left: auto; font-weight: 800; font-variant-numeric: tabular-nums; }
-.anno { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .8px; font-size: 8.5px; font-weight: 700; color: var(--tan-deep, #8a5a2b);
+.anno { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .8px; font-size: 0.5rem; font-weight: 700; color: var(--tan-deep, #8a5a2b);
   border: 1px solid color-mix(in srgb, var(--tan, #c2925a) 45%, transparent); background: color-mix(in srgb, var(--tan, #c2925a) 12%, transparent);
   border-radius: 5px; padding: 1px 5px; margin-left: 6px; vertical-align: middle; }
 /* Account fields stay 2-up on phones (Jac 2026-07-11) — short fields pair, wide ones (email/address/notes) span. Only drop to 1 col on the very narrowest handsets so inputs never crush. */
@@ -4213,20 +4229,20 @@ body { font-variant-numeric: tabular-nums; }
 
 .funnel-fields { margin-top: 11px; gap: 5px; }
 .funnel-sublabel { margin-top: 11px; margin-bottom: 3px; font-family: 'Saira Condensed', var(--font); text-transform: uppercase;
-  letter-spacing: 1px; font-size: 9.5px; color: var(--txt-3); font-weight: 700; }
+  letter-spacing: 1px; font-size: 0.5588rem; color: var(--txt-3); font-weight: 700; }
 /* interest type tags on the linked/interest pills (Cat = safety-orange, Make = leather-tan) */
-.pill.ref .ref-tag { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 8px;
+.pill.ref .ref-tag { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 0.4706rem;
   font-weight: 800; padding: 2px 4px; border-radius: 4px; background: color-mix(in srgb, var(--accent) 20%, transparent); margin-right: 1px; }
 .pill.ref.tone-tan { color: var(--tan, #c2925a); border-color: color-mix(in srgb, var(--tan, #c2925a) 45%, transparent);
   background: color-mix(in srgb, var(--tan, #c2925a) 14%, transparent); }
 .pill.ref.tone-tan .ref-tag { background: color-mix(in srgb, var(--tan, #c2925a) 26%, transparent); }
-.dd-itag { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 8px; font-weight: 800;
+.dd-itag { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 0.4706rem; font-weight: 800;
   padding: 1px 4px; border-radius: 4px; margin-right: 5px; }
 .dd-itag.cat { color: var(--accent); background: var(--accent-soft); }
 .dd-itag.mk { color: var(--tan, #c2925a); background: color-mix(in srgb, var(--tan, #c2925a) 16%, transparent); }
-.dd-sec-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 9px; font-weight: 700;
+.dd-sec-lbl { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 0.5294rem; font-weight: 700;
   color: var(--txt-3); padding: 6px 9px 3px; }
-.dd-empty { padding: 5px 9px; color: var(--txt-3); font-size: 11.5px; }
+.dd-empty { padding: 5px 9px; color: var(--txt-3); font-size: 0.6765rem; }
 
 /* NEXT ACTIONS — a running list; each row is ONE line, date FIRST, RYG by the action's date */
 .na-list { margin-top: 11px; display: flex; flex-direction: column; gap: 5px; }
@@ -4240,15 +4256,15 @@ body { font-variant-numeric: tabular-nums; }
 .nextact.due .na-dot { background: var(--red); box-shadow: 0 0 0 3px color-mix(in srgb, var(--red) 22%, transparent); }
 .nextact.soon .na-dot { background: var(--yellow); }
 .nextact.ok .na-dot { background: var(--green); }
-.na-when { flex: 0 0 auto; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 10px;
+.na-when { flex: 0 0 auto; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 0.5882rem;
   font-weight: 800; padding: 2px 7px; border-radius: 6px; line-height: 1.4; }
 .nextact.due .na-when { color: #fff; background: var(--red); }
 .nextact.soon .na-when { color: #1a1205; background: var(--yellow); }
 .nextact.ok .na-when { color: var(--txt-2); background: var(--panel-2); border: 1px solid var(--line); }
-.na-txt { flex: 1; min-width: 0; font-size: 12px; font-weight: 600; color: var(--txt); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.na-txt { flex: 1; min-width: 0; font-size: 0.7059rem; font-weight: 600; color: var(--txt); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .na-acts { flex: 0 0 auto; display: inline-flex; gap: 4px; }
 .na-acts button { width: 22px; height: 22px; border-radius: 6px; border: 1px solid var(--line); background: var(--panel-2);
-  cursor: pointer; display: grid; place-items: center; font-size: 12px; line-height: 1; padding: 0; }
+  cursor: pointer; display: grid; place-items: center; font-size: 0.7059rem; line-height: 1; padding: 0; }
 .na-acts button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .na-done { color: var(--green); }
 .na-done:hover { background: color-mix(in srgb, var(--green) 18%, var(--panel-2)); border-color: var(--green); }
@@ -4258,20 +4274,20 @@ body { font-variant-numeric: tabular-nums; }
 /* ACTION LOG — collapsible, under Next Actions; open body scrolls internally + pushes flow down */
 .acthist { margin-top: 13px; border-top: 1px dashed var(--line); padding-top: 11px; }
 .ah-hd { display: flex; align-items: center; width: 100%; background: transparent; border: none; cursor: pointer; padding: 2px 0;
-  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.2px; font-size: 10.5px; font-weight: 700; color: var(--txt-2); }
+  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.2px; font-size: 0.6176rem; font-weight: 700; color: var(--txt-2); }
 .ah-hd:hover { color: var(--txt); }
 .ah-hd:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
 .ah-hd .ah-cnt { color: var(--txt-3); font-weight: 600; margin-left: 6px; }
 .ah-hd .ah-chev { color: var(--txt-3); margin-left: auto; padding-left: 8px; }
 .ah-body { margin-top: 9px; max-height: 128px; overflow: auto; display: flex; flex-direction: column; gap: 6px; padding-right: 4px; }
-.ah-row { display: flex; gap: 10px; font-size: 11.5px; color: var(--txt-2); padding: 6px 9px; background: var(--panel);
+.ah-row { display: flex; gap: 10px; font-size: 0.6765rem; color: var(--txt-2); padding: 6px 9px; background: var(--panel);
   border-radius: 7px; border: 1px solid var(--line-soft); }
-.ah-when { flex: 0 0 auto; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 9.5px;
+.ah-when { flex: 0 0 auto; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: .5px; font-size: 0.5588rem;
   color: var(--txt-3); min-width: 40px; padding-top: 1px; }
 .ah-ic { font-weight: 800; margin-right: 3px; }
 .ah-ic.done { color: var(--green); }
 .ah-ic.cancel { color: var(--red); }
-.ah-empty { color: var(--txt-3); font-size: 11.5px; padding: 2px 0; }
+.ah-empty { color: var(--txt-3); font-size: 0.6765rem; padding: 2px 0; }
 
 /* membership lifecycle actions, re-homed into the agreements window (§3.7) */
 .ag-lifecycle-wrap { margin-top: 14px; padding-top: 12px; border-top: 1.5px dashed var(--tan, #c2925a); }
@@ -4285,8 +4301,8 @@ body { font-variant-numeric: tabular-nums; }
 .inv-summary { display: flex; gap: 7px; flex-wrap: wrap; margin: -2px 0 12px; }
 .kchip { display: inline-flex; flex-direction: column; align-items: center; gap: 1px; padding: 6px 12px; border-radius: 10px;
   background: var(--panel); border: 1px solid var(--line); min-width: 76px; }
-.kchip .kc-v { font-size: 15px; font-weight: 800; font-variant-numeric: tabular-nums; }
-.kchip .kc-l { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 9px; color: var(--txt-3); }
+.kchip .kc-v { font-size: 0.8824rem; font-weight: 800; font-variant-numeric: tabular-nums; }
+.kchip .kc-l { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-size: 0.5294rem; color: var(--txt-3); }
 .kchip.due .kc-v { color: var(--red); }
 .kchip.paid .kc-v { color: var(--green); }
 .inv-scroll { max-height: 340px; overflow: auto; padding-right: 3px; display: flex; flex-direction: column; gap: 7px; }
@@ -4300,12 +4316,12 @@ body { font-variant-numeric: tabular-nums; }
   background: linear-gradient(180deg, var(--panel-2), var(--panel)); box-shadow: var(--chip-shadow); }
 .soon-ico { width: 34px; height: 34px; color: var(--tan); opacity: .85; }
 .soon-ico svg { width: 100%; height: 100%; }
-.soon-title { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 20px; color: var(--txt); }
-.soon-tag { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 10px;
+.soon-title { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 1.1765rem; color: var(--txt); }
+.soon-tag { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.5px; font-weight: 700; font-size: 0.5882rem;
   color: var(--tan-deep); background: color-mix(in srgb, var(--tan) 16%, transparent); border: 1px solid color-mix(in srgb, var(--tan) 45%, transparent);
   border-radius: 999px; padding: 3px 10px; }
-.soon-sub { font-size: 12px; color: var(--txt-3); line-height: 1.5; }
-.inv-empty { font-size: 12px; padding: 4px 0; }
+.soon-sub { font-size: 0.7059rem; color: var(--txt-3); line-height: 1.5; }
+.inv-empty { font-size: 0.7059rem; padding: 4px 0; }
 
 /* Rows lift one elevation above the card (depth-by-lightness): the surface reads a step
    lighter than --card, --chip-shadow floats it, and a hairline inset top-highlight gives the
@@ -4320,12 +4336,12 @@ body { font-variant-numeric: tabular-nums; }
 .inv-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .ir-stat { width: 3px; align-self: stretch; border-radius: 3px; flex: 0 0 auto; margin: -2px 0; background: var(--gray); }
 .ir-stat.due { background: var(--red); } .ir-stat.paid { background: var(--green); } .ir-stat.part { background: var(--yellow); }
-.ir-id { font-family: ui-monospace, monospace; font-weight: 700; font-size: 12px; letter-spacing: .3px; flex: 0 0 auto; }
+.ir-id { font-family: ui-monospace, monospace; font-weight: 700; font-size: 0.7059rem; letter-spacing: .3px; flex: 0 0 auto; }
 .ir-mid { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
-.ir-desc { color: var(--txt-2); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.ir-date { color: var(--txt-3); font-size: 10.5px; }
-.ir-amt { font-weight: 800; font-size: 13px; font-variant-numeric: tabular-nums; text-align: right; flex: 0 0 auto; }
-.ir-amt small { display: block; font-weight: 600; font-size: 9.5px; letter-spacing: .5px; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; color: var(--txt-3); }
+.ir-desc { color: var(--txt-2); font-size: 0.6471rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ir-date { color: var(--txt-3); font-size: 0.6176rem; }
+.ir-amt { font-weight: 800; font-size: 0.7647rem; font-variant-numeric: tabular-nums; text-align: right; flex: 0 0 auto; }
+.ir-amt small { display: block; font-weight: 600; font-size: 0.5588rem; letter-spacing: .5px; font-family: 'Saira Condensed', var(--font); text-transform: uppercase; color: var(--txt-3); }
 .ir-amt.due small { color: var(--red); } .ir-amt.paid small { color: var(--green); } .ir-amt.part small { color: var(--yellow); }
 .ir-chev { color: var(--txt-3); flex: 0 0 auto; display: inline-flex; }
 .ir-chev svg { width: 15px; height: 15px; }
@@ -4336,7 +4352,7 @@ body { font-variant-numeric: tabular-nums; }
 .io-bar { background: linear-gradient(180deg, var(--card-head), var(--panel-2)); padding: 11px 13px; border-bottom: 1px solid var(--line); }
 .io-bar-top { display: flex; align-items: center; gap: 9px; cursor: pointer; flex-wrap: wrap; row-gap: 7px; }   /* clicking anywhere in the header collapses (not just the chevron); wraps so the Print pill never overflows a narrow phone sheet */
 .io-bar-top .pill.ghost { flex: 0 0 auto; }   /* the Save-PDF pill keeps its label — never squished by the row */
-.io-id { font-family: ui-monospace, monospace; font-weight: 800; font-size: 14px; }
+.io-id { font-family: ui-monospace, monospace; font-weight: 800; font-size: 0.8235rem; }
 .io-collapse { width: 24px; height: 24px; border-radius: 7px; border: 1px solid var(--line); background: var(--panel); color: var(--txt-3);
   cursor: pointer; display: grid; place-items: center; flex: 0 0 auto; }
 .io-collapse svg { width: 14px; height: 14px; transform: rotate(180deg); }
@@ -4345,7 +4361,7 @@ body { font-variant-numeric: tabular-nums; }
 /* R29 — the status pill that IS the action menu; fill = pay state; SOLID when open */
 .io-menu-wrap { margin-left: auto; position: relative; }
 .io-statmenu { display: inline-flex; align-items: center; gap: 7px; height: 26px; padding: 0 8px 0 12px; border-radius: 999px;
-  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10px;
+  font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.5882rem;
   border: none; cursor: pointer; color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,.8); }
 .io-statmenu .cv { display: grid; place-items: center; width: 16px; height: 16px; border-radius: 50%; background: rgba(0,0,0,.28); }
 .io-statmenu .cv svg { width: 11px; height: 11px; }
@@ -4360,7 +4376,7 @@ body { font-variant-numeric: tabular-nums; }
 .io-menu { position: absolute; top: 31px; right: 0; z-index: 5; min-width: 152px; background: var(--panel-2); border: 1px solid var(--line);
   border-radius: 11px; box-shadow: var(--shadow); padding: 5px; display: flex; flex-direction: column; gap: 1px; }
 .im-item { display: flex; align-items: center; gap: 9px; height: 32px; padding: 0 11px; border-radius: 8px; border: none; background: transparent;
-  color: var(--txt); font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; text-align: left; width: 100%; }
+  color: var(--txt); font: inherit; font-size: 0.7059rem; font-weight: 600; cursor: pointer; text-align: left; width: 100%; }
 .im-item:hover:not([disabled]) { background: var(--panel); }
 .im-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .im-item[disabled] { color: var(--txt-3); cursor: not-allowed; }
@@ -4381,9 +4397,9 @@ body { font-variant-numeric: tabular-nums; }
   .io-sheet-wrap .pr-head { gap: 10px; align-items: center; }
   .io-sheet-wrap .pr-brandwrap { gap: 8px; min-width: 0; }
   .io-sheet-wrap .pr-logo { width: 38px; height: 38px; flex-basis: 38px; }
-  .io-sheet-wrap .pr-brand { font-size: 21px; letter-spacing: .3px; }
-  .io-sheet-wrap .pr-sub { font-size: 9.5px; letter-spacing: 1px; }
-  .io-sheet-wrap .pr-datestamp { font-size: 22px; letter-spacing: .5px; }
+  .io-sheet-wrap .pr-brand { font-size: 1.2353rem; letter-spacing: .3px; }
+  .io-sheet-wrap .pr-sub { font-size: 0.5588rem; letter-spacing: 1px; }
+  .io-sheet-wrap .pr-datestamp { font-size: 1.2941rem; letter-spacing: .5px; }
   .io-sheet-wrap .pr-meta { column-gap: 13px; }   /* stay 2-up on mobile to match desktop (Jac 2026-07-11) — just tighten the print-page gap so it fits the narrow sheet */
   .io-sheet-wrap .pr-meta > div { gap: 8px; min-width: 0; }
   .io-sheet-wrap .pr-meta > div > :last-child { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -4394,10 +4410,10 @@ body { font-variant-numeric: tabular-nums; }
   .io-sheet-wrap .pr-logs { grid-template-columns: 1fr; gap: 12px; }
 }
 /* on-sheet affordances (white-document colors — fixed like the rest of .pr-doc) */
-.pr-line-src { display: inline-flex; align-items: center; gap: 3px; font-size: 10px; color: #1864d6; font-weight: 700;
+.pr-line-src { display: inline-flex; align-items: center; gap: 3px; font-size: 0.5882rem; color: #1864d6; font-weight: 700;
   border: 1px solid #b9d2f7; background: #eef4fe; border-radius: 6px; padding: 0 5px; margin-left: 5px; cursor: pointer; }
 .pr-line-src:hover { background: #dfeaff; }
-.pr-po-edit { font-size: 9.5px; color: #1864d6; border: 1px dashed #b9d2f7; border-radius: 5px; padding: 0 5px; margin-left: 4px; cursor: pointer; }
+.pr-po-edit { font-size: 0.5588rem; color: #1864d6; border: 1px dashed #b9d2f7; border-radius: 5px; padding: 0 5px; margin-left: 4px; cursor: pointer; }
 /* §3.4 — the transient +Invoice DROP pill: create a fresh invoice for this customer from a
    released rental/WO/unit. Inherits the R5b blue-add (.anchor) look; hidden until a valid
    lineable drag OR an invoice menu-link is in flight; a full-width drop zone in the section.
@@ -4427,7 +4443,7 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
    a single date/datetime is entered (rental WINDOW keeps its timeline winpicker). */
 .datefield { display: inline-flex; align-items: center; gap: 7px; width: 100%; height: 36px; padding: 0 12px;
   background: var(--bg-2); border: 1px solid var(--line); border-radius: 9px; color: var(--txt);
-  font: inherit; font-size: 13px; cursor: pointer; text-align: left; }
+  font: inherit; font-size: 0.7647rem; cursor: pointer; text-align: left; }
 .datefield svg { width: 15px; height: 15px; color: var(--txt-3); flex: 0 0 auto; }
 .datefield.empty span { color: var(--txt-3); }
 .datefield:hover, .datefield.on { border-color: var(--accent-line); }
@@ -4446,7 +4462,7 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .inv-data .hitem .spacer { display: none; }
 .inv-data .inv-tot > b, .inv-data .inv-line > b { min-width: 84px; text-align: right; flex: 0 0 auto; }
 .inv-div { height: 1px; background: var(--line-soft); margin: 5px 0; }
-.inv-tot.big b { font-size: 14px; }
+.inv-tot.big b { font-size: 0.8235rem; }
 .inv-tot.due b { color: var(--accent); }
 
 /* ── RENTAL CALENDAR CARD (rcc) — 2 × 3 mini-calendar grid ─────────────────
@@ -4466,13 +4482,13 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
    row 2: customer + balance (Jac 2026-06-23) */
 .rcc-head { display: flex; flex-direction: column; gap: 4px; flex-shrink: 0; }
 .rcc-h1 { display: flex; align-items: center; gap: 7px; min-width: 0; justify-content: space-between; }
-.rcc-units { font-size: 12px; font-weight: 700; color: var(--txt); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; display: flex; align-items: center; gap: 0; }
-.rcc-uname { font-weight: 700; font-size: 12px; white-space: nowrap; }
-.rcc-usep { color: var(--txt-3); font-size: 11px; }
+.rcc-units { font-size: 0.7059rem; font-weight: 700; color: var(--txt); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; display: flex; align-items: center; gap: 0; }
+.rcc-uname { font-weight: 700; font-size: 0.7059rem; white-space: nowrap; }
+.rcc-usep { color: var(--txt-3); font-size: 0.6471rem; }
 .rcc-h2 { display: flex; align-items: baseline; justify-content: space-between; gap: 7px; min-width: 0; }
-.rcc-cust { font-size: 12px; font-weight: 600; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
-.rcc-bal { font-size: 12.5px; font-weight: 800; white-space: nowrap; flex-shrink: 0; font-variant-numeric: tabular-nums; }
-.rcc-rating { display: inline-flex; align-items: center; gap: 2px; font-size: 11.5px; font-weight: 800; color: var(--accent); flex-shrink: 0; margin-left: 2px; font-variant-numeric: tabular-nums; }
+.rcc-cust { font-size: 0.7059rem; font-weight: 600; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
+.rcc-bal { font-size: 0.7353rem; font-weight: 800; white-space: nowrap; flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.rcc-rating { display: inline-flex; align-items: center; gap: 2px; font-size: 0.6765rem; font-weight: 800; color: var(--accent); flex-shrink: 0; margin-left: 2px; font-variant-numeric: tabular-nums; }
 .rcc-rating svg { width: 12px; height: 12px; fill: var(--accent); stroke: none; }
 .rcc-bal.paid { color: var(--green); }
 .rcc-bal.due { color: var(--yellow); }
@@ -4481,7 +4497,7 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .rcc-set { color: var(--txt-3); font-style: italic; font-weight: 400; }
 /* WEEKDAY LETTERS — Mon–Fri, aligned over the 5 calendar columns */
 .rcc-dow { display: grid; grid-template-columns: repeat(5, 1fr); flex-shrink: 0; }
-.rcc-dow span { text-align: center; font-size: 9.5px; font-weight: 700; color: var(--txt-3); text-transform: uppercase; font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .6px; }
+.rcc-dow span { text-align: center; font-size: 0.5588rem; font-weight: 700; color: var(--txt-3); text-transform: uppercase; font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .6px; }
 /* CALENDAR — 5 weekday columns (closed weekends), bigger dots/labels for legibility */
 .rcc-body { flex: 1; display: grid; grid-template-columns: repeat(5, 1fr); column-gap: 0; row-gap: 2px; align-content: center; min-height: 0; }
 /* the dot sits at the cell's vertical centre; the start time floats above it and the
@@ -4489,9 +4505,9 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
    behind the dots (no column-gap → consecutive in-window bars touch into a continuous
    thread, breaking at week edges). */
 .rcc-day { position: relative; display: flex; align-items: center; justify-content: center; min-width: 0; height: 26px; }
-.rcc-t { position: absolute; top: 0; left: 50%; transform: translateX(-50%); font-size: 9px; font-weight: 700; line-height: 10px; color: var(--txt-2); text-align: center; white-space: nowrap; font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .2px; z-index: 3; }
-.rcc-day.is-start .rcc-t, .rcc-day.is-end .rcc-t { font-size: 11px; font-weight: 800; color: var(--txt); }
-.rcc-n { position: absolute; bottom: 0; left: 50%; transform: translateX(-50%); font-size: 10px; font-weight: 800; line-height: 10px; color: var(--txt); text-align: center; white-space: nowrap; z-index: 3; font-variant-numeric: tabular-nums; }
+.rcc-t { position: absolute; top: 0; left: 50%; transform: translateX(-50%); font-size: 0.5294rem; font-weight: 700; line-height: 10px; color: var(--txt-2); text-align: center; white-space: nowrap; font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .2px; z-index: 3; }
+.rcc-day.is-start .rcc-t, .rcc-day.is-end .rcc-t { font-size: 0.6471rem; font-weight: 800; color: var(--txt); }
+.rcc-n { position: absolute; bottom: 0; left: 50%; transform: translateX(-50%); font-size: 0.5882rem; font-weight: 800; line-height: 10px; color: var(--txt); text-align: center; white-space: nowrap; z-index: 3; font-variant-numeric: tabular-nums; }
 .rcc-n.mon { color: var(--txt-3); font-weight: 700; font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .4px; }
 .rcc-dot { position: relative; z-index: 2; width: 11px; height: 11px; border-radius: 50%; background: var(--line); display: flex; align-items: center; justify-content: center; color: transparent; }
 .rcc-dot svg { width: 8px; height: 8px; display: block; }
@@ -4509,7 +4525,7 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .rcc-day.is-start .rcc-dot svg, .rcc-day.is-end .rcc-dot svg { width: 15px; height: 15px; }
 /* month-1st: no dot, just the big month abbrev */
 .rcc-day.is-mon1st .rcc-dot { display: none; }
-.rcc-n.mon1st { font-size: 13px; font-weight: 800; color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .6px; bottom: 50%; transform: translate(-50%, 50%); }
+.rcc-n.mon1st { font-size: 0.7647rem; font-weight: 800; color: var(--txt-2); font-family: 'Saira Condensed', system-ui, sans-serif; letter-spacing: .6px; bottom: 50%; transform: translate(-50%, 50%); }
 
 /* ── CUSTOMER ROW (cr): ONE left-packed line — name · phone·type · pay-$ · funnel.
    Half-height (Jac 2026-06-23): tight vertical padding; phone·type reflows UNDER the
@@ -4518,7 +4534,7 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .row[data-card="customers"] { padding-top: 6px; padding-bottom: 6px; }   /* +50% (Jac 2026-07-17; was 4px) */
 .cr { display: flex; align-items: center; gap: 8px; min-width: 0; justify-content: flex-start; }
 .cr-id { flex: 0 1 auto; min-width: 0; display: flex; align-items: baseline; gap: 8px; }
-.cr-name { flex: 0 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 20px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }   /* +50% (Jac 2026-07-17; was 13.5px) */
+.cr-name { flex: 0 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 1.1765rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }   /* +50% (Jac 2026-07-17; was 13.5px) */
 /* ec-red: official flagging-red text treatment — --red halo bleeds into 65%-red+white fill, no hard seam. */
 .cr-name.ec-red,
 .rcc-uname.ec-red,
@@ -4605,8 +4621,8 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .pill.gate.dim.c-red .t, .pill.gate.dim.c-red { color:#fff; -webkit-text-fill-color:#fff; text-shadow:0 1px 1px rgba(0,0,0,.5); }   /* light shadow only — white on the dark transparent interior is already high-contrast; the primary's heavy shadow (for white-on-bright-fill) was muddying it */
 .pill:is([data-r="R3"],[data-r="R3b"]):not(.focal).c-red svg, .pill.gate.dim.c-red svg { color:#fff; -webkit-text-fill-color:#fff; filter:drop-shadow(0 1px 2px rgba(0,0,0,.9)); }
 .pill:is([data-r="R3"],[data-r="R3b"]):not(.focal).c-yellow .t { color:var(--yellow); -webkit-text-fill-color:var(--yellow); text-shadow:none; }
-.cr-sub { flex: 0 1 auto; min-width: 0; font-size: 11.5px; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.cr-pay { flex: 0 0 auto; font-size: 13px; font-weight: 700; font-style: italic; white-space: nowrap; }
+.cr-sub { flex: 0 1 auto; min-width: 0; font-size: 0.6765rem; color: var(--txt-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cr-pay { flex: 0 0 auto; font-size: 0.7647rem; font-weight: 700; font-style: italic; white-space: nowrap; }
 .cr-pay.spend { color: var(--green); }
 .cr-pay.due { color: var(--yellow); }
 .cr-pay.over { color: var(--red); }
@@ -4628,7 +4644,7 @@ body.dragging[data-drag="workOrders"] .inv-add-pill,
 .qa-field.qa-first, .qa-field.qa-last { flex: 1 1 100px; }
 .qa-field.qa-phone { flex: 1 1 130px; }
 .qa-field.qa-funnel { flex: 0 0 auto; }
-.qa-in { background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; height: var(--qa-h); padding: 0 11px; color: var(--txt); font: inherit; font-size: 12.5px; width: 100%; min-width: 0; }   /* min-width:0 lets the inputs shrink past their intrinsic size so nowrap can hold all four on one line instead of overflowing (Jac 2026-07-17) */
+.qa-in { background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; height: var(--qa-h); padding: 0 11px; color: var(--txt); font: inherit; font-size: 0.7353rem; width: 100%; min-width: 0; }   /* min-width:0 lets the inputs shrink past their intrinsic size so nowrap can hold all four on one line instead of overflowing (Jac 2026-07-17) */
 .qa-in:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 /* The R1 funnel gate rides the row at the SAME height as the inputs (Jac 2026-07-17 —
    the 22px global gate looked short next to the fields). Scoped to .qa-cust so the app-wide
@@ -4655,7 +4671,7 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
 .card[data-card="units"] .list .showmore { grid-column: 1 / -1; }
 .ucard { height: 100%; display: flex; flex-direction: column; gap: 7px; padding: 9px 9px; border: 2px solid var(--ur-hl, var(--line)); border-radius: 12px; overflow: hidden; }
 .uc-top { display: flex; align-items: center; justify-content: space-between; gap: 6px; }   /* corner mark optically centres on the name line */
-.uc-name { flex: 1 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; font-weight: 700; font-size: 14px; line-height: 1.1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.uc-name { flex: 1 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .5px; font-weight: 700; font-size: 0.8235rem; line-height: 1.1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 /* Danger name: crisp lighter red, NO red halo (the glow blurred it illegible — Jac
    2026-07-01). A subtle dark shadow separates it from the panel; the red card border
    already flags danger, so the name only needs to READ. (Restored 2026-07-03 — the
@@ -4668,13 +4684,13 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
 .list > .grp-hd:first-child { margin-top: 5px; }   /* clear the card's hazard-stripe top cap */
 /* Drag-to-reorder (Jac 2026-07-04) — same ⠿ grip language as .dt-grip (dispatch rail).
    A tap anywhere on the header still toggles collapse; a drag on the grip reorders. */
-.grp-grip { flex: 0 0 auto; color: var(--txt-3); font-size: 10px; cursor: grab; line-height: 1; }
+.grp-grip { flex: 0 0 auto; color: var(--txt-3); font-size: 0.5882rem; cursor: grab; line-height: 1; }
 .grp-hd.grp-dragging { opacity: .4; }
 .grp-hd.grp-dragover::before { content: ''; position: absolute; left: 0; right: 0; top: -2px; height: 2px; background: var(--blue); border-radius: 2px; }   /* drop-line indicator — blue (commit-intent), never orange (reserved for selected/ignition/linked) */
 .grp-chev { flex: 0 0 auto; display: inline-flex; color: var(--sec, var(--txt-2)); }
 .grp-chev svg { width: 16.5px; height: 16.5px; transform: rotate(90deg); transition: transform .15s ease; }   /* +50% to match .grp-label (Jac 2026-07-17; was 11px) */
 .grp-hd.is-collapsed .grp-chev svg { transform: rotate(0deg); }                                           /* collapsed → points right */
-.grp-label { flex: 0 0 auto; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 16.5px; line-height: 1; color: var(--sec, var(--txt-2)); }   /* +50% group titles (Jac 2026-07-17; was 11px) */
+.grp-label { flex: 0 0 auto; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.9706rem; line-height: 1; color: var(--sec, var(--txt-2)); }   /* +50% group titles (Jac 2026-07-17; was 11px) */
 .grp-hd::after { content: ''; flex: 1 1 auto; border-top: 2px solid var(--sec, var(--line)); opacity: .5; }   /* solid (was dashed) + +20% thicker (1.5px → 2px, the next rung on the line-weight scale — Jac 2026-07-10) */
 .grp-hd:hover .grp-label, .grp-hd:hover .grp-chev { filter: brightness(1.2); }
 /* Group RAIL (Jac 2026-07-10) — a vertical guide down the left edge of each group's rows,
@@ -4692,7 +4708,7 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
 /* §2.7 Trips AUTO-RUN — an actionPill (R17) living inside the day header; the header's own
    grip/chevron/label are already stamped Saira caps, so the button picks up the same voice
    here (the builder itself stays plain body-font everywhere else it's used). */
-.grp-hd .pill.c-commit { flex: 0 0 auto; height: 17px; padding: 0 8px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 9.5px; cursor: pointer; }
+.grp-hd .pill.c-commit { flex: 0 0 auto; height: 17px; padding: 0 8px; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-size: 0.5588rem; cursor: pointer; }
 /* Red group header (Needs Attention / No Show / Unpaid / Collections / Late) — raw
    --red at this tiny 7.9px stamped size read illegible (Jac 2026-07-03). Same lighter
    mix as the danger card name, NO glow — a halo would blur type this small even worse. */
@@ -4704,14 +4720,14 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
    text-underline (too busy this small) and force inline-block so ellipsis is reliable
    (the base .flag is inline-flex, tuned for an icon+label pair this corner no longer has). */
 .uc-flags .flags { height: auto; min-width: 0; }
-.uc-flags .flag { display: inline-block; max-width: 100%; height: auto; padding: 0 1px; font-size: 10px; line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; background-image: none; padding-bottom: 0; }
-.uc-cat { display: flex; align-items: center; gap: 5px; color: var(--txt-2); font-size: 12px; min-width: 0; }
+.uc-flags .flag { display: inline-block; max-width: 100%; height: auto; padding: 0 1px; font-size: 0.5882rem; line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom; background-image: none; padding-bottom: 0; }
+.uc-cat { display: flex; align-items: center; gap: 5px; color: var(--txt-2); font-size: 0.7059rem; min-width: 0; }
 .uc-caticon { flex: 0 0 auto; width: 16px; height: 16px; color: var(--txt-3); display: flex; align-items: center; justify-content: flex-start; }   /* glyph hugs the same left rail as the name above; sized to sit with the 12px label, not out-weigh it */
 .uc-caticon svg { width: 15px; height: 15px; display: block; }
 .uc-catname { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .uc-pills { display: flex; flex-direction: column; gap: 6px; }
 .uc-slot { display: flex; }
-.uc-slot .pill { width: 100%; font-size: 10px; padding: 0 8px; gap: 4px; letter-spacing: .1px; justify-content: center; align-items: center; }   /* icon + label ride together, centred as one group; NO overflow:hidden here (the label handles its own ellipsis) so nothing clips the glyphs */
+.uc-slot .pill { width: 100%; font-size: 0.5882rem; padding: 0 8px; gap: 4px; letter-spacing: .1px; justify-content: center; align-items: center; }   /* icon + label ride together, centred as one group; NO overflow:hidden here (the label handles its own ellipsis) so nothing clips the glyphs */
 .uc-slot .pill svg { flex: 0 0 auto; }
 .uc-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; line-height: 1.5; }   /* line-height ≥ glyph height so the ellipsis clip is horizontal-only — a tight 1.0 line sliced the letter bottoms. The line-box is flex-centred, so caps sit optically centred without a nudge. */
 /* ── CATEGORY MINI-CARD (catr) — Jac 2026-06-25: the category as a vertical unit
@@ -4816,7 +4832,7 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
   .catframes .cf { animation: none !important; }
   .catframes .cf1 { opacity: 1 !important; }
 }
-.catr-name { flex: 1 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 13px; line-height: 1.1; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.catr-name { flex: 1 1 auto; min-width: 0; font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .6px; font-weight: 700; font-size: 0.7647rem; line-height: 1.1; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
 /* the availability row in the rulebook R3b pill language: a full-width LEAD pill
    (N Avail / Next date / None·reason) over a PASS · NR · FAIL trio. Each slot is the
    click target (the whole slot, not just the pill) — lead opens units / the next-free
@@ -4825,7 +4841,7 @@ body.is-phone .card[data-card="units"] .list { grid-template-columns: repeat(2, 
 .catr-tally-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 4px; }
 /* the trio runs 3-across in a ~200px card — trim pad + type so "n Pass" fits without
    ellipsis (the dense-grid legible-minimum override, per the design language). */
-.catr-tally-row .pill { padding: 0 5px; font-size: 9px; letter-spacing: .1px; gap: 3px; }
+.catr-tally-row .pill { padding: 0 5px; font-size: 0.5294rem; letter-spacing: .1px; gap: 3px; }
 .catr-slot { display: flex; align-items: center; justify-content: center; min-width: 0; }
 .catr-slot .pill { width: 100%; text-align: center; justify-content: center; overflow: hidden; }
 .catr-slot .pill .t { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
@@ -4837,8 +4853,8 @@ button.catr-slot { cursor: pointer; padding: 0; background: none; border: 0; fon
    set off by a single saddle-stitch seam from the status pills above. */
 .catr-rates { margin-top: auto; display: flex; flex-direction: column; gap: 2px; border-top: 1px dashed var(--line); padding-top: 6px; }
 .catr-rate { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
-.catr-rk { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 600; font-size: 10px; color: var(--txt-3); }
-.catr-rv { font-size: 12.5px; font-weight: 700; white-space: nowrap; }
+.catr-rk { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: .8px; font-weight: 600; font-size: 0.5882rem; color: var(--txt-3); }
+.catr-rv { font-size: 0.7353rem; font-weight: 700; white-space: nowrap; }
 .catr-rv.none { color: var(--txt-3); font-weight: 600; }
 
 /* ── CUSTOMER ROW (cr-statuses): account-type + funnel, equal-width, right-pinned. ── */
@@ -4856,7 +4872,7 @@ button.catr-slot { cursor: pointer; padding: 0; background: none; border: 0; fon
 /* ════ §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) ════ */
 :root { --arc-apex: 110px; }   /* cancel-arc apex — JS sets ≈20% of the middle card per drag; this is the fallback. Tune me (Jac). */
 #drag-layer { position: fixed; inset: 0; z-index: 9400; pointer-events: none; }   /* above .hover-preview (9000); children inherit pointer-events:none */
-.drag-ghost { position: fixed; left: 0; top: 0; z-index: 9500; display: flex; align-items: center; gap: 7px; max-width: 240px; padding: 7px 12px; border-radius: 999px; background: var(--panel); border: 1px solid var(--accent); box-shadow: 0 0 0 2px var(--accent-line), 0 14px 34px -10px rgba(0,0,0,.65); color: var(--accent); font-size: 12.5px; font-weight: 700; pointer-events: none; will-change: transform; }
+.drag-ghost { position: fixed; left: 0; top: 0; z-index: 9500; display: flex; align-items: center; gap: 7px; max-width: 240px; padding: 7px 12px; border-radius: 999px; background: var(--panel); border: 1px solid var(--accent); box-shadow: 0 0 0 2px var(--accent-line), 0 14px 34px -10px rgba(0,0,0,.65); color: var(--accent); font-size: 0.7353rem; font-weight: 700; pointer-events: none; will-change: transform; }
 .drag-ghost svg { width: 14px; height: 14px; flex: 0 0 auto; }
 .drag-ghost .dg-t { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 /* §M-touch — PICKUP CUE: the ghost chip POPS in the instant a drag lifts, so the user
@@ -4875,14 +4891,14 @@ button.catr-slot { cursor: pointer; padding: 0; background: none; border: 0; fon
   position: relative; z-index: 4; flex: 0 0 auto; overflow: hidden; }   /* flex:0 0 auto — NEVER shrink (a height-constrained phone card was squashing it to a sliver); z-index above the card-body fade */
 .link-banner::before { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 6px;
   background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 8px, #14181d 8px 16px); }
-.link-banner .lb-txt { flex: 1; min-width: 0; font-size: 12.5px; color: var(--txt); }
+.link-banner .lb-txt { flex: 1; min-width: 0; font-size: 0.7353rem; color: var(--txt); }
 .link-banner .lb-txt b { color: var(--accent); font-weight: 700; }
-.link-banner .lb-sub { color: var(--txt-3); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 11px; margin-left: 5px; }
+.link-banner .lb-sub { color: var(--txt-3); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.2px; font-size: 0.6471rem; margin-left: 5px; }
 /* §17b — link confirm popup body */
 .lc-body { padding: 4px 2px 2px; }
-.lc-line { font-size: 13.5px; color: var(--txt); line-height: 1.5; }
+.lc-line { font-size: 0.7941rem; color: var(--txt); line-height: 1.5; }
 .lc-line b { color: var(--accent); font-weight: 700; }
-.lc-price { margin-top: 10px; font-size: 13px; color: var(--txt); }
+.lc-price { margin-top: 10px; font-size: 0.7647rem; color: var(--txt); }
 .lc-price b { color: var(--green); font-weight: 700; }
 .lc-price.muted { color: var(--txt-3); }
 /* §M2 ZIP ZONES (phone) — edge rails of valid drop-target cards during a drag. Steel
@@ -4902,7 +4918,7 @@ button.catr-slot { cursor: pointer; padding: 0; background: none; border: 0; fon
   background: repeating-linear-gradient(135deg, var(--zip-hue, var(--accent)) 0 13px, #14181d 13px 26px); }
 .zip-left::before  { right: 0; } .zip-right::before { left: 0; }
 .zip-zone .zz-ico { display: inline-flex; color: var(--zip-hue, var(--accent)); } .zip-zone .zz-ico svg { width: 22px; height: 22px; }
-.zip-zone .zz-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 11px; line-height: 1.05; text-align: center; }
+.zip-zone .zz-lbl { font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 0.6471rem; line-height: 1.05; text-align: center; }
 .zip-zone.hot { color: var(--zip-hue, var(--accent)); border-color: var(--zip-hue, var(--accent));
   box-shadow: 0 14px 44px -12px #000, inset 0 0 34px -10px var(--zip-hue, var(--accent)); }
 @keyframes zipInL { from { transform: translateX(-100%); } to { transform: none; } }
@@ -4923,7 +4939,7 @@ button.catr-slot { cursor: pointer; padding: 0; background: none; border: 0; fon
 .cancel-arc .ca-inner { display: flex; align-items: center; gap: 9px; color: #e7ebf0; transition: color .12s ease; }
 .cancel-arc.hot .ca-inner { color: #ff6b6b; }
 .cancel-arc .ca-ico { width: 20px; height: 20px; flex: 0 0 auto; }
-.cancel-arc .ca-label { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 17px; font-weight: 800; letter-spacing: 2px; text-transform: uppercase; }
+.cancel-arc .ca-label { font-family: 'Saira Condensed', system-ui, sans-serif; font-size: 1rem; font-weight: 800; letter-spacing: 2px; text-transform: uppercase; }
 @media (prefers-reduced-motion: no-preference) {
   .cancel-arc.hot .ca-inner { animation: arcArm .9s ease-in-out infinite; }
   @keyframes arcArm { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.06); } }
@@ -5042,7 +5058,7 @@ body.dragging .row.drop-ok { opacity: 1; }
 }
 [data-theme="yard"] .c-titlecard .c-title {
   font-family:'Saira Condensed', system-ui, sans-serif;
-  text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:14.5px;
+  text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:0.8529rem;
 }
 
 /* ── The wrangler seasoning — a worn leather-tan saddle-stitch under the deck ─ */
@@ -5190,7 +5206,7 @@ body.dragging .row.drop-ok { opacity: 1; }
 }
 [data-theme="bluedsteel"] .c-titlecard .c-title {
   font-family:'Saira Condensed', system-ui, sans-serif;
-  text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:14.5px;
+  text-transform:uppercase; letter-spacing:.8px; font-weight:800; font-size:0.8529rem;
 }
 [data-theme="bluedsteel"] .bottombar { margin-top: 2px; }
 
@@ -5333,7 +5349,7 @@ body.dragging .row.drop-ok { opacity: 1; }
   --pr-accent: #e08a00; --pr-stripe: #ffc21c;   /* default = open/caution; overridden per status below */
   position: relative; max-width: 760px; margin: 0 auto; padding: 20px 24px 26px;
   color: var(--pr-ink); background: var(--pr-paper);
-  font-family: Geist, system-ui, sans-serif; font-size: 12.5px; line-height: 1.5;
+  font-family: Geist, system-ui, sans-serif; font-size: 0.7353rem; line-height: 1.5;
   -webkit-print-color-adjust: exact; print-color-adjust: exact;
 }
 .pr-doc.is-paid { --pr-accent: #2f9e44; --pr-stripe: #37b04d; }   /* paid in full → green */
@@ -5345,24 +5361,24 @@ body.dragging .row.drop-ok { opacity: 1; }
 .pr-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
 .pr-brandwrap { display: flex; align-items: center; gap: 11px; }
 .pr-logo { width: 46px; height: 46px; flex: 0 0 46px; border-radius: 10px; object-fit: cover; }
-.pr-brand { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 30px; letter-spacing: .5px; line-height: .95; }
-.pr-sub { font-family: 'Saira Condensed', sans-serif; font-size: 11px; letter-spacing: 1.4px; color: var(--pr-mut); text-transform: uppercase; margin-top: 2px; }
-.pr-datestamp { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 34px; letter-spacing: 1px; color: var(--pr-accent); line-height: .9; text-align: right; white-space: nowrap; }
+.pr-brand { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 1.7647rem; letter-spacing: .5px; line-height: .95; }
+.pr-sub { font-family: 'Saira Condensed', sans-serif; font-size: 0.6471rem; letter-spacing: 1.4px; color: var(--pr-mut); text-transform: uppercase; margin-top: 2px; }
+.pr-datestamp { font-family: 'Saira Condensed', sans-serif; font-weight: 800; font-size: 2rem; letter-spacing: 1px; color: var(--pr-accent); line-height: .9; text-align: right; white-space: nowrap; }
 .pr-hazard { height: 7px; margin: 10px 0 16px; border-radius: 2px; background: repeating-linear-gradient(135deg, var(--pr-stripe) 0 11px, #14181d 11px 22px); }
 /* Meta grid on saddle-stitch dotted rules */
 .pr-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 3px 26px; margin-bottom: 16px; }
 .pr-meta > div { display: flex; justify-content: space-between; gap: 12px; border-bottom: 1px dotted var(--pr-line); padding: 3px 0; }
-.pr-k { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 10.5px; color: var(--pr-mut); }
+.pr-k { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 700; font-size: 0.6176rem; color: var(--pr-mut); }
 .pr-v { font-weight: 600; }
 /* Rental soft cards — single-line header (bold title first, then meta, subtotal right) */
 .pr-groups { display: flex; flex-direction: column; gap: 9px; margin-bottom: 14px; }
 .pr-card { background: #fffdf8; border: 1px solid var(--pr-line); border-radius: 12px; padding: 9px 14px 6px; break-inside: avoid; }
 .pr-card-h { display: flex; align-items: baseline; gap: 9px; padding-bottom: 6px; margin-bottom: 3px; border-bottom: 2px dashed var(--pr-tan); }
-.pr-card-t { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 13px; white-space: nowrap; }
-.pr-card-m { flex: 1 1 auto; font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 10.5px; color: var(--pr-mut); }
+.pr-card-t { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 0.7647rem; white-space: nowrap; }
+.pr-card-m { flex: 1 1 auto; font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: .6px; font-size: 0.6176rem; color: var(--pr-mut); }
 .pr-card-m > span + span::before { content: ' · '; }
 .pr-card-m .pr-prov { color: var(--pr-tan); }
-.pr-card-sub { margin-left: auto; font-weight: 800; font-size: 13px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.pr-card-sub { margin-left: auto; font-weight: 800; font-size: 0.7647rem; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .pr-line { display: flex; align-items: center; justify-content: space-between; padding: 4px 2px; border-bottom: 1px solid var(--pr-rule); }
 .pr-card-lines .pr-line:last-child { border-bottom: none; }
 .pr-desc { display: flex; align-items: center; min-width: 0; }
@@ -5381,20 +5397,20 @@ body.dragging .row.drop-ok { opacity: 1; }
 .pr-cust-photo { width: 108px; height: 108px; border-radius: 50%; object-fit: cover; border: 2px solid var(--pr-tan); filter: grayscale(.55) sepia(.16) contrast(.96) brightness(1.03); opacity: .9; }
 .pr-tot { flex: 0 0 300px; }
 .pr-tot > div { display: flex; justify-content: space-between; padding: 4px 0; border-bottom: 1px dotted var(--pr-line); }
-.pr-tot .pr-big { font-weight: 800; font-size: 15px; border-bottom: 2px solid var(--pr-ink); }
-.pr-tot .pr-due { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 17px; color: var(--pr-accent); border-bottom: none; padding-top: 8px; }
+.pr-tot .pr-big { font-weight: 800; font-size: 0.8824rem; border-bottom: 2px solid var(--pr-ink); }
+.pr-tot .pr-due { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1px; font-weight: 800; font-size: 1rem; color: var(--pr-accent); border-bottom: none; padding-top: 8px; }
 /* PAID rubber stamp — inherits the status accent (green when paid) */
-.pr-stamp { transform: rotate(-8deg); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 22px; color: var(--pr-accent); border: 3px solid var(--pr-accent); border-radius: 6px; padding: 6px 15px; opacity: .9; background: rgba(247, 242, 234, .66); }
+.pr-stamp { transform: rotate(-8deg); font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 2px; font-weight: 800; font-size: 1.2941rem; color: var(--pr-accent); border: 3px solid var(--pr-accent); border-radius: 6px; padding: 6px 15px; opacity: .9; background: rgba(247, 242, 234, .66); }
 .pr-stamp.on-photo { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%) rotate(-8deg); }
 /* Separated amendment logs — Invoice Log (left) · Rental Log (right) */
 .pr-logs { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; margin-top: 16px; padding-top: 10px; border-top: 2px dashed var(--pr-tan); break-inside: avoid; }
-.pr-log-h { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 12px; margin-bottom: 6px; }
-.pr-am-row { display: flex; gap: 10px; padding: 3px 0; border-bottom: 1px dotted var(--pr-line); font-size: 11px; }
-.pr-am-when { flex: 0 0 104px; font-family: 'Saira Condensed', sans-serif; letter-spacing: .3px; color: var(--pr-mut); text-transform: uppercase; font-size: 10px; padding-top: 1px; }
+.pr-log-h { font-family: 'Saira Condensed', sans-serif; text-transform: uppercase; letter-spacing: 1.4px; font-weight: 800; font-size: 0.7059rem; margin-bottom: 6px; }
+.pr-am-row { display: flex; gap: 10px; padding: 3px 0; border-bottom: 1px dotted var(--pr-line); font-size: 0.6471rem; }
+.pr-am-when { flex: 0 0 104px; font-family: 'Saira Condensed', sans-serif; letter-spacing: .3px; color: var(--pr-mut); text-transform: uppercase; font-size: 0.5882rem; padding-top: 1px; }
 .pr-am-tx em { color: var(--pr-mut); font-style: italic; }
-.pr-am-empty { color: var(--pr-mut); font-style: italic; font-size: 11px; }
+.pr-am-empty { color: var(--pr-mut); font-style: italic; font-size: 0.6471rem; }
 /* Footer */
-.pr-foot { margin-top: 20px; padding-top: 10px; border-top: 1px solid var(--pr-rule); font-size: 11px; color: var(--pr-mut); }
+.pr-foot { margin-top: 20px; padding-top: 10px; border-top: 1px solid var(--pr-rule); font-size: 0.6471rem; color: var(--pr-mut); }
 
 /* ── KPI MASK — remove this block to restore ring visibility (Jac) ── */
 .kpi-ring, .big-ring, .menu-team-ring { filter: blur(12px); pointer-events: none; }
@@ -5420,11 +5436,11 @@ body.dragging .row.drop-ok { opacity: 1; }
 }
 #sync-banner .sb-stamp {
   font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase;
-  letter-spacing: 1.4px; font-weight: 800; font-size: 14px; color: var(--red);
+  letter-spacing: 1.4px; font-weight: 800; font-size: 0.8235rem; color: var(--red);
   white-space: nowrap; flex-shrink: 0;
 }
 #sync-banner .sb-sub {
-  font-family: var(--font); font-size: 12.5px; color: var(--txt-2);
+  font-family: var(--font); font-size: 0.7353rem; color: var(--txt-2);
   flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 #sync-banner .pill { flex-shrink: 0; }
@@ -5454,21 +5470,21 @@ body.sync-failing #sched-banner { top: 40px; }   /* an active R25 sync band outr
 #sched-banner .scb-stamp {
   display: inline-flex; align-items: center; gap: 6px;
   font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase;
-  letter-spacing: 1.4px; font-weight: 800; font-size: 14px; color: var(--yellow); white-space: nowrap;
+  letter-spacing: 1.4px; font-weight: 800; font-size: 0.8235rem; color: var(--yellow); white-space: nowrap;
 }
 #sched-banner .scb-stamp svg { width: 15px; height: 15px; }
 #sched-banner .scb-count {
   display: inline-flex; align-items: center; justify-content: center;
   min-width: 19px; height: 19px; padding: 0 5px; border-radius: 9px;
   background: var(--yellow); color: #1a1205;
-  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 12px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; font-weight: 800; font-size: 0.7059rem;
 }
 #sched-banner .scb-list { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; padding-top: 1px; }
-#sched-banner .scb-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 12.5px; }
+#sched-banner .scb-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 0.7353rem; }
 #sched-banner .scb-note { color: var(--txt); min-width: 0; }
 #sched-banner .scb-time {
   font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase;
-  letter-spacing: .8px; font-weight: 700; font-size: 11.5px; color: var(--yellow); white-space: nowrap;
+  letter-spacing: .8px; font-weight: 700; font-size: 0.6765rem; color: var(--yellow); white-space: nowrap;
 }
 #sched-banner .scb-time.scb-anytime { color: var(--txt-3); }
 #sched-banner .close-x { flex-shrink: 0; margin-top: 1px; }
@@ -5485,5 +5501,5 @@ body.sync-failing.sched-due #app { padding-top: calc(40px + var(--sched-band, 46
 .sw-toast-stripe { align-self: stretch; width: 13px; border-radius: var(--chip-radius) 0 0 var(--chip-radius);
   background: repeating-linear-gradient(135deg, var(--yellow, #f5c542) 0 13px, #14181d 13px 26px); }
 .sw-toast-msg { font-family: 'Saira Condensed', var(--font); text-transform: uppercase; letter-spacing: 1.4px;
-  font-weight: 600; font-size: 12px; color: var(--txt-2); }
+  font-weight: 600; font-size: 0.7059rem; color: var(--txt-2); }
 .sw-toast .pill.ignition:focus-visible, .sw-toast .x:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }


### PR DESCRIPTION
## What & why

Mobile ignored the iOS **Text-Size accessibility slider** (Dynamic Type) because every font size in the app was hard `px` — **675** in `style.css`, **100** app-UI inline sizes in `app.js`, and **zero** `rem`/`em`. iOS Safari only resizes web text to the system Text-Size setting when the page roots its sizing on Apple's Dynamic Type font keywords and cascades through relative units, so an all-`px` page is *structurally* inert to the slider.

## Approach

- **`html` gets a 17px `rem` anchor** (= the iOS default `-apple-system-body` size), so every `(Npx / 17)rem` renders **byte-identical** at the default Text-Size and on every desktop browser. Added `text-size-adjust: 100%` to stop rotate auto-inflation.
- **On touch devices only** — `@media (hover: none) and (pointer: coarse)` — the anchor binds to `font: -apple-system-body`, so the iOS Text-Size slider now resizes the whole app. Scoped to touch so desktop keeps the flat baseline — notably **macOS Safari**, where `-apple-system-body` resolves to a fixed ~13px and would otherwise shrink the whole app.
- **Converted all font-size `px` → `rem` (÷17)** in `style.css` + the app-UI inline styles in `app.js`. **Skipped** the 4 popout/print-doc `<style>` blocks (signing PDF, membership PDF, sign-pad, Fleet-QR sheet) — they open in separate windows with their own root and are fixed-size print surfaces, so `rem` there wouldn't track our anchor.

## Verification

- **Default computed sizes unchanged** (`body` = 14px at default) — proven by driving the app headless.
- **Forcing the anchor to 1.5×** scales all text in lockstep with the layout intact (login plate: wordmark, stamped labels, input, ignition button all grew proportionally, nothing clipped).
- **Gates green:** `smoke` ✅ · `logic` 686/686 ✅ · `gen-rule-usage --check` ✅ · `check-window-catalog` ✅ · `gen-code-map --check` ✅ · lease/lease-deploy/promote suites ✅. Units-only → no R-rulebook / `rule-usage.js` drift.

## Review note

The real proof is on a physical iPhone (Chromium can't emulate Dynamic Type) — deployed to staging for device review. Known follow-up to watch on-device: font sizes on a handful of **fixed-height** controls (pills / gate buttons) may want their heights relaxed at the largest accessibility sizes; will pin any offenders after the iPhone review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UBzdzqv2izv5X6o6NBnJd

---
_Generated by [Claude Code](https://claude.ai/code/session_017UBzdzqv2izv5X6o6NBnJd)_