### PR TITLE
Cache-bust: bump ?v= to 20260718g so the comms jank fix reaches devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260718f" />
+  <link rel="stylesheet" href="style.css?v=20260718g" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260718f"></script>
-  <script type="module" src="app.js?v=20260718f"></script>
+  <script src="rule-usage.js?v=20260718g"></script>
+  <script type="module" src="app.js?v=20260718g"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
## What & why

Follow-up to #728. The jank fix merged and promoted, but **deck-mode deploys don't bump the shared `?v=` token**, so both #722 and #728 shipped under `20260718f`. Production's CDN (`max-age=600`) and the service-worker cache (`rw-shell-<token>`, keyed on `?v=`) kept serving the pre-fix `app.js` — the fix was live in source but wouldn't cleanly reach already-loaded devices.

## The change

Bump the three `?v=` refs in `index.html` (`style.css` / `rule-usage.js` / `app.js`) `20260718f` → `20260718g`. Per `sw.js`, the token becomes the SW cache name, so bumping it **rolls the SW cache in lockstep** (R13) and busts the CDN — delivering the fix cleanly and firing the app's built-in update prompt. `app.js` derives the SW-registration token from its own `?v=` (`app.js:17277`), so the one bump flows everywhere.

`index.html` only — no code change.

## Note (infra gap)

The deck→production path has no `?v=` bump step (neither `deploy-staging` deck mode nor `promote.mjs` bumps it). Worth teaching one of them to bump on a production-bound deploy so this manual step isn't needed each time — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhgpRCxBW5ckC384sdoHzr)_