### PR TITLE
tools: auto-bump ?v= on served-file changes + CI guard against stale ships

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -60,6 +60,15 @@ deploy** (a numbered `d/<feature>-<n>/` folder); under `--slots` it's a slot. Ch
    blind to. If it surfaces a real correctness bug, **stop and fix before the PR.** This
    review is the enforced gate here: merges land via the PR/squash (not a local command a
    hook can intercept), so the review discipline is what actually guards the merge.
+   - **Auto-bump the `?v=` cache-bust token (before the PR).** Run `node tools/bump-cachebust.mjs`
+     — it commits a `?v=` bump to the feature branch **iff** a served, versioned file
+     (`app.js`/`style.css`/`rule-usage.js`) changed vs trunk and the token wasn't already bumped
+     (a clean **no-op** otherwise — e.g. a config-only branch, or a slot deploy that already
+     bumped). This is what makes a **deck-mode** ship actually reach devices: production serves the
+     branch root with `max-age=600` and the service worker caches by `?v=`, so a served change
+     under an **unchanged** token serves stale bytes live. **Push the bump commit** so it rides
+     into the PR. The CI guard `ci/check-cachebust.mjs` (in the `smoke` job) **fails the merge** if
+     the bump was skipped, so this can't be forgotten.
 3. **PR to `trunk`** (draft is fine); let CI (`smoke`) pass — `trunk` is branch-protected, so the
    required check MUST be green before merge. Fix a red conflict with trunk first (a pure `?v=`
    token conflict resolves mechanically; anything substantive, resolve by hand).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Promote content-freshness resolver (pure-Node, injected probe)
         run: node ci/promote-test.mjs
 
+      - name: Cache-bust token logic (pure-Node)
+        run: node ci/cachebust-test.mjs
+
       - name: Rulebook field catalog is current
         run: node ci/gen-rule-usage.mjs --check
 
@@ -54,6 +57,11 @@ jobs:
 
       - name: Code Atlas index is current
         run: node tools/gen-code-map.mjs --check
+
+      # Served-file change vs trunk MUST carry a ?v= bump, or production/the service
+      # worker serve stale cached bytes. Self-fetches trunk's tip (shallow-safe).
+      - name: Cache-bust token bumped when served files change
+        run: node ci/check-cachebust.mjs
 
       - name: DESIGN.md valid & in sync with style.css
         run: node ci/check-design-md.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,14 +107,21 @@ say-so:
 **Gates (must pass before push):** `node ci/smoke.mjs`, `node ci/logic-test.mjs`,
 `node ci/lease-test.mjs`, `node ci/lease-deploy-test.mjs`, `node ci/promote-test.mjs`,
 `node ci/gen-rule-usage.mjs --check`, `node ci/check-window-catalog.mjs`,
-`node tools/gen-code-map.mjs --check`. Port 8000 is reserved —
+`node tools/gen-code-map.mjs --check`, `node ci/cachebust-test.mjs`,
+`node ci/check-cachebust.mjs`. Port 8000 is reserved —
 swap to 9147 first: `sed -i 's/8000/9147/g' ci/smoke.mjs ci/logic-test.mjs`, run, then `git
 checkout -- ci/`. The `lease-*` and `promote-test` suites are **pure-Node** (mocked git seam /
 injected probe, no browser/server) — **excluded from the port swap** and never touch the network.
 
 **Cache-bust every deploy:** bump the shared `?v=` on `style.css`, `rule-usage.js`, and
