### PR TITLE
Normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,53 @@
+# Line endings — LF everywhere, in the repo AND in the working tree.
+#
+# Why this file exists (2026-07-18). With core.autocrlf=true and no attributes,
+# a Windows checkout puts CRLF in the working tree while the committed blobs are
+# LF. Git hides the difference (`git diff` normalizes, so the tree looks clean),
+# but any tool that reads bytes off disk sees CRLF and disagrees with git.
+#
+# What that actually broke: the two generator drift gates cry wolf. Both
+# `ci/gen-rule-usage.mjs --check` and `tools/gen-code-map.mjs --check` build
+# their expected output in memory with plain \n and then strict-compare it to
+# the file on disk (gen-rule-usage.mjs:45-46, gen-code-map.mjs:169-170 — neither
+# normalizes newlines). On a CRLF checkout they report "STALE" / "out of date"
+# with ZERO real drift: regenerating produces an empty `git diff`. It reads as a
+# red drift gate, and the honest fix looks like committing a regenerated file
+# that has no actual content change. CI runs ubuntu-latest, so this was a
+# local-Windows-only failure — invisible to the CI that's supposed to catch it.
+#
+# Also protective: `.claude/hooks/session-start.sh` is a `#!/bin/bash` script. A
+# CRLF shebang line breaks on Linux with a "bad interpreter" error, so pinning
+# LF keeps it executable everywhere.
+#
+# NOT a reason for this file: the /promote staging-freshness gate. That path was
+# already immune by design — `tools/lib/promote-freshness.mjs` runs every hashed
+# read through `normalizeForHash()` (CRLF and lone CR → LF) on BOTH sides, the
+# `git show` side and the served-bytes side, precisely so a Windows deploy vs a
+# Linux promote host can't produce a false mismatch. `ci/promote-test.mjs` has a
+# dedicated test for it. Don't cite promote as motivation here; it isn't.
+#
+# The committed blobs are ALREADY LF, so this file changes no committed content
+# (`git add --renormalize .` stages nothing). It only makes the working tree
+# agree with the blobs, which is what the generator gates assume.
+#
+# Note for Windows: after this lands, refresh an existing checkout once with
+#   git rm --cached -r -q . && git reset --hard
+# COMMIT OR STASH FIRST — `reset --hard` discards uncommitted work without
+# asking. The renormalize itself is content-neutral; the reset is not.
+
+* text=auto eol=lf
+
+# Binary — never normalize, never diff as text.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.mp4   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+*.pdf   binary
+*.zip   binary


### PR DESCRIPTION
## Root cause

`core.autocrlf=true` with no `.gitattributes`. Committed blobs are **LF**; a Windows working tree is **CRLF**. Git hides the split — `git diff` normalizes, so the tree reads clean — but tools that read bytes *off disk* disagree with git.

Evidence (three independent methods):

| | blob | working tree |
|---|---|---|
| `git cat-file -p … \| tr -cd '\r'` | **0 CR bytes** | 1 CR per line |
| `style.css` size | 509,488 | 515,112 (delta 5,624 = its line count) |
| `rule-usage.js` tail (`xxd`) | `};\n` | `};\r\n` |

## What it breaks

**The two generator drift gates cry wolf.** `ci/gen-rule-usage.mjs --check` and `tools/gen-code-map.mjs --check` build their expected output in memory with plain `\n`, then strict-compare against the file on disk — [gen-rule-usage.mjs:45-46](../blob/trunk/ci/gen-rule-usage.mjs#L45-L46) and [gen-code-map.mjs:169-170](../blob/trunk/tools/gen-code-map.mjs#L169-L170), neither of which normalizes newlines. On a CRLF checkout both report `STALE` / `out of date` with **zero** real drift; regenerating produces an empty `git diff`.

Reproduced on clean `trunk` before this branch. CI runs `ubuntu-latest`, so this was a **local-Windows-only** failure — invisible to the CI that's meant to catch drift, and it presents as a red gate on a change that didn't cause it.

**Also protective:** `.claude/hooks/session-start.sh` is a `#!/bin/bash` script; a CRLF shebang fails on Linux with `bad interpreter`.

## Correction — what this is NOT about

An earlier draft of this PR claimed the `/promote` staging-freshness gate could never match hashes, since `deploy-staging.mjs:262` copies working-tree bytes (CRLF) while `promote.mjs:167` hashes `git show trunk:<file>` (LF).

**That claim is false**, and adversarial review caught it. `tools/lib/promote-freshness.mjs` already runs every hashed read through `normalizeForHash()` (CRLF and lone CR → LF) on **both** sides — the `git show` side and the served-bytes side — with a comment naming this exact Windows-deploy/Linux-promote scenario, and `ci/promote-test.mjs` has a dedicated passing test (`contentHash ignores CRLF-vs-LF`). That code predates this branch.

The error was tracing the two call sites without following `contentHash` into `promote-freshness.mjs`. Promote is not a motivation for this change; the generator gates are. Left documented in the commit message and the file header so the bad reasoning isn't rediscovered later.

## The fix

`* text=auto eol=lf`, plus explicit `binary` pins.

Fixed at the root rather than by teaching each comparator to normalize: one declarative file covers current and future tools.

Includes `*.mp4` — `assets/login-intro.mp4` was the only binary relying on git's `text=auto` NUL-byte heuristic while every other binary type was pinned.

## Safety

- **No committed content changes.** Blobs are already LF, so `git add --renormalize .` stages **0** files. This diff is one new file, nothing else.
- **Nothing needs CRLF.** No `.bat`/`.cmd` tracked. A full-repo byte scan found CR bytes in only 13 files — all binary assets.
- **3 `.ps1` files verified safe** — no BOM, no CRLF dependency; PowerShell executes LF scripts natively.
- **Production bytes unchanged** — Pages serves the blobs, LF before and after.

## Verification

- `gen-rule-usage --check` → **PASS** (was FAIL) · `gen-code-map --check` → **PASS** (was FAIL)
- All ten runnable local gates green, plus `node --check` on the five served modules
- `ci/check-cachebust.mjs` passes — no served-file blob changed, so no `?v=` bump

## Ship path

Config-only: `.gitattributes` is not served and no served blob changed. Ships by `/merge` alone.

## For Windows checkouts

Existing checkouts keep CRLF on disk until refreshed once:

```
git rm --cached -r -q . && git reset --hard
```

**Commit or stash first** — `reset --hard` discards uncommitted work. (Caveat is in the file header too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)