### PR TITLE
MEMORY: record the /build skill (PR #716)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,19 @@
 > Keep it lean; the first ~200 lines are what a session actually leans on.
 
 ## Decisions
+- **2026-07-18 — `/build` skill added** (merged to trunk, PR #716; config-only → production
+  untouched). A pre-gate build step that sits BEFORE the ship flow (`/build → /deploy → /merge →
+  /promote`): it takes the currently-outlined feature to **deploy-ready** (full CI gate set green,
+  committed & pushed on the feature branch), then **STOPS one step short of `/deploy`**. Contract
+  (Jac locked it via popup): **build everything buildable, never stall, never guess** — anything
+  that needs Jac or is genuinely ambiguous is **deferred** (NOT guessed, NOT `FEATURES`-flag-stubbed)
+  to a single end-of-run **batched popup + written DEFERRED report**. Hard-defer classes: money /
+  auth / PII-isolation / WO-completion / irreversible-or-live. Backend `Code.gs` is written
+  build-now, but the `/clasp` **push** carries `/clasp`'s confirm-before-push gate, so push +
+  go-live editor deploy are batched into the hand-back, not fired autonomously. A fresh-context
+  review caught + fixed two canon contradictions pre-merge (autonomous-push vs the `/clasp` rail; a
+  stray gate-skip carve-out). Wired into CLAUDE.md → *Deploy & gates* and `/start`'s sibling-skills
+  list. Skill: `.claude/skills/build/SKILL.md`.
 - **2026-07-18 — Phone SWIPE RAIL SHIPPED LIVE (§M8, PR #713, `?v=20260718d`).** Phone swipe
   steps a single 5-card ribbon — **Categories · Units · Rentals · Customers · Sales** — instead
   of the old 3-column swipe (one more swipe past Units → Categories, past Customers → Sales).


### PR DESCRIPTION
## What

Adds a Decisions-log entry to `MEMORY.md` recording the new **`/build`** skill (shipped in #716).

## Why

`/end` refreshes the git-committed cross-session memory before close-out. `/build` is a durable workflow addition, so it belongs in the Decisions log a fresh clone reads at `/start`.

## Change

- `MEMORY.md` — one Decisions entry: what `/build` does, its build-everything / defer-never-guess contract, the hard-defer classes, the `/clasp` confirm-before-push reconciliation, and where it's wired into `CLAUDE.md` + `/start`.

Config-only (MEMORY.md is not served by Pages) — ships by merge alone, production untouched. Drift guards pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197uVjwa3YXjX3WGhJGvLnE

---
_Generated by [Claude Code](https://claude.ai/code/session_0197uVjwa3YXjX3WGhJGvLnE)_