-`app.js` in `index.html` (Pages serves `max-age=600`, no per-file hashing). Don't add `?v=`
-to the ES-module imports inside `app.js`. (`deploy-staging.mjs` bumps it for you.)
+`app.js` in `index.html` (Pages serves `max-age=600`, no per-file hashing; the service worker
+keys its cache on `?v=`). Don't add `?v=` to the ES-module imports inside `app.js`. **Slot**
+`deploy-staging.mjs` bumps it for you; **deck** mode does NOT (the immutable folder path is
+staging's cache key), so a deck ship that reaches production would serve stale bytes under an
+unchanged token — `/merge` runs **`node tools/bump-cachebust.mjs`** to land the bump on the
+feature branch (a no-op unless a served, versioned file changed vs trunk), and the CI guard
+**`ci/check-cachebust.mjs`** (in the `smoke` job) fails any served-file change to trunk that
+skipped the bump. Logic + format live in `tools/lib/cachebust.mjs` (tested by `ci/cachebust-test.mjs`).
 
 **Session title = this session's PRs.** On opening a PR, append its number to
 `.claude/.session-prs` (gitignored) and surface a one-tap `/rename #<nums> · <branch-label>`

--- a/ci/cachebust-test.mjs
+++ b/ci/cachebust-test.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Pure-Node unit suite for the ?v= cache-bust logic (tools/lib/cachebust.mjs) — no
+// git, no network, no browser. Mirrors ci/promote-test.mjs style. Guards the token
+// format + the bump-verdict decision that ci/check-cachebust.mjs and
+// tools/bump-cachebust.mjs both rely on.
+
+import {
+  nextToken, incrementSuffix, readSharedToken, bumpTokenInHtml, bumpVerdict, readCacheBustState,
+} from '../tools/lib/cachebust.mjs';
+
+let pass = 0, fail = 0;
+const ok = (cond, label) => { if (cond) { pass++; console.log(`  ✓ ${label}`); } else { fail++; console.log(`  ✗ ${label}`); } };
+const eq = (a, b, label) => ok(JSON.stringify(a) === JSON.stringify(b), `${label} (got ${JSON.stringify(a)})`);
+
+console.log('cachebust suite');
+
+// ── incrementSuffix: odometer with carry ──
+eq(incrementSuffix(''), 'a', 'incrementSuffix empty → a');
+eq(incrementSuffix('a'), 'b', 'incrementSuffix a → b');
+eq(incrementSuffix('z'), 'aa', 'incrementSuffix z → aa (carry)');
+eq(incrementSuffix('az'), 'ba', 'incrementSuffix az → ba');
+eq(incrementSuffix('zz'), 'aaa', 'incrementSuffix zz → aaa');
+
+// ── nextToken: fresh day resets, same day increments ──
+eq(nextToken('20260718h', '20260718'), '20260718i', 'same-day bump h → i');
+eq(nextToken('20260717z', '20260718'), '20260718a', 'new day resets → a');
+eq(nextToken('', '20260718'), '20260718a', 'empty/unknown → today a');
+eq(nextToken('garbage', '20260718'), '20260718a', 'malformed → today a');
+
+// ── readSharedToken ──
+const good = 'x style.css?v=20260718h y rule-usage.js?v=20260718h z app.js?v=20260718h';
+eq(readSharedToken(good), { token: '20260718h' }, 'readSharedToken agrees → token');
+ok(!!readSharedToken('style.css?v=1 rule-usage.js?v=2 app.js?v=1').error, 'readSharedToken mismatch → error');
+ok(!!readSharedToken('style.css?v=1 rule-usage.js?v=1').error, 'readSharedToken missing app.js → error');
+
+// ── bumpTokenInHtml: all three refs move together, imports untouched ──
+const src = '<link href="style.css?v=20260718h"><script src="rule-usage.js?v=20260718h"></script>' +
+  '<script type="module" src="app.js?v=20260718h"></script><!-- import "./x.js" (no ?v=) -->';
+const bumped = bumpTokenInHtml(src, '20260718');
+eq(bumped.oldToken, '20260718h', 'bumpTokenInHtml oldToken');
+eq(bumped.newToken, '20260718i', 'bumpTokenInHtml newToken');
+ok((bumped.html.match(/\?v=20260718i/g) || []).length === 3, 'bumpTokenInHtml moves all 3 refs');
+ok(/import "\.\/x\.js"/.test(bumped.html), 'bumpTokenInHtml leaves un-versioned imports alone');
+
+// ── bumpVerdict: the decision the guard/tool share ──
+eq(bumpVerdict({ servedChanged: [], headToken: 'a', baseToken: 'a' }).needsBump, false, 'no served change → no bump');
+eq(bumpVerdict({ servedChanged: ['app.js'], headToken: '20260718h', baseToken: '20260718h' }).needsBump, true,
+  'served change + unchanged token → NEEDS bump');
+eq(bumpVerdict({ servedChanged: ['app.js'], headToken: '20260718i', baseToken: '20260718h' }).needsBump, false,
+  'served change + bumped token → no bump');
+eq(bumpVerdict({ servedChanged: ['style.css'], headToken: '20260718h', baseToken: '20260718h' }).needsBump, true,
+  'token collision with trunk (equal, both present) → NEEDS bump');
+
+// ── readCacheBustState with an injected git runner (no real git) ──
+const fakeGit = (map) => (args) => {
+  const key = args.join(' ');
+  if (key.startsWith('diff --name-only')) return map.changed;
+  if (key === 'show HEAD:index.html') return map.head;
+  if (key.endsWith(':index.html')) return map.base;
+  throw new Error('unexpected git call: ' + key);
+};
+const st = readCacheBustState(fakeGit({
+  changed: 'app.js\n',
+  head: 'style.css?v=20260718h rule-usage.js?v=20260718h app.js?v=20260718h',
+  base: 'style.css?v=20260718h rule-usage.js?v=20260718h app.js?v=20260718h',
+}));
+eq(st.servedChanged, ['app.js'], 'readCacheBustState parses changed files');
+eq(st.headToken, '20260718h', 'readCacheBustState reads HEAD token');
+eq(bumpVerdict(st).needsBump, true, 'readCacheBustState feeds a NEEDS-bump verdict');
+
+console.log(fail === 0 ? `\n✅ Cachebust suite: ${pass}/${pass} checks passed.` : `\n❌ Cachebust suite: ${fail} FAILED, ${pass} passed.`);
+process.exit(fail === 0 ? 0 : 1);

--- a/ci/check-cachebust.mjs
+++ b/ci/check-cachebust.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// ── ci/check-cachebust.mjs — the guarantee that no ship silently serves stale bytes ──
+//
+// Fails when a branch changes a served, versioned file (app.js / style.css /
+// rule-usage.js) vs trunk but does NOT bump the shared ?v= cache-bust token in
+// index.html. Without the bump, production (served from the branch root with
+// max-age=600, and cached by the service worker keyed on ?v=) keeps serving the
+// pre-change app.js under the same URL — the exact stale-delivery trap that made a
+// manual ?v= bump necessary after the deck deploy path shipped code under an
+// unchanged token. Deck mode intentionally doesn't bump ?v= (staging's immutable
+// folder path is its cache key); this guard is what forces the bump before trunk.
+//
+// The fix is one command — `node tools/bump-cachebust.mjs` (or just let /merge run
+// it) — so a red here is trivially cleared. Compares TIPS (trunk vs HEAD), so it
+// also catches a token that collides with trunk's, and needs no merge-base history
+// (safe in a shallow CI checkout). Runs locally and as a step in the `smoke` CI job.
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readCacheBustState, bumpVerdict } from '../tools/lib/cachebust.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const baseIdx = process.argv.indexOf('--base');
+const base = baseIdx >= 0 ? process.argv[baseIdx + 1] : 'origin/trunk';
+
+const git = (a) => execFileSync('git', a, { cwd: ROOT, encoding: 'utf8' }).trim();
+const gitTry = (a) => { try { return git(a); } catch { return null; } };
+
+// Make sure the base tip is present (shallow CI checkout won't have origin/trunk yet).
+if (base === 'origin/trunk') gitTry(['fetch', '--no-tags', '--depth=1', 'origin', 'trunk']);
+
+let state;
+try {
+  state = readCacheBustState((a) => git(a), base);
+} catch (e) {
+  console.error(`check-cachebust: could not compare against ${base} — ${String(e.message || e).split('\n')[0]}`);
+  console.error(`check-cachebust: ensure ${base} is fetched (CI: the smoke job fetches trunk; local: git fetch origin trunk).`);
+  process.exit(1);
+}
+
+if (state.baseError || state.headError) {
+  console.error(`check-cachebust: 🔴 index.html cache-bust token is malformed — ${state.headError || state.baseError}`);
+  process.exit(1);
+}
+
+const verdict = bumpVerdict(state);
+if (verdict.needsBump) {
+  console.error('check-cachebust: 🔴 served files changed but the ?v= cache-bust token was NOT bumped.');
+  console.error(`  ${verdict.reason}.`);
+  console.error('  Production serves the branch root with max-age=600 and the service worker caches by ?v=,');
+  console.error('  so promoting this under an unchanged token would serve the OLD app.js to already-loaded devices.');
+  console.error('  Fix (one command):  node tools/bump-cachebust.mjs   (or let /merge run it for you), then push.');
+  process.exit(1);
+}
+
+console.log(`check-cachebust: ✓ ${verdict.reason}.`);

