### PR TITLE
Fix lazy-audit template: comment no longer shadows the <style> tag

### DIFF
--- a/.claude/skills/lazy-audit/assets/audit-report.template.html
+++ b/.claude/skills/lazy-audit/assets/audit-report.template.html
@@ -1,6 +1,6 @@
 <!--
   /lazy-audit — artifact TEMPLATE (yard data-plate design system).
-  REUSE THE <style> BLOCK VERBATIM. Re-author only the body for the audit at hand.
+  REUSE THE STYLE BLOCK BELOW VERBATIM. Re-author only the body for the audit at hand.
   Publish with the Artifact tool (load the artifact-design skill first). Favicon: 🚜.
   HONESTY: the card mock is a reconstruction, not a screenshot (the live app is SMS-gated).
   Use ILLUSTRATIVE names only — never a real customer record (public repo + live PII).


### PR DESCRIPTION
## What

The leading HTML comment in `.claude/skills/lazy-audit/assets/audit-report.template.html` contained the literal token `<style>`:

> REUSE THE `<style>` BLOCK VERBATIM.

Any script extracting the house style block with `tpl.indexOf("<style>")` matched **that occurrence, inside the comment**, rather than the real `<style>` tag on line 13.

## Impact

The published artifact's `<head>` carried comment prose ("BLOCK VERBATIM. Re-author only the body…"), a stray `-->`, and the template's own placeholder `<title>&lt;Surface&gt; Audit — as &lt;Persona&gt; sees it</title>`, which then **overrode the real title**. The CSS still loaded, so the page looked mostly fine and the corruption was easy to miss.

This bit during a real `/lazy-audit` run on 2026-07-18 — the first published artifact shipped corrupted before it was caught.

## Fix

Reword so the token appears only once, at the real tag:

```diff
- REUSE THE <style> BLOCK VERBATIM. Re-author only the body for the audit at hand.
+ REUSE THE STYLE BLOCK BELOW VERBATIM. Re-author only the body for the audit at hand.
```

Chosen over the alternative (documenting a skip-past-the-comment step in `SKILL.md`) as the smaller, more durable fix — it needs no cooperation from the extractor.

## Verification

Ran a naive `tpl.indexOf("<style>")` extraction — the exact pattern that caused the bug:

- Match now lands at index 834, **line 13** — the real tag.
- Extracted block starts `<style>`, ends `</style>`, 17,655 bytes.
- Block contains **none** of: `VERBATIM`, `Re-author`, `Artifact tool`, the stray `-->`, the placeholder `<title>`.

**CSS is byte-identical** — sha256 `2bcb1cd05e53a0da`, 17,655 bytes, before and after. Whole-file delta is 4 characters, all on line 3. The house design system is untouched.

## Ship path

Config-only — the sole changed file lives under `.claude/` and is never served by Pages. Per `/live`, this ships by `/merge` alone: no staging deploy, no `?v=` bump, production pointer intentionally untouched.

## Note for reviewers

`ci/gen-rule-usage.mjs --check` and `tools/gen-code-map.mjs --check` fail on a Windows working copy (`core.autocrlf=true`, no `.gitattributes`): the generators emit LF, the checkout is CRLF, so the checks report STALE with zero actual content drift. They pass on Linux CI. Unrelated to this change — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)