### PR TITLE
Warn (never block) on unfit rentals and implausible hour readings

### DIFF
--- a/app.js
+++ b/app.js
@@ -18233,7 +18233,7 @@ function dispatchDrop(p, t) {
     const res = linkUnitToRental(r.rentalId, u.unitId);
     if (!res) return;
     render();
-    toast(`Unit ${u.name} → ${r.startDate && r.endDate ? 'rental ' + fmtWindow(r.startDate, r.endDate) : 'Quote'}${res.overbooked ? ' — ⚠ OVERBOOKED' : ''}`);
+    toast(`Unit ${u.name} → ${r.startDate && r.endDate ? 'rental ' + fmtWindow(r.startDate, r.endDate) : 'Quote'}${res.overbooked ? ' — ⚠ OVERBOOKED' : ''}${res.warn?.length ? ' — ⚠ ' + res.warn.join(' · ') : ''}`);   // §readiness — warn, never block
     dropFlash(`.card[data-card="rentals"] [data-pill-card="units"][data-pill-rec="${u.unitId}"]`, `.row[data-card="rentals"][data-rec="${r.rentalId}"], .card[data-card="rentals"]`);
     return;
   }
@@ -19648,7 +19648,30 @@ function startInlineEdit(span) {
     const u = IDX.unit.get(recId);
     input.value = u?.currentHours ?? '';
     input.type = 'number'; input.placeholder = 'Hours';
-    commit = () => { if (done) return; done = true; if (u && input.value !== '') { const old = u.currentHours; const v = Number(input.value); if (old !== v) { u.currentHours = v; reindex('units', u); logAction(u, `Hours: ${auditVal(old)} → ${auditVal(v)}`); } } render(); };
+    // §hours-sanity — WARN, never refuse (Jac 2026-07-18). currentHours is the sole input to every
+    // service countdown, the fleet average, category ROI and $/Hr, and it is stamped permanently
+    // onto any WO opened while it is wrong — yet it took any number at all. A 10× typo
+    // (1,738.5 → 17,385.5) sat in production for 26 days before a human caught it. Two anomalies
+    // are named now: a meter cannot physically run BACKWARDS, and a jump past ~2× the last reading
+    // is almost always a missed decimal. The value is still written either way — the warning rides
+    // the toast AND the unit's own history, so a bad number is reviewable later instead of silent.
+    commit = () => {
+      if (done) return; done = true;
+      if (u && input.value !== '') {
+        const old = u.currentHours; const v = Number(input.value);
+        if (old !== v) {
+          const prior = Number(old) || 0;
+          const odd = !Number.isFinite(v) ? 'not a number'
+            : (v < prior) ? `reads BACKWARDS (was ${num(prior)})`
+              : (prior > 0 && v > prior * 2) ? `is ${(v / prior).toFixed(1)}× the last reading (${num(prior)}) — check for a missed decimal`
+                : '';
+          u.currentHours = v; reindex('units', u);
+          logAction(u, `Hours: ${auditVal(old)} → ${auditVal(v)}${odd ? ` — ⚠ ${odd}` : ''}`);
+          if (odd) toast(`⚠ ${u.name}: ${num(v)} HRS ${odd}. Saved anyway — fix it here if that's wrong.`);
+        }
+      }
+      render();
+    };
   } else if (kind === 'invoicePO') {
     const inv = IDX.invoice.get(recId);
     input.value = inv?.po || ''; input.placeholder = 'PO #';
@@ -23134,10 +23157,23 @@ function linkUnitToRental(rentalId, unitId) {
     return null;
   }
   addUnitToRental(r, unitId);
+  // §readiness — WARN, never block (Jac 2026-07-18). Nothing on the rental path used to mention
+  // readiness at all: a unit with a failed inspection and a badly overdue service attached to a
+  // customer rental silently, and the rental screen said nothing about it. These two conditions
+  // now ride out on the success toast + the rental's own log. They are deliberately NON-blocking —
+  // the fleet gate above is the only hard stop — because a broken machine sometimes genuinely has
+  // to go out, and the person doing it should be told, not stopped.
+  // Deliberately NOT via topServiceForUnit: that returns the WASH row whenever one is requested,
+  // which would let a pending wash hide a 200-hr-overdue engine service from this very warning.
+  // unitServiceRows is already sorted worst-first, so the first past-due non-wash row IS the worst.
+  const warn = [];
+  if (u.inspectionStatus === 'Failed') warn.push('FAILED INSPECTION');
+  const svcDue = unitServiceRows(u).find((s) => s.taskId !== 'svc-wash' && s.status === 'past-due');
+  if (svcDue) warn.push(`SERVICE ${svcText(svcDue)}`);
   if (r.invoiceId) { syncRentalLines(r); syncTransportLine(r); }   // bill the newly-added unit (rental + transport lines) onto the existing invoice
-  logAction(r, `Unit + ${u.name}${conflicts.length ? ' — OVERBOOKED' : ''}`);
+  logAction(r, `Unit + ${u.name}${conflicts.length ? ' — OVERBOOKED' : ''}${warn.length ? ' — ⚠ ' + warn.join(' · ') : ''}`);
   reindexDraft('rentals', r);
-  return { added: u, overbooked: conflicts.length > 0 };
+  return { added: u, overbooked: conflicts.length > 0, warn };
 }
 /** Link a customer to a rental — with the §9 blacklist gate pulled up-front
  *  (it otherwise only fires later, in setRentalStatus). */

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27689 lines, 41 chapters
+## app.js — 27725 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -39,16 +39,16 @@
 | APP-29 | 16812–17161 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
 | APP-30 | 17162–17537 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
 | APP-31 | 17538–17541 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17542–20030 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 20031–21334 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21335–22871 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22872–23354 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23355–23357 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23358–24583 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