--- a/tools/bump-cachebust.mjs
+++ b/tools/bump-cachebust.mjs
@@ -60,7 +60,17 @@ function main() {
     return;
   }
 
-  // Bump the working-tree index.html (it should equal HEAD's at integration time).
+  // index.html must be clean first: the verdict came from the committed HEAD blob, so the bump
+  // has to start from that same token — a stray working-tree edit (e.g. a `--dry-run` bump left
+  // un-reverted) would otherwise bump from the wrong base and fold that stray diff into the commit.
+  const cleanUnstaged = gitTry(['diff', '--quiet', '--', 'index.html']) !== null;
+  const cleanStaged = gitTry(['diff', '--cached', '--quiet', '--', 'index.html']) !== null;
+  if (!cleanUnstaged || !cleanStaged) {
+    console.error('bump-cachebust: index.html has uncommitted changes — commit or revert them first, so the bump starts from the committed token.');
+    process.exit(1);
+  }
+
+  // Bump the (now-verified-clean) working-tree index.html — equals HEAD's at this point.
   const res = bumpTokenInHtml(readFileSync(INDEX, 'utf8'));
   if (res.error) { console.error(`bump-cachebust: ${res.error} Fix index.html by hand first.`); process.exit(1); }
   writeFileSync(INDEX, res.html);
