### PR TITLE
Trips: driver scoping — a bound driver sees their own runs (Mine·All toggle)

### DIFF
--- a/app.js
+++ b/app.js
@@ -9474,7 +9474,9 @@ function memberCount(member, session) {
   //     (oldest 78 days) still showed a badge of 4, counting only today-forward.
   //   • counts trips, not raw stops — the card body renders tripsFor(), so once two stops are
   //     doubled into one run the badge stays equal to the rows underneath it.
-  if (member === 'calendar') return tripsFor().filter((t) => !t.done).length;
+  //   • runs through the SAME tripsScopeFilter as the card body (§1), so a bound driver's badge
+  //     counts THEIR scoped board and can never drift from the rows below it.
+  if (member === 'calendar') return tripsScopeFilter(tripsFor()).filter((t) => !t.done).length;
   try { let r = listFor(member, session); if (member === 'units') r = unitsVisible(r, session.cards.units); if (member === 'rentals') r = rentalsVisible(r, session, session.cards.rentals); return r.length; } catch { return 0; }
 }
 /** How many units NEED the crew — drives the red alert on the Units tab (the
@@ -9647,9 +9649,19 @@ function calendarCardEl(session) {
   const body = el('div', 'card-body cal-body');
   const q = (state.calSearch || '').trim();
   const mapOpen = tripsMapOpen();
+  // §1 driver scoping — a bound driver gets a Mine·All toggle in the graph-button slot; the active
+  // segment rides the ONE orange (selected-tab, rule R3/#3). Other roles / unbound logins: no toggle.
+  const scope = tripsScope();
+  const scopeSeg = tripsScopeOffered()
+    ? segCtl([
+        { label: 'Mine', js: 'js-trips-scope', data: { scope: 'mine' }, on: scope === 'mine' ? 'orange' : null },
+        { label: 'All', js: 'js-trips-scope', data: { scope: 'all' }, on: scope === 'all' ? 'orange' : null },
+      ], 'trips-scopeseg')
+    : '';
   const bar = el('div', 'listbar');
   bar.innerHTML = `
     <button class="bv-btn js-tripsmap${mapOpen ? ' on' : ''}" data-tip="${mapOpen ? 'Hide the live map' : 'Live map'}">${I.graph}</button>
+    ${scopeSeg}
     <div class="mini-searchwrap${q ? ' has-query' : ''}">
     <input class="mini-search" placeholder="Search trips…" value="${esc(state.calSearch || '')}" data-card="calendar" />
   </div>`;
@@ -9676,13 +9688,14 @@ function calendarCardEl(session) {
       : `<div class="trips-map-ph"><span class="map-pin" aria-hidden="true">${ICO_PIN}</span><span class="map-tag stamp" style="font-size:0.6471rem;color:var(--accent)">Map offline</span><span class="map-sub">The run below still drives the day.</span></div>${gmaps}`;
     scroll.appendChild(panel);
   }
-  let trips = tripsFor();
+  let trips = tripsScopeFilter(tripsFor());   // §1 driver scoping — mine (assigned + unassigned) vs the whole yard
   if (q) trips = trips.filter((t) => tripMatches(t, q));
   trips = [...trips].sort(tripSort);
   const list = el('div', 'list');
   if (!trips.length) {
-    const label = q ? 'No Matching Trips' : 'No Hauls On The Books';
-    const hint = q ? `No trips match "${q}".` : 'Rentals with delivery or recovery land here on their own.';
+    const scopedMine = tripsScopeOffered() && scope === 'mine';
+    const label = q ? 'No Matching Trips' : (scopedMine ? 'No Runs On Your Board' : 'No Hauls On The Books');
+    const hint = q ? `No trips match "${q}".` : (scopedMine ? 'Nothing assigned to you yet — tap All to see the whole yard.' : 'Rentals with delivery or recovery land here on their own.');
     list.innerHTML = `<div class="trip-empty"><span class="trip-empty-label">${esc(label)}</span><span class="trip-empty-hint">${esc(hint)}</span></div>`;
   } else {
     appendGroupedSections(list, trips, {}, 'calendar');
@@ -11832,6 +11845,36 @@ const tripsMapOpen = () => {
   try { const v = localStorage.getItem('jactec.tripsMap'); return v == null ? currentRole !== 'driver' : v === '1'; } catch (e) { return true; }
 };
 const tripsMapSetOpen = (on) => { _mapOpenSession = null; try { localStorage.setItem('jactec.tripsMap', on ? '1' : '0'); } catch (e) {} };
+/* Driver scoping (spec rentals-dispatch §1, Jac 2026-07-18) — the Trips card is the DRIVER's landing
+   (ROLE_LANDING.driver). A driver defaults to seeing only their own runs (assigned to them OR still
+   unassigned), with a listbar toggle to the whole yard; an unbound/demo login (no roster id) always
+   sees all, mirroring chatVisibleToMe's `!mine` short-circuit.
+   myDriverId() must resolve the viewer to the SAME id that got written onto a trip. driverRoster()
+   keys each driver as `e2.id || e2.name` (a roster row predating stable ids falls back to its name),
+   and THAT value is what lands on eu.deliveryDriverId/recoveryDriverId — so we resolve OUR id the
+   identical id-or-name way. (myRosterId() returns String(id) only and would silently miss a
+   name-keyed driver's own runs — the trap this helper exists to avoid.) */
+function myDriverId() {
+  const me = (currentUser || '').trim().toLowerCase();
+  if (!me) return null;
+  const hit = ((state.settings && state.settings.employees) || []).find((e) => (e.name || '').trim().toLowerCase() === me);
+  return hit ? String(hit.id || hit.name) : null;
+}
+const tripsScope = () => {
+  const dflt = currentRole === 'driver' ? 'mine' : 'all';
+  try { const v = localStorage.getItem('jactec.tripsScope'); return v === 'mine' || v === 'all' ? v : dflt; } catch (e) { return dflt; }
+};
+const tripsScopeSet = (v) => { try { localStorage.setItem('jactec.tripsScope', v === 'mine' ? 'mine' : 'all'); } catch (e) {} };
+/* The scope toggle is only OFFERED to a bound driver (see calendarCardEl), and this is the single
+   choke point BOTH the card body and the tab badge run through — so the badge can never drift from
+   the rows (the invariant #745 established). Any non-driver role, an unbound viewer, or 'all' mode
+   passes through unfiltered. */
+const tripsScopeFilter = (trips) => {
+  const my = myDriverId();
+  if (!my || currentRole !== 'driver' || tripsScope() !== 'mine') return trips;
+  return trips.filter((t) => !t.driverId || String(t.driverId) === my);
+};
+const tripsScopeOffered = () => currentRole === 'driver' && !!myDriverId();
 const isLocalDemo = () => (location.hash || '').toLowerCase().includes('local');
 let _dispMapFailed = false;   // a genuine Maps load failure → the panel flips to the plate (re-opening the panel retries)
 let _dispMap = null, _dispView = null, _dispMarkers = [], _dispRoute = null, _dispGeo = {}, _dispGeoPending = {};
