### PR TITLE
MEMORY: record the 5-card phone swipe rail shipped live (#713)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,17 @@
 > Keep it lean; the first ~200 lines are what a session actually leans on.
 
 ## Decisions
+- **2026-07-18 — Phone SWIPE RAIL SHIPPED LIVE (§M8, PR #713, `?v=20260718d`).** Phone swipe
+  steps a single 5-card ribbon — **Categories · Units · Rentals · Customers · Sales** — instead
+  of the old 3-column swipe (one more swipe past Units → Categories, past Customers → Sales).
+  **Calendar** (the Dispatch/Driver grid) is the ONE off-rail card: its chip swaps it into the
+  CENTER slot in place of Rentals (reachable, never a swipe stop). Built on the existing native
+  scroll-snap track (`MOBILE_RAIL` + `mobileRailMembers`/`mobileRailIndex`/`mobileRailPanelEl`);
+  **`state.mobileCol` stays the COLUMN index (0–2)** — the rail index (0–4) folds back to it via
+  `COLUMN_OF`, so zip-zones/drag, cross-column links, the footer jog and session sync are all
+  untouched. Retired the dead `MOBILE_SWIPE_ORDER` / `MAIN_CARDS` constants + the `columnEl`
+  phone branch (superseded by `mobileRailPanelEl`). No new stamped elements (reuses `.col` +
+  chip row), so no R-rulebook/window-catalog churn.
 - **2026-07-17 — Cross-device user sync SHIPPED LIVE (`userSync` ON, PRs #692+#702+#685, `?v=20260717ab`).**
   A logged-in PERSON's prefs / saved Views / dispatcher route state / comms state / resume-column
   follow them across devices, keyed on `personId` **resolved SERVER-SIDE from the session token**


### PR DESCRIPTION
## What & why

Docs-only follow-up to #713 (which is merged + live). Adds a **Decisions** entry to `MEMORY.md` recording the §M8 5-card phone swipe rail so future sessions start knowing phone swipe is a 5-card ribbon (Categories · Units · Rentals · Customers · Sales), Calendar is the one off-rail card (center swap-in-place), and `state.mobileCol` stays the column index.

The two cloud-session gotchas this session re-hit (CI `workflow_dispatch` kick, Playwright headless-shell path) were **already** documented in MEMORY.md, so no Gotchas change.

## Scope
`MEMORY.md` only — no served-site file changes, so this ships by `/merge` alone (no deploy, no promote; production is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqzZsWx2aMNqTogWf8EMHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqzZsWx2aMNqTogWf8EMHW)_