@@ -68,12 +78,13 @@ function main() {
   console.log(`bump-cachebust: bumped shared ?v= token ${res.oldToken} → ${res.newToken} in index.html.`);
 
   if (noCommit) {
-    console.log('bump-cachebust: --no-commit — index.html left staged in the working tree (commit it before /merge).');
+    console.log('bump-cachebust: --no-commit — index.html left modified in the working tree (commit it before /merge).');
     return;
   }
-  git(['add', '--', 'index.html']);
-  git(['commit', '-m', `Cache-bust: bump ?v= to ${res.newToken} (served files changed vs trunk)`]);
-  console.log(`bump-cachebust: committed the bump. Push it so it rides through /merge → /promote to production.`);
+  // Scope the commit to index.html ONLY — a bare `git commit` would sweep in anything else already
+  // staged, shipping unrelated files under a misleading "Cache-bust" message (review catch).
+  git(['commit', '-m', `Cache-bust: bump ?v= to ${res.newToken} (served files changed vs trunk)`, '--', 'index.html']);
+  console.log(`bump-cachebust: committed the bump (index.html only). Push it so it rides through /merge → /promote to production.`);
 }
 
 main();

--- a/tools/bump-cachebust.mjs
+++ b/tools/bump-cachebust.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// ── tools/bump-cachebust.mjs — auto-bump the ?v= cache-bust token when a branch
+// changes a served, versioned file but hasn't bumped the token yet ───────────────
+//
+// WHY. In deck mode `deploy-staging.mjs` does NOT bump ?v= (the immutable d/<id>/
+// folder path is the *staging* cache guarantee). But PRODUCTION is served from the
+// branch root at app.jacrentals.com/app.js?v=<token> with max-age=600, and the
+// service worker keys its cache on ?v= — so a deck ship that promotes under an
+// UNCHANGED token means the CDN + installed PWAs keep serving the pre-change bytes.
+// This closes that gap: run at integration time (the /merge gate runs it for you),
+// it lands a committed ?v= bump on the feature branch so production gets fresh bytes.
+//
+// It is IDEMPOTENT and SCOPED: it bumps only when app.js/style.css/rule-usage.js
+// actually differ from trunk AND the shared token still equals trunk's. No served
+// change, or an already-bumped token → it's a clean no-op. Pairs with the CI guard
+// ci/check-cachebust.mjs, which fails a ship that skipped the bump.
+//
+// Usage:
+//   node tools/bump-cachebust.mjs [--base <ref>] [--no-commit]
+//     --base <ref>   compare against this ref instead of origin/trunk
+//     --no-commit    write the bumped index.html but don't commit it
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readCacheBustState, bumpVerdict, bumpTokenInHtml } from './lib/cachebust.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const INDEX = join(ROOT, 'index.html');
+
+const args = process.argv.slice(2);
+const noCommit = args.includes('--no-commit');
+const baseIdx = args.indexOf('--base');
+const base = baseIdx >= 0 ? args[baseIdx + 1] : 'origin/trunk';
+
+const git = (a) => execFileSync('git', a, { cwd: ROOT, encoding: 'utf8' }).trim();
+const gitTry = (a) => { try { return git(a); } catch { return null; } };
+
+function main() {
+  // Best-effort refresh of the base tip so a local run compares against current trunk.
+  // If offline / no remote, fall through and use whatever origin/trunk we already have.
+  if (base === 'origin/trunk') gitTry(['fetch', 'origin', 'trunk']);
+
+  let state;
+  try {
+    state = readCacheBustState((a) => git(a), base);
+  } catch (e) {
+    console.error(`bump-cachebust: could not read git state vs ${base} — ${String(e.message || e).split('\n')[0]}`);
+    console.error(`bump-cachebust: is ${base} fetched? (run: git fetch origin trunk)`);
+    process.exit(1);
+  }
+
+  if (state.baseError) { console.error(`bump-cachebust: ${base}:index.html — ${state.baseError}`); process.exit(1); }
+  if (state.headError) { console.error(`bump-cachebust: HEAD:index.html — ${state.headError} Fix index.html by hand first.`); process.exit(1); }
+
+  const verdict = bumpVerdict(state);
+  if (!verdict.needsBump) {
+    console.log(`bump-cachebust: no bump needed — ${verdict.reason}.`);
+    return;
+  }
+
+  // Bump the working-tree index.html (it should equal HEAD's at integration time).
+  const res = bumpTokenInHtml(readFileSync(INDEX, 'utf8'));
+  if (res.error) { console.error(`bump-cachebust: ${res.error} Fix index.html by hand first.`); process.exit(1); }
+  writeFileSync(INDEX, res.html);
+  console.log(`bump-cachebust: ${verdict.reason}`);
+  console.log(`bump-cachebust: bumped shared ?v= token ${res.oldToken} → ${res.newToken} in index.html.`);
+
+  if (noCommit) {
+    console.log('bump-cachebust: --no-commit — index.html left staged in the working tree (commit it before /merge).');
+    return;
+  }
+  git(['add', '--', 'index.html']);
+  git(['commit', '-m', `Cache-bust: bump ?v= to ${res.newToken} (served files changed vs trunk)`]);
+  console.log(`bump-cachebust: committed the bump. Push it so it rides through /merge → /promote to production.`);
+}
+
+main();