@@ -18992,6 +19035,8 @@ function onClick(e) {
   if (closest('.js-trip-town')) { e.stopPropagation(); const b = closest('.js-trip-town'); return tripTownGo(b.dataset.id, b.dataset.day); }
   // §2.1 Trips — map panel toggle (the graph-button slot); re-opening retries a failed Maps load
   if (closest('.js-tripsmap')) { e.stopPropagation(); const on = !tripsMapOpen(); tripsMapSetOpen(on); if (on) _dispMapFailed = false; return render(); }
+  // §1 driver scoping — flip the Trips card between the driver's own runs and the whole yard
+  if (closest('.js-trips-scope')) { e.stopPropagation(); tripsScopeSet(closest('.js-trips-scope').dataset.scope); return render(); }
   // §2.3 free-form route arrows — these win over the stop-open below (the icon lives inside the row)
   if (closest('.js-disp-stop') && !closest('.js-disp-time') && !closest('.disp-grip') && !closest('.js-site-go')) { e.stopPropagation(); return anchorRecord('rentals', closest('.js-disp-stop').dataset.rec); }
   if (closest('.js-disp-tok') && !closest('.dt-time') && !closest('.dt-grip') && !closest('.js-site-go') && !closest('.pill')) { e.stopPropagation(); return dispatchFocusStop(closest('.js-disp-tok').dataset.id); }   // §2.3 cockpit: tap a rail stop → focus it on the map (the customer pill opens the rental)

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27716 lines, 41 chapters
+## app.js — 27761 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -25,30 +25,30 @@
 | APP-15 | 7420–7619 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
 | APP-16 | 7620–9195 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
 | APP-17 | 9196–9455 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 9456–9905 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
-| APP-19 | 9906–10030 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 10031–10202 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 10203–10538 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
-| APP-22 | 10539–12122 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
-| APP-23 | 12123–12165 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 12166–13008 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 13009–14743 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
-| APP-26 | 14744–15088 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
-| APP-27 | 15089–15573 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 15574–16832 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
-| APP-29 | 16833–17182 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
-| APP-30 | 17183–17558 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
-| APP-31 | 17559–17562 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17563–20057 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 20058–21361 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21362–22898 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22899–23381 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23382–23384 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23385–24610 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
-| APP-38 | 24611–25750 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25751–25757 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25758–26088 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26089–27716 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-18 | 9456–9918 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
+| APP-19 | 9919–10043 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 10044–10215 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 10216–10551 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
+| APP-22 | 10552–12165 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+141) |
+| APP-23 | 12166–12208 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 12209–13051 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 13052–14786 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
+| APP-26 | 14787–15131 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
+| APP-27 | 15132–15616 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 15617–16875 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
+| APP-29 | 16876–17225 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
+| APP-30 | 17226–17601 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
+| APP-31 | 17602–17605 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 17606–20102 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 20103–21406 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21407–22943 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22944–23426 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23427–23429 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23430–24655 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
+| APP-38 | 24656–25795 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25796–25802 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25803–26133 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26134–27761 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260719d" />
+  <link rel="stylesheet" href="style.css?v=20260719e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260719d"></script>
-  <script type="module" src="app.js?v=20260719d"></script>
+  <script src="rule-usage.js?v=20260719e"></script>
+  <script type="module" src="app.js?v=20260719e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/style.css
+++ b/style.css
@@ -1079,6 +1079,9 @@ select.lf-in { appearance: none; cursor: pointer; }
 .card > .listbar { flex: 0 0 auto; position: static; background: var(--card); }
 .listbar .mini-search { flex: 1; min-width: 0; height: 32px; padding: 0 11px; border-radius: var(--chip-radius); background: var(--panel); border: 1px solid var(--line); color: var(--txt); font-size: 0.7059rem; box-shadow: var(--chip-shadow); }
 .listbar .mini-search:focus { outline: none; border-color: var(--accent-line); }
