### PR TITLE
Crew SMS alerts (STUB): driver-assigned + schedule-change triggers

### DIFF
--- a/app.js
+++ b/app.js
@@ -11353,6 +11353,9 @@ function assignStopDriver(rentalId, unitId, task, driverId) {
   eu[f] = nv;
   logAction(r, `${IDX.unit.get(eu.unitId)?.name || 'Unit'} — ${task === 'Deliver' ? 'delivery' : 'recovery'} driver → ${nv ? driverName(nv) : 'unassigned'}`);
   reindex('rentals', r);
+  // §C crew alert (STUB) — the newly-assigned driver would get a "you're on this run" text. Gated on
+  // the Crew Alerts flag (default off) + composed/logged only, never sent live (see staffAlertMaybe).
+  if (nv) staffAlertMaybe('driverAssigned', { rosterId: nv, leg: task === 'Deliver' ? 'delivery' : 'pickup', unit: IDX.unit.get(eu.unitId)?.name || 'the unit', addr: task === 'Deliver' ? (eu.deliveryAddress || '') : (eu.recoveryAddress || eu.deliveryAddress || ''), date: day });
   return true;
 }
 /* §2.3 Trip materialization store (Phase 3, spec 2026-07-09 §2.3) — mirrors
@@ -11939,8 +11942,59 @@ function tripSetTime(day, tripId, time) {
   dayStore[tripId] = { time, order: cur ? cur.order : trip.stops.slice(), rev: (cur ? cur.rev || 0 : 0) + 1 };
   tripsSaveDay(day, dayStore);
   tripPushSoon(day, tripId);   // §2.3 Phase 4 — debounced sync of this one trip's new time
+  // §C crew alert (STUB) — an ASSIGNED trip whose time actually moved would ping its driver. Gated +
+  // stubbed; only fires on a real change so an Auto-Run rewrite to the same time stays quiet.
+  if (trip.driverId && trip.time !== time) staffAlertMaybe('scheduleChange', { rosterId: trip.driverId, unit: trip.unit, date: day, time });
   return true;
 }
+
+/* ── Crew SMS alerts (STUB) — the §C staff auto-triggers (driver assigned · schedule changed · morning
+   summary) from docs/superpowers/plans/2026-07-14-notifications-BCD-plan.md ───────────────────────────
+   They route through the SAME staff channel the crew broadcast uses: the backend sendStaffMessage_
+   resolves the phone SERVER-SIDE from the rosterId (a stable ref, NEVER a client phone) and owns every
+   gate (manager+, crew SMS consent, quiet-hours). TWO things are DELIBERATELY not live — Jac's calls:
+     1. STAFF_ALERTS_LIVE stays false. A fired trigger COMPOSES the message + recipient and records it to
+        the stubbed outbox (+ console), but never sends. Flip to true only after Jac approves the wording
+        AND the backend auto-trigger build lands (the manual staff-broadcast path is deployed; the three
+        auto-triggers are not — see docs/handoffs/BACKEND-DEPLOY-QUEUE.md).
+     2. The wording below is a DRAFT for Jac to approve, not final copy.
+   A trigger only composes when its Settings → Notifications → Crew Alerts flag is on (default off), so
+   with defaults this whole path is inert — zero behavior change until Jac opts in. */
+const STAFF_ALERTS_LIVE = false;   // Jac's go — never flip without approved wording + the backend trigger build
+const staffAlertOutbox = [];       // stubbed "what WOULD have sent" — newest last, capped at 50
+function staffAlertEnabled(kind) {
+  const staff = (state.settings && state.settings.notifications && state.settings.notifications.staff) || NOTIF_DEFAULTS.staff;
+  return !!(staff && staff[kind] && staff[kind].enabled);
+}
+function staffAlertCompose(kind, ctx) {   // DRAFT wording — Jac approves before go-live. → { rosterId, template, text } | null
+  if (kind === 'driverAssigned') return { rosterId: ctx.rosterId, template: 'staff-run', text: `Jac Rentals: you're on the ${ctx.leg} of ${ctx.unit}${ctx.addr ? ` — ${ctx.addr}` : ''}${ctx.date ? ` (${ctx.date})` : ''}. Open the app for the run.` };
+  if (kind === 'scheduleChange') return { rosterId: ctx.rosterId, template: 'staff-schedule', text: `Jac Rentals: your run${ctx.unit ? ` for ${ctx.unit}` : ''}${ctx.date ? ` on ${ctx.date}` : ''} moved to ${ctx.time || 'a new time'}. Check the app.` };
+  if (kind === 'morningSummary') return { rosterId: ctx.rosterId, template: 'staff-summary', text: `Good morning${ctx.name ? `, ${ctx.name}` : ''} — ${ctx.count} run${ctx.count === 1 ? '' : 's'} on your board today. Open the app for the order.` };
+  return null;
+}
+function staffAlertMaybe(kind, ctx) {
+  try {
+    if (!staffAlertEnabled(kind) || !ctx || !ctx.rosterId) return;   // flag off, or nobody to notify
+    const msg = staffAlertCompose(kind, ctx);
+    if (!msg || !msg.text) return;
+    const entry = { kind, to: driverName(msg.rosterId), rosterId: msg.rosterId, template: msg.template, text: msg.text, at: Date.now() };
+    staffAlertOutbox.push(entry); if (staffAlertOutbox.length > 50) staffAlertOutbox.shift();
+    try { window.__rwStaffAlerts = staffAlertOutbox; } catch (e) {}
+    console.info('[crew-alert STUB — not sent]', kind, '→', entry.to + ':', msg.text);
+    if (STAFF_ALERTS_LIVE) { /* go-live (Jac + backend trigger build): backendCall('sendStaffMessage', { template: msg.template, text: msg.text, rosterId: msg.rosterId, override: false }); */ }
+  } catch (e) { /* an alert must NEVER break the action that triggered it */ }
+}
+/* Morning summary — a per-driver digest of today's OPEN runs. Composing is client-side; the DAILY firing
+   must be a backend time-trigger (like Phase B's reminder sweep — editor-installed, not client cron), so
+   this builds + previews only. window.__rwMorningSummaries([dayISO]) logs what each driver would receive;
+   wiring the daily send is Jac's backend step. */
+function morningSummaryDrafts(dayISO) {
+  const day = dayISO || TODAY_ISO;
+  const byDriver = {};
+  tripsFor().filter((t) => t.day === day && !t.done && t.driverId).forEach((t) => { (byDriver[t.driverId] = byDriver[t.driverId] || []).push(t); });
+  return Object.keys(byDriver).map((rid) => ({ to: driverName(rid), runs: byDriver[rid].length, text: staffAlertCompose('morningSummary', { rosterId: rid, name: driverName(rid), count: byDriver[rid].length }).text }));
+}
+try { window.__rwMorningSummaries = (d) => { const ds = morningSummaryDrafts(d); console.info('[morning-summary STUB — not sent]', ds); return ds; }; } catch (e) {}
 
 /* Deadline anchors for a day's runs (spec §2.7: "stops with a set time, AND stops belonging
    to rentals with a start/end date that implies an arrival deadline"). Every trip passed in

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27716 lines, 41 chapters
+## app.js — 27770 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -29,26 +29,26 @@
 | APP-19 | 9906–10030 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
 | APP-20 | 10031–10202 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
 | APP-21 | 10203–10538 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
-| APP-22 | 10539–12122 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
-| APP-23 | 12123–12165 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 12166–13008 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 13009–14743 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
-| APP-26 | 14744–15088 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
-| APP-27 | 15089–15573 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 15574–16832 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
-| APP-29 | 16833–17182 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
-| APP-30 | 17183–17558 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
-| APP-31 | 17559–17562 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17563–20057 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 20058–21361 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21362–22898 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22899–23381 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23382–23384 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23385–24610 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
-| APP-38 | 24611–25750 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25751–25757 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25758–26088 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26089–27716 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-22 | 10539–12176 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+142) |
+| APP-23 | 12177–12219 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 12220–13062 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 13063–14797 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
+| APP-26 | 14798–15142 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
+| APP-27 | 15143–15627 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 15628–16886 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
+| APP-29 | 16887–17236 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
+| APP-30 | 17237–17612 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
+| APP-31 | 17613–17616 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 17617–20111 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 20112–21415 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21416–22952 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22953–23435 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23436–23438 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23439–24664 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
+| APP-38 | 24665–25804 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25805–25811 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25812–26142 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26143–27770 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260719d" />
+  <link rel="stylesheet" href="style.css?v=20260719e" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260719d"></script>
-  <script type="module" src="app.js?v=20260719d"></script>
+  <script src="rule-usage.js?v=20260719e"></script>
+  <script type="module" src="app.js?v=20260719e"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Builds the SMS half of the driver-assignment alerts specified in the audit handoff (§4b) and the `2026-07-14-notifications-BCD-plan.md` §C triggers. **Stubbed — nothing sends. Held as a draft for your review, and the wording needs your sign-off before go-live.**

## What it wires

The scaffolding already existed and was inert: `NOTIF_DEFAULTS.staff.{driverAssigned,scheduleChange}` flags (default off), the Crew Alerts settings card, and the server-side `sendStaffMessage` path. This connects two frontend-firable triggers to that path:

- **Driver assigned** → hooked in `assignStopDriver` (fires when a leg gets a driver).
- **Schedule changed** → hooked in `tripSetTime` (fires only when an *assigned* trip's time actually moves — an Auto-Run rewrite to the same time stays quiet).

## Why it's safe to merge as-is

Three independent guards, so with defaults the whole path is **completely inert — zero behavior change**:
1. `STAFF_ALERTS_LIVE = false` — a fired trigger **composes** the message + recipient and records it to a stubbed outbox (`window.__rwStaffAlerts`) + `console.info`, but the `sendStaffMessage` call is commented behind that constant. Nothing texts.
2. A trigger only composes when its Crew Alerts flag is **on** (all default off).
3. Only a **`rosterId`** crosses the wire — the backend resolves the phone and owns crew consent + quiet-hours. **No phone/PII leaves the client.**

Every alert is wrapped in try/catch so it can never break the dispatch action that triggered it.

## Draft wording — please approve or edit before go-live

- **Driver assigned:** `Jac Rentals: you're on the delivery of Backhoe 310 — 1234 Main St (2026-07-20). Open the app for the run.`
- **Schedule changed:** `Jac Rentals: your run for Backhoe 310 on 2026-07-20 moved to 9:00. Check the app.`
- **Morning summary:** `Good morning, Dewey — 3 runs on your board today. Open the app for the order.`

## Deferred to you (hard-defers, per the handoff)

- **Go-live** = flip `STAFF_ALERTS_LIVE` **and** land the backend auto-trigger build (`BACKEND-DEPLOY-QUEUE` — the manual `staff-broadcast` path is deployed; these auto-triggers are not). Your call.
- **Morning summary** is composed + previewable now (`window.__rwMorningSummaries()`), but its *daily* firing must be a backend time-trigger (editor-installed, like the reminder sweep) — not a client cron. Not wired here.
- The **in-app toast/badge half** of F-1 (so office/dispatch see an assignment without being the SMS recipient) is still separate and unbuilt.

## Verification

Inert by default, so CI `smoke`/`logic` exercise the unchanged paths (flags off → no-op). app.js parses; drift gates green. The live send + real driver phone can only be verified once the backend trigger lands and you approve go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ps5kqg7c6iNkaNdGdCHYZF)_