--- a/tools/deploy-staging.mjs
+++ b/tools/deploy-staging.mjs
@@ -69,6 +69,7 @@ import {
 // nothing landed. The advisory marker is diagnostic-only (gitignored). See the plan §5.7 / §6.
 import { pathToFileURL } from 'node:url';
 import { acquire as leaseAcquire, renew as leaseRenew, release as leaseRelease } from './staging-lease.mjs';
+import { bumpTokenInHtml } from './lib/cachebust.mjs';
 import { writeMarkerAtomic, clearMarker, DEFAULT_TTL_MINUTES } from './lib/staging-control.mjs';
 
 // Refuse to deploy from these — a short feature branch is the whole point of Gate 1.
@@ -213,57 +214,15 @@ function deriveSiteFiles() {
   return discovered.sort();
 }
 
-// ── the shared ?v= cache-bust token ──
+// ── the shared ?v= cache-bust token (format + bump logic live in ./lib/cachebust.mjs,
+// the ONE source shared with tools/bump-cachebust.mjs + ci/check-cachebust.mjs) ──
 
-function todayStamp() {
-  const d = new Date();
-  return `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, '0')}${String(d.getUTCDate()).padStart(2, '0')}`;
-}
-// Matches the existing history in index.html: YYYYMMDD + an alpha suffix that
-// increments for repeat deploys the same day (…20260710e, 20260710f, 20260710g…).
-function incrementSuffix(s) {
-  if (!s) return 'a';
-  const arr = s.split('');
-  for (let i = arr.length - 1; i >= 0; i--) {
-    if (arr[i] !== 'z') { arr[i] = String.fromCharCode(arr[i].charCodeAt(0) + 1); return arr.join(''); }
-    arr[i] = 'a';
-  }
-  return 'a' + arr.join('');
-}
-function nextToken(oldToken) {
-  const today = todayStamp();
-  const m = /^(\d{8})([a-z]*)$/i.exec(oldToken);
-  if (!m || m[1] !== today) return today + 'a';
-  return today + incrementSuffix(m[2].toLowerCase());
-}
-
-// Bumps the ONE shared token across style.css/rule-usage.js/app.js in index.html.
-// Deliberately does NOT touch app.js's internal ES-module import specifiers (they never
-// carry ?v= — see CLAUDE.md: a relative import drops the query string, so a versioned +
-// unversioned copy of a sub-module would instantiate twice).
+// Bumps the ONE shared token across style.css/rule-usage.js/app.js in index.html on disk.
 function bumpVersionToken(indexHtmlAbs) {
-  const html = readFileSync(indexHtmlAbs, 'utf8');
-  const patterns = [
-    ['style.css', /(\bstyle\.css\?v=)([\w-]+)/],
-    ['rule-usage.js', /(\brule-usage\.js\?v=)([\w-]+)/],
-    ['app.js', /(\bapp\.js\?v=)([\w-]+)/],
-  ];
-  const tokens = new Set();
-  for (const [name, re] of patterns) {
-    const m = re.exec(html);
-    if (!m) fail(`deploy-staging: could not find a ?v= token on ${name} in index.html — the cache-bust pattern may have changed; update this script.`);
-    tokens.add(m[2]);
-  }
-  if (tokens.size !== 1) {
-    fail(`deploy-staging: style.css/rule-usage.js/app.js don't share one ?v= token in index.html ` +
-      `(found: ${[...tokens].join(', ')}) — CLAUDE.md requires one shared token. Fix index.html by hand first.`);
-  }
-  const oldToken = [...tokens][0];
-  const newToken = nextToken(oldToken);
-  let next = html;
-  for (const [, re] of patterns) next = next.replace(re, `$1${newToken}`);
-  writeFileSync(indexHtmlAbs, next);
-  return { oldToken, newToken };
+  const res = bumpTokenInHtml(readFileSync(indexHtmlAbs, 'utf8'));
+  if (res.error) fail(`deploy-staging: ${res.error} Fix index.html by hand first.`);
+  writeFileSync(indexHtmlAbs, res.html);
+  return { oldToken: res.oldToken, newToken: res.newToken };
 }
 
 // ── syncing files into a fresh clone of the staging repo ──

--- a/tools/lib/cachebust.mjs
+++ b/tools/lib/cachebust.mjs
@@ -1,0 +1,98 @@
+// ── Shared ?v= cache-bust token logic ────────────────────────────────────────
+// The ONE shared token across style.css / rule-usage.js / app.js in index.html
+// (CLAUDE.md → Deploy & gates). Extracted here so deploy-staging.mjs (the bumper),
+// tools/bump-cachebust.mjs (the auto-bump), and ci/check-cachebust.mjs (the guard)
+// all agree on the format — YYYYMMDD + an alpha suffix that increments for repeat
+// bumps the same day (…20260710e, …f, …g). Pure string/date helpers only, no I/O.
+
+// The three sub-resources the token versions. index.html itself is served WITHOUT a
+// ?v= (it's the entry doc, cache-busted by a Pages purge + max-age), so a change to
+// ONLY index.html needs no bump — the token protects the cached app.js/style.css/
+// rule-usage.js, which the browser + service worker key on ?v=.
+export const VERSIONED = ['style.css', 'rule-usage.js', 'app.js'];
+
+const tokenRe = (name) => new RegExp(`(\\b${name.replace('.', '\\.')}\\?v=)([\\w-]+)`);
+
+export function todayStamp(date = new Date()) {
+  return `${date.getUTCFullYear()}${String(date.getUTCMonth() + 1).padStart(2, '0')}${String(date.getUTCDate()).padStart(2, '0')}`;
+}
+
+// 'a' → 'b' … 'z' → 'aa' (odometer carry), never empty.
+export function incrementSuffix(s) {
+  if (!s) return 'a';
+  const arr = s.split('');
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (arr[i] !== 'z') { arr[i] = String.fromCharCode(arr[i].charCodeAt(0) + 1); return arr.join(''); }
+    arr[i] = 'a';
+  }
+  return 'a' + arr.join('');
+}
+
+// Next token: a fresh day resets to <today>a; the same day increments the suffix.
+export function nextToken(oldToken, today = todayStamp()) {
+  const m = /^(\d{8})([a-z]*)$/i.exec(oldToken || '');
+  if (!m || m[1] !== today) return today + 'a';
+  return today + incrementSuffix(m[2].toLowerCase());
+}
+
+// Read the ONE shared token from index.html's markup. Returns { token } when all three
+// versioned refs agree, or { error } describing the mismatch/absence — never throws, so
+// callers (the guard especially) can turn it into their own clean failure message.
+export function readSharedToken(html) {
+  const tokens = new Set();
+  for (const name of VERSIONED) {
+    const m = tokenRe(name).exec(html);
+    if (!m) return { error: `could not find a ?v= token on ${name} in index.html — the cache-bust pattern may have changed.` };
+    tokens.add(m[2]);
+  }
+  if (tokens.size !== 1) {
+    return { error: `style.css/rule-usage.js/app.js don't share one ?v= token in index.html (found: ${[...tokens].join(', ')}) — CLAUDE.md requires one shared token.` };
+  }
+  return { token: [...tokens][0] };
+}
+
+// Gather the cache-bust comparison state from git via an INJECTED runner
+// `sh(args: string[]) => string` (git stdout, throws on failure). Injection keeps this one
+// implementation shared by the bump tool, the CI guard, and the pure-Node test. Compares the
+// base branch's TIP to HEAD's tip (two-dot: tree vs tree, so it needs no merge-base history —
+// safe in a shallow CI checkout — and it catches a token that collides with trunk's, not just
+// one that failed to move). base defaults to 'origin/trunk'.
+export function readCacheBustState(sh, base = 'origin/trunk') {
+  const servedChanged = sh(['diff', '--name-only', base, 'HEAD', '--', ...VERSIONED])
+    .split('\n').map((s) => s.trim()).filter(Boolean);
+  const headRead = readSharedToken(sh(['show', 'HEAD:index.html']));
+  const baseRead = readSharedToken(sh(['show', `${base}:index.html`]));
+  return {
+    servedChanged,
+    headToken: headRead.token || null,
+    baseToken: baseRead.token || null,
+    headError: headRead.error || null,
+    baseError: baseRead.error || null,
+  };
+}
+
+// Decision (pure): given which versioned files changed vs the base branch and the two
+// shared tokens, does this branch still need a ?v= bump before it can safely reach
+// production? A versioned served-file change under an UNCHANGED token is the stale-delivery
+// trap — same app.js?v=<token> URL, new bytes → the CDN + service worker keep serving the
+// old copy. An equal-but-both-present token also fails (a collision: two different app.js
+// under one token), so a concurrent branch that reused the same next-token is caught too.
+export function bumpVerdict({ servedChanged, headToken, baseToken }) {
+  if (!servedChanged || servedChanged.length === 0) return { needsBump: false, reason: 'no versioned served-file change vs trunk' };
+  if (headToken && baseToken && headToken !== baseToken) return { needsBump: false, reason: `?v= bumped ${baseToken} → ${headToken}` };
+  return { needsBump: true, reason: `${servedChanged.join(', ')} changed vs trunk but the shared ?v= is unchanged (${headToken})` };
+}
+
+// Bump the shared token across all three refs (pure string transform). Returns
+// { oldToken, newToken, html } on success or { error }. Deliberately never touches
+// app.js's internal ES-module import specifiers (they carry no ?v= — a relative import
+// drops the query string, so a versioned + unversioned copy would instantiate twice).
+export function bumpTokenInHtml(html, today = todayStamp()) {
+  const read = readSharedToken(html);
+  if (read.error) return { error: read.error };
+  const oldToken = read.token;
+  const newToken = nextToken(oldToken, today);
+  let next = html;
+  for (const name of VERSIONED) next = next.replace(tokenRe(name), `$1${newToken}`);
+  return { oldToken, newToken, html: next };
+}