+/* driver-scope toggle (§1) rides between the map button and the search — hold its natural height so
+   the mobile dock's align-items:stretch doesn't balloon the segmented control */
+.listbar .trips-scopeseg { flex: 0 0 auto; align-self: center; }
 /* §12 sort control — ONE unified chip: [field ⌄ │ ▲▼]. The two segments share a
    single steel chip (no second box, no extra horizontal space) split by a
    saddle-stitch seam, matching the .card-jog stepper (recognition over recall). */


### PR DESCRIPTION
Builds the "my trips" driver scoping specified in the Calendar/Driver audit handoff (§1/§4a). **Held as a draft for your review** — not auto-merged.

## What

The Trips card (the driver role's landing — `ROLE_LANDING.driver`) rendered the whole yard's board with no notion of who was looking at it. Now:

- A **bound driver** defaults to **their own runs** — assigned to them **OR** still unassigned — with a `Mine · All` segmented toggle (R14) in the listbar's graph-button slot to see the whole yard.
- **Other roles and unbound/demo logins are unchanged**: they see all trips and get no toggle, mirroring `chatVisibleToMe`'s `!mine` short-circuit (the house precedent for "un-rostered login isn't shown an empty list").
- The choice persists per-device (`localStorage jactec.tripsScope`), defaulting to `mine` for the driver role.
- The empty state is scope-aware ("No Runs On Your Board — nothing assigned to you yet, tap All to see the whole yard").

## The `driverRoster()` id trap (handled)

`driverRoster()` keys each driver as `e2.id || e2.name`, so a roster row predating stable ids yields the driver's **name** as their id — and that value is what lands on `eu.deliveryDriverId`/`recoveryDriverId`. `myRosterId()` returns `String(id)` only, so comparing against it would **silently miss** a name-keyed driver's own runs. `myDriverId()` resolves the viewer the identical id-or-name way, so the match holds either way.

## Badge stays consistent

`memberCount`'s calendar badge runs through the **same** `tripsScopeFilter` as the card body, so a driver's badge counts THEIR scoped board and can never drift from the rows below it — preserving the badge==rows invariant #745 just established.

## Design

New UI ran through `/jactec-ui`: reuses `segCtl` (R14, already stamped `data-r`), the active segment rides the ONE orange (`on-orange` = selected-tab, rule #3), one CSS rule holds its height in the listbar across desktop + the mobile dock. No new rule/stamp, no rule-usage or window-catalog drift.

## Verification

Boot + regression covered by CI `smoke`. app.js parses; local drift gates green (rule-usage, code-map, window-catalog, check-cachebust). **The bound-driver end-to-end (a real logged-in driver seeing only their runs) can't be driven from a cloud session** — login is SMS-gated and headless Chromium can't reach staging (documented in the handoff / PR #621). Worth a 30-second eyeball on staging as a driver before promote.

## Deferred for your call

- **Should non-driver roles (dispatch/office) also get the Mine·All toggle?** Kept it driver-only for a minimal blast radius; easy to widen if you want a dispatcher to filter to their own deliveries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ps5kqg7c6iNkaNdGdCHYZF)_