### PR TITLE
Staging chrome: single bottom-left indicator on the deck host

### DIFF
--- a/app.js
+++ b/app.js
@@ -25995,15 +25995,20 @@ function mountEnvFavicon() {
 // know which app — and WHICH staging slot — you're testing. The staging pool serves the SAME
 // files, so the slot number + color is the only tell.
 function mountEnvBadge() {
-  if (APP_ENV === 'production' || document.getElementById('env-badge')) return;
+  if (APP_ENV === 'production' || document.getElementById('env-edge')) return;
   const slotCls = ' env-' + APP_ENV + (APP_SLOT ? ' env-slot-' + APP_SLOT : '');
-  const b = document.createElement('div');
-  b.id = 'env-badge';
-  b.className = 'env-badge' + slotCls;
-  b.innerHTML = '<span>' + (APP_ENV === 'local' ? 'LOCAL' : 'STAGING') + '</span>'
-    + (APP_SLOT ? '<span class="env-badge-num">' + APP_SLOT + '</span>' : '');
-  b.setAttribute('aria-hidden', 'true');
-  document.body.appendChild(b);
+  // On the staging deck host the bottom-left "Staging ▾" switcher IS the env indicator, so skip
+  // the redundant STAGING badge pill there (Jac 2026-07-18). Keep it for LOCAL + the slot-2/3
+  // backup paths (no switcher there), and keep the top edge bar + favicon everywhere non-prod.
+  if (!isStagingHost()) {
+    const b = document.createElement('div');
+    b.id = 'env-badge';
+    b.className = 'env-badge' + slotCls;
+    b.innerHTML = '<span>' + (APP_ENV === 'local' ? 'LOCAL' : 'STAGING') + '</span>'
+      + (APP_SLOT ? '<span class="env-badge-num">' + APP_SLOT + '</span>' : '');
+    b.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(b);
+  }
   const edge = document.createElement('div');
   edge.id = 'env-edge';
   edge.className = 'env-edge' + slotCls;

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27650 lines, 41 chapters
+## app.js — 27655 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -47,8 +47,8 @@
 | APP-37 | 23344–24568 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
 | APP-38 | 24569–25708 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
 | APP-39 | 25709–25715 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25716–26022 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26023–27650 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-40 | 25716–26027 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26028–27655 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260718h" />
+  <link rel="stylesheet" href="style.css?v=20260718i" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260718h"></script>
-  <script type="module" src="app.js?v=20260718h"></script>
+  <script src="rule-usage.js?v=20260718i"></script>
+  <script type="module" src="app.js?v=20260718i"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -5591,7 +5591,7 @@ body.sync-failing.sched-due #app { padding-top: calc(40px + var(--sched-band, 46
    host (never production/#local). A fixed "Staging ▾" nav to jump between numbered deploys.
    Bespoke .deck-* classes (not lint-family), token-styled with hard fallbacks since it paints
    before the app's theme is applied. ── */
-.deck-switcher { position: fixed; right: 12px; bottom: 12px; z-index: 100000;
+.deck-switcher { position: fixed; left: 12px; bottom: 12px; z-index: 100000;
   font-family: 'Saira Condensed', var(--font, system-ui, sans-serif); }
 .deck-btn { display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 12px;
   border-radius: 8px; border: 1px solid var(--accent-line, rgba(255,122,26,.5));
@@ -5601,7 +5601,7 @@ body.sync-failing.sched-due #app { padding-top: calc(40px + var(--sched-band, 46
 .deck-btn:hover { border-color: var(--accent, #ff7a1a); }
 .deck-btn:focus-visible { outline: 2px solid var(--accent, #ff7a1a); outline-offset: 2px; }
 .deck-chev { font-size: 10px; }
-.deck-menu { position: absolute; right: 0; bottom: 38px; min-width: 330px; max-width: 94vw;
+.deck-menu { position: absolute; left: 0; bottom: 38px; min-width: 330px; max-width: 94vw;
   max-height: 62vh; overflow-y: auto; background: var(--panel, #15171c);
   border: 1px solid var(--line, #262a31); border-radius: 10px;
   box-shadow: 0 18px 40px -20px rgba(0,0,0,.85); padding: 5px; }


### PR DESCRIPTION
## What

On the staging **deck host** the "Staging ▾" switcher moves to the **bottom-left** and becomes the sole env indicator; the now-redundant "STAGING" slot badge is dropped there (it's kept for LOCAL and the slot-2/3 backup paths, where no switcher renders). The top edge stripe + tab favicon are unchanged everywhere non-prod.

## Why

Jac's request (2026-07-18): with the deck switcher in place, the separate "STAGING 1" slot badge in the opposite corner is redundant — consolidate to one bottom-left indicator.

## Changes

- **`app.js` `mountEnvBadge()`** — badge pill now only renders when `!isStagingHost()`; idempotency guard moves to `#env-edge` (always mounted). Edge bar + favicon unchanged.
- **`style.css`** — `.deck-switcher` `right → left: 12px`; `.deck-menu` `right → left: 0` (dropdown stays on-screen, opens upward-left).
- Bumps the shared `?v=` to `20260718i`.

Dev-gated chrome — invisible on production. Byte-verified on staging deck deploy `work-queue-92oeso-3`.

## Verification

Gates green: `smoke` ✅, `logic` 706/706, `deck` 24/24, `lease` 77/77, `lease-deploy` 42/42, `rule-usage`/`window-catalog`/`code-map` current. Placement reviewed via before/after mockup (GitHub Pages was mid-outage on the reviewer's route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oRTXJzNA6qMjepSLLJomC

---
_Generated by [Claude Code](https://claude.ai/code/session_015oRTXJzNA6qMjepSLLJomC)_