--- a/tools/lib/cachebust.mjs
+++ b/tools/lib/cachebust.mjs
@@ -11,7 +11,7 @@
 // rule-usage.js, which the browser + service worker key on ?v=.
 export const VERSIONED = ['style.css', 'rule-usage.js', 'app.js'];
 
-const tokenRe = (name) => new RegExp(`(\\b${name.replace('.', '\\.')}\\?v=)([\\w-]+)`);
+const tokenRe = (name) => new RegExp(`(\\b${name.replace(/\./g, '\\.')}\\?v=)([\\w-]+)`);
 
 export function todayStamp(date = new Date()) {
   return `${date.getUTCFullYear()}${String(date.getUTCMonth() + 1).padStart(2, '0')}${String(date.getUTCDate()).padStart(2, '0')}`;


### PR DESCRIPTION
## What & why

Closes the deck→production cache-bust gap that made the manual `?v=` bump (#729) necessary — the infra follow-up parked in #732.

**The gap:** deck mode deliberately doesn't bump `?v=` (staging's immutable `d/<id>/` folder path is its cache key), but **production** serves the branch root with `max-age=600` and the **service worker caches by `?v=`** — so a deck ship that promotes under an *unchanged* token serves the pre-change `app.js` to already-loaded devices. `promote.mjs`'s own "live serves `?v=<token>`" check is trivially true when the token never moved, so it didn't catch it.

## The change (config-only — no served files)

- **`tools/lib/cachebust.mjs`** — one source for the token format + bump/verdict logic. `deploy-staging.mjs` now imports it (its local `todayStamp`/`incrementSuffix`/`nextToken`/`bumpVersionToken` collapsed into a thin file-I/O wrapper — behavior unchanged, verified via `--dry-run` + the `lease-deploy` suite).
- **`tools/bump-cachebust.mjs`** — `/merge` runs this. Commits a `?v=` bump on the feature branch **iff** a served, versioned file (`app.js`/`style.css`/`rule-usage.js`) changed vs trunk and the token wasn't already bumped. Idempotent no-op otherwise (config-only branches, or a slot deploy that already bumped).
- **`ci/check-cachebust.mjs`** — the guarantee: fails a trunk-bound served-file change that skipped the bump. Compares **tips** (so it also catches a token colliding with trunk's) and self-fetches trunk (shallow-safe). Added to the `smoke` CI job — no new required-check config needed.
- **`ci/cachebust-test.mjs`** — pure-Node suite (23 checks) for the shared logic.
- `/merge` skill + `CLAUDE.md` document the tool + guard.

## Testing

- Full local gate set green, incl. the new `cachebust-test` (23/23) and `check-cachebust`; `lease-deploy` 42/42 confirms the `deploy-staging` refactor.
- **End-to-end proven:** a simulated `app.js` change → guard **fails** with the fix command → `bump-cachebust` bumps `20260718h→i` and commits → guard **passes**.
- This branch is config-only, so the guard correctly reports "no bump needed."

Ships by `/merge` alone (nothing served changes → no deploy, no promote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhgpRCxBW5ckC384sdoHzr)_