### PR TITLE
Deck launcher: iframe the newest deploy so /d/ stays bookmarkable + MEMORY refresh

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,26 @@
 > Keep it lean; the first ~200 lines are what a session actually leans on.
 
 ## Decisions
+- **2026-07-18 — STAGING DECK is the new DEFAULT staging path — SHIPPED LIVE (PRs #720 + #734).** Replaces
+  the 3-slot lease pool as the default (slots kept as the `--slots` BACKUP, unchanged). `node
+  tools/deploy-staging.mjs` (no flags) writes the site to an **immutable numbered folder**
+  `d/<feature>-<n>/` in the staging repo, rewrites a served manifest `d/deploys.json` (newest-20,
+  older pruned), and updates a stable **`/d/` launcher** (bookmark once → always redirects to newest) —
+  all in one commit with push-race CAS-retry. **No lease** (immutable paths ⇒ nothing to arbitrate, so
+  concurrent sessions never contend — this was the fix for the slot-contention pain). A dev-gated in-app
+  **`Staging ▾` switcher** (bottom-**left** after #734; badge dropped there) lists recent deploys + jumps
+  between them — Claude names an id/label to open. `?v=` is NOT bumped in deck mode (the unique folder
+  path IS the cache key); `/merge`'s `bump-cachebust` lands the bump before a served change reaches
+  trunk. `promote.mjs` freshness content-hashes trunk against the newest deck folder (or a slot).
+  Core `tools/lib/staging-deck.mjs` + `ci/deck-test.mjs` (24). Spec/plan:
+  `docs/superpowers/{specs,plans}/2026-07-18-staging-deck-*.md`.
+- **2026-07-18 — Dated-action CUSTOMER FUNNEL — SHIPPED LIVE (PR #693).** Each funnel layer is a dated
+  next-action slot glowing **red/yellow/green** by urgency (`naUrgency` due/soon/ok); "notes = actions"
+  (a layer's action = an OPEN scheduled `activityLog` entry tagged `fkey`+`stage`, via
+  `funnelLayerAction`). Signed/Paid terminal = **solid primary blue** (closed-won); multiple layers
+  armable at once; the extra-actions list is **date-sorted**; ✓ logs but does NOT advance (advance is a
+  separate button, `advanceFunnelLayer`); rental funnel participates; past-reached layers = quiet steel
+  history. `markMembershipSigned` stamps `funnelLog.member.Signed.date` so the won-layer isn't blank.
 - **2026-07-18 — Phone GESTURES SHIPPED LIVE + PROMOTED (PR #725, `?v=20260718h`).** Three phone-only
   native-app gestures; **desktop byte-identical**. (A) **Swipe-toggle decks (new rule R36)** — the
   customer funnel (Rental↔Equipment Sales), Invoices (Open·All·Transactions), and the comms Text/Email
@@ -225,6 +245,21 @@
   one line through single-column pan mode; the `<480px` query re-enables wrap for the mobile stack.
 
 ## Gotchas
+- **The Staging Deck (`d/`) shares the slot-1 repo, so a STALE-checkout session wipes it** (2026-07-18,
+  #720). The deck folders live at `d/` inside `rental-wrangler-staging` — the SAME repo slot-1 deploys
+  wipe. Any session still running the **pre-#720** `deploy-staging.mjs` (whose `syncFiles` doesn't
+  preserve `d/**`) DELETES the whole deck on its next slot deploy → Jac's `/d/` bookmark 404s. The fix
+  (`syncFiles` skips `d/**` + the manifest) is on trunk+production now, but only protects the deck once
+  each session **cycles onto the new code** — you can't force other sessions to update, so it
+  **self-heals over minutes-to-hours** as stale sessions end. Immediate relief: re-run
+  `node tools/deploy-staging.mjs` (~30s, additive — restores `d/` without touching root). Confirmed
+  cured once the old sessions closed (an updated session then deployed to slot 1 and left `d/` intact).
+- **`promote.mjs` deck-freshness probe can transiently TIME OUT during a GitHub incident** (2026-07-18).
+  A `curl: (28) Operation timed out` on the deck-folder probe makes promote fall back to the slots,
+  find no match, and **refuse** (correctly — it won't ship ahead of a staging site it can't verify).
+  Not real drift: confirm the deck folder serves trunk's `?v=` (a quick `curl -m 15`), then just
+  **re-run** `promote --yes` — the probe succeeds once GitHub is stable. Don't reach for
+  `--skip-staging-check` unless staging is genuinely unreachable.
 - **iOS Safari composites a `transform`/`will-change` element ABOVE a non-promoted sibling's text**
   (2026-07-18, #725). A sliding toggle "thumb" moved via `transform: translateX` + `will-change` painted
   OVER the button LABEL on iOS (invisible label) even though it sat at z-index:0 below the z-index:1

--- a/tools/deploy-staging.mjs
+++ b/tools/deploy-staging.mjs
@@ -462,17 +462,28 @@ async function deployDeck({ files, branch, cred, label, shortSha, dirty }) {
       const { manifest: nextManifest, dropIds } = addAndPrune(manifest, entry);
       mkdirSync(join(cloneDir, DECK_DIR), { recursive: true });
       writeFileSync(join(cloneDir, MANIFEST_PATH), serializeManifest(nextManifest));
-      // Stable launcher: d/index.html always redirects to the NEWEST deploy, so ONE permanent
-      // bookmark (…/rental-wrangler-staging/d/) always lands on the latest build + its in-app
-      // Staging switcher — never clobbered by slot deploys, always current.
+      // Stable launcher: d/index.html loads the NEWEST deploy in a full-screen IFRAME (NOT a
+      // redirect), so the address bar stays at …/rental-wrangler-staging/d/ — ONE permanent
+      // bookmark that never captures a (prunable) deploy id and so never goes stale (Jac 2026-07-18).
+      // The iframe src is an immutable folder path, so the cache guarantee still holds; a tiny
+      // manifest fetch upgrades to the very-newest in case this launcher HTML itself was CDN-cached
+      // (max-age=600). The in-app Staging switcher works inside the same-origin frame.
       const newestId = nextManifest.deploys[0].id;
+      const newestJs = JSON.stringify(newestId);
       writeFileSync(join(cloneDir, DECK_DIR, 'index.html'),
-        `<!doctype html><html lang="en"><meta charset="utf-8"><title>Staging deck</title>`
-        + `<meta http-equiv="refresh" content="0; url=./${newestId}/">`
-        + `<body style="background:#0b0c0f;color:#a7afbc;font:14px system-ui,sans-serif;padding:26px">`
-        + `<p>Opening the latest staging deploy… `
-        + `<a style="color:#ff7a1a" href="./${newestId}/">${newestId}</a></p>`
-        + `<script>location.replace('./${newestId}/')</script></body></html>\n`);
+        `<!doctype html><html lang="en"><head><meta charset="utf-8">`
+        + `<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">`
+        + `<title>Staging · Rental Wrangler</title>`
+        + `<style>html,body{margin:0;height:100%;background:#0b0c0f;overflow:hidden}`
+        + `#app{border:0;width:100%;height:100%;display:block}`
+        + `noscript a{color:#ff7a1a;font:14px system-ui,sans-serif}</style></head>`
+        + `<body><iframe id="app" title="Rental Wrangler staging — newest deploy" src="./${newestId}/"></iframe>`
+        + `<noscript><p style="color:#a7afbc;font:14px system-ui,sans-serif;padding:20px">`
+        + `<a href="./${newestId}/">Open the newest staging deploy →</a></p></noscript>`
+        + `<script>fetch('./deploys.json?cb='+Date.now(),{cache:'no-store'})`
+        + `.then(function(r){return r.json()}).then(function(m){var d=(m.deploys||[])[0];`
+        + `if(d&&d.id!==${newestJs})document.getElementById('app').src='./'+encodeURIComponent(d.id)+'/'})`
+        + `.catch(function(){})</script></body></html>\n`);
       for (const drop of dropIds) rmSync(join(cloneDir, DECK_DIR, drop), { recursive: true, force: true });
 
       // [R1] stage ONLY d/** (adds + mods + deletes) — root (slot-1 content) is never touched.


### PR DESCRIPTION
## What

Two config-only (non-served) changes:

1. **`tools/deploy-staging.mjs` — iframe launcher.** The `/d/` launcher redirected to `./<newest>/`, so bookmarking after the redirect captured the deploy id — which 404s once that deploy is pruned (Jac hit this). Now `d/index.html` loads the newest deploy in a **full-screen iframe**: the address bar stays at `…/rental-wrangler-staging/d/`, so the bookmark is permanent and never stale. The iframe src is the immutable folder path (cache guarantee holds); a manifest fetch upgrades to the very-newest if the launcher HTML was CDN-cached. The app has no frame-busting and is same-origin, so the in-app `Staging ▾` switcher still works inside the frame.

2. **`MEMORY.md` refresh.** Records the Staging Deck as the new default staging path (#720/#734) and the dated-action customer funnel (#693) under Decisions; adds two Gotchas — the deck/slot-1 co-location wipe by stale-checkout sessions, and the promote deck-freshness transient probe timeout.

## Why

Jac can't keep a working staging bookmark: the redirect leaks the (prunable) deploy id into the URL. The iframe keeps `/d/` in the address bar so one bookmark lasts forever.

## Verification

Non-served (tooling + docs) → ships by `/merge` alone, production untouched. `deck` 24/24, `lease-deploy` 42/42, syntax clean. Iframe launcher deployed + verified live on staging `/d/` (serves `<iframe src="./work-queue-92oeso-4/">`, no redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oRTXJzNA6qMjepSLLJomC

---
_Generated by [Claude Code](https://claude.ai/code/session_015oRTXJzNA6qMjepSLLJomC)_