### PR TITLE
comms: make Texts/Email threads open instantly (Messenger-style)

### DIFF
--- a/app.js
+++ b/app.js
@@ -17130,6 +17130,11 @@ function initTooltip() {
   tipEl = el('div', 'tooltip'); document.body.appendChild(tipEl);
   document.addEventListener('mouseover', (e) => {
     if (!HOVER_CAPABLE || DRAG.active) return;   // §15c — no tooltips mid-drag; never on touch (first-tap hover)
+    // Hover-preload a customer comms thread (Texts/Email only) so the click opens instantly — a
+    // backstop for tabs the on-summon prefetch didn't reach. commsFetchMsgs is idempotent, so repeat
+    // mouseovers on the same tab are cheap no-ops; touch opens ride the on-open prefetch instead.
+    const ctab = e.target.closest('.comms-tab[data-comms-tab], .js-comms-mrow[data-cust]');
+    if (ctab && (state.commsRail.cat === 'text' || state.commsRail.cat === 'email')) commsFetchMsgs(ctab.dataset.commsTab || ctab.dataset.cust);
     const t = e.target.closest('[data-tip]');
     if (!t) return;
     clearTimeout(tipTimer);
@@ -26615,7 +26620,12 @@ function refreshCommsThreads(force) {
   commsThreadsLoading = true;
   backendCall('commsThreads').then((r) => {
     commsThreadsLoading = false;
-    if (r && r.ok && Array.isArray(r.threads)) { commsThreads = r.threads; commsThreadsAt = Date.now(); render(); }
+    if (r && r.ok && Array.isArray(r.threads)) {
+      commsThreads = r.threads; commsThreadsAt = Date.now();
+      const cat = state.commsRail.cat;
+      if (cat === 'text' || cat === 'email') commsPrefetchThreads(cat);   // warm the summoned category so every open is instant
+      render();
+    }
   }).catch(() => { commsThreadsLoading = false; });
 }
 /* A thread's presence in ONE channel. Backend ≥v75 sends a per-channel `channels`
@@ -26717,19 +26727,64 @@ function commsWranglerWorst() {
   commsWranglerConvs().forEach((x) => { const s = commsWranglerStatus(x); if (!worst || COMMS_ST_RANK[s] < COMMS_ST_RANK[worst]) worst = s; });
   return (!worst || worst === 'gray') ? 'green' : worst;
 }
-/* ── per-customer thread messages (messagesFor — bodies + maskedTo + fromUsed) ── */
-const commsMsgs = new Map();        // customerId -> { loading, at, messages }
+/* ── per-customer thread messages (messagesFor — bodies + maskedTo + fromUsed) ──
+   Opening a customer thread should feel INSTANT (Messenger metaphor, Jac 2026-07-18) — the
+   customer channels are the ONLY comms that hit the network to render (Team rides the APP-23
+   chat store, Mr. Wrangler rides state.wrangler — both local, both instant; the AI's reply is
+   the only thing that's allowed to take a beat). Three moves close the gap: (1) PREFETCH a
+   summoned category's thread bodies so the click lands on a cache hit (commsPrefetchThreads);
+   (2) HOVER-preload a tab (the §mouseover hook); (3) render the last message INSTANTLY from the
+   thread rollup while the full history hydrates in behind it (commsPopupHtml). entry.promise lets
+   the prefetch pump gate concurrency on the one slow GAS backend WITHOUT double-fetching —
+   commsFetchMsgs is idempotent, so a click simply reuses any in-flight prefetch and re-renders on
+   its completion. 30s cache; a stale re-open shows its old messages while it revalidates. */
+const commsMsgs = new Map();        // customerId -> { loading, at, messages, promise }
 function commsFetchMsgs(customerId, force) {
   if (!commsOnline()) return null;
-  let entry = commsMsgs.get(String(customerId));
-  if (entry && (entry.loading || (!force && Date.now() - entry.at < 30000))) return entry;
-  entry = { loading: true, at: entry ? entry.at : 0, messages: entry ? entry.messages : null };
-  commsMsgs.set(String(customerId), entry);
-  backendCall('messagesFor', { customerId }).then((r) => {
-    entry.loading = false;
+  const idS = String(customerId);
+  let entry = commsMsgs.get(idS);
+  if (entry && (entry.loading || (!force && Date.now() - entry.at < 30000))) return entry;   // in-flight or fresh → reuse (prefetch + click share one call)
+  entry = { loading: true, at: entry ? entry.at : 0, messages: entry ? entry.messages : null, promise: null };
+  commsMsgs.set(idS, entry);
+  entry.promise = backendCall('messagesFor', { customerId }).then((r) => {
+    entry.loading = false; entry.promise = null;
     if (r && r.ok && Array.isArray(r.messages)) { entry.messages = r.messages; entry.at = Date.now(); render(); }
-  }).catch(() => { entry.loading = false; });
+  }).catch(() => { entry.loading = false; entry.promise = null; });
   return entry;
+}
+/* Prefetch a summoned customer category's thread bodies so opening any tab is a cache hit. Capped
+   to the most-recently-active threads and drained a few lanes at a time — one GAS web app serves
+   every call, so a burst of dozens would just choke the backend and defeat the point. Idempotent +
+   cache-aware (skips anything already warm/in-flight), so it's safe to call on every summon/poll. */
+const COMMS_PREFETCH_CAP = 12;      // most-recent threads to warm per summon
+const COMMS_PREFETCH_LANES = 3;     // parallel messagesFor calls — keep the single GAS backend breathing
+let commsPrefetchQ = [], commsPrefetchLive = 0;
+function commsPrefetchThreads(cat) {
+  if (!commsOnline()) return;
+  const channel = COMMS_CAT_META[cat] && COMMS_CAT_META[cat].channel;
+  if (!channel || !commsThreads) return;
+  const now = Date.now();
+  commsThreadsFor(cat)
+    .slice()
+    .sort((a, b) => String(b.lastWhen || '').localeCompare(String(a.lastWhen || '')))   // most-recently-active first — the likeliest opens
+    .slice(0, COMMS_PREFETCH_CAP)
+    .forEach((t) => {
+      const id = String(t.customerId), e = commsMsgs.get(id);
+      if (e && (e.loading || now - e.at < 30000)) return;                                // already warm/in-flight — skip
+      if (!commsPrefetchQ.includes(id)) commsPrefetchQ.push(id);
+    });
+  commsPrefetchPump();
+}
+function commsPrefetchPump() {
+  while (commsPrefetchLive < COMMS_PREFETCH_LANES && commsPrefetchQ.length) {
+    const id = commsPrefetchQ.shift();
+    const e = commsMsgs.get(id);
+    if (e && (e.loading || Date.now() - e.at < 30000)) continue;                         // warmed since queued (a click/hover beat us) — drop it
+    const entry = commsFetchMsgs(id);
+    if (!entry || !entry.promise) continue;                                              // offline or instant cache hit — nothing to await
+    commsPrefetchLive++;
+    entry.promise.then(() => { commsPrefetchLive--; commsPrefetchPump(); });             // next lane once this body lands
+  }
 }
 const commsDrafts = new Map();      // `${cat}|${customerId}` -> composer draft (survives re-renders)
 const commsSending = new Set();     // in-flight send keys (disables the ignition)
@@ -26790,16 +26845,38 @@ function commsPopupHtml(cat, t, id) {
   const name = (c && fullName(c)) || String(id);
   const st = commsConvStatus(t, meta.channel);
   const entry = commsFetchMsgs(id);
+  const fmtWhen = (w) => { const d = w ? new Date(w) : null; return (d && !isNaN(d)) ? d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) : ''; };
   const msgs = ((entry && entry.messages) || []).filter((m) => m.channel === meta.channel)
     .sort((a, b) => String(a.when || '').localeCompare(String(b.when || '')));
-  const stamp = (m) => { const d = m.when ? new Date(m.when) : null; return (d && !isNaN(d)) ? d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) : ''; };
-  const rows = msgs.map((m) => {
-    const me = m.direction !== 'inbound';
-    const metaLine = me
-      ? [m.status === 'failed' ? '✕ Failed' : 'Sent', m.maskedTo || '', m.fromUsed ? 'from ' + m.fromUsed : '', stamp(m)].filter(Boolean).join(' · ')
-      : [name, stamp(m)].filter(Boolean).join(' · ');
-    return `<div class="cp-row${me ? ' me' : ''}"><div class="cp-cell"><div class="cp-bub${me ? ' me' : ''}${m.status === 'failed' ? ' failed' : ''}">${esc(m.body || m.subject || '(no text)')}</div><div class="cp-meta">${esc(metaLine)}</div></div></div>`;
-  }).join('') || `<div class="cp-empty">${entry && entry.loading ? 'Rounding up the thread…' : 'No messages yet — say the word.'}</div>`;
+  const bubble = (o) => `<div class="cp-row${o.me ? ' me' : ''}${o.preview ? ' cp-preview' : ''}"><div class="cp-cell"><div class="cp-bub${o.me ? ' me' : ''}${o.failed ? ' failed' : ''}">${esc(o.text)}</div><div class="cp-meta">${esc(o.meta)}</div></div></div>`;
+  let rows;
+  if (msgs.length) {
+    rows = msgs.map((m) => {
+      const me = m.direction !== 'inbound';
+      const metaLine = me
+        ? [m.status === 'failed' ? '✕ Failed' : 'Sent', m.maskedTo || '', m.fromUsed ? 'from ' + m.fromUsed : '', fmtWhen(m.when)].filter(Boolean).join(' · ')
+        : [name, fmtWhen(m.when)].filter(Boolean).join(' · ');
+      return bubble({ me, failed: m.status === 'failed', text: m.body || m.subject || '(no text)', meta: metaLine });
+    }).join('');
+  } else if (entry && entry.loading) {
+    // INSTANT open (Messenger metaphor, Jac 2026-07-18): the thread rollup ALREADY carries the last
+    // message — paint it the moment the window opens while the full history hydrates in behind it,
+    // instead of a blocking "Rounding up the thread…" spinner. Prefetch usually beats us here, so the
+    // full thread is already cached; this covers the cold thread (never opened, hover missed).
+    const ch = t && commsThreadChannel(t, meta.channel);
+    if (ch && ch.lastSnippet) {
+      const me = ch.lastDirection !== 'inbound';
+      const metaLine = me
+        ? [ch.lastStatus === 'failed' ? '✕ Failed' : 'Sent', fmtWhen(ch.lastWhen)].filter(Boolean).join(' · ')
+        : [name, fmtWhen(ch.lastWhen)].filter(Boolean).join(' · ');
+      rows = `<div class="cp-hydrate" aria-hidden="true">Rounding up the rest…</div>`
+        + bubble({ me, failed: ch.lastStatus === 'failed', text: ch.lastSnippet, meta: metaLine, preview: true });
+    } else {
+      rows = `<div class="cp-empty">Rounding up the thread…</div>`;   // no rollup snippet to preview (fresh, never-messaged thread)
+    }
+  } else {
+    rows = `<div class="cp-empty">No messages yet — say the word.</div>`;
+  }
   // D7 FROM picker — only for email, only when the shop has >1 connected alias
   let fromRow = '';
   if (meta.channel === 'email') {
@@ -26998,7 +27075,7 @@ function commsSummonChannel(ch) {
   const rail = state.commsRail, prev = rail.cat;
   if (prev && prev !== cat) commsLeaveCat(prev);
   rail.cat = cat;
-  refreshCommsThreads();
+  refreshCommsThreads(); commsPrefetchThreads(cat);   // warm bodies now (covers already-loaded threads the poll throttles past) + on the poll's return
   const s = rail.sessions[cat];
   s.menuOpen = true; s.lastOpen = null;   // show the list + toggle; no auto-opened window
   saveCommsRail(); render();
@@ -27023,7 +27100,7 @@ function commsToggleCat(cat) {
   }
   const prev = rail.cat;
   rail.cat = cat; if (prev) commsLeaveCat(prev);
-  if (COMMS_CAT_META[cat].channel) refreshCommsThreads();
+  if (COMMS_CAT_META[cat].channel) { refreshCommsThreads(); commsPrefetchThreads(cat); }   // warm the thread bodies so opening a tab is instant
   // summon the last session — its remembered LAST-open conversation is the ONE window restored
   const s = rail.sessions[cat];
   if (cat === 'team' && s.lastOpen) {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27222 lines, 41 chapters
+## app.js — 27299 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -37,18 +37,18 @@
 | APP-27 | 14872–15356 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
 | APP-28 | 15357–16553 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+112) |
 | APP-29 | 16554–16903 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
-| APP-30 | 16904–17253 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+8) |
-| APP-31 | 17254–17257 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17258–19735 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 19736–21039 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21040–22573 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22574–23056 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23057–23059 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23060–24284 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 24285–25424 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25425–25431 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25432–25738 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25739–27222 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+74) |
+| APP-30 | 16904–17258 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, hideTip, …(+8) |
+| APP-31 | 17259–17262 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 17263–19740 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 19741–21044 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21045–22578 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22579–23061 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23062–23064 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23065–24289 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
+| APP-38 | 24290–25429 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25430–25436 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25437–25743 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25744–27299 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+79) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/style.css
+++ b/style.css
@@ -1629,6 +1629,17 @@ select.lf-in { appearance: none; cursor: pointer; }
 .cp-bub.me { background: var(--bub-me); border-color: var(--bub-me); color: var(--on-bub-me); border-radius: 16px; border-bottom-right-radius: 5px; }
 .cp-bub.failed { border-color: var(--red); box-shadow: 0 0 0 1px color-mix(in srgb, var(--red) 45%, transparent); }
 .cp-meta { font-size: 0.5588rem; color: var(--txt-3); padding: 0 4px; }
+/* Instant-open hydrate (Jac 2026-07-18): opening a Texts/Email thread paints the last message the
+   moment the window opens (from the thread rollup) while the full history loads in behind it — the
+   thread feels instant, like Messenger. The preview bubble sits a touch dimmer than a settled
+   message; the stamped divider reads as "catching the rest up", steel-line, no extra orange. */
+.cp-preview { opacity: .74; }
+.cp-hydrate { align-self: center; display: flex; align-items: center; gap: 7px; margin: 3px 0 5px;
+  font-family: 'Saira Condensed', system-ui, sans-serif; text-transform: uppercase; letter-spacing: 1.6px;
+  font-weight: 700; font-size: 0.5588rem; color: var(--txt-3); white-space: nowrap; }
+.cp-hydrate::before, .cp-hydrate::after { content: ''; height: 1px; width: 20px; background: var(--line); }
+@media (prefers-reduced-motion: no-preference) { .cp-hydrate { animation: cpHydratePulse 1.15s ease-in-out infinite; } }
+@keyframes cpHydratePulse { 0%, 100% { opacity: .5; } 50% { opacity: 1; } }
 /* D7 FROM picker chip — email only, >1 connected alias */
 .cp-fromrow { padding: 7px 10px 0; border-top: 1px solid var(--line); flex: 0 0 auto; }
 .cp-from { display: inline-flex; align-items: center; gap: 5px; max-width: 100%; padding: 3px 9px; border-radius: 999px; border: 1px dashed var(--line); background: var(--bg-2); color: var(--txt-2); font-size: 0.6471rem; overflow: hidden; }


### PR DESCRIPTION
## What & why

Opening a customer **Texts/Email** thread showed a blocking **"Rounding up the thread…"** spinner for the length of a slow Apps Script round-trip (`messagesFor`). Customer channels are the **only** comms that hit the network to render — **Team** rides the local chat store and **Mr. Wrangler** rides `state.wrangler`, so both already open instantly. That's exactly why Jac reported the customer comms as slow while Mr. Wrangler "can have more tolerance."

Goal: make the customer channels feel native, like Facebook Messenger / iMessage — the thread is there the instant you open it.

## Root cause

- `commsPopupHtml` renders a thread's history from `commsFetchMsgs` → `messagesFor` (`app.js`). On the **first** open of a thread in a session there's no cache, so the window shows the spinner until the GAS call returns.
- Every open path fired that fetch **at click time**, so the data was never ready before the window opened.

## The fix (front-end only — no backend deploy)

- **Prefetch on summon** — when a customer category is summoned (or its thread list loads), warm the ~12 most-recently-active threads' bodies in the background, drained **3 lanes at a time** so a burst never chokes the single GAS backend. `commsFetchMsgs` now exposes a promise and stays **idempotent**, so a click reuses any in-flight prefetch instead of double-fetching.
- **Hover-preload** — mousing over a customer thread tab / list row warms it (mouse-only; touch rides the on-open prefetch).
- **Instant last-message preview** — a cold thread paints its **last message immediately** from the thread rollup (which we already have) while the full history hydrates in behind it, instead of the blocking spinner.

Mr. Wrangler is untouched — its reply keeps the tolerance it always had. `Team` untouched (already instant).

## Design

The preview bubble reuses the existing `.cp-bub`/`.cp-meta` message chrome; the only new UI is a small `.cp-hydrate` "Rounding up the rest…" divider — stamped Saira Condensed, steel-line, no extra orange (yard data-plate language). Respects `prefers-reduced-motion`.

## Testing

- Local gates green: `gen-rule-usage --check` ✓, `check-window-catalog` ✓ (48 kinds), `gen-code-map --check` ✓, plus the pure-Node suites (`lease` 77/77, `lease-deploy` 42/42, `promote` 23/23).
- Browser gates (`smoke`, `logic-test`) run in CI (Playwright wedges locally on this box).
- **Not yet driven on staging** — recommend a `/deploy` + Claude-in-Chrome pass on a real Texts/Email thread before merge, since this touches the live customer-comms surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhgpRCxBW5ckC384sdoHzr)_