-| APP-38 | 24584–25723 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25724–25730 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25731–26061 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26062–27689 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-32 | 17542–20053 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 20054–21357 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21358–22894 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22895–23390 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23391–23393 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23394–24619 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
+| APP-38 | 24620–25759 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25760–25766 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25767–26097 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26098–27725 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260719b" />
+  <link rel="stylesheet" href="style.css?v=20260719c" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260719b"></script>
-  <script type="module" src="app.js?v=20260719b"></script>
+  <script src="rule-usage.js?v=20260719c"></script>
+  <script type="module" src="app.js?v=20260719c"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Two non-blocking guards on paths that previously said nothing at all. Both are **warn-only by explicit owner decision** — the machine still attaches, the number still saves. Neither adds a gate, a block, or an override.

### 1 · Readiness warning when a unit is attached to a rental

Nothing on the rental path checked readiness. A unit with a **failed inspection** and a badly **overdue service** attached to a customer rental silently, and the rental screen never mentioned it — searching the whole rental detail for *failed / not ready / overdue / service / inspect / warning* returned nothing.

`linkUnitToRental` now collects two conditions and returns them, so the drop's success toast names them — alongside the existing `⚠ OVERBOOKED` marker it already used for exactly this purpose. Also written to the rental's own action log, so the warning **outlives the toast**.

Deliberately **not** sourced from `topServiceForUnit`: that returns the WASH row whenever a wash is requested, which would let a pending wash hide a badly overdue engine service from this very warning. `unitServiceRows` is already sorted worst-first, so the first past-due non-wash row *is* the worst.

**Verified live in `#local`** — dragging a unit with a failed inspection and a 2,732-hour-overdue service onto a quote:

> `Unit Worm → Quote — ⚠ FAILED INSPECTION · SERVICE 2732 HRS overdue`

…and the same text lands in the rental's log. The unit still attaches.

### 2 · Sanity warning on the unit hours field

`currentHours` is the sole input to every service countdown, the fleet hours average, category ROI and `$/Hr`, and is stamped permanently onto any WO opened while it is wrong — yet it accepted any number at all. A 10× typo (`1,738.5 → 17,385.5`) sat in production for **26 days** before a human caught it.

Two anomalies are now named: a meter that reads **backwards** (physically impossible), and a jump past **~2×** the last reading (almost always a missed decimal). The value is written either way; the warning rides the toast **and** the unit's history, so a bad number is reviewable later instead of silent.

**Verified live** — entering `31,220` against a prior `3,122`:

> `⚠ Worm: 31,220 HRS is 10.0× the last reading (3,122) — check for a missed decimal. Saved anyway — fix it here if that's wrong.`

Logged as `Hours: 3122 → 31220 — ⚠ is 10.0× the last reading (3,122)…`, and the value saves.

Unit-tested across 8 boundary cases: backwards, exactly 2× (quiet), just past 2× (warns), first reading from zero (quiet), unchanged, normal drift.

---

**Gates:** all 10 green — smoke, logic **706/706**, lease, lease-deploy, promote, rule-usage, window-catalog, code-map, cachebust, check-cachebust.

**Note:** stacks alongside #741 (independent functions, no overlap). Both bump `?v=` to `20260719a`, so whichever merges second will need a one-line `index.html` conflict resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)