### PR TITLE
comms: fix summon jank — background thread warms no longer force a render

### DIFF
--- a/app.js
+++ b/app.js
@@ -17231,7 +17231,7 @@ function initTooltip() {
     // backstop for tabs the on-summon prefetch didn't reach. commsFetchMsgs is idempotent, so repeat
     // mouseovers on the same tab are cheap no-ops; touch opens ride the on-open prefetch instead.
     const ctab = e.target.closest('.comms-tab[data-comms-tab], .js-comms-mrow[data-cust]');
-    if (ctab && (state.commsRail.cat === 'text' || state.commsRail.cat === 'email')) commsFetchMsgs(ctab.dataset.commsTab || ctab.dataset.cust);
+    if (ctab && (state.commsRail.cat === 'text' || state.commsRail.cat === 'email')) commsFetchMsgs(ctab.dataset.commsTab || ctab.dataset.cust, false, { quiet: true });
     const t = e.target.closest('[data-tip]');
     if (!t) return;
     clearTimeout(tipTimer);
@@ -26858,16 +26858,26 @@ function commsWranglerWorst() {
    commsFetchMsgs is idempotent, so a click simply reuses any in-flight prefetch and re-renders on
    its completion. 30s cache; a stale re-open shows its old messages while it revalidates. */
 const commsMsgs = new Map();        // customerId -> { loading, at, messages, promise }
-function commsFetchMsgs(customerId, force) {
+function commsFetchMsgs(customerId, force, opts) {
   if (!commsOnline()) return null;
   const idS = String(customerId);
+  // A displayed caller (the open thread window / an open customer card, via commsPopupHtml /
+  // commsCustSectionHtml) wants a repaint the moment bodies land. A BACKGROUND warm (the summon
+  // prefetch pump, a hover) does NOT — it just fills the cache. Rendering on every warm meant a
+  // summon fired up to 12 full #app rebuilds in a burst, which froze/janked the phone until the
+  // burst drained (Jac, 2026-07-18). renderOnDone gates that: quiet warms stay silent, and a later
+  // displayed caller UPGRADES an in-flight warm so an opened-mid-prefetch thread still hydrates.
+  const wantRender = !(opts && opts.quiet);
   let entry = commsMsgs.get(idS);
-  if (entry && (entry.loading || (!force && Date.now() - entry.at < 30000))) return entry;   // in-flight or fresh → reuse (prefetch + click share one call)
-  entry = { loading: true, at: entry ? entry.at : 0, messages: entry ? entry.messages : null, promise: null };
+  if (entry) {
+    if (wantRender) entry.renderOnDone = true;
+    if (entry.loading || (!force && Date.now() - entry.at < 30000)) return entry;   // in-flight or fresh → reuse (prefetch + click share one call)
+  }
+  entry = { loading: true, at: entry ? entry.at : 0, messages: entry ? entry.messages : null, promise: null, renderOnDone: wantRender };
   commsMsgs.set(idS, entry);
   entry.promise = backendCall('messagesFor', { customerId }).then((r) => {
     entry.loading = false; entry.promise = null;
-    if (r && r.ok && Array.isArray(r.messages)) { entry.messages = r.messages; entry.at = Date.now(); render(); }
+    if (r && r.ok && Array.isArray(r.messages)) { entry.messages = r.messages; entry.at = Date.now(); if (entry.renderOnDone) render(); }
   }).catch(() => { entry.loading = false; entry.promise = null; });
   return entry;
 }
@@ -26899,7 +26909,7 @@ function commsPrefetchPump() {
     const id = commsPrefetchQ.shift();
     const e = commsMsgs.get(id);
     if (e && (e.loading || Date.now() - e.at < 30000)) continue;                         // warmed since queued (a click/hover beat us) — drop it
-    const entry = commsFetchMsgs(id);
+    const entry = commsFetchMsgs(id, false, { quiet: true });                            // warm silently — no render on a background body landing (the summon repaint already happened)
     if (!entry || !entry.promise) continue;                                              // offline or instant cache hit — nothing to await
     commsPrefetchLive++;
     entry.promise.then(() => { commsPrefetchLive--; commsPrefetchPump(); });             // next lane once this body lands

--- a/app.js
+++ b/app.js
@@ -26857,7 +26857,17 @@ function commsWranglerWorst() {
    the prefetch pump gate concurrency on the one slow GAS backend WITHOUT double-fetching —
    commsFetchMsgs is idempotent, so a click simply reuses any in-flight prefetch and re-renders on
    its completion. 30s cache; a stale re-open shows its old messages while it revalidates. */
-const commsMsgs = new Map();        // customerId -> { loading, at, messages, promise }
+const commsMsgs = new Map();        // customerId -> { loading, at, messages, promise, renderOnDone }
+// True when this customer's thread is the one CURRENTLY on screen (the open comms popup / phone
+// full-screen thread). Checked at fetch-completion so a quiet warm that lands on the OPEN thread
+// still repaints it — covers hovering the open thread's own tab after its 30s cache expired, where
+// the warm rebuilt the entry with renderOnDone off (bug caught in review, 2026-07-18).
+function commsThreadOnScreen(idS) {
+  const cat = state.commsRail.cat;
+  if (cat !== 'text' && cat !== 'email') return false;
+  const s = state.commsRail.sessions[cat];
+  return !!(s && String(s.lastOpen) === idS);
+}
 function commsFetchMsgs(customerId, force, opts) {
   if (!commsOnline()) return null;
   const idS = String(customerId);
@@ -26877,7 +26887,7 @@ function commsFetchMsgs(customerId, force, opts) {
   commsMsgs.set(idS, entry);
   entry.promise = backendCall('messagesFor', { customerId }).then((r) => {
     entry.loading = false; entry.promise = null;
-    if (r && r.ok && Array.isArray(r.messages)) { entry.messages = r.messages; entry.at = Date.now(); if (entry.renderOnDone) render(); }
+    if (r && r.ok && Array.isArray(r.messages)) { entry.messages = r.messages; entry.at = Date.now(); if (entry.renderOnDone || commsThreadOnScreen(idS)) render(); }
   }).catch(() => { entry.loading = false; entry.promise = null; });
   return entry;
 }

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27428 lines, 41 chapters
+## app.js — 27438 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -48,7 +48,7 @@
 | APP-38 | 24390–25529 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
 | APP-39 | 25530–25536 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
 | APP-40 | 25537–25843 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25844–27428 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+79) |
+| APP-41 | 25844–27438 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27418 lines, 41 chapters
+## app.js — 27428 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -48,7 +48,7 @@
 | APP-38 | 24390–25529 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
 | APP-39 | 25530–25536 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
 | APP-40 | 25537–25843 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 25844–27418 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+79) |
+| APP-41 | 25844–27428 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+79) |
 
 ## config.js — 697 lines, 0 chapters
 


### PR DESCRIPTION
## What & why

Follow-up to #722. Jac reported that comms takes a while to "start working" and the phone feels **frozen and jumpy** on first open — but great once it's going.

**Root cause:** the instant-open prefetch called `render()` on **every** `messagesFor` completion, including the up-to-12 background warms fired when the Customers rail is summoned (`app.js` `commsFetchMsgs` → `render()`). On a phone that's ~12 full `#app` rebuilds in a burst → main-thread saturation → freeze + dropped frames, until the burst drains. Worst when comms is the **first** thing opened (nothing cached → all 12 fetch **and** render). Once cached, no burst — hence "great once it's working."

## The fix

Background warms now fill the cache **silently**:
- `commsFetchMsgs(customerId, force, opts)` takes `{ quiet: true }` and only calls `render()` on completion when the thread is actually on screen (tracked via `entry.renderOnDone`).
- The **prefetch pump** and **hover-preload** pass `{ quiet: true }`.
- A **displayed** caller (the open thread window via `commsPopupHtml`, or an open customer card via `commsCustSectionHtml`) — and the open-thread action — leave `quiet` off, which **upgrades** an in-flight quiet warm's `renderOnDone`, so a thread opened *mid-prefetch* still hydrates.

Net: **one** render for the thread you open, not a dozen for the ones you didn't. The instant-open behavior (prefetch, hover-preload, instant last-message preview) is otherwise unchanged.

## Testing

- Local gates green: `gen-rule-usage --check` ✓, `check-window-catalog` ✓, `gen-code-map --check` ✓.
- Browser gates (`smoke`) run in CI.
- Traced every `commsFetchMsgs` caller: only the two background warms (pump, hover) are quiet; all displayed/open paths render as before. Not driven on a real phone from this session (environment blocks a headless browser from egress) — worth a phone check that first-open comms is smooth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhgpRCxBW5ckC384sdoHzr)_