### PR TITLE
docs(design): Labs pipeline — design-system kit, atoms canvas, prompts

### DIFF
--- a/docs/design/LABS-PIPELINE.md
+++ b/docs/design/LABS-PIPELINE.md
@@ -1,0 +1,90 @@
+# Design Labs pipeline — continuation doc
+
+**Read this first in a new session.** Everything needed to continue the redesign is in files;
+nothing important lives only in a chat. Started 2026-07-25.
+
+## The plan in one line
+Jac approves **every inch** of the site by designing it in **Claude Design Labs**, screen by screen,
+foundations first — then Claude Code implements it by **rewriting the builder functions** in `app.js`
+to emit the approved markup. (Codex is NOT in use.)
+
+## How the pieces fit
+- **Design Labs** = where each screen is designed + approved. It is blind to our code; it only knows
+  the synced design system. It emits static HTML/CSS in our idiom.
+- **`docs/design/rw-design-system/`** = the code-accurate kit (the design system's source of truth).
+  Jac syncs it to Labs with `/design-sync` from a **local** Claude Code session (a cloud/web session
+  cannot authorize — that's expected, not a bug).
+- **Implementation** = rewrite what the builders (`rowEl`, `cardEl`, chip helpers…) *emit*. The data
+  plumbing (`IDX`, derivations) does not change; only the returned markup does. This is why the kit is
+  built on our real tokens/classes — so approved mockups drop in rather than needing translation.
+
+## Prompt framework — EVERY Labs prompt gets these three
+1. **⭐ North Star** — one sentence: the single thing this screen decides.
+2. **🚫 Out of scope (anti-objectives)** — an explicit "do not critique/redesign this here" list.
+   This is the leash: without it, every screen tempts a full-app rescue and nothing ever locks.
+3. **♻️ Inherit** — the already-locked components this mockup must reuse **verbatim**. Once a thing is
+   locked it rides onto every later screen unchanged.
+
+**One screen = one Labs session = one artifact.** Consistency comes from the synced design system +
+the Inherit list, NOT from session continuity. Start a fresh Labs session per screen.
+
+## Build order (foundations first)
+- **Tier 0.0 — Atoms** ✅ **LOCKED 2026-07-25** (see decisions below).
+- **Tier 0.1 — Containers** ← **NEXT.** Card frame · card header · list row · section/plate ·
+  panel/popup · **action/overflow menu**. Design each as its own artifact and lock BEFORE anything
+  composes them.
+- **Tier 0.2 — App shell** — 3-column yard grid, top bar, footer rail; decides how a row-expansion
+  relates to the columns. *A first draft exists (parked) — it revealed the real tension: the detail
+  view's horizontal section rail does NOT fit a ⅓-width column, so the shell must decide
+  break-out-wider vs anchor-panel vs in-column.*
+- **Tier 1 — Detail view** — bounded height + section rail that pages one section at a time, each rail
+  chip carrying its rolled-up Signal + primary Door, History pinned. *A first draft exists (parked)
+  and PROVED the model works; it locks once it sits inside the approved shell.*
+- **Tier 2 — Per-card content** — Units · Rentals (calendar-anchored) · Customers · Trips · Invoices…
+- **Tier 3 — Cross-cutting** — item/comms tabs · footer-rail open chats · notifications/toasts ·
+  settings boards · creation flows/wizards · empty+loading+login+mobile reflow.
+
+## Locked decisions (do not reopen)
+- **The palette/type tokens** — the `html.dv2` redesign set in `style.css` (CVD-tuned; `--yellow:#eed44b`,
+  `--red:#ff4242`, `--blue:#6394cc`, `--commit:#2f6fd0`, `--accent:#ff7e1f`).
+- **Atoms consistency pass (2026-07-25)** — applied to the kit from Jac's Labs review:
+  - **Three control shapes, one per family** — state chips **squared** (`--chip-radius:2px`), records
+    **rounded** (`--item-radius:8px`), actions **pill** (Doors only). ⚠️ This SUPERSEDES the old
+    "two radii / one 7px chip radius" line in the `style` skill — that canon is now stale.
+  - **Body voice = Archivo** (mono voice unchanged). Loaded via the Google Fonts `<link>` in
+    `index.html` (fonts are CDN-loaded, NOT bundled — adding Archivo is a one-line change).
+  - **Outline chips are TRUE outlines** — transparent bg + 1px border in the status hue (the ten
+    `--*-bg` tint backfills were deleted; the tokens remain for plates). New `--red-line` keeps red
+    legible on dark once the tint is gone.
+  - **`.menu` DROPPED entirely.** The status *picker* is now `.seg--stack` (the segmented toggle,
+    stacked). A menu of unrelated **actions** (⋯ → Duplicate/Export/Archive/Delete) is a DIFFERENT
+    job and is queued as a **container**, not an atom.
+  - **New atom: Pin** (`.pin`) — universal corner marker, colour=state/fill=today like a Signal,
+    13px, zero layout footprint, hover explains, click teleports.
+  - Universal hover ring (outside the element, no layout shift), one focus ring, real `<button>`s for
+    every tappable atom, no atom shrinks/wraps in a flex row.
+
+## Files (all in the repo — durable)
+- `docs/design/rw-design-system/` — the kit: `tokens.css`, `foundations/`, `elements/`, `components/`.
+  **This is what gets `/design-sync`'d to Labs.**
+- `docs/design/atoms-canvas.html` — all atom families on one editable page (the review surface).
+- `docs/design/prompts/` — the Labs prompts written so far (atoms, detail views, shell).
+- `docs/design/labs-build-order.md` — the framework + full build order.
+- `docs/design/reference/` — the ~16 earlier mockups (list views, trips, inbox, dashboard, funnel,
+  inspection, intake…) + `decision-notes.md`. Still valid as design references.
+- `docs/research/` — the ~171-finding UX research corpus behind the redesign.
+
+## Ship state (2026-07-25)
+- **production is FROZEN** at `0fac006` and Jac is deliberately holding it there. Do **not** promote
+  without his explicit say-so.
+- **trunk** is ahead of production by ~21 commits: the app.js module split (#767), the dv2 redesign
+  scaffolding (inert — gated behind `FEATURES.designV2`, off in production), docs/research, and some
+  RENTALS/Trips bugfixes. A promote would be a clean fast-forward; the only user-visible change would
+  be those bugfixes.
+- The container clones **shallow** — if git reports trunk/production as "diverged" with no common
+  ancestor, run `git fetch --deepen=200 origin trunk` before believing it.
+
+## Next action
+Design the **containers** (Tier 0.1) in Labs, starting with the **card frame + header + list row** —
+the anatomy shared by all 7 cards. Write the prompt with the three-part framework above, and put the
+locked atoms in its **Inherit** list.

--- a/docs/design/atoms-canvas.html
+++ b/docs/design/atoms-canvas.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Atoms</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
 :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -18,15 +19,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+}
+@supports (color: oklch(from red l c h)){
+  :root{ --red-line: oklch(from var(--red) .74 .215 h); }
 }
 
 /* ================= page chrome — ONE simple layout for every atom section ================= */
@@ -71,15 +77,19 @@ code{font-family:var(--font-mono)}
   border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
   letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
 .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-.signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
 .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-.signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
 .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-.signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
 .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-.signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
 .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-.signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+/* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+.signal--outline{background:transparent; border:1px solid currentColor}
+.signal--gray.signal--outline  {color:var(--gray)}
+.signal--blue.signal--outline  {color:var(--blue)}
+.signal--yellow.signal--outline{color:var(--yellow)}
+.signal--green.signal--outline {color:var(--green)}
+.signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+/* C7 — read-only atoms say so with the cursor */
+.signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
 /* ---- GATE — a Signal you can turn: + leading centred chevron ---- */
 .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -98,15 +108,15 @@ code{font-family:var(--font-mono)}
   font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
   text-transform:uppercase; color:var(--txt-3)}
 .stamp--more{color:var(--accent)}
-.stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+.stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
 /* ---- REF — a linked record: accent-tinted icon backing + name ---- */
-.ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-  border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-  font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+.ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+  border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+  font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
   text-decoration:none; cursor:pointer}
 .ref:hover{border-color:var(--accent)}
-.ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+.ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
   align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
 .ref__icon svg{width:12px; height:12px}
 .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -118,19 +128,23 @@ code{font-family:var(--font-mono)}
   border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
   letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
 .door--commit {background:var(--commit); color:var(--on-commit)}
-.door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+/* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+.door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+  border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+.door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
 .door--money  {background:var(--green); color:var(--on-green)}
 .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
 .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
 .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
 .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-  font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+  font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
   border-right:1px solid var(--line); cursor:pointer; background:transparent}
 .seg__opt:last-child{border-right:0}
 .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
 .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
 .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+.seg__opt--on-green{background:var(--green); color:var(--on-green)}
 .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
 /* ---- FIELDS / links ---- */
@@ -141,12 +155,17 @@ code{font-family:var(--font-mono)}
 .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
   font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
 .contact svg{color:var(--accent); width:14px; height:14px}
-.contact__v{border-bottom:1.4px solid transparent}
+.contact__v{border-bottom:1.5px solid transparent}
 .contact:hover .contact__v{border-bottom-color:var(--accent)}
-.hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-  border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-.hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-.dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+/* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+.hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+.hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+  text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+.hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--accent-soft); color:var(--accent)}
+.hlink__ext svg{width:10px; height:10px; display:block}
+.dead-text{color:var(--txt-2)}
 
 /* ============================================================================
    Supporting text-role classes — used by the Texts spec table and the Buttons
@@ -166,18 +185,75 @@ code{font-family:var(--font-mono)}
 .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
 .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
 
-/* ============================================================================
-   Status-picker menu — used by the Gates "opens a status picker" demo only.
-   ============================================================================ */
-.menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-.menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-  color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-.menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-  border-bottom:1px solid var(--line-soft); cursor:pointer}
-.menu__i:last-child{border-bottom:0}
-.menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-.menu__i.on{font-weight:800}
-.menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+/* ============================ consistency pass — [B]/[C] additions ============================ */
+.ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+/* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+  margin:0; text-align:left}
+button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+/* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+.gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+.contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+/* C8 — press dips the fill on filled tappables */
+.gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+/* C9 — hover INK reserved for atoms that navigate or switch */
+.seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+.ref:hover, .contact:hover{color:var(--accent)}
+/* C10 — one focus ring for every tappable atom */
+.gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+.ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+  outline-offset:2px}
+
+/* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+.seg--state .seg__opt{border-right:0}
+.seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+  box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+.seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+  box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+.seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+/* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+.seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+.seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+  border-bottom:1px solid var(--line); justify-content:flex-start}
+.seg--stack .seg__opt:last-child{border-bottom:0}
+
+/* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+   Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+   zero layout footprint (absolute, no margin, no reserved space). */
+.pin-wrap{position:relative; display:inline-flex; flex:none}
+.pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+  height:13px; min-width:13px; padding:0 4px;
+  display:inline-flex; align-items:center; justify-content:center; gap:3px;
+  border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+  letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+  cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+.pin svg{width:9px; height:9px; display:block}
+.pin--gray  {background:var(--gray);     color:var(--on-gray)}
+.pin--blue  {background:var(--blue);     color:var(--on-blue)}
+.pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+.pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+.pin--green {background:var(--green);    color:var(--on-green)}
+.pin--outline{background:var(--panel); border:1px solid currentColor}
+.pin--gray.pin--outline  {color:var(--gray)}
+.pin--blue.pin--outline  {color:var(--blue)}
+.pin--yellow.pin--outline{color:var(--yellow)}
+.pin--green.pin--outline {color:var(--green)}
+.pin--red.pin--outline   {color:var(--red-line)}
+.pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+.pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+  padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+  border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+  line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+.pin[data-tip]:hover:after,
+.pin[data-tip]:focus-visible:after{display:block}
+
+/* ---- misc demo scaffolding: Pin group host tile (page-local, not shared vocabulary) ---- */
+.pin-tile{width:56px; height:40px; border-radius:8px; border:1px solid var(--line); background:var(--card);
+  display:inline-flex; align-items:center; justify-content:center; color:var(--txt-3)}
+.pin-tile svg{width:18px; height:18px}
 </style>
 </head>
 <body>
@@ -219,7 +295,7 @@ code{font-family:var(--font-mono)}
     </div>
     <div class="panel pad" style="margin-top:14px">
       <div class="group-label">--font (body voice)</div>
-      <code style="font-size:12px">"Geist", -apple-system, "Segoe UI", sans-serif</code>
+      <code style="font-size:12px">"Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif</code>
       <div class="group-label">--font-mono (stamped voice)</div>
       <code style="font-size:12px">ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace</code>
     </div>
@@ -279,22 +355,22 @@ code{font-family:var(--font-mono)}
     <div class="panel pad">
       <div class="group-label">Every gate colour — a Signal you can turn</div>
       <div class="row">
-        <span class="gate gate--gray"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>n/a</span>
-        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>waiting</span>
-        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>do now</span>
-        <span class="gate gate--red"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>overdue</span>
-        <span class="gate gate--green"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>done</span>
+        <button type="button" class="gate gate--gray"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>n/a</button>
+        <button type="button" class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>waiting</button>
+        <button type="button" class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>do now</button>
+        <button type="button" class="gate gate--red"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>overdue</button>
+        <button type="button" class="gate gate--green"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>done</button>
       </div>
       <div class="group-label">Opens a status picker</div>
       <div class="row">
-        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
-        <div class="menu">
-          <div class="menu__h">Move rental to…</div>
-          <div class="menu__i"><span class="menu__sw" style="background:var(--gray)"></span>Reserved</div>
-          <div class="menu__i on"><span class="menu__sw" style="background:var(--blue)"></span>On Rent</div>
-          <div class="menu__i"><span class="menu__sw" style="background:var(--yellow)"></span>End Rent</div>
-          <div class="menu__i"><span class="menu__sw" style="background:var(--green)"></span>Returned</div>
-        </div>
+        <button type="button" class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</button>
+        <span class="seg seg--stack" style="max-width:190px">
+          <button type="button" class="seg__opt seg__opt--on-accent" style="justify-content:center">Move rental to…</button>
+          <button type="button" class="seg__opt">Reserved</button>
+          <button type="button" class="seg__opt seg__opt--on-blue">On Rent</button>
+          <button type="button" class="seg__opt">End Rent</button>
+          <button type="button" class="seg__opt">Returned</button>
+        </span>
       </div>
     </div>
   </section>
@@ -334,7 +410,7 @@ code{font-family:var(--font-mono)}
       <div class="group-label">In situ — a mock list row</div>
       <div class="row">
         <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span>12k Excavator</a>
-        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>due back</span>
+        <button type="button" class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>due back</button>
         <span class="stamp">non-member</span><span class="stamp-sep">·</span><span class="stamp">PO 4821</span>
         <span class="signal signal--red signal--outline">field call</span>
       </div>
@@ -346,45 +422,45 @@ code{font-family:var(--font-mono)}
     <h2 class="atom-label"><span class="n">07</span>Buttons / Doors · Verb actions</h2>
     <div class="panel">
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Commit / create</div><div class="spec-row__rr">solid --commit</div></div>
-        <div class="spec-row__ex"><button class="door door--commit">Save</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--commit">Save</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">+Add</div><div class="spec-row__rr">dashed outline, --commit</div></div>
-        <div class="spec-row__ex"><span class="door door--add">+ Add</span></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--add"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>Add</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Takes money</div><div class="spec-row__rr">solid --green</div></div>
-        <div class="spec-row__ex"><button class="door door--money">Collect Payment</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--money">Collect Payment</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Destructive-confirm</div><div class="spec-row__rr">solid --red-fill</div></div>
-        <div class="spec-row__ex"><button class="door door--destroy">Delete Rental</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--destroy">Delete Rental</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Cancel / secondary</div><div class="spec-row__rr">ghost — the one quiet look</div></div>
-        <div class="spec-row__ex"><button class="door door--ghost">Cancel</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--ghost">Cancel</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Active toggle segment</div><div class="spec-row__rr">filled Signal chip of selected status; falls back to orange</div></div>
         <div class="spec-row__ex">
-          <span class="seg"><span class="seg__opt seg__opt--on-yellow">Do Now</span><span class="seg__opt">Later</span></span>
-          <span class="seg"><span class="seg__opt seg__opt--on-accent">Insured</span><span class="seg__opt">Uninsured</span></span>
+          <span class="seg"><button type="button" class="seg__opt seg__opt--on-yellow">Do Now</button><button type="button" class="seg__opt">Later</button></span>
+          <span class="seg seg--state"><button type="button" class="seg__opt seg__opt--on-green">Insured</button><button type="button" class="seg__opt seg__opt--off-red">Uninsured</button></span>
         </div></div>
     </div>
     <div class="panel pad" style="margin-top:14px">
       <div class="group-label">Form footer — commit vs. cancel</div>
       <div class="row" style="justify-content:flex-end">
-        <button class="door door--ghost">Cancel</button>
-        <button class="door door--commit">Save Rental</button>
+        <button type="button" class="door door--ghost">Cancel</button>
+        <button type="button" class="door door--commit">Save Rental</button>
       </div>
       <div class="group-label">Add-line row</div>
-      <div class="row"><span class="door door--add">+ Add Unit</span><span class="door door--add">+ Add Note</span></div>
+      <div class="row"><button type="button" class="door door--add"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>Add Unit</button><button type="button" class="door door--add"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>Add Note</button></div>
       <div class="group-label">Payment &amp; destructive</div>
       <div class="row">
-        <button class="door door--money">Collect Payment</button>
-        <button class="door door--destroy">Delete Rental</button>
+        <button type="button" class="door door--money">Collect Payment</button>
+        <button type="button" class="door door--destroy">Delete Rental</button>
       </div>
       <div class="group-label">Filter / segmented toggle bar</div>
       <div class="row">
         <span class="seg">
-          <span class="seg__opt seg__opt--on-accent">All</span>
-          <span class="seg__opt">Mine</span>
-          <span class="seg__opt">Yard</span>
+          <button type="button" class="seg__opt seg__opt--on-accent">All</button>
+          <button type="button" class="seg__opt">Mine</button>
+          <button type="button" class="seg__opt">Yard</button>
         </span>
         <span class="seg">
-          <span class="seg__opt seg__opt--on-red">Overdue</span>
-          <span class="seg__opt">Due Soon</span>
-          <span class="seg__opt">Later</span>
+          <button type="button" class="seg__opt seg__opt--on-red">Overdue</button>
+          <button type="button" class="seg__opt">Due Soon</button>
+          <button type="button" class="seg__opt">Later</button>
         </span>
       </div>
     </div>
@@ -396,8 +472,8 @@ code{font-family:var(--font-mono)}
     <div class="panel pad">
       <div class="group-label">Field (select-style input)</div>
       <div class="row">
-        <span class="field">Rider: All-risk <span class="field__car">▾</span></span>
-        <span class="field">Deposit: $250 <span class="field__car">▾</span></span>
+        <button type="button" class="field">Rider: All-risk <span class="field__car">▾</span></button>
+        <button type="button" class="field">Deposit: $250 <span class="field__car">▾</span></button>
       </div>
       <div class="group-label">Contact — the number itself is the link</div>
       <div class="row">
@@ -405,9 +481,32 @@ code{font-family:var(--font-mono)}
       </div>
       <div class="group-label">Hyperlink — the "true hyperlink ↗" + plain dead text, for contrast</div>
       <div class="row">
-        <a class="hlink">service schedule <span class="hlink__ext">↗</span></a>
+        <a class="hlink">service schedule<span class="hlink__ext"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg></span></a>
         <span class="dead-text">S/N 4471-K</span><span class="t-hint">— a plain, non-tappable fact</span>
       </div>
+    </div>
+  </section>
+
+
+  <!-- ============================= 9. PINS ============================= -->
+  <section class="atom" id="pins">
+    <h2 class="atom-label"><span class="n">09</span>Pins · Corner markers</h2>
+    <div class="panel pad">
+      <div class="group-label">Every state colour — filled (today) vs. outline, anchored on a host's top-right corner</div>
+      <div class="row">
+        <span class="pin-wrap"><span class="pin-tile">A</span><a class="pin pin--gray" data-tip="Nothing pending">·</a></span>
+        <span class="pin-wrap"><span class="pin-tile">B</span><a class="pin pin--blue pin--outline" data-tip="Waiting on customer">2</a></span>
+        <span class="pin-wrap"><span class="pin-tile">C</span><a class="pin pin--yellow" data-tip="Due back today">MON</a></span>
+        <span class="pin-wrap"><span class="pin-tile">D</span><a class="pin pin--red" data-tip="3 unread field calls">3</a></span>
+        <span class="pin-wrap"><span class="pin-tile">E</span><a class="pin pin--green pin--outline" data-tip="Closed out today">✓</a></span>
+      </div>
+      <div class="group-label">Content is free — number, weekday, icon; hover/focus explains via data-tip, click teleports</div>
+      <div class="row">
+        <span class="pin-wrap"><span class="pin-tile"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span><a class="pin pin--red" data-tip="Rental #4471 — 3 days overdue">3</a></span>
+        <span class="pin-wrap"><span class="pin-tile"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><a class="pin pin--yellow" data-tip="Due back Thu">THU</a></span>
+      </div>
+      <p class="t-hint" style="margin:10px 0 0">13px tall — deliberately off the 24px control ladder — and zero layout footprint: absolutely
+        positioned, no margin, no reserved space. Colour = state, fill = today, exactly like a Signal.</p>
     </div>
   </section>
 

--- a/docs/design/atoms-canvas.html
+++ b/docs/design/atoms-canvas.html
@@ -1,0 +1,416 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Atoms</title>
+<style>
+:root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+}
+
+/* ================= page chrome — ONE simple layout for every atom section ================= */
+*{box-sizing:border-box}
+html,body{margin:0}
+body{background:var(--bg)}
+.page{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+  -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+.sheet{max-width:1040px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+code{font-family:var(--font-mono)}
+
+.masthead{padding-bottom:20px; margin-bottom:8px; border-bottom:1px solid var(--line)}
+.masthead h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(20px,3.2vw,26px);
+  letter-spacing:-.01em; color:var(--txt); margin:0 0 6px; line-height:1.15}
+.masthead h1 .hl{color:var(--accent)}
+.masthead p{margin:0; font-size:12.5px; color:var(--txt-3)}
+
+.atom{margin-top:40px; padding-top:8px}
+.atom-label{display:flex; align-items:baseline; gap:8px; font-family:var(--font-mono); font-size:11px;
+  font-weight:800; letter-spacing:.14em; text-transform:uppercase; color:var(--txt-3);
+  margin:0 0 12px; padding-bottom:8px; border-bottom:1px solid var(--line)}
+.atom-label .n{color:var(--accent)}
+
+.group-label{font-family:var(--font-mono); font-size:10px; font-weight:800; letter-spacing:.08em;
+  text-transform:uppercase; color:var(--txt-3); margin:18px 0 9px}
+.group-label:first-child{margin-top:0}
+
+.panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+.pad{padding:18px 20px}
+.row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+.row.tight{gap:6px}
+
+/* ============================================================================
+   SHARED VOCABULARY — Signal / Gate / Stamp / Ref / Door / Seg / Field / links
+   Included ONCE — identical across all 8 source cards (tokens.css + each
+   rw-design-system/*.html <style> block share this verbatim). Class names are
+   unchanged so edits here map straight back to the kit.
+   ============================================================================ */
+
+/* ---- SIGNAL — read-only state; colour=state, fill=today ---- */
+.signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+  border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+  letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+.signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+.signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+.signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+.signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+.signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+.signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+.signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+.signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+.signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+.signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+/* ---- GATE — a Signal you can turn: + leading centred chevron ---- */
+.gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+  border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+  letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+.gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+.gate__chev svg{width:12px; height:12px; display:block}
+.gate--blue  {background:var(--blue);     color:var(--on-blue)}
+.gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+.gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+.gate--green {background:var(--green);    color:var(--on-green)}
+.gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+/* ---- STAMP — a quiet fact: chip text, no box, no colour ---- */
+.stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+  font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+  text-transform:uppercase; color:var(--txt-3)}
+.stamp--more{color:var(--accent)}
+.stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+/* ---- REF — a linked record: accent-tinted icon backing + name ---- */
+.ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+  border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+  font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  text-decoration:none; cursor:pointer}
+.ref:hover{border-color:var(--accent)}
+.ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+.ref__icon svg{width:12px; height:12px}
+.ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+.ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+.ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+/* ---- DOOR — a verb action: radius=pill, colour=intent, never status ---- */
+.door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+  border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+  letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+.door--commit {background:var(--commit); color:var(--on-commit)}
+.door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+.door--money  {background:var(--green); color:var(--on-green)}
+.door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+.door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+.seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+.seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+  font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+  border-right:1px solid var(--line); cursor:pointer; background:transparent}
+.seg__opt:last-child{border-right:0}
+.seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+.seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+.seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+.seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+/* ---- FIELDS / links ---- */
+.field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+  border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+  font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+.field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+.contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+  font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+.contact svg{color:var(--accent); width:14px; height:14px}
+.contact__v{border-bottom:1.4px solid transparent}
+.contact:hover .contact__v{border-bottom-color:var(--accent)}
+.hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+  border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+.hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+.dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+/* ============================================================================
+   Supporting text-role classes — used by the Texts spec table and the Buttons
+   taxonomy table (role / example two-column row).
+   ============================================================================ */
+.spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+.spec-row:last-child{border-bottom:0}
+.spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+.spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+  text-transform:uppercase; color:var(--txt)}
+.spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+.spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+
+.t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+.t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+.t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+.t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+.t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+/* ============================================================================
+   Status-picker menu — used by the Gates "opens a status picker" demo only.
+   ============================================================================ */
+.menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+.menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+  color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+.menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+  border-bottom:1px solid var(--line-soft); cursor:pointer}
+.menu__i:last-child{border-bottom:0}
+.menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+.menu__i.on{font-weight:800}
+.menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+</style>
+</head>
+<body>
+<div class="page"><div class="sheet">
+
+  <div class="masthead">
+    <h1>Rental Wrangler — <span class="hl">Atoms</span></h1>
+    <p>Family-view canvas · the 8 atom groups, consolidated on one token set. Dark-only, editable.</p>
+  </div>
+
+  <!-- ============================= 1. TEXTS ============================= -->
+  <section class="atom" id="texts">
+    <h2 class="atom-label"><span class="n">01</span>Texts · Type voices</h2>
+    <div class="panel">
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Stamped label</div><div class="spec-row__rr">mono · 700–800 · uppercase · tracked</div></div>
+        <div class="spec-row__ex"><span class="t-stamp2" style="font-size:14px">Work Orders</span><span class="t-stamp2">Purchase date</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Record name</div><div class="spec-row__rr">sans · bold · sentence-case</div></div>
+        <div class="spec-row__ex"><span class="t-name">Boudreaux Marine LLC</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Value / prose</div><div class="spec-row__rr">sans · regular</div></div>
+        <div class="spec-row__ex"><span class="t-prose">Marine construction · Cameron, LA — net 15 terms.</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Number / ID / $ / time</div><div class="spec-row__rr">mono · tabular-nums</div></div>
+        <div class="spec-row__ex"><span class="t-num">#4471 · $4,250.00 · 2h ago · S/N 4471-K</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Chip / flag text</div><div class="spec-row__rr">mono · 700 · caps · label-size</div></div>
+        <div class="spec-row__ex"><span class="signal signal--yellow signal--filled">due back</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Hint / empty state</div><div class="spec-row__rr">sans · italic · muted</div></div>
+        <div class="spec-row__ex"><span class="t-hint">No cards on file yet</span></div>
+      </div>
+    </div>
+    <div class="panel pad" style="margin-top:14px">
+      <div class="group-label">--font (body voice)</div>
+      <code style="font-size:12px">"Geist", -apple-system, "Segoe UI", sans-serif</code>
+      <div class="group-label">--font-mono (stamped voice)</div>
+      <code style="font-size:12px">ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace</code>
+    </div>
+  </section>
+
+  <!-- ============================= 2. STAMPS ============================= -->
+  <section class="atom" id="stamps">
+    <h2 class="atom-label"><span class="n">02</span>Stamps · Quiet facts</h2>
+    <div class="panel pad">
+      <div class="group-label">A Signal with its quiet Stamp siblings</div>
+      <div class="row tight">
+        <span class="signal signal--red signal--filled" style="margin-right:2px">owed 16d</span>
+        <span class="stamp">non-member</span><span class="stamp-sep">·</span>
+        <span class="stamp">excavator</span><span class="stamp-sep">·</span>
+        <span class="stamp">PO 4821</span><span class="stamp-sep">·</span>
+        <span class="stamp stamp--more">+2</span>
+      </div>
+      <div class="group-label">Stamp alone — never a status</div>
+      <div class="row tight">
+        <span class="stamp">S/N 4471-K</span><span class="stamp-sep">·</span>
+        <span class="stamp">2019</span><span class="stamp-sep">·</span>
+        <span class="stamp">75hp</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================= 3. SIGNALS ============================= -->
+  <section class="atom" id="signals">
+    <h2 class="atom-label"><span class="n">03</span>Signals · Read-only state</h2>
+    <div class="panel pad">
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--gray signal--outline">n/a</span>
+        <span class="signal signal--gray signal--filled">n/a</span>
+      </div>
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--blue signal--outline">waiting</span>
+        <span class="signal signal--blue signal--filled">on rent</span>
+      </div>
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--yellow signal--outline">near due</span>
+        <span class="signal signal--yellow signal--filled">due back</span>
+      </div>
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--red signal--outline">field call</span>
+        <span class="signal signal--red signal--filled">3 days overdue</span>
+      </div>
+      <div class="row">
+        <span class="signal signal--green signal--filled">returned today</span>
+        <span class="t-hint">green is filled-only in practice — a completion, not a temperature; ages to gray tomorrow.</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================= 4. GATES ============================= -->
+  <section class="atom" id="gates">
+    <h2 class="atom-label"><span class="n">04</span>Gates · Turnable state</h2>
+    <div class="panel pad">
+      <div class="group-label">Every gate colour — a Signal you can turn</div>
+      <div class="row">
+        <span class="gate gate--gray"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>n/a</span>
+        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>waiting</span>
+        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>do now</span>
+        <span class="gate gate--red"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>overdue</span>
+        <span class="gate gate--green"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>done</span>
+      </div>
+      <div class="group-label">Opens a status picker</div>
+      <div class="row">
+        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
+        <div class="menu">
+          <div class="menu__h">Move rental to…</div>
+          <div class="menu__i"><span class="menu__sw" style="background:var(--gray)"></span>Reserved</div>
+          <div class="menu__i on"><span class="menu__sw" style="background:var(--blue)"></span>On Rent</div>
+          <div class="menu__i"><span class="menu__sw" style="background:var(--yellow)"></span>End Rent</div>
+          <div class="menu__i"><span class="menu__sw" style="background:var(--green)"></span>Returned</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================= 5. REFS ============================= -->
+  <section class="atom" id="refs">
+    <h2 class="atom-label"><span class="n">05</span>Refs · Linked records</h2>
+    <div class="panel pad">
+      <div class="group-label">Every linked record is a Ref — its own type icon, never one generic glyph</div>
+      <div class="row">
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon Contracting</a>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span>Skid Steer <span class="ref__id">SS-12</span></a>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span>Invoice <span class="ref__id">#4460</span></a>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>Rental <span class="ref__id">#4471</span></a>
+      </div>
+      <div class="group-label">Walks across cards — a trace</div>
+      <div class="ref-trace">
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon</a><span class="ref-trace__arrow">→</span>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>Rental <span class="ref__id">#4471</span></a><span class="ref-trace__arrow">→</span>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span>#4460</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================= 6. CHIPS ============================= -->
+  <section class="atom" id="chips">
+    <h2 class="atom-label"><span class="n">06</span>Chips · The matrix</h2>
+    <div class="panel pad">
+      <div class="group-label">Filled / outline matrix — every status</div>
+      <div class="row">
+        <span class="signal signal--gray signal--outline">n/a</span><span class="signal signal--gray signal--filled">n/a</span>
+        <span class="signal signal--blue signal--outline">waiting</span><span class="signal signal--blue signal--filled">waiting</span>
+        <span class="signal signal--yellow signal--outline">do now</span><span class="signal signal--yellow signal--filled">do now</span>
+        <span class="signal signal--red signal--outline">bad</span><span class="signal signal--red signal--filled">bad</span>
+        <span class="signal signal--green signal--filled">done today</span>
+      </div>
+      <div class="group-label">In situ — a mock list row</div>
+      <div class="row">
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span>12k Excavator</a>
+        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>due back</span>
+        <span class="stamp">non-member</span><span class="stamp-sep">·</span><span class="stamp">PO 4821</span>
+        <span class="signal signal--red signal--outline">field call</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================= 7. BUTTONS / DOORS ============================= -->
+  <section class="atom" id="buttons">
+    <h2 class="atom-label"><span class="n">07</span>Buttons / Doors · Verb actions</h2>
+    <div class="panel">
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Commit / create</div><div class="spec-row__rr">solid --commit</div></div>
+        <div class="spec-row__ex"><button class="door door--commit">Save</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">+Add</div><div class="spec-row__rr">dashed outline, --commit</div></div>
+        <div class="spec-row__ex"><span class="door door--add">+ Add</span></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Takes money</div><div class="spec-row__rr">solid --green</div></div>
+        <div class="spec-row__ex"><button class="door door--money">Collect Payment</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Destructive-confirm</div><div class="spec-row__rr">solid --red-fill</div></div>
+        <div class="spec-row__ex"><button class="door door--destroy">Delete Rental</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Cancel / secondary</div><div class="spec-row__rr">ghost — the one quiet look</div></div>
+        <div class="spec-row__ex"><button class="door door--ghost">Cancel</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Active toggle segment</div><div class="spec-row__rr">filled Signal chip of selected status; falls back to orange</div></div>
+        <div class="spec-row__ex">
+          <span class="seg"><span class="seg__opt seg__opt--on-yellow">Do Now</span><span class="seg__opt">Later</span></span>
+          <span class="seg"><span class="seg__opt seg__opt--on-accent">Insured</span><span class="seg__opt">Uninsured</span></span>
+        </div></div>
+    </div>
+    <div class="panel pad" style="margin-top:14px">
+      <div class="group-label">Form footer — commit vs. cancel</div>
+      <div class="row" style="justify-content:flex-end">
+        <button class="door door--ghost">Cancel</button>
+        <button class="door door--commit">Save Rental</button>
+      </div>
+      <div class="group-label">Add-line row</div>
+      <div class="row"><span class="door door--add">+ Add Unit</span><span class="door door--add">+ Add Note</span></div>
+      <div class="group-label">Payment &amp; destructive</div>
+      <div class="row">
+        <button class="door door--money">Collect Payment</button>
+        <button class="door door--destroy">Delete Rental</button>
+      </div>
+      <div class="group-label">Filter / segmented toggle bar</div>
+      <div class="row">
+        <span class="seg">
+          <span class="seg__opt seg__opt--on-accent">All</span>
+          <span class="seg__opt">Mine</span>
+          <span class="seg__opt">Yard</span>
+        </span>
+        <span class="seg">
+          <span class="seg__opt seg__opt--on-red">Overdue</span>
+          <span class="seg__opt">Due Soon</span>
+          <span class="seg__opt">Later</span>
+        </span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================= 8. FIELDS ============================= -->
+  <section class="atom" id="fields">
+    <h2 class="atom-label"><span class="n">08</span>Fields · Inputs / contact links</h2>
+    <div class="panel pad">
+      <div class="group-label">Field (select-style input)</div>
+      <div class="row">
+        <span class="field">Rider: All-risk <span class="field__car">▾</span></span>
+        <span class="field">Deposit: $250 <span class="field__car">▾</span></span>
+      </div>
+      <div class="group-label">Contact — the number itself is the link</div>
+      <div class="row">
+        <a class="contact"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z"/></svg><span class="contact__v">(337) 555-0142</span></a>
+      </div>
+      <div class="group-label">Hyperlink — the "true hyperlink ↗" + plain dead text, for contrast</div>
+      <div class="row">
+        <a class="hlink">service schedule <span class="hlink__ext">↗</span></a>
+        <span class="dead-text">S/N 4471-K</span><span class="t-hint">— a plain, non-tappable fact</span>
+      </div>
+    </div>
+  </section>
+
+</div></div>
+</body>
+</html>

--- a/docs/design/labs-build-order.md
+++ b/docs/design/labs-build-order.md
@@ -1,0 +1,56 @@
+# Labs pipeline — prompt framework + build order
+
+**Pipeline: option C.** Every screen goes through Design Labs; Jac approves every inch.
+Two rules keep it focused instead of redundant.
+
+## Rule 1 — North Star per prompt (objective + anti-objectives)
+Every prompt opens with:
+- **North Star (objective):** ONE sentence — what this screen is deciding. The only thing to approve here.
+- **Out of scope (anti-objectives):** an explicit list of what NOT to critique or redesign in this
+  prompt — because it's already locked, or it belongs to a later screen. This is the leash on the
+  "save the whole app from everything wrong" urge. If it's on this list, it doesn't matter *here*.
+
+## Rule 2 — Inherit locked elements (carry-forward)
+Every prompt names the already-approved components it MUST reuse **verbatim** (not redesign). Once
+the card header is locked, it appears unchanged on every later mockup. Labs is told to embed them;
+Jac is reminded they're decided. Each screen approved adds its components to the registry below.
+
+## Locked-elements registry (grows as we approve)
+- ✅ **Design system** — tokens, palette, type, Signal·Gate·Stamp·Ref·Door (synced to Labs).
+- ⏳ **Bounded-detail + section-rail model** — the current screen; locks on approval.
+- _(each approved screen appends its components here, so later prompts inherit them)_
+
+## Build order (dependency-driven — foundations first, then fill)
+**Tier 0.0 — ATOMS (the builder elements — review the kit, refine, LOCK):**
+0. **Texts · flags · chips · buttons** — Signal·Gate·Stamp·Ref·Door + Buttons/Chips/Fields/Stamps.
+   Already drafted in the design-system kit on our real tokens. Review deliberately, refine, LOCK.
+
+**Tier 0.1 — CONTAINERS (the reusable shells everything is poured into — design, LOCK):**
+1. **Card frame · card header · list row · section/plate · panel/popup · action-menu** — the shells,
+   designed as their own artifacts and approved BEFORE anything composes them. (Header + row shared
+   by all 7 cards.)
+   - **action / overflow menu** — added 2026-07-25. `.menu` was DROPPED from the atoms (the status
+     *picker* is now `.seg--stack`). A menu of unrelated **actions** (⋯ → Duplicate · Export ·
+     Archive · Delete) is a different job and a *container*, not an atom — design it here so it
+     never gets improvised mid-screen.
+
+**Tier 0.2 — THE SHELL (composes the locked containers):**
+2. **App shell** — 3-column yard grid, top bar, footer rail. Decides column widths AND *how a
+   row-expansion relates to the columns* (the 3-col question). ← current draft parks here.
+
+**Tier 1 — INTERACTION MODEL:**
+3. **Bounded detail + section rail** — expand-in-place (already drafted; locks once it sits in the shell).
+
+**Tier 2 — PER-CARD CONTENT (inherits Tiers 0–1):**
+4. Units · 5. Rentals (calendar-anchored) · 6. Customers · 7. remaining cards (Trips, Invoices…)
+   — each card's list groups + its section set.
+
+**Tier 3 — CROSS-CUTTING SURFACES (inherit the frame):**
+8. Item tabs / Comms tabs · 9. footer-rail open chats · 10. notifications / toasts / popup
+   notifications · 11. settings boards · 12. creation flows / functional popups / wizards ·
+   13. states — empty/loading, login, mobile reflow.
+
+## Note on sequencing
+We started at **Tier 1** (detail view) before **Tier 0** (shell). The detail *model* is proven —
+keep it. Next we lock the **shell**, which also resolves the 3-column-vs-rail tension (below), and
+becomes the first frame every later screen inherits.

--- a/docs/design/prompts/prompt-00-atoms.md
+++ b/docs/design/prompts/prompt-00-atoms.md
@@ -1,0 +1,43 @@
+# Labs — Prompt 0.0 · Lock the Atoms (the builder elements)
+
+**This is a review-and-refine pass, not a regenerate.** The atoms already exist in the kit,
+code-accurate on our real tokens. Open them, scrutinize every inch, refine what's off, LOCK.
+
+**Canvas — open these atom cards from the `rw-design-system` folder** (they each render one atom
+with its variants):
+- `foundations/type.html` — **texts** (the two voices: stamped-mono vs body-sans)
+- `elements/stamp.html` — **quiet facts / IDs / numbers**
+- `elements/signal.html` — **flags** (read-only state, filled vs outline, all state colours)
+- `elements/gate.html` — **turnable state** (the chevron)
+- `elements/ref.html` — **linked records**
+- `components/chips.html` — the **chip** matrix
+- `elements/door.html` + `components/buttons.html` — **buttons / actions** (commit · +Add · money · destroy · ghost · cancel · active-toggle)
+- `components/fields.html` — **inputs / contact links**
+
+---
+
+## ⭐ North Star — the one thing this pass decides
+Scrutinize, refine, and **LOCK** the builder atoms — the smallest pieces every screen is made of.
+Once locked, no later screen gets to re-open them.
+
+## 🚫 Out of scope (NOT here)
+- **Containers** — the card frame, card header, list row, section/plate, panel/popup. That's the very
+  next tier; don't design them here.
+- **Any screen layout** — shell, detail view, per-card content. Later.
+- **The palette / type / token VALUES** — settled canon. The hexes are CVD-tuned and locked from prior
+  colour work; don't reopen them unless one is genuinely broken (tell me if so).
+
+## ♻️ Inherit (settled — do not redesign)
+- The **palette, the two type voices, and the tokens.** The atoms are built *on* these; they're the
+  ground floor and they're already locked.
+
+## The ask
+Judge the atoms as **one family**: do the chips, buttons, flags, stamps, refs read as siblings — same
+control height, same baseline, same radii, same weight logic? Walk each atom's variants and refine
+spacing / weight / size / states until each is *exactly* right. Note any inconsistency across the set.
+When an atom is right, it's **locked** — it becomes a carried-forward element on every screen after.
+
+## After you lock
+Tell me what (if anything) you changed. I fold your changes into the code-accurate kit and **re-sync
+the design system**, so the grounding every later screen reads = your locked atoms. Then we design the
+**containers** on top of them.

--- a/docs/design/prompts/prompt-01-detail-views.md
+++ b/docs/design/prompts/prompt-01-detail-views.md
@@ -1,0 +1,52 @@
+# Claude Design Labs — Prompt 1 of N · Detail Views (Units / Rentals / Customers)
+
+**Uploads for this session (attach both):**
+1. `design-system.html` — the **Rental Wrangler Design System**. This is the locked ground truth: the steel palette + colour law, the two type voices, the size/control rules, and the five-part element vocabulary (**Signal · Gate · Stamp · Ref · Door**). Everything you build uses *only* these pieces, at these values. Do not invent new colours, new component types, or new type styles.
+2. `detail-views.html` — the **current** detail-view mockup (the starting point you're evolving). It shows the three records — a **Unit**, a **Rental**, a **Customer** — each rendered as a vertical *plate-stack*: every section stacked open at once (Inspection, Services, Work Orders, Specs, GPS… then a History footer). It's built correctly to the design system — but stacking every section open makes the record **too tall**. Your job is to fix exactly that, without losing anything.
+
+---
+
+## The product, in one breath
+Rental Wrangler is the yard-management app for **JacRentals**, a heavy-equipment rental company. A user clicks a row in a list (a unit, a rental, a customer) and it **expands in place** to reveal that record's detail. The look is a **dark industrial "yard data-plate"** — matte steel, one safety-orange accent, stamped condensed labels. It is **dark-theme only** (never emit a light mode).
+
+## The one problem to solve
+When a record expands inline, showing **all** its sections stacked open makes it **enormous** — the Customer record alone runs ~5 phone-screens tall. We want the richness of every section **without** the height. The settled answer is a **bounded, paging** detail view driven by a **section rail**. Build that.
+
+## The target model — build this exactly
+
+**1. Inline expand, bounded height.**
+The detail lives *inside* an expanded list row (keep that — do not turn it into a separate full page). The expansion opens to **one fixed maximum height** that **every record obeys** — Units, Rentals, and Customers all expand to the same height envelope, so the list never jumps around unpredictably. Use a clamped target (e.g. `clamp(320px, 62vh, 660px)`) so it's generous on desktop and sane on a phone. **A single section that's taller than that envelope scrolls *inside its own pane*** — the record's outer height never grows past the envelope.
+
+**2. A section RAIL across the top.**
+Directly under the record's header, lay a **horizontal rail of section chips** — one chip per section (Inspection, Services, Work Orders, Specs, GPS, Investment, Notes… for a Unit; the Rental/Customer sets differ, see below). Each chip is the section's **at-a-glance summary**, and the rail is how you move between sections. Every chip carries **three things**:
+   - **A rolled-up Signal** — the single worst state inside that section, as a **Signal** dot/chip from the vocabulary. (A Work-Orders section with one overdue WO rolls up **red**; a Services section with a wash due today rolls up **yellow**; an all-clear section rolls up **grey**.) This is the whole point: because the rail shows *every* section's rolled-up state at once, **paging hides nothing** — the user always sees where the trouble is, even on sections they haven't opened.
+   - **Colour = state** — the chip's colour **is** that rolled-up Signal state (red > yellow > blue > green > grey, hottest wins). Never colour a chip by anything else.
+   - **The section's primary action** — the one **Door** (verb action) that section most wants, sitting **on the rail chip itself** (e.g. Inspection → *Start inspection*; Work Orders → *New WO*; Payment → *Charge*). One primary Door per chip, not a menu.
+
+**3. The rail PAGES — one section open at a time.**
+Clicking a chip **pages** that section into the single content pane below the rail. Only **one** section's body is shown at a time; the rail stays fixed above it, always showing all sections' rolled-up signals. Moving between sections is a chip click — no long scroll, no accordion stack. The pane swaps content (a smooth, quick swipe-style transition is welcome, but subtle — matte, no glow, no bounce). The **first** section shown on open is the record's **Signal summary / most-urgent** section (land the user on what needs them).
+
+**4. History, pinned as a footer.**
+Return the **History footer** the current mockup already has (`12 Inspections · 3 WOs · 5 Rentals · 8 Washes`, etc.) — a thin, pinned strip at the **bottom** of the expanded record, always visible under the paging pane. It's a Ref-style set of counts that opens the record's history/search. It is **not** one of the rail's paging sections — it's a persistent footer.
+
+**5. Normal section order.**
+Keep the sections in their **natural, familiar order** on the rail (the order the current mockup uses per card). Don't re-sort by severity — the rail's *colour* already surfaces severity; the *order* stays stable so muscle memory holds.
+
+## The three records to render (same model, three section sets)
+Use the sections already in `detail-views.html`:
+- **Unit:** Inspection · Services · Work Orders · Specs · GPS · Investment · Notes → History footer.
+- **Rental:** Rental · (its sections per the mockup) → History footer.
+- **Customer:** Account · Funnel · Invoices · Activity · Payment → History footer.
+Render all three so the model is proven on the lightest (Unit) through the densest (Customer).
+
+## Hard constraints (from the design system — do not drift)
+- **Only** the five vocabulary pieces: **Signal** (read-only state), **Gate** (turnable state), **Stamp** (quiet fact), **Ref** (linked record), **Door** (verb action). *Nothing does two jobs.* No new component types.
+- **Colour = state; fill = today.** Status colours mean state only; **buttons/Doors carry no status colour** (actions are neutral — white/deep-action-blue commit, ghost secondary). Green = **Done today** only. Blue = **Waiting** (someone else's move). Red = bad. Yellow = your move now. Grey = nothing.
+- **Two type voices:** stamped/condensed for labels, chips, IDs, and tabular numbers; body-sans for record names and prose. Dollar figures and counts use the stamped/tabular voice.
+- **Matte.** No glow, no neon, no drop-shadow bloom. One safety-orange accent, kept under ~10% of the surface (icons, active toggle, gate mark).
+- **Dark-theme only.** Emit no light-mode styles.
+
+## Deliverable
+**One** self-contained, iterable HTML artifact (inline CSS/JS, no external deps) that renders all **three** detail views to the target model above, so we can click the rail chips and watch sections page within the bounded height. Make the rail, the paging, the rolled-up signals, the on-chip primary Doors, the internal scroll of an over-tall section, and the pinned History footer all **real and clickable** — this is a working mockup we'll iterate on, not a static picture.
+
+**When you're done,** give me a one-paragraph note on any place the target model and the design system pulled against each other and how you resolved it (e.g. where a primary Door wanted a status colour but the button rule forbids it).

--- a/docs/design/prompts/prompt-02-shell.md
+++ b/docs/design/prompts/prompt-02-shell.md
@@ -1,0 +1,47 @@
+# Claude Design Labs — Prompt 2 · The App Shell (the 3-column yard frame)
+
+**Design system:** Rental Wrangler Design System (already in place — build only from it).
+**Optional reference:** you may be shown the detail-view draft. If so, treat it as a **black-box payload** — the content that appears when a row expands. Do **NOT** restyle or redesign its internals here.
+
+---
+
+## ⭐ North Star — the one thing this screen decides
+Design the **app shell**: the 3-column yard frame every other screen lives inside — *and* decide **how a list row expands within it.**
+
+## 🚫 Out of scope (do NOT touch here — locked elsewhere or a later screen)
+- The **detail-view internals** — the section rail, the section bodies, the History footer. Separate, in-progress screen. Treat an expanded detail as an opaque block; don't restyle it.
+- **Per-card content** — the actual groups and rows inside Units vs Rentals vs Customers, and their section sets. Later screens.
+- **Notifications, toasts, settings, open comms threads, creation popups.** Later screens.
+- **New colours or components.** Everything comes from the design system — nothing invented.
+
+## ♻️ Inherit (reuse verbatim)
+- The **Rental Wrangler Design System** — tokens, palette, the two type voices, and the Signal·Gate·Stamp·Ref·Door vocabulary. Every chip, label, and action uses these.
+
+---
+
+## The frame to render
+Rental Wrangler is a heavy-equipment rental-yard app (JacRentals). The home screen is a **3-column grid, side by side**, dark data-plate look, matte, desktop-first:
+
+- **Column 1 — Units** · title toggles **Units ↔ Categories**
+- **Column 2 — Rentals** · title toggles **Rentals ↔ Calendar**, with a **Trips** sibling tab in the header
+- **Column 3 — Customers** · title toggles **Customers ↔ Sales**
+
+Each column is a **card**:
+- a **header** — left-aligned title-toggle · a search field · filter chips (e.g. **To-Do** / **Done**) · a sort control · a small **graph** button;
+- above a **scrolling list of rows** (render a few realistic collapsed rows per column — name, category/meta, a rolled-up Signal, a primary action).
+
+Around the grid:
+- a **top bar** — brand mark, current role, global chrome;
+- a **footer rail** — a slim comms / notifications / quick-action rail (just the rail, not open threads).
+
+## ⚖️ The one hard decision — row expansion
+When a user clicks a row to open its detail, the detail uses a **horizontal section rail** that does **not** fit a ⅓-width column. So the frame must give it room. **Render 2–3 honest treatments of what happens on expand, side by side or toggleable, so we can pick one:**
+
+1. **Break-out wider** — the expanded row grows in place to span ~2 columns (or full width); the other column(s) compress or dim behind it.
+2. **Anchor panel** — clicking a row pins it and opens a wider detail panel docked beside/over the grid; the list stays visible, the detail gets real width.
+3. **In-column (the honest worst case)** — the row expands inside its own ⅓ column with the rail wrapping/scrolling, so we can see exactly how cramped it gets and rule it out on sight.
+
+Use a realistic expanded record in each so the width tradeoff is visible. Keep the collapsed 3-column state as the baseline in every treatment.
+
+## Deliverable
+**One** iterable HTML artifact: the collapsed 3-column shell (top bar + three card headers + a few rows each + footer rail) **plus** the 2–3 expansion treatments, all built from the design system. Note any place the frame and the design system pulled against each other.

--- a/docs/design/rw-consistency-pass.css
+++ b/docs/design/rw-consistency-pass.css
@@ -1,0 +1,175 @@
+/* ============================================================================
+   Rental Wrangler — atom consistency pass, ready to commit to the design system.
+   Source of truth for the review: Atoms.dc.html (section 00 lists every id).
+   Rules below are UNSCOPED (the [data-pass] wrapper was review-only).
+
+   Where each block goes:
+     [A] tokens/tokens.css      — token changes + 2 new tokens
+     [B] _ds_bundle.css         — revised component rules
+     [C] _ds_bundle.css         — new: Pin atom, seg--state, seg--stack
+     [D] notes / deletions
+   ============================================================================ */
+
+
+/* ============================ [A] tokens/tokens.css ======================== */
+:root{
+  /* C14 · body voice: Archivo replaces Geist (mono voice unchanged).
+     Ship the woff2 next to Geist, or load weights 400;500;600;700;800. */
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
+
+  /* C13/C17 · THREE control shapes, one per family:
+     state chips squared · records rounded · actions pill (Doors only) */
+  --chip-radius: 2px;   /* was 7px — Signal, Gate, Field, Seg */
+  --item-radius: 8px;   /* NEW — Ref, +Add: things that are/link records */
+  --pill-radius: 999px; /* Doors only */
+
+  /* C18 · red at full chroma but higher lightness: the only legible red on the
+     dark surfaces once outline chips lost their tint (~6:1 vs --panel). */
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));
+}
+@supports (color: oklch(from red l c h)){
+  :root{ --red-line: oklch(from var(--red) .74 .215 h); }
+}
+
+
+/* ========================= [B] _ds_bundle.css — revisions ================== */
+
+/* C15 · the secondary chip is a TRUE outline: no tint backfill, 1px border in its
+   own status hue. Replaces every .signal--*.signal--outline background rule. */
+.signal--outline{background:transparent; border:1px solid currentColor}
+.signal--gray.signal--outline  {color:var(--gray)}
+.signal--blue.signal--outline  {color:var(--blue)}
+.signal--yellow.signal--outline{color:var(--yellow)}
+.signal--green.signal--outline {color:var(--green)}
+.signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+
+/* C7 · read-only atoms say so with the cursor */
+.signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
+
+/* C4 · the stamp separator is a true sibling of the stamps it sits between */
+.stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700}
+
+/* C3/C17 · Ref: content size on the ladder + the item radius */
+.ref{font-size:13px; border-radius:var(--item-radius); padding:0 10px 0 3px}
+.ref__icon{border-radius:5px}
+
+/* C5 · segment text is the ONE chip size, so a selected segment really is the
+   filled Signal chip of its status */
+.seg__opt{font-size:11px; letter-spacing:.05em}
+/* the kit had no green segment — it does now, on the chip's own tokens */
+.seg__opt--on-green{background:var(--green); color:var(--on-green)}
+
+/* M10 · +Add is built on the Ref pattern (it adds/links items): item radius, the
+   same icon holder with the + inside it, dashed commit border kept.
+   Markup: <button class="door door--add"><span class="ref__icon">{+ svg}</span>Add Unit</button> */
+.door--add{border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+.door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
+
+/* C1/C2/M12 · link atoms: 24px box, underline on the LABEL only, the out-marker is
+   a drawn arrow in the house icon holder.
+   Markup: <a class="hlink">service schedule<span class="hlink__ext">{↗ svg}</span></a> */
+.hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center}
+.hlink{border-bottom:0; padding-bottom:0; gap:7px; text-decoration:underline;
+  text-decoration-color:var(--accent); text-decoration-thickness:1.5px; text-underline-offset:3px}
+.hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+  display:inline-flex; align-items:center; justify-content:center;
+  background:var(--accent-soft); color:var(--accent)}
+.hlink__ext svg{width:10px; height:10px; display:block}
+.contact__v{border-bottom-width:1.5px}
+
+/* C19 · no atom shrinks or wraps inside a flex row */
+.ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap}
+
+/* C12 · every tappable atom is a real <button type="button">; zero the sides the
+   kit doesn't own so a segment still bleeds to its track */
+button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+  margin:0; text-align:left}
+button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+/* C20 · ONE universal hover: an accent ring drawn OUTSIDE the element, so no atom's
+   own border, fill or size changes and nothing in the layout moves.
+   On a segmented toggle the ring goes around the TRACK, never a single cell. */
+.gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+.contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+
+/* C8 · press dips the fill on filled tappables */
+.gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+
+/* C9 · hover INK is reserved for the atoms that navigate or switch */
+.seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+.ref:hover, .contact:hover{color:var(--accent)}
+
+/* C10 · one focus ring for every tappable atom */
+.gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+.ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+  outline-offset:2px}
+
+
+/* ============================ [C] _ds_bundle.css — new ===================== */
+
+/* M11 · a STATE pair toggle reads as Signals: the live state is the filled chip of
+   its status, the other side is the secondary outline in ITS OWN hue. Neutral pairs
+   (do now / later) and no-status pairs (details / activity, orange) stay plain.
+   Markup: <span class="seg seg--state">
+             <button class="seg__opt seg__opt--on-green">Insured</button>
+             <button class="seg__opt seg__opt--off-red">Uninsured</button></span> */
+.seg--state .seg__opt{border-right:0}
+.seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+  box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+.seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+  box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+.seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+/* M7 · the status picker IS the segmented toggle, stacked. Header cell is the same
+   shape filled accent (border-bottom:0 so it sits flush on the stack). */
+.seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+.seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+  border-bottom:1px solid var(--line); justify-content:flex-start}
+.seg--stack .seg__opt:last-child{border-bottom:0}
+
+/* N1 · PIN — the universal corner marker (new atom).
+   Colour = state, fill = today, exactly like a Signal. Content is free: number,
+   weekday, date, icon. Hover explains (data-tip), click teleports to the record.
+   Anchored at 70% over its host's top-right corner so ownership is unambiguous.
+   13px tall — deliberately off the 24px control ladder — and ZERO layout footprint:
+   absolutely positioned, no margin, no reserved space.
+   Markup: <span class="pin-wrap">{host}<a class="pin pin--red" data-tip="…">3</a></span> */
+.pin-wrap{position:relative; display:inline-flex; flex:none}
+.pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+  height:13px; min-width:13px; padding:0 4px;
+  display:inline-flex; align-items:center; justify-content:center; gap:3px;
+  border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+  letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+  cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+.pin svg{width:9px; height:9px; display:block}
+.pin--gray  {background:var(--gray);     color:var(--on-gray)}
+.pin--blue  {background:var(--blue);     color:var(--on-blue)}
+.pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+.pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+.pin--green {background:var(--green);    color:var(--on-green)}
+.pin--outline{background:var(--panel); border:1px solid currentColor}
+.pin--gray.pin--outline  {color:var(--gray)}
+.pin--blue.pin--outline  {color:var(--blue)}
+.pin--yellow.pin--outline{color:var(--yellow)}
+.pin--green.pin--outline {color:var(--green)}
+.pin--red.pin--outline   {color:var(--red-line)}
+.pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+.pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+  padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+  border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+  line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+.pin[data-tip]:hover:after,
+.pin[data-tip]:focus-visible:after{display:block}
+
+
+/* ================================ [D] notes =============================== */
+/* 1. DELETE the ten .signal--*.signal--outline{background:var(--*-bg)} rules — [B]
+      replaces them. The --*-bg tints stay in tokens (plates still use them).
+   2. .menu / .menu__h / .menu__i / .menu__sw are SUPERSEDED as a status picker by
+      .seg--stack. Keep the classes if other surfaces use them; the picker should not.
+   3. Doors are the only atom on --pill-radius. Nothing else may take it.
+   4. Font: add Archivo woff2 to fonts/ (weights 400–800) alongside Geist, or the
+      Google Fonts link; --font-mono is untouched.
+   5. Docs to update: Signal (outline is a border now), Ref + Door (three radii),
+      Sizing (add --item-radius, the 13px pin, the 24px control law), and a new
+      Pin page. Chips page: green stays filled-only for live status. */

--- a/docs/design/rw-design-system/README.md
+++ b/docs/design/rw-design-system/README.md
@@ -1,9 +1,10 @@
 # Rental Wrangler — design-system preview package
 
-This is a code-accurate design-system package for **Rental Wrangler** (JacRentals): 12 self-contained
-preview cards under `foundations/`, `elements/`, and `components/`, plus `tokens.css` (the raw
+This is a code-accurate design-system package for **Rental Wrangler** (JacRentals): 13 self-contained
+preview cards under `foundations/`, `elements/`, and `components/` (including the **Pin** corner-marker
+card added in the 2026-07-25 consistency pass), plus `tokens.css` (the raw
 token stylesheet) — built from the **locked `html.dv2` redesign tokens** in `style.css` (not the
-legacy `:root` values), rendering the **Signal · Gate · Stamp · Ref · Door** vocabulary from the
+legacy `:root` values), rendering the **Signal · Gate · Stamp · Ref · Door · Pin** vocabulary from the
 `wrangler-style` and `style` skills. Every file is **vanilla HTML + CSS only** (no React, no JS
 framework) and renders standalone when opened directly or dragged into a prompt — that's also how to
 use it: attach the files you need to a Claude Design Labs prompt to ground a generation, or sync the

--- a/docs/design/rw-design-system/README.md
+++ b/docs/design/rw-design-system/README.md
@@ -1,0 +1,16 @@
+# Rental Wrangler — design-system preview package
+
+This is a code-accurate design-system package for **Rental Wrangler** (JacRentals): 12 self-contained
+preview cards under `foundations/`, `elements/`, and `components/`, plus `tokens.css` (the raw
+token stylesheet) — built from the **locked `html.dv2` redesign tokens** in `style.css` (not the
+legacy `:root` values), rendering the **Signal · Gate · Stamp · Ref · Door** vocabulary from the
+`wrangler-style` and `style` skills. Every file is **vanilla HTML + CSS only** (no React, no JS
+framework) and renders standalone when opened directly or dragged into a prompt — that's also how to
+use it: attach the files you need to a Claude Design Labs prompt to ground a generation, or sync the
+whole folder as a design system via `/design-sync` in a local Claude Code session so Design Labs emits
+code matching this idiom. Dark-only, matte, no glow — there is no light mode.
+
+**The one rule underneath every file here: nothing does two jobs.** Signal reports state and nothing
+else; Gate is the one Signal you can turn; Stamp is a plain fact with no colour; Ref is the only thing
+that links to another record; Door is the only thing that carries an action colour — and it never
+borrows a status hue to mean "click me."

--- a/docs/design/rw-design-system/components/buttons.html
+++ b/docs/design/rw-design-system/components/buttons.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Buttons</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -274,8 +349,8 @@
     <h3 class="mini">Form footer — commit vs. cancel</h3>
     <div class="panel pad">
       <div class="row" style="justify-content:flex-end">
-        <button class="door door--ghost">Cancel</button>
-        <button class="door door--commit">Save Rental</button>
+        <button type="button" class="door door--ghost">Cancel</button>
+        <button type="button" class="door door--commit">Save Rental</button>
       </div>
     </div>
   </section>
@@ -283,7 +358,7 @@
   <section>
     <h3 class="mini">Add-line row</h3>
     <div class="panel pad">
-      <div class="row"><span class="door door--add">+ Add Unit</span><span class="door door--add">+ Add Note</span></div>
+      <div class="row"><button type="button" class="door door--add"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>Add Unit</button><button type="button" class="door door--add"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>Add Note</button></div>
     </div>
   </section>
 
@@ -291,8 +366,8 @@
     <h3 class="mini">Payment &amp; destructive</h3>
     <div class="panel pad">
       <div class="row">
-        <button class="door door--money">Collect Payment</button>
-        <button class="door door--destroy">Delete Rental</button>
+        <button type="button" class="door door--money">Collect Payment</button>
+        <button type="button" class="door door--destroy">Delete Rental</button>
       </div>
     </div>
   </section>
@@ -302,14 +377,14 @@
     <div class="panel pad">
       <div class="row">
         <span class="seg">
-          <span class="seg__opt seg__opt--on-accent">All</span>
-          <span class="seg__opt">Mine</span>
-          <span class="seg__opt">Yard</span>
+          <button type="button" class="seg__opt seg__opt--on-accent">All</button>
+          <button type="button" class="seg__opt">Mine</button>
+          <button type="button" class="seg__opt">Yard</button>
         </span>
         <span class="seg">
-          <span class="seg__opt seg__opt--on-red">Overdue</span>
-          <span class="seg__opt">Due Soon</span>
-          <span class="seg__opt">Later</span>
+          <button type="button" class="seg__opt seg__opt--on-red">Overdue</button>
+          <button type="button" class="seg__opt">Due Soon</button>
+          <button type="button" class="seg__opt">Later</button>
         </span>
       </div>
       <p class="rule">The selected segment shows the <b>filled Signal chip of that option's own status</b> — an

--- a/docs/design/rw-design-system/components/buttons.html
+++ b/docs/design/rw-design-system/components/buttons.html
@@ -1,0 +1,325 @@
+<!-- @dsCard group="Components" name="Buttons" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Buttons</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Components</p>
+    <h1>Buttons</h1>
+    <p class="lede">The Door taxonomy rendered as a usable button row, in the toolbar/footer contexts it actually ships in.</p>
+    
+  </div>
+
+  <p class="rule" style="margin-top:0">The Door taxonomy (elements/door.html) composed as real toolbar rows —
+    how it actually sits inside a form footer, a destructive confirm, and a filter bar.</p>
+
+  <section>
+    <h3 class="mini">Form footer — commit vs. cancel</h3>
+    <div class="panel pad">
+      <div class="row" style="justify-content:flex-end">
+        <button class="door door--ghost">Cancel</button>
+        <button class="door door--commit">Save Rental</button>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="mini">Add-line row</h3>
+    <div class="panel pad">
+      <div class="row"><span class="door door--add">+ Add Unit</span><span class="door door--add">+ Add Note</span></div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="mini">Payment &amp; destructive</h3>
+    <div class="panel pad">
+      <div class="row">
+        <button class="door door--money">Collect Payment</button>
+        <button class="door door--destroy">Delete Rental</button>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="mini">Filter / segmented toggle bar</h3>
+    <div class="panel pad">
+      <div class="row">
+        <span class="seg">
+          <span class="seg__opt seg__opt--on-accent">All</span>
+          <span class="seg__opt">Mine</span>
+          <span class="seg__opt">Yard</span>
+        </span>
+        <span class="seg">
+          <span class="seg__opt seg__opt--on-red">Overdue</span>
+          <span class="seg__opt">Due Soon</span>
+          <span class="seg__opt">Later</span>
+        </span>
+      </div>
+      <p class="rule">The selected segment shows the <b>filled Signal chip of that option's own status</b> — an
+        "Overdue" tab selected shows filled-red, not a generic highlight. Options with no status fall back to orange.</p>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/components/chips.html
+++ b/docs/design/rw-design-system/components/chips.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Chips</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -288,7 +363,7 @@
     <div class="panel pad">
       <div class="row">
         <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span>12k Excavator</a>
-        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>due back</span>
+        <button type="button" class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>due back</button>
         <span class="stamp">non-member</span><span class="stamp-sep">·</span><span class="stamp">PO 4821</span>
         <span class="signal signal--red signal--outline">field call</span>
       </div>

--- a/docs/design/rw-design-system/components/chips.html
+++ b/docs/design/rw-design-system/components/chips.html
@@ -1,0 +1,303 @@
+<!-- @dsCard group="Components" name="Chips" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Chips</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Components</p>
+    <h1>Chips</h1>
+    <p class="lede">The filled/outline Signal matrix across every state colour, then composed in situ alongside a Gate and Stamps.</p>
+    
+  </div>
+
+  <p class="rule" style="margin-top:0">Signal chips composed together, the way a real row uses them — a status
+    matrix, then chips mixed with a Gate and Stamps inside a mock list-row.</p>
+
+  <section>
+    <h3 class="mini">Filled / outline matrix — every status</h3>
+    <div class="panel pad">
+      <div class="row">
+        <span class="signal signal--gray signal--outline">n/a</span><span class="signal signal--gray signal--filled">n/a</span>
+        <span class="signal signal--blue signal--outline">waiting</span><span class="signal signal--blue signal--filled">waiting</span>
+        <span class="signal signal--yellow signal--outline">do now</span><span class="signal signal--yellow signal--filled">do now</span>
+        <span class="signal signal--red signal--outline">bad</span><span class="signal signal--red signal--filled">bad</span>
+        <span class="signal signal--green signal--filled">done today</span>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="mini">In situ — a mock list row</h3>
+    <div class="panel pad">
+      <div class="row">
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span>12k Excavator</a>
+        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>due back</span>
+        <span class="stamp">non-member</span><span class="stamp-sep">·</span><span class="stamp">PO 4821</span>
+        <span class="signal signal--red signal--outline">field call</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/components/fields.html
+++ b/docs/design/rw-design-system/components/fields.html
@@ -1,0 +1,308 @@
+<!-- @dsCard group="Components" name="Fields" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Fields</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Components</p>
+    <h1>Fields</h1>
+    <p class="lede">A text input, a contact link, and a hyperlink — all at the one control height.</p>
+    
+  </div>
+
+  <p class="rule" style="margin-top:0">Text input, a contact link, and a hyperlink — all riding the one control
+    height <code>var(--h)</code>.</p>
+
+  <section>
+    <h3 class="mini">Field (select-style input)</h3>
+    <div class="panel pad">
+      <div class="row">
+        <span class="field">Rider: All-risk <span class="field__car">▾</span></span>
+        <span class="field">Deposit: $250 <span class="field__car">▾</span></span>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="mini">Contact — the number itself is the link</h3>
+    <div class="panel pad">
+      <div class="row">
+        <a class="contact"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z"/></svg><span class="contact__v">(337) 555-0142</span></a>
+      </div>
+      <p class="rule">Honest-affordance: tappable ⇒ looks it; not ⇒ plain text. No fake hover-underlines.</p>
+    </div>
+  </section>
+
+  <section>
+    <h3 class="mini">Hyperlink — the "true hyperlink ↗"</h3>
+    <div class="panel pad">
+      <div class="row">
+        <a class="hlink">service schedule <span class="hlink__ext">↗</span></a>
+        <span class="dead-text">S/N 4471-K</span><span class="t-hint">— a plain, non-tappable fact, for contrast</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/components/fields.html
+++ b/docs/design/rw-design-system/components/fields.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Fields</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -274,8 +349,8 @@
     <h3 class="mini">Field (select-style input)</h3>
     <div class="panel pad">
       <div class="row">
-        <span class="field">Rider: All-risk <span class="field__car">▾</span></span>
-        <span class="field">Deposit: $250 <span class="field__car">▾</span></span>
+        <button type="button" class="field">Rider: All-risk <span class="field__car">▾</span></button>
+        <button type="button" class="field">Deposit: $250 <span class="field__car">▾</span></button>
       </div>
     </div>
   </section>
@@ -294,7 +369,7 @@
     <h3 class="mini">Hyperlink — the "true hyperlink ↗"</h3>
     <div class="panel pad">
       <div class="row">
-        <a class="hlink">service schedule <span class="hlink__ext">↗</span></a>
+        <a class="hlink">service schedule<span class="hlink__ext"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg></span></a>
         <span class="dead-text">S/N 4471-K</span><span class="t-hint">— a plain, non-tappable fact, for contrast</span>
       </div>
     </div>

--- a/docs/design/rw-design-system/components/section-plate.html
+++ b/docs/design/rw-design-system/components/section-plate.html
@@ -1,0 +1,369 @@
+<!-- @dsCard group="Components" name="Section plate" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Section plate</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Components</p>
+    <h1>Section plate</h1>
+    <p class="lede">The section-header "plate" grammar the detail views use: a left state-stripe, a stamped label, a rolled-up summary, and a primary Door.</p>
+    
+  </div>
+
+  <div class="callout"><b>Plate grammar</b> — every section is the same repeated plate: left status-bar + stamped
+    label + summary + a rolled-up Signal + chevron → body. Header colour = the <b>worst item inside</b> (rollup).</div>
+
+  <section>
+    <h2 class="sub">Rolled up hottest-wins — one plate per state</h2>
+    <div class="panel pad" style="display:flex; flex-direction:column; gap:14px">
+      
+    <div class="plate plate--red">
+      <div class="plate__head">
+        <span class="plate__stripe"></span>
+        <span class="plate__label">Field Calls</span>
+        <span class="plate__summary">1 unit flagged in the field</span>
+        <span class="signal signal--red signal--filled">3d overdue</span>
+        <span class="plate__chevron">›</span>
+      </div>
+      <div class="plate__body">
+        <span class="signal signal--yellow signal--filled">due back</span>
+        <span class="signal signal--red signal--filled">3 days overdue</span>
+        <span class="stamp">6 total</span>
+        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+      </div>
+    </div>
+      
+    <div class="plate plate--yellow">
+      <div class="plate__head">
+        <span class="plate__stripe"></span>
+        <span class="plate__label">End Rent</span>
+        <span class="plate__summary">2 due back today · 1 overdue</span>
+        <span class="signal signal--yellow signal--filled">due back</span>
+        <span class="plate__chevron">›</span>
+      </div>
+      <div class="plate__body">
+        <span class="signal signal--yellow signal--filled">due back</span>
+        <span class="signal signal--red signal--filled">3 days overdue</span>
+        <span class="stamp">6 total</span>
+        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+      </div>
+    </div>
+      
+    <div class="plate plate--blue">
+      <div class="plate__head">
+        <span class="plate__stripe"></span>
+        <span class="plate__label">On Rent</span>
+        <span class="plate__summary">4 out, none due yet</span>
+        <span class="signal signal--blue signal--filled">waiting</span>
+        <span class="plate__chevron">›</span>
+      </div>
+      <div class="plate__body">
+        <span class="signal signal--yellow signal--filled">due back</span>
+        <span class="signal signal--red signal--filled">3 days overdue</span>
+        <span class="stamp">6 total</span>
+        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+      </div>
+    </div>
+      
+    <div class="plate plate--green">
+      <div class="plate__head">
+        <span class="plate__stripe"></span>
+        <span class="plate__label">Returned</span>
+        <span class="plate__summary">2 closed out today</span>
+        <span class="signal signal--green signal--filled">done today</span>
+        <span class="plate__chevron">›</span>
+      </div>
+      <div class="plate__body">
+        <span class="signal signal--yellow signal--filled">due back</span>
+        <span class="signal signal--red signal--filled">3 days overdue</span>
+        <span class="stamp">6 total</span>
+        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+      </div>
+    </div>
+      
+    <div class="plate plate--gray">
+      <div class="plate__head">
+        <span class="plate__stripe"></span>
+        <span class="plate__label">Reserved</span>
+        <span class="plate__summary">nothing due, nothing overdue</span>
+        <span class="signal signal--gray signal--outline">n/a</span>
+        <span class="plate__chevron">›</span>
+      </div>
+      <div class="plate__body">
+        <span class="signal signal--yellow signal--filled">due back</span>
+        <span class="signal signal--red signal--filled">3 days overdue</span>
+        <span class="stamp">6 total</span>
+        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+      </div>
+    </div>
+    </div>
+  </section>
+
+  <div class="callout warn"><b>Group taxonomy.</b> Attention groups (Field Calls, Failed) exist and are coloured only
+    because something is wrong — hidden entirely when empty. Lifecycle groups (On Rent, Reserved, Available) are
+    always present, gray by default, and take colour only when a member inside triggers it. Groups are never named
+    after status — colour already says "how much," the name says "where."</div>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/components/section-plate.html
+++ b/docs/design/rw-design-system/components/section-plate.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Section plate</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -286,7 +361,7 @@
         <span class="signal signal--yellow signal--filled">due back</span>
         <span class="signal signal--red signal--filled">3 days overdue</span>
         <span class="stamp">6 total</span>
-        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+        <button type="button" class="door door--commit" style="margin-left:auto">Round Up</button>
       </div>
     </div>
       
@@ -302,7 +377,7 @@
         <span class="signal signal--yellow signal--filled">due back</span>
         <span class="signal signal--red signal--filled">3 days overdue</span>
         <span class="stamp">6 total</span>
-        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+        <button type="button" class="door door--commit" style="margin-left:auto">Round Up</button>
       </div>
     </div>
       
@@ -318,7 +393,7 @@
         <span class="signal signal--yellow signal--filled">due back</span>
         <span class="signal signal--red signal--filled">3 days overdue</span>
         <span class="stamp">6 total</span>
-        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+        <button type="button" class="door door--commit" style="margin-left:auto">Round Up</button>
       </div>
     </div>
       
@@ -334,7 +409,7 @@
         <span class="signal signal--yellow signal--filled">due back</span>
         <span class="signal signal--red signal--filled">3 days overdue</span>
         <span class="stamp">6 total</span>
-        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+        <button type="button" class="door door--commit" style="margin-left:auto">Round Up</button>
       </div>
     </div>
       
@@ -350,7 +425,7 @@
         <span class="signal signal--yellow signal--filled">due back</span>
         <span class="signal signal--red signal--filled">3 days overdue</span>
         <span class="stamp">6 total</span>
-        <button class="door door--commit" style="margin-left:auto">Round Up</button>
+        <button type="button" class="door door--commit" style="margin-left:auto">Round Up</button>
       </div>
     </div>
     </div>

--- a/docs/design/rw-design-system/elements/door.html
+++ b/docs/design/rw-design-system/elements/door.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Door</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -274,19 +349,19 @@
     <h2 class="sub">The full taxonomy</h2>
     <div class="panel">
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Commit / create</div><div class="spec-row__rr">solid --commit</div></div>
-        <div class="spec-row__ex"><button class="door door--commit">Save</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--commit">Save</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">+Add</div><div class="spec-row__rr">dashed outline, --commit</div></div>
-        <div class="spec-row__ex"><span class="door door--add">+ Add</span></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--add"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>Add</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Takes money</div><div class="spec-row__rr">solid --green</div></div>
-        <div class="spec-row__ex"><button class="door door--money">Collect Payment</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--money">Collect Payment</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Destructive-confirm</div><div class="spec-row__rr">solid --red-fill</div></div>
-        <div class="spec-row__ex"><button class="door door--destroy">Delete Rental</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--destroy">Delete Rental</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Cancel / secondary</div><div class="spec-row__rr">ghost — the one quiet look</div></div>
-        <div class="spec-row__ex"><button class="door door--ghost">Cancel</button></div></div>
+        <div class="spec-row__ex"><button type="button" class="door door--ghost">Cancel</button></div></div>
       <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Active toggle segment</div><div class="spec-row__rr">filled Signal chip of selected status; falls back to orange</div></div>
         <div class="spec-row__ex">
-          <span class="seg"><span class="seg__opt seg__opt--on-yellow">Do Now</span><span class="seg__opt">Later</span></span>
-          <span class="seg"><span class="seg__opt seg__opt--on-accent">Insured</span><span class="seg__opt">Uninsured</span></span>
+          <span class="seg"><button type="button" class="seg__opt seg__opt--on-yellow">Do Now</button><button type="button" class="seg__opt">Later</button></span>
+          <span class="seg seg--state"><button type="button" class="seg__opt seg__opt--on-green">Insured</button><button type="button" class="seg__opt seg__opt--off-red">Uninsured</button></span>
         </div></div>
     </div>
   </section>

--- a/docs/design/rw-design-system/elements/door.html
+++ b/docs/design/rw-design-system/elements/door.html
@@ -1,0 +1,302 @@
+<!-- @dsCard group="Elements" name="Door" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Door</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Elements</p>
+    <h1>Door</h1>
+    <p class="lede">A verb action. Doors carry NO status colour — each intent (commit, +Add, money, destructive, cancel, toggle) owns its own colour instead.</p>
+    
+  </div>
+
+  <div class="callout"><b>Door</b> — a verb action, radius = pill (999). Carries <b>no status colour</b>; each
+    intent owns its own action colour instead.</div>
+
+  <section>
+    <h2 class="sub">The full taxonomy</h2>
+    <div class="panel">
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Commit / create</div><div class="spec-row__rr">solid --commit</div></div>
+        <div class="spec-row__ex"><button class="door door--commit">Save</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">+Add</div><div class="spec-row__rr">dashed outline, --commit</div></div>
+        <div class="spec-row__ex"><span class="door door--add">+ Add</span></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Takes money</div><div class="spec-row__rr">solid --green</div></div>
+        <div class="spec-row__ex"><button class="door door--money">Collect Payment</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Destructive-confirm</div><div class="spec-row__rr">solid --red-fill</div></div>
+        <div class="spec-row__ex"><button class="door door--destroy">Delete Rental</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Cancel / secondary</div><div class="spec-row__rr">ghost — the one quiet look</div></div>
+        <div class="spec-row__ex"><button class="door door--ghost">Cancel</button></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn">Active toggle segment</div><div class="spec-row__rr">filled Signal chip of selected status; falls back to orange</div></div>
+        <div class="spec-row__ex">
+          <span class="seg"><span class="seg__opt seg__opt--on-yellow">Do Now</span><span class="seg__opt">Later</span></span>
+          <span class="seg"><span class="seg__opt seg__opt--on-accent">Insured</span><span class="seg__opt">Uninsured</span></span>
+        </div></div>
+    </div>
+  </section>
+
+  <div class="callout warn">No Door, chip, or button ever repurposes a status hue to mean "click me." Commit/money/
+    destructive are <b>action</b> colours, never <b>status</b> colours.</div>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/elements/gate.html
+++ b/docs/design/rw-design-system/elements/gate.html
@@ -1,0 +1,317 @@
+<!-- @dsCard group="Elements" name="Gate" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Gate</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Elements</p>
+    <h1>Gate</h1>
+    <p class="lede">A turnable state: a leading, optically-centred chevron that hugs the text (≤2px gap). No orange dot.</p>
+    
+  </div>
+
+  <div class="callout"><b>Gate</b> — a Signal you can <b>turn</b>: the same chip plus a leading, optically-centred
+    chevron that <b>hugs the text (≤2px gap)</b>. <b>No orange dot.</b> Opens a status picker.</div>
+
+  <section>
+    <h2 class="sub">Canonical gates — turnable Waiting / turnable Do-now</h2>
+    <div class="panel pad">
+      <div class="row">
+        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
+        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>end rent</span>
+      </div>
+      <p class="rule">The chevron is what tells a <b>turnable blue Gate</b> apart from a <b>read-only blue Waiting
+        Signal</b> — so both can share <code>--blue</code> without colliding. Blue never overloads.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">Gate is structurally Signal + chevron — every colour, for completeness</h2>
+    <div class="panel pad">
+      <div class="row">
+        <span class="gate gate--gray"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>n/a</span>
+        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>waiting</span>
+        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>do now</span>
+        <span class="gate gate--red"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>overdue</span>
+        <span class="gate gate--green"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>done</span>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">Opens a status picker</h2>
+    <div class="row">
+      <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
+      <div class="menu">
+        <div class="menu__h">Move rental to…</div>
+        <div class="menu__i"><span class="menu__sw" style="background:var(--gray)"></span>Reserved</div>
+        <div class="menu__i on"><span class="menu__sw" style="background:var(--blue)"></span>On Rent</div>
+        <div class="menu__i"><span class="menu__sw" style="background:var(--yellow)"></span>End Rent</div>
+        <div class="menu__i"><span class="menu__sw" style="background:var(--green)"></span>Returned</div>
+      </div>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/elements/gate.html
+++ b/docs/design/rw-design-system/elements/gate.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Gate</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -274,8 +349,8 @@
     <h2 class="sub">Canonical gates — turnable Waiting / turnable Do-now</h2>
     <div class="panel pad">
       <div class="row">
-        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
-        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>end rent</span>
+        <button type="button" class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</button>
+        <button type="button" class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>end rent</button>
       </div>
       <p class="rule">The chevron is what tells a <b>turnable blue Gate</b> apart from a <b>read-only blue Waiting
         Signal</b> — so both can share <code>--blue</code> without colliding. Blue never overloads.</p>
@@ -286,11 +361,11 @@
     <h2 class="sub">Gate is structurally Signal + chevron — every colour, for completeness</h2>
     <div class="panel pad">
       <div class="row">
-        <span class="gate gate--gray"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>n/a</span>
-        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>waiting</span>
-        <span class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>do now</span>
-        <span class="gate gate--red"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>overdue</span>
-        <span class="gate gate--green"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>done</span>
+        <button type="button" class="gate gate--gray"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>n/a</button>
+        <button type="button" class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>waiting</button>
+        <button type="button" class="gate gate--yellow"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>do now</button>
+        <button type="button" class="gate gate--red"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>overdue</button>
+        <button type="button" class="gate gate--green"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>done</button>
       </div>
     </div>
   </section>
@@ -298,14 +373,14 @@
   <section>
     <h2 class="sub">Opens a status picker</h2>
     <div class="row">
-      <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
-      <div class="menu">
-        <div class="menu__h">Move rental to…</div>
-        <div class="menu__i"><span class="menu__sw" style="background:var(--gray)"></span>Reserved</div>
-        <div class="menu__i on"><span class="menu__sw" style="background:var(--blue)"></span>On Rent</div>
-        <div class="menu__i"><span class="menu__sw" style="background:var(--yellow)"></span>End Rent</div>
-        <div class="menu__i"><span class="menu__sw" style="background:var(--green)"></span>Returned</div>
-      </div>
+      <button type="button" class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</button>
+      <span class="seg seg--stack" style="max-width:190px">
+        <button type="button" class="seg__opt seg__opt--on-accent" style="justify-content:center">Move rental to…</button>
+        <button type="button" class="seg__opt">Reserved</button>
+        <button type="button" class="seg__opt seg__opt--on-blue">On Rent</button>
+        <button type="button" class="seg__opt">End Rent</button>
+        <button type="button" class="seg__opt">Returned</button>
+      </span>
     </div>
   </section>
 

--- a/docs/design/rw-design-system/elements/pin.html
+++ b/docs/design/rw-design-system/elements/pin.html
@@ -1,10 +1,10 @@
-<!-- @dsCard group="Elements" name="Ref" -->
+<!-- @dsCard group="Elements" name="Pin" -->
 <!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Rental Wrangler — Ref</title>
+<title>Rental Wrangler — Pin</title>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
@@ -331,46 +331,68 @@
   .pin[data-tip]:hover:after,
   .pin[data-tip]:focus-visible:after{display:block}
 
+  /* ---- misc demo scaffolding: Pin host tile (page-local, not shared vocabulary) ---- */
+  .pin-host{width:56px; height:40px; border-radius:8px; border:1px solid var(--line); background:var(--card);
+    display:inline-flex; align-items:center; justify-content:center; color:var(--txt-3)}
+  .pin-host svg{width:18px; height:18px}
 </style>
 </head>
 <body>
 <div class="wrap"><div class="sheet">
   <div class="top">
     <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Elements</p>
-    <h1>Ref</h1>
-    <p class="lede">A linked record: it carries the parent icon and walks across cards.</p>
+    <h1>Pin</h1>
+    <p class="lede">The universal corner marker. Colour = state, fill = today — exactly like a Signal — anchored on a host so ownership is unambiguous.</p>
     
   </div>
 
-  <div class="callout"><b>Ref</b> — a linked record: a square <b>accent-tinted icon backing</b> holding the parent's
-    type icon + the name (body voice). Radius = the one chip radius. Orange-marked = touchable. Not a status chip —
-    walks across cards.</div>
+  <div class="callout"><b>Pin</b> — a small corner marker anchored at 70% over its host's top-right corner. Content is
+    free: a number, a weekday, a date, an icon. Hover/focus explains via <code>data-tip</code>; click teleports to the
+    record. 13px tall — deliberately off the 24px control ladder — and zero layout footprint: absolutely positioned,
+    no margin, no reserved space.</div>
 
   <section>
-    <h2 class="sub">Every linked record is a Ref — its own type icon, never one generic glyph</h2>
+    <h2 class="sub">Every state colour — filled (today) vs. outline</h2>
+    <div class="panel pad">
+      <div class="row" style="margin-bottom:18px">
+        <span class="pin-wrap"><span class="pin-host">A</span><a class="pin pin--gray" data-tip="Nothing pending">&middot;</a></span>
+        <span class="pin-wrap"><span class="pin-host">B</span><a class="pin pin--blue" data-tip="Waiting on customer">2</a></span>
+        <span class="pin-wrap"><span class="pin-host">C</span><a class="pin pin--yellow" data-tip="Due back today">MON</a></span>
+        <span class="pin-wrap"><span class="pin-host">D</span><a class="pin pin--red" data-tip="3 unread field calls">3</a></span>
+        <span class="pin-wrap"><span class="pin-host">E</span><a class="pin pin--green" data-tip="Closed out today">&check;</a></span>
+      </div>
+      <div class="row">
+        <span class="pin-wrap"><span class="pin-host">A</span><a class="pin pin--gray pin--outline" data-tip="Nothing pending">&middot;</a></span>
+        <span class="pin-wrap"><span class="pin-host">B</span><a class="pin pin--blue pin--outline" data-tip="Waiting on customer">2</a></span>
+        <span class="pin-wrap"><span class="pin-host">C</span><a class="pin pin--yellow pin--outline" data-tip="Due back today">MON</a></span>
+        <span class="pin-wrap"><span class="pin-host">D</span><a class="pin pin--red pin--outline" data-tip="3 unread field calls">3</a></span>
+        <span class="pin-wrap"><span class="pin-host">E</span><a class="pin pin--green pin--outline" data-tip="Closed out today">&check;</a></span>
+      </div>
+      <p class="rule">Green is filled-only in practice, same as Signal — a completion, not a temperature.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">Content is free — number, weekday, icon</h2>
     <div class="panel pad">
       <div class="row">
-        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon Contracting</a>
-        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span>Skid Steer <span class="ref__id">SS-12</span></a>
-        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span>Invoice <span class="ref__id">#4460</span></a>
-        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>Rental <span class="ref__id">#4471</span></a>
+        <span class="pin-wrap"><span class="pin-host"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span><a class="pin pin--red" data-tip="Rental #4471 &mdash; 3 days overdue">3</a></span>
+        <span class="pin-wrap"><span class="pin-host"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><a class="pin pin--yellow" data-tip="Due back Thursday">THU</a></span>
+        <span class="pin-wrap"><span class="pin-host"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span><a class="pin pin--blue" data-tip="Invoice #4460 &mdash; waiting on customer">&middot;</a></span>
       </div>
+      <p class="rule">A Pin's host can be anything — a Ref icon, a Stamp, a plain tile. The Pin itself never resizes or
+        re-colours its host; it only sits on top of the host's top-right corner.</p>
     </div>
   </section>
 
   <section>
-    <h2 class="sub">Walks across cards — a trace</h2>
+    <h2 class="sub">Anchored, not laid out</h2>
     <div class="panel pad">
-      <div class="ref-trace">
-        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon</a><span class="ref-trace__arrow">→</span>
-        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>Rental <span class="ref__id">#4471</span></a><span class="ref-trace__arrow">→</span>
-        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span>#4460</a>
-      </div>
+      <p class="rule" style="margin:0">Absolutely positioned at <code>top:0; left:100%; transform:translate(-70%,-50%)</code>
+        over the host, inside a <code>.pin-wrap{position:relative}</code>. It reserves no width, no height, no margin
+        &mdash; the host's own box never changes size to make room for it.</p>
     </div>
   </section>
-
-  <div class="callout warn"><b>Every occurrence, not just inline body text.</b> A card's own title/header is a Ref
-    too, everywhere that record's name/ID appears — unit · customer · rental · invoice · category — never plain text.</div>
 
   <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
     <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no

--- a/docs/design/rw-design-system/elements/ref.html
+++ b/docs/design/rw-design-system/elements/ref.html
@@ -1,0 +1,305 @@
+<!-- @dsCard group="Elements" name="Ref" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Ref</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Elements</p>
+    <h1>Ref</h1>
+    <p class="lede">A linked record: it carries the parent icon and walks across cards.</p>
+    
+  </div>
+
+  <div class="callout"><b>Ref</b> — a linked record: a square <b>accent-tinted icon backing</b> holding the parent's
+    type icon + the name (body voice). Radius = the one chip radius. Orange-marked = touchable. Not a status chip —
+    walks across cards.</div>
+
+  <section>
+    <h2 class="sub">Every linked record is a Ref — its own type icon, never one generic glyph</h2>
+    <div class="panel pad">
+      <div class="row">
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon Contracting</a>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span>Skid Steer <span class="ref__id">SS-12</span></a>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span>Invoice <span class="ref__id">#4460</span></a>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>Rental <span class="ref__id">#4471</span></a>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">Walks across cards — a trace</h2>
+    <div class="panel pad">
+      <div class="ref-trace">
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon</a><span class="ref-trace__arrow">→</span>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span>Rental <span class="ref__id">#4471</span></a><span class="ref-trace__arrow">→</span>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span>#4460</a>
+      </div>
+    </div>
+  </section>
+
+  <div class="callout warn"><b>Every occurrence, not just inline body text.</b> A card's own title/header is a Ref
+    too, everywhere that record's name/ID appears — unit · customer · rental · invoice · category — never plain text.</div>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/elements/signal.html
+++ b/docs/design/rw-design-system/elements/signal.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Signal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>

--- a/docs/design/rw-design-system/elements/signal.html
+++ b/docs/design/rw-design-system/elements/signal.html
@@ -1,0 +1,324 @@
+<!-- @dsCard group="Elements" name="Signal" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Signal</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Elements</p>
+    <h1>Signal</h1>
+    <p class="lede">Read-only state. Colour = state, fill = today. The rolled-up worst state, never tappable to change it.</p>
+    
+  </div>
+
+  <div class="callout"><b>Signal</b> — a coloured chip reporting <b>read-only</b> state. Not tappable to change it.
+    Colour = state, fill = today. Click teleports to the source record.</div>
+
+  <section>
+    <h2 class="sub">Every state colour — filled vs. outline</h2>
+    <div class="panel pad">
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--gray signal--outline">n/a</span>
+        <span class="signal signal--gray signal--filled">n/a</span>
+      </div>
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--blue signal--outline">waiting</span>
+        <span class="signal signal--blue signal--filled">on rent</span>
+      </div>
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--yellow signal--outline">near due</span>
+        <span class="signal signal--yellow signal--filled">due back</span>
+      </div>
+      <div class="row" style="margin-bottom:16px">
+        <span class="signal signal--red signal--outline">field call</span>
+        <span class="signal signal--red signal--filled">3 days overdue</span>
+      </div>
+      <div class="row">
+        <span class="signal signal--green signal--filled">returned today</span>
+        <span class="t-hint">green is filled-only in practice — a completion, not a temperature; ages to gray tomorrow.</span>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">Three-tier read</h2>
+    <div class="panel pad">
+      <ol style="margin:0; padding-left:20px; color:var(--txt-2); font-size:13px; line-height:1.9">
+        <li><b>Colour + fill</b> — the instant at-a-glance state.</li>
+        <li><b>The word on the chip</b> — what it is.</li>
+        <li><b>Hover / Tab-focus / long-press</b> — why, and what it blocks.</li>
+      </ol>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">Rollup precedence — hottest wins</h2>
+    <div class="panel pad">
+      <div class="row" style="margin-bottom:10px"><code>red &gt; yellow &gt; blue &gt; green &gt; gray</code></div>
+      <p class="rule" style="margin:0">Fixed, never resolved ad hoc per renderer. A group header, card cap, or
+        rolled-up count always shows the worst item inside — the fire is never hidden under a calm header.</p>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/elements/stamp.html
+++ b/docs/design/rw-design-system/elements/stamp.html
@@ -1,0 +1,304 @@
+<!-- @dsCard group="Elements" name="Stamp" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Stamp</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Elements</p>
+    <h1>Stamp</h1>
+    <p class="lede">A quiet fact — no pill, no colour, just plain stamped mono text sitting beside a Signal.</p>
+    
+  </div>
+
+  <div class="callout"><b>Stamp</b> — a plain fact: chip <b>text</b>, no box, no colour (<code>--txt-3</code>),
+    stamped voice. Sits beside a Signal as its quiet sibling. Budget overflow → <code>+N</code> in accent.</div>
+
+  <section>
+    <h2 class="sub">A Signal with its quiet Stamp siblings</h2>
+    <div class="panel pad">
+      <div class="row tight">
+        <span class="signal signal--red signal--filled" style="margin-right:2px">owed 16d</span>
+        <span class="stamp">non-member</span><span class="stamp-sep">·</span>
+        <span class="stamp">excavator</span><span class="stamp-sep">·</span>
+        <span class="stamp">PO 4821</span><span class="stamp-sep">·</span>
+        <span class="stamp stamp--more">+2</span>
+      </div>
+      <p class="rule">One glance: the coloured box is the state, the plain stamps are just facts. Overflow past the
+        budget rolls into a single accent-coloured <code>+N</code>.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">Stamp alone — never a status</h2>
+    <div class="panel pad">
+      <div class="row tight">
+        <span class="stamp">S/N 4471-K</span><span class="stamp-sep">·</span>
+        <span class="stamp">2019</span><span class="stamp-sep">·</span>
+        <span class="stamp">75hp</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/elements/stamp.html
+++ b/docs/design/rw-design-system/elements/stamp.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Stamp</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>

--- a/docs/design/rw-design-system/foundations/palette.html
+++ b/docs/design/rw-design-system/foundations/palette.html
@@ -1,0 +1,623 @@
+<!-- @dsCard group="Foundations" name="Palette & colour law" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Palette & colour law</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Foundations</p>
+    <h1>Palette & colour law</h1>
+    <p class="lede">Every token as a swatch — surfaces, text, accent, status, action, leather — plus the law that governs them.</p>
+    
+  </div>
+
+  <section id="law">
+    <h2 class="sub">The colour law</h2>
+    <div class="callout law">
+      <b>Colour = state. Fill = today.</b> Status colours mean STATE ONLY — buttons/actions are neutral and never
+      borrow one. Rollup precedence, hottest wins: <code>red &gt; yellow &gt; blue &gt; green &gt; gray</code>.
+      <b>Green</b> = Done <i>today</i> only (ages to gray the next day). <b>Blue</b> = Waiting (someone else's move).
+      <b>Red</b> = bad. <b>Yellow</b> = your move now. <b>Gray</b> = nothing.
+    </div>
+  </section>
+
+  <section id="surfaces">
+    <h2 class="sub">Surfaces &amp; lines</h2>
+    <div class="swatch-grid">
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--bg)"><span class="swatch__tag" style="color:#eef2f7">bg</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#0a0d11</div>
+      <div class="swatch__name">--bg</div>
+      <div class="swatch__mean">App base — the ~60% surface.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--bg-2)"><span class="swatch__tag" style="color:#eef2f7">bg-2</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#0f1318</div>
+      <div class="swatch__name">--bg-2</div>
+      <div class="swatch__mean">Secondary app base tint.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--panel)"><span class="swatch__tag" style="color:#eef2f7">panel</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#171d25</div>
+      <div class="swatch__name">--panel</div>
+      <div class="swatch__mean">Panel surface — nav, side rails, menus.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--panel-2)"><span class="swatch__tag" style="color:#eef2f7">panel-2</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#1b222c</div>
+      <div class="swatch__name">--panel-2</div>
+      <div class="swatch__mean">Secondary panel tint.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--card)"><span class="swatch__tag" style="color:#eef2f7">card</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#12171e</div>
+      <div class="swatch__name">--card</div>
+      <div class="swatch__mean">Record / list-row surface.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--card-head)"><span class="swatch__tag" style="color:#eef2f7">card-head</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#1a212b</div>
+      <div class="swatch__name">--card-head</div>
+      <div class="swatch__mean">Card header strip / section head.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--line)"><span class="swatch__tag" style="color:#eef2f7">line</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#2c343f</div>
+      <div class="swatch__name">--line</div>
+      <div class="swatch__mean">The standard hairline border.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--line-soft)"><span class="swatch__tag" style="color:#eef2f7">line-soft</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#212834</div>
+      <div class="swatch__name">--line-soft</div>
+      <div class="swatch__mean">Soft inner divider (row-to-row).</div>
+    </div>
+  </div>
+    </div>
+  </section>
+
+  <section id="text">
+    <h2 class="sub">Text</h2>
+    <div class="swatch-grid">
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--txt)"><span class="swatch__tag" style="color:#0a0d11">txt</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#eef2f7</div>
+      <div class="swatch__name">--txt</div>
+      <div class="swatch__mean">Primary ink — names, headings, values you read.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--txt-2)"><span class="swatch__tag" style="color:#0a0d11">txt-2</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#aab4c1</div>
+      <div class="swatch__name">--txt-2</div>
+      <div class="swatch__mean">Secondary ink — meta, sub-labels, prose.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--txt-3)"><span class="swatch__tag" style="color:#0a0d11">txt-3</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#838e9c</div>
+      <div class="swatch__name">--txt-3</div>
+      <div class="swatch__mean">Tertiary ink — Stamp fact text, icons, borders.</div>
+    </div>
+  </div>
+    </div>
+  </section>
+
+  <section id="accent">
+    <h2 class="sub">Accent — <span class="hl">touchable</span>, the ONE safety orange</h2>
+    <div class="swatch-grid">
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--accent)"><span class="swatch__tag" style="color:#1a1205">accent</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#ff7e1f</div>
+      <div class="swatch__name">--accent</div>
+      <div class="swatch__mean">"You can act on this" — Refs, Gate chevrons, toggle fallback, carets. Dark ink always.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--accent-soft)"><span class="swatch__tag" style="color:#eef2f7">accent-soft</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(255,126,31,.15)</div>
+      <div class="swatch__name">--accent-soft</div>
+      <div class="swatch__mean">Soft accent wash — Ref icon backing.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--accent-line)"><span class="swatch__tag" style="color:#eef2f7">accent-line</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(255,126,31,.5)</div>
+      <div class="swatch__name">--accent-line</div>
+      <div class="swatch__mean">Accent-tinted border/line.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--orange)"><span class="swatch__tag" style="color:#1a1205">orange</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#ff7e1f</div>
+      <div class="swatch__name">--orange</div>
+      <div class="swatch__mean">Alias of --accent used by some call sites.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--orange-bg)"><span class="swatch__tag" style="color:#eef2f7">orange-bg</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(255,126,31,.14)</div>
+      <div class="swatch__name">--orange-bg</div>
+      <div class="swatch__mean">Alias of --accent-soft.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--on-orange)"><span class="swatch__tag" style="color:#eef2f7">on-orange</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#1a1205</div>
+      <div class="swatch__name">--on-orange</div>
+      <div class="swatch__mean">The dark ink that always sits on accent fills.</div>
+    </div>
+  </div>
+    </div>
+  </section>
+
+  <section id="status">
+    <h2 class="sub">Status — <span class="hl">colour = state</span>, a thermometer (never decoration)</h2>
+    <div class="swatch-grid">
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--gray)"><span class="swatch__tag" style="color:#12171d">gray</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#8b94a3</div>
+      <div class="swatch__name">--gray</div>
+      <div class="swatch__mean">N/A · nothing to do. Coolest.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--gray-bg)"><span class="swatch__tag" style="color:#eef2f7">gray-bg</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(139,148,163,.14)</div>
+      <div class="swatch__name">--gray-bg</div>
+      <div class="swatch__mean">Soft gray wash — outline/at-rest gray chips.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--blue)"><span class="swatch__tag" style="color:#0a1220">blue</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#6394cc</div>
+      <div class="swatch__name">--blue</div>
+      <div class="swatch__mean">Waiting — incomplete, on-time, no rush. Muted so it stops fighting orange.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--blue-bg)"><span class="swatch__tag" style="color:#eef2f7">blue-bg</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(99,148,204,.15)</div>
+      <div class="swatch__name">--blue-bg</div>
+      <div class="swatch__mean">Soft blue wash — outline Waiting chips.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--yellow)"><span class="swatch__tag" style="color:#241d05">yellow</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#eed44b</div>
+      <div class="swatch__name">--yellow</div>
+      <div class="swatch__mean">Do-now · near/due · time-sensitive. Warm. CVD floor — see spacing.html.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--yellow-bg)"><span class="swatch__tag" style="color:#eef2f7">yellow-bg</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(238,212,75,.15)</div>
+      <div class="swatch__name">--yellow-bg</div>
+      <div class="swatch__mean">Soft yellow wash — outline do-now chips.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--red)"><span class="swatch__tag" style="color:#3a0505">red</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#ff4242</div>
+      <div class="swatch__name">--red</div>
+      <div class="swatch__mean">Bad · overdue. Outline chips/bars/dots — filled white-on-red fails AA.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--red-bg)"><span class="swatch__tag" style="color:#eef2f7">red-bg</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(255,66,66,.13)</div>
+      <div class="swatch__name">--red-bg</div>
+      <div class="swatch__mean">Soft red wash — outline red chips.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--red-fill)"><span class="swatch__tag" style="color:#fdfdfd">red-fill</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#d63636</div>
+      <div class="swatch__name">--red-fill</div>
+      <div class="swatch__mean">The deepened filled red — with near-white ink clears AA at 4.65.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--on-red-fill)"><span class="swatch__tag" style="color:#0a0d11">on-red-fill</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#fdfdfd</div>
+      <div class="swatch__name">--on-red-fill</div>
+      <div class="swatch__mean">Near-white ink on --red-fill (never pure #fff).</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--green)"><span class="swatch__tag" style="color:#06231a">green</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#34d399</div>
+      <div class="swatch__name">--green</div>
+      <div class="swatch__mean">Done — today only. Ages to gray tomorrow, snaps to red on revert.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--green-bg)"><span class="swatch__tag" style="color:#eef2f7">green-bg</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">rgba(52,211,153,.14)</div>
+      <div class="swatch__name">--green-bg</div>
+      <div class="swatch__mean">Soft green wash — outline done chips.</div>
+    </div>
+  </div>
+    </div>
+  </section>
+
+  <section id="action">
+    <h2 class="sub">Action — <span class="hl">commit</span>, never a status colour</h2>
+    <div class="swatch-grid">
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--commit)"><span class="swatch__tag" style="color:#fdfdfd">commit</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#2f6fd0</div>
+      <div class="swatch__name">--commit</div>
+      <div class="swatch__mean">The one deep blue meaning "commit / create / write" — Save solid, +Add dashed.</div>
+    </div>
+  </div>
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--on-commit)"><span class="swatch__tag" style="color:#0a0d11">on-commit</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#fdfdfd</div>
+      <div class="swatch__name">--on-commit</div>
+      <div class="swatch__mean">Near-white ink on commit fills — clears AA at 4.80.</div>
+    </div>
+  </div>
+    </div>
+    <div class="callout info"><b>Deep vs pale, never adjacent.</b> Blue is already a status colour (Waiting). Commit
+      is a deep, saturated, solid <i>button</i>; Waiting is a pale, desaturated, tiny <i>chip</i>. Different
+      saturation, different shape — they never read as the same thing.</div>
+  </section>
+
+  <section id="leather">
+    <h2 class="sub">Leather — restrained seasoning only</h2>
+    <div class="swatch-grid">
+      
+  <div class="swatch">
+    <div class="swatch__blk" style="background:var(--tan)"><span class="swatch__tag" style="color:#2a1400">tan</span></div>
+    <div class="swatch__info">
+      <div class="swatch__val">#c2925a</div>
+      <div class="swatch__name">--tan</div>
+      <div class="swatch__mean">Wrangler/ranch touches — tiny, never a status, never the dominant note.</div>
+    </div>
+  </div>
+    </div>
+  </section>
+
+  <section id="structural">
+    <h2 class="sub">Structural additions (not colours)</h2>
+    <div class="panel pad">
+      <div class="row" style="margin-bottom:8px"><code>--h: 24px</code><span class="t-hint">— the one control height (style skill, 24–28px range)</span></div>
+      <div class="row" style="margin-bottom:8px"><code>--chip-radius: 7px</code><span class="t-hint">— the one chip radius (states)</span></div>
+      <div class="row" style="margin-bottom:8px"><code>--pill-radius: 999px</code><span class="t-hint">— the one pill radius (actions) — added, paired with --chip-radius</span></div>
+      <div class="row" style="margin-bottom:8px"><code>--radius: 14px</code><span class="t-hint">— container/panel corner radius (cards, plates) — a THIRD radius, but for containers, not controls</span></div>
+      <div class="row"><code>--font</code> / <code>--font-mono</code><span class="t-hint">— the two type voices, see type.html</span></div>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/foundations/palette.html
+++ b/docs/design/rw-design-system/foundations/palette.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Palette & colour law</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -608,10 +683,11 @@
     <h2 class="sub">Structural additions (not colours)</h2>
     <div class="panel pad">
       <div class="row" style="margin-bottom:8px"><code>--h: 24px</code><span class="t-hint">— the one control height (style skill, 24–28px range)</span></div>
-      <div class="row" style="margin-bottom:8px"><code>--chip-radius: 7px</code><span class="t-hint">— the one chip radius (states)</span></div>
-      <div class="row" style="margin-bottom:8px"><code>--pill-radius: 999px</code><span class="t-hint">— the one pill radius (actions) — added, paired with --chip-radius</span></div>
-      <div class="row" style="margin-bottom:8px"><code>--radius: 14px</code><span class="t-hint">— container/panel corner radius (cards, plates) — a THIRD radius, but for containers, not controls</span></div>
-      <div class="row"><code>--font</code> / <code>--font-mono</code><span class="t-hint">— the two type voices, see type.html</span></div>
+      <div class="row" style="margin-bottom:8px"><code>--chip-radius: 2px</code><span class="t-hint">— was 7px; squared state chips (Signal/Gate/Field/Seg)</span></div>
+      <div class="row" style="margin-bottom:8px"><code>--item-radius: 8px</code><span class="t-hint">— NEW: records (Ref, +Add)</span></div>
+      <div class="row" style="margin-bottom:8px"><code>--pill-radius: 999px</code><span class="t-hint">— the one pill radius — Doors ONLY, paired with --chip-radius/--item-radius</span></div>
+      <div class="row" style="margin-bottom:8px"><code>--radius: 14px</code><span class="t-hint">— container/panel corner radius (cards, plates) — a separate radius, but for containers, not controls</span></div>
+      <div class="row"><code>--font</code> / <code>--font-mono</code><span class="t-hint">— the two type voices (--font is now Archivo), see type.html</span></div>
     </div>
   </section>
 

--- a/docs/design/rw-design-system/foundations/spacing.html
+++ b/docs/design/rw-design-system/foundations/spacing.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Size, control & radii</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -274,13 +349,13 @@
       <div class="row">
         <span class="signal signal--red signal--outline">field call</span>
         <span class="signal signal--yellow signal--filled">due back</span>
-        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
+        <button type="button" class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</button>
         <span class="stamp">non-member</span>
         <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon</a>
-        <span class="door door--add">+ Invoice</span>
-        <span class="seg"><span class="seg__opt seg__opt--on-accent">Insured</span><span class="seg__opt">Uninsured</span></span>
-        <button class="door door--commit">Save</button>
-        <button class="door door--ghost">Cancel</button>
+        <button type="button" class="door door--add"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>Invoice</button>
+        <span class="seg seg--state"><button type="button" class="seg__opt seg__opt--on-green">Insured</button><button type="button" class="seg__opt seg__opt--off-red">Uninsured</button></span>
+        <button type="button" class="door door--commit">Save</button>
+        <button type="button" class="door door--ghost">Cancel</button>
       </div>
     </div>
   </section>
@@ -302,14 +377,16 @@
     <h2 class="sub">The radii — controls get two, containers get a third</h2>
     <div class="panel">
       <div class="radii-row">
-        <div class="radii-item"><div class="radii-box chip"></div><div class="radii-lab"><b>7px</b>chip — statuses (Signal/Gate/Stamp/Ref)</div></div>
-        <div class="radii-item"><div class="radii-box pill"></div><div class="radii-lab"><b>999px</b>pill — actions (Door)</div></div>
+        <div class="radii-item"><div class="radii-box chip"></div><div class="radii-lab"><b>2px</b>chip — state (Signal/Gate/Field/Seg)</div></div>
+        <div class="radii-item"><div class="radii-box" style="border-radius:var(--item-radius)"></div><div class="radii-lab"><b>8px</b>item — records (Ref, +Add)</div></div>
+        <div class="radii-item"><div class="radii-box pill"></div><div class="radii-lab"><b>999px</b>pill — actions (Doors ONLY)</div></div>
         <div class="radii-item"><div class="radii-box container"></div><div class="radii-lab"><b>14px</b>container — cards, panels, plates (not a control)</div></div>
       </div>
     </div>
-    <div class="callout">The <code>style</code> skill's "two radii" rule governs <b>inline controls</b> — shape
-      signals action-vs-state pre-read. <code>--radius:14px</code> is a separate, container-level corner radius for
-      cards/panels/plates and doesn't compete with that rule.</div>
+    <div class="callout">The <code>style</code> skill's "radii" rule governs <b>inline controls</b> — shape
+      signals action-vs-state pre-read: <b>chip</b> (state) / <b>item</b> (record) / <b>pill</b> (action, Doors only).
+      <code>--radius:14px</code> is a separate, container-level corner radius for cards/panels/plates and doesn't
+      compete with that rule.</div>
   </section>
 
   <section>

--- a/docs/design/rw-design-system/foundations/spacing.html
+++ b/docs/design/rw-design-system/foundations/spacing.html
@@ -1,0 +1,339 @@
+<!-- @dsCard group="Foundations" name="Size, control & radii" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Size, control & radii</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Foundations</p>
+    <h1>Size, control & radii</h1>
+    <p class="lede">The measurable numbers every control must hit: one control height, one size ladder, two control radii (plus a separate container radius), the 60-30-10 accent budget, and the two state functions.</p>
+    
+  </div>
+
+  <section>
+    <h2 class="sub">One control height, one baseline</h2>
+    <div class="panel pad">
+      <p class="t-hint" style="margin:0 0 12px">every control · height var(--h) = 24px · centred on the line</p>
+      <div class="row">
+        <span class="signal signal--red signal--outline">field call</span>
+        <span class="signal signal--yellow signal--filled">due back</span>
+        <span class="gate gate--blue"><span class="gate__chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span>
+        <span class="stamp">non-member</span>
+        <a class="ref"><span class="ref__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon</a>
+        <span class="door door--add">+ Invoice</span>
+        <span class="seg"><span class="seg__opt seg__opt--on-accent">Insured</span><span class="seg__opt">Uninsured</span></span>
+        <button class="door door--commit">Save</button>
+        <button class="door door--ghost">Cancel</button>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">The size ladder — no value off it</h2>
+    <div class="panel">
+      <div class="ladder-row"><span class="ladder-row__px">28px</span><span class="ladder-row__role">value</span><span class="ladder-row__demo" style="font-size:28px;font-weight:800">1,732.3</span></div>
+      <div class="ladder-row"><span class="ladder-row__px">15px</span><span class="ladder-row__role">title</span><span class="ladder-row__demo" style="font-size:15px;font-weight:700">Boudreaux Marine LLC</span></div>
+      <div class="ladder-row"><span class="ladder-row__px">13px</span><span class="ladder-row__role">content</span><span class="ladder-row__demo" style="font-size:13px">Marine construction · Cameron, LA</span></div>
+      <div class="ladder-row"><span class="ladder-row__px">12px</span><span class="ladder-row__role">field</span><span class="ladder-row__demo" style="font-size:12px">Purchase date</span></div>
+      <div class="ladder-row"><span class="ladder-row__px">11px</span><span class="ladder-row__role">label &amp; every chip</span><span class="ladder-row__demo" style="font-size:11px;text-transform:uppercase;font-family:var(--font-mono);font-weight:700">due back</span></div>
+      <div class="ladder-row"><span class="ladder-row__px">10px</span><span class="ladder-row__role">small</span><span class="ladder-row__demo" style="font-size:10px;color:var(--txt-3)">S/N 4471-K</span></div>
+      <div class="ladder-row"><span class="ladder-row__px">9.5px</span><span class="ladder-row__role">finest</span><span class="ladder-row__demo" style="font-size:9.5px;color:var(--txt-3)">last synced 2m ago</span></div>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">The radii — controls get two, containers get a third</h2>
+    <div class="panel">
+      <div class="radii-row">
+        <div class="radii-item"><div class="radii-box chip"></div><div class="radii-lab"><b>7px</b>chip — statuses (Signal/Gate/Stamp/Ref)</div></div>
+        <div class="radii-item"><div class="radii-box pill"></div><div class="radii-lab"><b>999px</b>pill — actions (Door)</div></div>
+        <div class="radii-item"><div class="radii-box container"></div><div class="radii-lab"><b>14px</b>container — cards, panels, plates (not a control)</div></div>
+      </div>
+    </div>
+    <div class="callout">The <code>style</code> skill's "two radii" rule governs <b>inline controls</b> — shape
+      signals action-vs-state pre-read. <code>--radius:14px</code> is a separate, container-level corner radius for
+      cards/panels/plates and doesn't compete with that rule.</div>
+  </section>
+
+  <section>
+    <h2 class="sub">60-30-10 accent budget</h2>
+    <div class="panel pad">
+      <div class="budget-bar"><span class="b-60">60% base surface</span><span class="b-30">30% supporting</span><span class="b-10">≤10%</span></div>
+      <div class="rule" style="margin-top:12px">If the accent exceeds ~10% of the visual weight, pull back. Neutrals
+        stay desaturated; status + accent may be loud — a deliberate hi-vis override of "muted = premium."</div>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="sub">The two state functions</h2>
+    <div class="panel">
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn" style="font-size:11px">colour = taskState(record)</div></div>
+        <div class="spec-row__ex"><span class="t-prose">→ state-bucket (blocked · now · later · done · none). One function; buttons carry no status colour.</span></div></div>
+      <div class="spec-row"><div class="spec-row__role"><div class="spec-row__rn" style="font-size:11px">fill = triggeredToday(record, ctx)</div></div>
+        <div class="spec-row__ex"><span class="t-prose">→ boolean. Filled only when a today-trigger actually fires; otherwise outline.</span></div></div>
+    </div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/foundations/type.html
+++ b/docs/design/rw-design-system/foundations/type.html
@@ -1,0 +1,327 @@
+<!-- @dsCard group="Foundations" name="Type voices" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rental Wrangler — Type voices</title>
+<style>
+  :root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  }
+
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{background:var(--bg)}
+  .wrap{background:var(--bg); color:var(--txt-2); font-family:var(--font); line-height:1.55;
+    -webkit-font-smoothing:antialiased; min-height:100vh; padding:40px 0 72px}
+  .sheet{max-width:960px; margin:0 auto; padding:0 clamp(16px,4vw,32px)}
+  code,.mono{font-family:var(--font-mono)}
+  b{color:var(--txt); font-weight:700}
+
+  .eyebrow{font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 10px}
+  .eyebrow .hl{color:var(--accent)}
+  h1{font-family:var(--font-mono); font-weight:800; font-size:clamp(22px,3.6vw,30px);
+    letter-spacing:-.01em; color:var(--txt); margin:0 0 10px; line-height:1.15}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:70ch; font-size:14px; color:var(--txt-2); margin:0 0 6px}
+  .rule{max-width:74ch; font-size:12.5px; color:var(--txt-3); margin:10px 0 0}
+  .rule b{color:var(--txt-2)}
+  .top{padding-bottom:22px; border-bottom:1px solid var(--line)}
+
+  section{margin-top:40px}
+  h2.sub{font-family:var(--font-mono); font-weight:800; font-size:12px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--txt-3); margin:0 0 14px; padding-bottom:8px;
+    border-bottom:1px solid var(--line)}
+  h2.sub .hl{color:var(--accent)}
+  h3.mini{font-family:var(--font-mono); font-size:11px; font-weight:800; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--txt-3); margin:22px 0 10px}
+  h3.mini:first-of-type{margin-top:0}
+
+  .panel{border:1px solid var(--line); border-radius:var(--radius); background:var(--panel); overflow:hidden}
+  .pad{padding:18px 20px}
+  .callout{border:1px solid var(--line); border-left:3px solid var(--accent); background:var(--card);
+    border-radius:0 9px 9px 0; padding:12px 15px; font-size:12.5px; color:var(--txt-2); margin-top:14px}
+  .callout b{color:var(--txt)}
+  .callout.warn{border-left-color:var(--yellow)}
+  .callout.info{border-left-color:var(--blue)}
+  .callout.law{border-left-color:var(--red)}
+
+  .foot{margin-top:56px; padding:20px 0 0; border-top:1px solid var(--line); font-size:12px;
+    color:var(--txt-3); max-width:82ch}
+  .foot b{color:var(--txt-2)}
+
+  .row{display:flex; gap:10px; flex-wrap:wrap; align-items:center}
+  .row.tight{gap:6px}
+
+  /* ================= SIGNAL — read-only state; colour=state, fill=today ================= */
+  .signal{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
+  .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
+  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
+  .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
+  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
+  .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
+  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
+  .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
+  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
+  .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
+  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+
+  /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
+  .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; white-space:nowrap; cursor:pointer; border:0}
+  .gate__chev{display:inline-flex; align-items:center; justify-content:center; width:12px; height:12px; flex:none}
+  .gate__chev svg{width:12px; height:12px; display:block}
+  .gate--blue  {background:var(--blue);     color:var(--on-blue)}
+  .gate--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .gate--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .gate--green {background:var(--green);    color:var(--on-green)}
+  .gate--gray  {background:var(--gray);     color:var(--on-gray)}
+
+  /* ================= STAMP — a quiet fact: chip text, no box, no colour ================= */
+  .stamp{height:var(--h); display:inline-flex; align-items:center; padding:0 3px;
+    font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt-3)}
+  .stamp--more{color:var(--accent)}
+  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+
+  /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+    text-decoration:none; cursor:pointer}
+  .ref:hover{border-color:var(--accent)}
+  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
+  .ref__icon svg{width:12px; height:12px}
+  .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
+  .ref-trace{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ref-trace__arrow{font-family:var(--font-mono); color:var(--txt-3); font-size:12px}
+
+  /* ================= DOOR — a verb action: radius=pill, colour=intent, never status ================= */
+  .door{height:var(--h); display:inline-flex; align-items:center; padding:0 15px;
+    border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
+    letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
+  .door--commit {background:var(--commit); color:var(--on-commit)}
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  .door--money  {background:var(--green); color:var(--on-green)}
+  .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
+  .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
+
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
+  .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
+    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    border-right:1px solid var(--line); cursor:pointer; background:transparent}
+  .seg__opt:last-child{border-right:0}
+  .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
+  .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
+  .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
+
+  /* ================= FIELDS / links ================= */
+  .field{height:var(--h); display:inline-flex; align-items:center; gap:8px; padding:0 10px;
+    border-radius:var(--chip-radius); border:1px solid var(--line); font-family:var(--font);
+    font-size:12px; color:var(--txt); cursor:pointer; background:transparent}
+  .field__car{color:var(--accent); font-family:var(--font-mono); font-size:10px}
+  .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
+    font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
+  .contact svg{color:var(--accent); width:14px; height:14px}
+  .contact__v{border-bottom:1.4px solid transparent}
+  .contact:hover .contact__v{border-bottom-color:var(--accent)}
+  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
+    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
+  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
+  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+
+  /* ================= PLATE — section-header grammar ================= */
+  .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
+  .plate__head{display:flex; align-items:center; gap:10px; min-height:42px; padding:0 14px;
+    border-bottom:1px solid var(--line); background:var(--card-head)}
+  .plate__stripe{width:3px; align-self:stretch; margin:8px 0; border-radius:2px; flex:none}
+  .plate__label{font-family:var(--font-mono); font-size:12px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; flex:none}
+  .plate__summary{flex:1; min-width:0; font-family:var(--font); font-size:12.5px; color:var(--txt-2);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .plate__chevron{color:var(--txt-3); font-family:var(--font-mono)}
+  .plate__body{padding:12px 14px; display:flex; gap:9px; flex-wrap:wrap; align-items:center}
+  .plate--gray   .plate__head{background:var(--gray-bg)}   .plate--gray   .plate__stripe{background:var(--gray)}   .plate--gray   .plate__label{color:var(--gray)}
+  .plate--blue   .plate__head{background:var(--blue-bg)}   .plate--blue   .plate__stripe{background:var(--blue)}   .plate--blue   .plate__label{color:var(--blue)}
+  .plate--yellow .plate__head{background:var(--yellow-bg)} .plate--yellow .plate__stripe{background:var(--yellow)} .plate--yellow .plate__label{color:var(--yellow)}
+  .plate--red    .plate__head{background:var(--red-bg)}    .plate--red    .plate__stripe{background:var(--red)}    .plate--red    .plate__label{color:var(--red)}
+  .plate--green  .plate__head{background:var(--green-bg)}  .plate--green  .plate__stripe{background:var(--green)}  .plate--green  .plate__label{color:var(--green)}
+
+  /* ================= misc demo scaffolding ================= */
+  .swatch-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:10px}
+  .swatch{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--card)}
+  .swatch__blk{height:52px; position:relative}
+  .swatch__tag{position:absolute; right:6px; bottom:5px; font-family:var(--font-mono); font-size:8.5px;
+    font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:1px 5px; border-radius:3px;
+    background:rgba(0,0,0,.28)}
+  .swatch__info{padding:9px 10px 10px}
+  .swatch__val{font-family:var(--font-mono); font-size:10.5px; font-weight:700; color:var(--txt);
+    word-break:break-all}
+  .swatch__name{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-3); margin-top:1px}
+  .swatch__mean{font-size:11.5px; color:var(--txt-2); margin-top:6px; line-height:1.4}
+
+  .spec-row{display:grid; grid-template-columns:170px 1fr; border-bottom:1px solid var(--line)}
+  .spec-row:last-child{border-bottom:0}
+  .spec-row__role{padding:14px; border-right:1px solid var(--line); background:var(--card-head)}
+  .spec-row__rn{font-family:var(--font-mono); font-size:10.5px; font-weight:800; letter-spacing:.05em;
+    text-transform:uppercase; color:var(--txt)}
+  .spec-row__rr{font-size:10.5px; color:var(--txt-3); margin-top:3px}
+  .spec-row__ex{padding:14px; display:flex; align-items:center; flex-wrap:wrap; gap:8px; min-width:0}
+  .t-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .t-prose{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  .t-num{font-family:var(--font-mono); font-size:13px; color:var(--txt-2); font-variant-numeric:tabular-nums; font-weight:600}
+  .t-hint{font-family:var(--font); font-size:12.5px; color:var(--txt-3); font-style:italic}
+  .t-stamp2{font-family:var(--font-mono); font-size:9.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3)}
+
+  .ladder-row{display:flex; align-items:baseline; gap:14px; padding:11px 16px; border-bottom:1px solid var(--line-soft)}
+  .ladder-row:last-child{border-bottom:0}
+  .ladder-row__px{font-family:var(--font-mono); font-size:11px; font-weight:800; color:var(--accent); width:48px; flex:none}
+  .ladder-row__role{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); width:160px; flex:none}
+  .ladder-row__demo{font-family:var(--font); color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+  .radii-row{display:flex; gap:20px; flex-wrap:wrap; padding:16px}
+  .radii-item{display:flex; flex-direction:column; align-items:center; gap:8px}
+  .radii-box{width:84px; height:44px; background:var(--card-head); border:1.5px solid var(--accent)}
+  .radii-box.chip{border-radius:var(--chip-radius)}
+  .radii-box.pill{border-radius:var(--pill-radius)}
+  .radii-box.container{border-radius:var(--radius)}
+  .radii-lab{font-family:var(--font-mono); font-size:10px; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--txt-2); text-align:center}
+  .radii-lab b{display:block; color:var(--txt); font-size:12px}
+
+  .budget-bar{display:flex; height:34px; border-radius:8px; overflow:hidden; border:1px solid var(--line)}
+  .budget-bar span{display:flex; align-items:center; justify-content:center; font-family:var(--font-mono);
+    font-size:10.5px; font-weight:800; letter-spacing:.04em}
+  .b-60{width:60%; background:var(--card-head); color:var(--txt-2)}
+  .b-30{width:30%; background:var(--panel); color:var(--txt-2)}
+  .b-10{width:10%; background:var(--accent); color:var(--on-orange)}
+
+  .therm{display:grid; grid-template-columns:repeat(4,1fr); border:1px solid var(--line); border-radius:11px; overflow:hidden}
+  @media (max-width:680px){ .therm{grid-template-columns:1fr 1fr} }
+  .tcell{padding:14px; border-right:1px solid var(--line); background:var(--card)}
+  .tcell:last-child{border-right:0}
+  .tdot{width:100%; height:9px; border-radius:4px; margin-bottom:9px}
+  .t-gray .tdot{background:var(--gray)} .t-blue .tdot{background:var(--blue)}
+  .t-yellow .tdot{background:var(--yellow)} .t-red .tdot{background:var(--red)}
+  .tname{font-family:var(--font-mono); font-size:12.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .t-gray .tname{color:var(--gray)} .t-blue .tname{color:var(--blue)}
+  .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
+  .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
+
+  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
+  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
+  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
+    border-bottom:1px solid var(--line-soft); cursor:pointer}
+  .menu__i:last-child{border-bottom:0}
+  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu__i.on{font-weight:800}
+  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
+
+  table.floors{width:100%; border-collapse:collapse}
+  table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
+  table.floors th{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--txt-3); background:var(--card-head)}
+  table.floors td.ratio{font-family:var(--font-mono); font-weight:700; color:var(--txt)}
+  table.floors td .pass{color:var(--green); font-weight:700}
+  table.floors td .fail{color:var(--red); font-weight:700}
+  table.floors tr:last-child td{border-bottom:0}
+
+</style>
+</head>
+<body>
+<div class="wrap"><div class="sheet">
+  <div class="top">
+    <p class="eyebrow">JacRentals · Rental Wrangler <span class="hl">·</span> Foundations</p>
+    <h1>Type voices</h1>
+    <p class="lede">Exactly two families, never a third: a stamped/condensed mono voice for labels, chips, IDs and every number — a clean body sans for record names and prose.</p>
+    
+  </div>
+
+  <section>
+    <h2 class="sub">The two voices — never a third family</h2>
+    <div class="panel">
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Stamped label</div><div class="spec-row__rr">mono · 700–800 · uppercase · tracked</div></div>
+        <div class="spec-row__ex"><span class="t-stamp2" style="font-size:14px">Work Orders</span><span class="t-stamp2">Purchase date</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Record name</div><div class="spec-row__rr">sans · bold · sentence-case</div></div>
+        <div class="spec-row__ex"><span class="t-name">Boudreaux Marine LLC</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Value / prose</div><div class="spec-row__rr">sans · regular</div></div>
+        <div class="spec-row__ex"><span class="t-prose">Marine construction · Cameron, LA — net 15 terms.</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Number / ID / $ / time</div><div class="spec-row__rr">mono · tabular-nums</div></div>
+        <div class="spec-row__ex"><span class="t-num">#4471 · $4,250.00 · 2h ago · S/N 4471-K</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Chip / flag text</div><div class="spec-row__rr">mono · 700 · caps · label-size</div></div>
+        <div class="spec-row__ex"><span class="signal signal--yellow signal--filled">due back</span></div>
+      </div>
+      <div class="spec-row">
+        <div class="spec-row__role"><div class="spec-row__rn">Hint / empty state</div><div class="spec-row__rr">sans · italic · muted</div></div>
+        <div class="spec-row__ex"><span class="t-hint">No cards on file yet</span></div>
+      </div>
+    </div>
+    <div class="callout">Numbers, IDs, timestamps and <b>dollar figures</b> always ride the stamped/mono voice with
+      tabular figures — so a column of money or dates lines up like a ledger, never the body sans.</div>
+  </section>
+
+  <section>
+    <h2 class="sub">The stacks, verbatim</h2>
+    <div class="panel pad">
+      <div style="margin-bottom:14px">
+        <div class="t-stamp2" style="margin-bottom:6px">--font (body voice)</div>
+        <code style="font-size:12px">"Geist", -apple-system, "Segoe UI", sans-serif</code>
+        <p class="t-prose" style="margin-top:8px">Record names, prose, values. Bold + sentence-case for names — never caps.</p>
+      </div>
+      <div>
+        <div class="t-stamp2" style="margin-bottom:6px">--font-mono (stamped voice)</div>
+        <code style="font-size:12px">ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace</code>
+        <p class="t-prose" style="margin-top:8px">Labels, chips (Signal/Gate/Stamp), IDs, and every tabular number/$ figure. Uppercase, ~0.03–0.06em tracking, 700–800 weight.</p>
+      </div>
+    </div>
+    <div class="callout warn"><b>Note.</b> The <code>wrangler-style</code> skill's written spec names a plain system-sans
+      stack (no Geist) for the body voice; the actual shipped <code>style.css</code> token — used verbatim here —
+      leads with <code>"Geist"</code>. This package follows the code (the brief's "absolute rule"); see the report for
+      the full disagreement note.</div>
+  </section>
+
+  <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the
+    <b>locked html.dv2</b> redesign tokens. Dark-only — no light mode is shipped or shown. Vanilla HTML + CSS, no
+    framework.</div>
+</div></div>
+</body>
+</html>

--- a/docs/design/rw-design-system/foundations/type.html
+++ b/docs/design/rw-design-system/foundations/type.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Rental Wrangler — Type voices</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
   :root{
   /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
@@ -19,15 +20,20 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+  }
+  @supports (color: oklch(from red l c h)){
+    :root{ --red-line: oklch(from var(--red) .74 .215 h); }
   }
 
   *{box-sizing:border-box}
@@ -80,15 +86,19 @@
     border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; white-space:nowrap}
   .signal--gray.signal--filled   {background:var(--gray);     color:var(--on-gray)}
-  .signal--gray.signal--outline  {background:var(--gray-bg);  color:var(--gray)}
   .signal--blue.signal--filled   {background:var(--blue);     color:var(--on-blue)}
-  .signal--blue.signal--outline  {background:var(--blue-bg);  color:var(--blue)}
   .signal--yellow.signal--filled {background:var(--yellow);   color:var(--on-yellow)}
-  .signal--yellow.signal--outline{background:var(--yellow-bg);color:var(--yellow)}
   .signal--red.signal--filled    {background:var(--red-fill); color:var(--on-red-fill)}
-  .signal--red.signal--outline   {background:var(--red-bg);   color:var(--red)}
   .signal--green.signal--filled  {background:var(--green);    color:var(--on-green)}
-  .signal--green.signal--outline {background:var(--green-bg); color:var(--green)}
+  /* C15 — true outline: transparent bg + 1px border in currentColor (old background-tint rules deleted) */
+  .signal--outline{background:transparent; border:1px solid currentColor}
+  .signal--gray.signal--outline  {color:var(--gray)}
+  .signal--blue.signal--outline  {color:var(--blue)}
+  .signal--yellow.signal--outline{color:var(--yellow)}
+  .signal--green.signal--outline {color:var(--green)}
+  .signal--red.signal--outline   {color:var(--red-line)}   /* C18 */
+  /* C7 — read-only atoms say so with the cursor */
+  .signal, .stamp, .stamp-sep, .dead-text, .t-hint{cursor:default}
 
   /* ================= GATE — a Signal you can turn: + leading centred chevron ================= */
   .gate{height:var(--h); display:inline-flex; align-items:center; gap:2px; padding:0 10px 0 7px;
@@ -107,15 +117,15 @@
     font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.05em;
     text-transform:uppercase; color:var(--txt-3)}
   .stamp--more{color:var(--accent)}
-  .stamp-sep{color:var(--line); font-family:var(--font-mono); font-size:11px}
+  .stamp-sep{height:var(--h); display:inline-flex; align-items:center; font-weight:700; color:var(--line); font-family:var(--font-mono); font-size:11px}
 
   /* ================= REF — a linked record: accent-tinted icon backing + name ================= */
-  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px;
-    border-radius:var(--chip-radius); border:1px solid var(--line); background:transparent;
-    font-family:var(--font); font-weight:600; font-size:12.5px; color:var(--txt);
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 10px 0 3px;
+    border-radius:var(--item-radius); border:1px solid var(--line); background:transparent;
+    font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt);
     text-decoration:none; cursor:pointer}
   .ref:hover{border-color:var(--accent)}
-  .ref__icon{width:18px; height:18px; border-radius:4px; flex:none; display:inline-flex;
+  .ref__icon{width:18px; height:18px; border-radius:5px; flex:none; display:inline-flex;
     align-items:center; justify-content:center; background:var(--accent-soft); color:var(--accent)}
   .ref__icon svg{width:12px; height:12px}
   .ref__id{font-family:var(--font-mono); font-size:9px; color:var(--txt-3); font-weight:600}
@@ -127,19 +137,23 @@
     border-radius:var(--pill-radius); font-family:var(--font-mono); font-size:11px; font-weight:800;
     letter-spacing:.05em; text-transform:uppercase; cursor:pointer; border:0; white-space:nowrap}
   .door--commit {background:var(--commit); color:var(--on-commit)}
-  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit); padding:0 13px}
+  /* M10 — +Add rides the Ref pattern: item radius, icon holder with the + inside, dashed commit border kept */
+  .door--add    {background:transparent; border:1.5px dashed var(--commit); color:var(--commit);
+    border-radius:var(--item-radius); gap:6px; padding:0 11px 0 3px}
+  .door--add .ref__icon{background:color-mix(in oklab, var(--commit) 25%, transparent); color:var(--commit)}
   .door--money  {background:var(--green); color:var(--on-green)}
   .door--destroy{background:var(--red-fill); color:var(--on-red-fill)}
   .door--ghost  {background:transparent; border:1px solid var(--line); color:var(--txt-2)}
 
   .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:var(--chip-radius); overflow:hidden}
   .seg__opt{display:inline-flex; align-items:center; padding:0 11px; font-family:var(--font-mono);
-    font-size:10px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt-3);
+    font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt-3);
     border-right:1px solid var(--line); cursor:pointer; background:transparent}
   .seg__opt:last-child{border-right:0}
   .seg__opt--on-yellow{background:var(--yellow); color:var(--on-yellow)}
   .seg__opt--on-red{background:var(--red-fill); color:var(--on-red-fill)}
   .seg__opt--on-blue{background:var(--blue); color:var(--on-blue)}
+  .seg__opt--on-green{background:var(--green); color:var(--on-green)}
   .seg__opt--on-accent{background:var(--accent); color:var(--on-orange)}
 
   /* ================= FIELDS / links ================= */
@@ -150,12 +164,17 @@
   .contact{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--font);
     font-size:13px; color:var(--txt); text-decoration:none; cursor:pointer}
   .contact svg{color:var(--accent); width:14px; height:14px}
-  .contact__v{border-bottom:1.4px solid transparent}
+  .contact__v{border-bottom:1.5px solid transparent}
   .contact:hover .contact__v{border-bottom-color:var(--accent)}
-  .hlink{font-family:var(--font); font-size:13px; color:var(--txt); text-decoration:none;
-    border-bottom:1.5px solid var(--accent); padding-bottom:1px; cursor:pointer}
-  .hlink__ext{font-family:var(--font-mono); color:var(--accent); font-size:10px}
-  .dead-text{font-family:var(--font); font-size:13px; color:var(--txt-2)}
+  /* C1/C2/M12 — link atoms: 24px box, underline on the LABEL only, out-marker is a drawn arrow in an icon holder */
+  .hlink, .dead-text{height:var(--h); display:inline-flex; align-items:center; font-family:var(--font); font-size:13px}
+  .hlink{color:var(--txt); text-decoration:underline; text-decoration-color:var(--accent);
+    text-decoration-thickness:1.5px; text-underline-offset:3px; gap:7px; cursor:pointer}
+  .hlink__ext{width:16px; height:16px; flex:none; border-radius:4px; text-decoration:none;
+    display:inline-flex; align-items:center; justify-content:center;
+    background:var(--accent-soft); color:var(--accent)}
+  .hlink__ext svg{width:10px; height:10px; display:block}
+  .dead-text{color:var(--txt-2)}
 
   /* ================= PLATE — section-header grammar ================= */
   .plate{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card)}
@@ -237,15 +256,6 @@
   .t-yellow .tname{color:var(--yellow)} .t-red .tname{color:var(--red)}
   .tmean{font-size:11.5px; color:var(--txt-2); margin-top:4px}
 
-  .menu{border:1px solid var(--line); border-radius:10px; overflow:hidden; background:var(--panel); width:190px}
-  .menu__h{font-family:var(--font-mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
-    color:var(--txt-3); padding:9px 12px; border-bottom:1px solid var(--line); background:var(--card-head)}
-  .menu__i{display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:12px; color:var(--txt);
-    border-bottom:1px solid var(--line-soft); cursor:pointer}
-  .menu__i:last-child{border-bottom:0}
-  .menu__sw{width:8px; height:8px; border-radius:2px; flex:none}
-  .menu__i.on{font-weight:800}
-  .menu__i.on:after{content:"\2713"; margin-left:auto; color:var(--accent); font-family:var(--font-mono); font-size:11px}
 
   table.floors{width:100%; border-collapse:collapse}
   table.floors th, table.floors td{padding:9px 12px; border-bottom:1px solid var(--line-soft); font-size:12px; text-align:left}
@@ -255,6 +265,71 @@
   table.floors td .pass{color:var(--green); font-weight:700}
   table.floors td .fail{color:var(--red); font-weight:700}
   table.floors tr:last-child td{border-bottom:0}
+
+  /* ============================ consistency pass — [B]/[C] additions ============================ */
+  .ref, .field, .seg, .seg__opt, .contact, .hlink, .dead-text, .stamp{flex:none; white-space:nowrap} /* C19 */
+
+  /* C12 — every tappable atom is a real <button type="button">; zero the sides the kit doesn't own */
+  button.gate, button.door, button.seg__opt, button.field{-webkit-appearance:none; appearance:none;
+    margin:0; text-align:left}
+  button.seg__opt{border-top:0; border-bottom:0; border-left:0}
+
+  /* C20 — ONE universal hover: an accent ring drawn OUTSIDE the element, nothing shifts */
+  .gate:hover, .door:hover, .seg:hover, .field:hover, .ref:hover,
+  .contact:hover, .hlink:hover, .pin[data-tip]:hover{outline:1.5px solid var(--accent); outline-offset:2px}
+  /* C8 — press dips the fill on filled tappables */
+  .gate:active, .door--commit:active, .door--money:active, .door--destroy:active{filter:brightness(.94)}
+  /* C9 — hover INK reserved for atoms that navigate or switch */
+  .seg__opt:not([class*="seg__opt--on"]):hover{color:var(--txt)}
+  .ref:hover, .contact:hover{color:var(--accent)}
+  /* C10 — one focus ring for every tappable atom */
+  .gate:focus-visible, .door:focus-visible, .seg__opt:focus-visible, .field:focus-visible,
+  .ref:focus-visible, .contact:focus-visible, .hlink:focus-visible{outline:2px solid var(--accent-line);
+    outline-offset:2px}
+
+  /* M11 — a STATE pair toggle reads as Signals: live = filled chip of its status, other side = outline in its own hue */
+  .seg--state .seg__opt{border-right:0}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]){background:transparent; color:var(--gray);
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset -1px 0 0 currentColor}
+  .seg--state .seg__opt:not([class*="seg__opt--on"]):first-child{
+    box-shadow:inset 0 1px 0 currentColor, inset 0 -1px 0 currentColor, inset 1px 0 0 currentColor}
+  .seg--state .seg__opt--off-red:not([class*="seg__opt--on"]){color:var(--red-line)}
+
+  /* M7 — the status picker IS the segmented toggle, stacked (supersedes the old picker pattern) */
+  .seg--stack{flex-direction:column; height:auto; align-items:stretch; width:100%}
+  .seg--stack .seg__opt{height:var(--h); flex:none; border-right:0;
+    border-bottom:1px solid var(--line); justify-content:flex-start}
+  .seg--stack .seg__opt:last-child{border-bottom:0}
+
+  /* N1 — PIN, the universal corner marker. colour=state, fill=today, exactly like a Signal.
+     Anchored at 70% over its host's top-right corner. 13px tall, off the 24px control ladder,
+     zero layout footprint (absolute, no margin, no reserved space). */
+  .pin-wrap{position:relative; display:inline-flex; flex:none}
+  .pin{position:absolute; top:0; left:100%; transform:translate(-70%,-50%); z-index:2;
+    height:13px; min-width:13px; padding:0 4px;
+    display:inline-flex; align-items:center; justify-content:center; gap:3px;
+    border-radius:var(--chip-radius); font-family:var(--font-mono); font-size:9px; font-weight:800;
+    letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; font-variant-numeric:tabular-nums;
+    cursor:pointer; text-decoration:none; outline:1.5px solid var(--panel)}
+  .pin svg{width:9px; height:9px; display:block}
+  .pin--gray  {background:var(--gray);     color:var(--on-gray)}
+  .pin--blue  {background:var(--blue);     color:var(--on-blue)}
+  .pin--yellow{background:var(--yellow);   color:var(--on-yellow)}
+  .pin--red   {background:var(--red-fill); color:var(--on-red-fill)}
+  .pin--green {background:var(--green);    color:var(--on-green)}
+  .pin--outline{background:var(--panel); border:1px solid currentColor}
+  .pin--gray.pin--outline  {color:var(--gray)}
+  .pin--blue.pin--outline  {color:var(--blue)}
+  .pin--yellow.pin--outline{color:var(--yellow)}
+  .pin--green.pin--outline {color:var(--green)}
+  .pin--red.pin--outline   {color:var(--red-line)}
+  .pin:focus-visible{outline:2px solid var(--accent-line); outline-offset:2px}
+  .pin:after{content:attr(data-tip); position:absolute; bottom:calc(100% + 8px); right:-2px; display:none;
+    padding:7px 10px; max-width:260px; background:var(--panel-2); border:1px solid var(--line);
+    border-radius:9px; color:var(--txt); font-family:var(--font); font-size:11.5px; font-weight:400;
+    line-height:1.4; letter-spacing:0; text-transform:none; white-space:nowrap; z-index:6; pointer-events:none}
+  .pin[data-tip]:hover:after,
+  .pin[data-tip]:focus-visible:after{display:block}
 
 </style>
 </head>
@@ -304,7 +379,7 @@
     <div class="panel pad">
       <div style="margin-bottom:14px">
         <div class="t-stamp2" style="margin-bottom:6px">--font (body voice)</div>
-        <code style="font-size:12px">"Geist", -apple-system, "Segoe UI", sans-serif</code>
+        <code style="font-size:12px">"Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif</code>
         <p class="t-prose" style="margin-top:8px">Record names, prose, values. Bold + sentence-case for names — never caps.</p>
       </div>
       <div>
@@ -313,10 +388,10 @@
         <p class="t-prose" style="margin-top:8px">Labels, chips (Signal/Gate/Stamp), IDs, and every tabular number/$ figure. Uppercase, ~0.03–0.06em tracking, 700–800 weight.</p>
       </div>
     </div>
-    <div class="callout warn"><b>Note.</b> The <code>wrangler-style</code> skill's written spec names a plain system-sans
-      stack (no Geist) for the body voice; the actual shipped <code>style.css</code> token — used verbatim here —
-      leads with <code>"Geist"</code>. This package follows the code (the brief's "absolute rule"); see the report for
-      the full disagreement note.</div>
+    <div class="callout warn"><b>Updated — consistency pass (C14).</b> <code>--font</code> moves from <code>"Geist"</code>
+      to <code>"Archivo"</code> for the body voice (<code>--font-mono</code> is unchanged). Ship the Archivo woff2
+      alongside Geist, or load the Google Fonts weights 400–800 — this preview links the Google Fonts stylesheet so it
+      renders correctly standalone.</div>
   </section>
 
   <div class="foot">Sourced from <b>wrangler-style</b> (decisions) + <b>style</b> (measurable rules), built on the

--- a/docs/design/rw-design-system/tokens.css
+++ b/docs/design/rw-design-system/tokens.css
@@ -15,13 +15,18 @@
   --red:#ff4242; --red-bg:rgba(255,66,66,.13);
   --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
   --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
-  --chip-radius:7px;
+  --chip-radius:2px;    /* C13/C17 — was 7px; squared state chips: Signal/Gate/Field/Seg */
   --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
   --radius:14px;
-  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font: "Archivo", "Helvetica Neue", -apple-system, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
   /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
   --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
-  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule — Doors ONLY */
+  --item-radius:8px;    /* NEW C13/C17 — records: Ref, +Add */
   --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+  --red-line: color-mix(in oklch, var(--red) 78%, var(--txt));  /* C18 — legible red outline on dark surfaces */
+}
+@supports (color: oklch(from red l c h)){
+  :root{ --red-line: oklch(from var(--red) .74 .215 h); }
 }

--- a/docs/design/rw-design-system/tokens.css
+++ b/docs/design/rw-design-system/tokens.css
@@ -1,0 +1,27 @@
+/* Rental Wrangler — design tokens
+ * Source of truth: html.dv2 in style.css (the locked redesign canon).
+ * See rw-design-system/README.md for usage notes.
+ */
+:root{
+  /* ---- LOCKED CANON (verbatim from html.dv2 in style.css — do not approximate) ---- */
+  --accent:#ff7e1f; --accent-soft:rgba(255,126,31,.15); --accent-line:rgba(255,126,31,.5);
+  --orange:#ff7e1f; --orange-bg:rgba(255,126,31,.14); --on-orange:#1a1205;
+  --bg:#0a0d11; --bg-2:#0f1318; --panel:#171d25; --panel-2:#1b222c;
+  --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#838e9c;
+  --green:#34d399; --green-bg:rgba(52,211,153,.14);
+  --yellow:#eed44b; --yellow-bg:rgba(238,212,75,.15);
+  --red:#ff4242; --red-bg:rgba(255,66,66,.13);
+  --blue:#6394cc; --blue-bg:rgba(99,148,204,.15);
+  --gray:#8b94a3; --gray-bg:rgba(139,148,163,.14);
+  --chip-radius:7px;
+  --red-fill:#d63636; --on-red-fill:#fdfdfd; --commit:#2f6fd0; --on-commit:#fdfdfd; --tan:#c2925a;
+  --radius:14px;
+  --font: "Geist", -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace;
+  /* ---- STRUCTURAL ADDITIONS (not in the locked block — see README/report) ---- */
+  --h:24px;             /* one control height — style skill's 24-28px range; matches shipped --dv2-h */
+  --pill-radius:999px;  /* the action radius, paired with --chip-radius for the "two radii" rule */
+  --on-gray:#12171d; --on-blue:#0a1220; --on-yellow:#241d05; --on-green:#06231a;
+}

--- a/docs/superpowers/specs/2026-07-20-decisions-ledger.md
+++ b/docs/superpowers/specs/2026-07-20-decisions-ledger.md
@@ -1,0 +1,485 @@
+# Decisions Ledger — 2026-07-20 design session
+
+**Purpose.** This is the flat, scannable index of every locked decision made during the
+2026-07-20 UI-redesign brainstorming session, cross-checked against every doc it should
+have landed in (`2026-07-20-list-views-inline-expand-design.md`, `wrangler-style`,
+`style`, `2026-07-20-mockup-critique-log.md`). Some decisions never made it into a doc —
+they lived only in the conversation. Those are rescued in full below. Everything else is
+indexed with a pointer to where it already lives, so nothing has to be re-derived from the
+raw transcript again.
+
+Nothing below is invented — every row traces to a specific exchange in the session. Where
+something was discussed but never actually settled, it's listed in **Still open**, not
+presented as decided.
+
+---
+
+## ⏱ Precedence — newer beats older (Jac, 2026-07-20)
+
+**When a rescued (older) decision conflicts with a newer one, the NEWER decision is canon.** This
+ledger preserves history — including early framings that were later refined — for *context*, never to
+override a current locked decision. Known refinements are flagged inline as **[refined → …]**. Do not
+let an archived early decision overtake a newer locked one.
+
+---
+
+## ⚠ NEWLY CAPTURED — was not in any doc
+
+### 1. The 5-part DNA: WORD · NUMBER · SIGNAL · DOOR · PLACE
+The whole redesign started from a reduction exercise: 399 findings → 25 jobs → 6 root
+problems → **5 behavioral parts**, each the single fix for a cluster of jobs. This is the
+conceptual spine everything else (including the Signal/Gate/Stamp/Ref/Door *component*
+vocabulary) hangs off, and it was never written down anywhere outside the conversation.
+- **SIGNAL** — urgency that climbs (row → group → tab → whole-yard count) and ranks by
+  severity. The fix for "spot the fire."
+- **NUMBER** — one honest, owned figure per fact, with provenance and an honest "unknown"
+  state (vs. a confident fake `$0`). The fix for "trust the screen."
+- **DOOR** — a verb-first action that carries its own guard/reason, visible before you
+  hit it. Notably, this single part was arrived at by **merging two root problems**
+  (reachability and reversibility) — a control that publishes its own guard *is* its own
+  door, which is the concrete "5 needs, 2 elements" example Jac asked for.
+- **WORD** — a durable, addressed inbox (the seed of the whole comms/get-told work later
+  in the session).
+- **PLACE** — one grammar, kept structure, reused builders across every card (the
+  "keep the WHERE" principle formalized).
+Rationale for keeping 5 rather than folding SIGNAL into NUMBER: they do genuinely
+different work (is-it-true vs. is-it-on-fire) and folding them would bury urgency inside
+"a number." The component vocabulary (**Signal · Gate · Stamp · Ref · Door**, now in
+`wrangler-style` §3) is this DNA's later, concrete on-screen incarnation — Gate is
+SIGNAL+DOOR merged into one turnable control, Stamp is NUMBER's plain-fact sibling, Ref is
+PLACE's cross-card link. That lineage — *why* the five components look the way they do —
+was never written down; only the end state was.
+
+### 2. The color system's full semantics and its origin story
+`style.md` documents the *mechanism* (`taskState → blocked·now·later·done·none`) but not
+the actual **meaning** Jac locked for each hue, nor the debate that produced it — and
+`wrangler-style.md` lists the hexes without stating what they mean.
+- Jac revealed the app's color system started as **his own invention** pre-dating this
+  project: Red = blocking/a gate stops you, Yellow = needs doing, Green = nothing to do.
+  He'd been tempted to launch a whole separate initiative around it, until this session's
+  research showed *why* it broke in production (red wasn't rationed — 44/60 rows red;
+  green was assigned by lifecycle, not health, so it lied over hidden fires).
+- **Final locked meanings** (superseding several intermediate proposals mid-session):
+  - **Grey = N/A / nothing** — the silent default.
+  - **Blue = Waiting** — "the ball's not in your court" (vendor, customer, the clock,
+    another department). Chosen specifically because the app had *no* representation for
+    in-flight/pending states (an ACH mid-settlement rendered identically to a stone-cold
+    overdue invoice). Confirmed by "Reserved = Waiting" (waiting on the pickup).
+  - **Yellow = your move, now** — kept to exactly this one meaning once Blue absorbed
+    "waiting" and routine work, which is what fixed Jac's "does yellow feel negative?"
+    worry (yellow only fires when it's genuinely urgent, never for routine to-dos).
+  - **Red = Bad** — deliberately widened by Jac from his original "blocked-only" meaning
+    to a general "wrong/bad," with the blocking-specific nuance recovered later via the
+    **fill bit** instead of spending a sixth hue.
+  - **Green = Done (today)** — a completion/recency state, not a permanent badge. Ages to
+    Grey the next day ("settles," becomes ambient). "Done re-alarms": if a completed
+    item reverts to bad, it snaps straight back to Red.
+  - **One function assigns color, always** — no renderer improvises its own (this was
+    the literal root cause of the original R/Y/G system's failure, per the research: every
+    card/renderer computed color independently).
+- **Rollup precedence, hottest wins: `red > yellow > blue > green > grey`.** This exact
+  order is never written in `style.md` (which only lists bucket names, no ordering).
+- **Buttons carry no status color, full stop** — made deliberately neutral (white "click
+  me" / ghost secondary) specifically to stop Blue doing double duty as both a
+  button-affirm color and a status color at the same time.
+
+### 3. Group taxonomy: Attention groups vs. Lifecycle groups
+A structural rule for every card's list groups, arrived at while designing Rentals'
+groups, never written to any doc:
+- **Attention groups** (e.g. Field Calls, Failed) exist and are colored *only* because
+  something is wrong — **hidden entirely when empty.**
+- **Lifecycle groups** (e.g. On Rent, Reserved, Available, End Rent) are **always
+  present**, grey by default, and take color *only* when a member inside triggers it. No
+  group is ever given a fixed/native color — this was an explicit rejection (to stop the
+  "green lied" bug from recurring at the group level, not just the row level).
+- **End Rent is inherently yellow** because its very membership means "due back today" —
+  this is how the corpus's "no forward-looking due-back bucket" finding (#110) got fully
+  solved, replacing an earlier, more awkward idea of encoding "due back" as a color
+  *inside* On Rent.
+- A "first-match cascade" model (a record could match multiple groups) was floated and
+  then explicitly dropped: Today/Tomorrow/This Week are **reservation start dates**, not
+  return dates, so it's a clean single-stage lifecycle timeline with no cascade needed.
+
+### 4. The real per-card lifecycle group lists
+Jac supplied these as the literal starting groups for each card's list view — never
+recorded in a doc, and they're the concrete instance of the taxonomy above:
+- **Customers:** Past Due, Not Due, Reserved, On Rent, Members, Non-Members.
+- **Rentals:** Today, Tomorrow, This Week, On Rent, Off Rent, End Rent, Returned, Quote,
+  No Show, Cancelled.
+- **Units (staff/mechanic view):** Field Calls, Not Ready/Failed+Reserved, Not Ready,
+  Failed, Transport, Reserved, On Rent, End Rent, Available, Incomplete (Office Work
+  Needed).
+- **Units (office+ view):** same set, reordered — Field Calls, Not Ready/Failed+Reserved,
+  Transport, Reserved, On Rent, End Rent, Available, Incomplete, Not Ready, Failed.
+- "Not Ready/Failed+Reserved" as its own top bucket is the dedicated home for the
+  broken-machine-promised-to-a-customer collision (finding #51).
+- **Groups must never be named after status** ("Bad"/"To-Do") — that double-encodes what
+  color already says; groups say *where* in the workflow, color says *how much* it needs
+  you. (Claude's own early mistake, corrected by Jac.)
+- **Role-scoped group order**: the same group set, reordered per role (mechanic floats
+  Not-Ready/Failed to the top, office sinks them) — one universal grouping engine, role
+  only supplies the priority. Role sets defaults, never walls a role off from other
+  cards' alerts (a mechanic still gets pinged if a rental he's on goes overdue).
+
+### 5. Quick-filter chips: "Your Work" and "Done"
+Header-level filters, distinct from groups, locked over several rounds — not written to
+any doc:
+- **"Your Work"** — hides any group holding only Green/Grey (all-clear); shows only
+  groups containing Red/Yellow/Blue. Does **not** re-bucket items, only hides/shows whole
+  groups; carries a rolled-up count. Deliberately chosen over four separate time-based
+  chips (Today/Tomorrow/Week/Done) because those are Rentals/Calendar-specific words that
+  don't fit Units (service language) or Customers (money/lead language) — a per-card
+  filter set would have broken "same builder everywhere."
+- **"Done"** — a sibling/opposite filter showing only items in the Green "done today"
+  state, so a user can re-find and re-touch what they just did. Explicitly *not* a group
+  (Jac: listing an item in multiple groups is "just wrong for our system") — it's a
+  filter over the item's one true group placement, same mechanism as Your Work, opposite
+  end.
+- The card-title toggle moved from **center to left-aligned** specifically to free header
+  space for these chips (plus the graph/search/sort) — Jac's own proposal, confirmed
+  useful for mobile too (frees room even for a single chip).
+
+### 6. The fill-bit's full debate history and the 3-tier hover contract
+`style.md` documents the final trigger list, but not how it got there or the hover
+contract layered on top:
+- **1st proposal (Jac): Filled = Blocking**, outline = "fix it but not gated." Claude
+  generalized this to all five hues and built an 11-example "real gates" artifact
+  (failed inspection, no card on file — 94.5% of the book has none, unsigned agreement,
+  ACH-in-flight, blacklist, part-on-order, overbook…).
+- **2nd proposal (Jac): Filled = Today** instead. Claude's honest compare showed
+  "Today" mostly repeats what groups+color already carry, while "Blocking" catches
+  something nothing else does — Claude recommended keeping Blocking, but Jac overruled
+  and locked Fill = Today.
+
+**[refined → current: `style` §6 / `triggeredToday`, see "Final correction" bullet below]:**
+neither of the two bullets above is current canon — **fill = the generous "curiosity
+magnet" rule** (`triggeredToday`: due/overdue/gating-now/needs-hands/near-clock/in-flight/
+flagged-live/closed-today), not "Filled = Blocking" (1st proposal) and not narrowly
+"Filled = Today" (2nd proposal). Both are the ancestors, kept for context, and do **not**
+override the final generous fill rule.
+
+- **Final correction (Jac), reached by explicitly rejecting Claude's own narrower
+  reading:** fill should be a **generous "look here"/curiosity magnet** — Jac wanted
+  future-dated items, in-flight/self-resolving items (ACH, e-sign), and dormant flags to
+  **all** fill too, because they "touch Today" in some live sense: *"I want users' eyes
+  to trigger special curiosity upon seeing a filled."* Only genuinely at-rest records
+  (idle unit, mid-rental with nothing due, plain member) stay hollow. This is the
+  decision the current `triggeredToday` trigger list encodes — the debate that produced
+  it wasn't written down.
+- **The 3-tier hover contract for a Signal/Gate chip** (locked alongside fill): (1)
+  color+fill = an instant read, (2) the word on the chip = what it is (Signal already
+  verbalizes it), (3) hover / Tab / long-press = *why* and *what it stops*. `wrangler-
+  style` only says "hover → explain + name the source" — the 3-tier breakdown and the
+  keyboard/touch equivalents (Tab, long-press) aren't recorded.
+
+### 7. The three-way color-role split that organized the whole "connective layer"
+The rule that unlocked text/links/flags design (born from a blue-collision trap): **status
+colors = what · orange = touchable · white = commit · everything else = plain honest
+text.** Nothing ever does two jobs. `wrangler-style` shows the resulting Signal/Ref/Door
+components but never states this organizing one-liner, which is the reason those three
+things don't collide.
+
+**[refined → §8 / `wrangler-style` §3]:** current canon is **commit = deep-blue `#2f6fd0` with white
+INK on it** — *not* "white = commit." White is the ink *on* the deep-blue commit pill; the early
+"white = commit" phrasing here is the ancestor, kept for context, and does **not** override the
+deep-blue-commit decision.
+
+### 8. The two-blues collision and its pill-shape resolution
+Blue was already spoken for as the *Waiting* status color, so a commit/save button
+couldn't reuse it. Resolution: commit got its **own** deep, more-saturated blue
+(`#2f6fd0`, distinct from status blue `#6394cc`) and is **always rendered as a solid pill
+shape**, so the two blues never read as the same control even though both are
+technically "blue." Jac confirmed this explicitly and asked for the pill shape to be
+pushed further ("maybe consider a true pill to differentiate it even more") — which is
+the origin of Doors generally being pill-radius. `wrangler-style` states the two hexes
+exist and flags one as revisit-worthy, but never explains *why* two blues exist or that
+the pill shape is the thing keeping them apart.
+
+### 9. Sandbox/staging architecture decisions and their rationale
+Three explicit architecture calls Jac made when scoping how the redesign would get built
+and reviewed, never written to any doc:
+- **Home: reuse the staging-2 slot**, not a dedicated new repo — specifically *because*
+  Jac wants finished cards to merge into trunk piecemeal as they're approved ("my hope is
+  that our system improvement is so simple that it is a piece of cake to soon push to
+  production").
+- **Backend data: read-only on live data**, no sandbox copy/backend needed — because
+  this is explicitly scoped as a **view-layer-only redesign**: "we're not changing the
+  business/app or workflows... we're improving how those workflows appear to humans...
+  we shouldn't need to write to the backend." This is *why* rollback is "free" (see
+  below) and is the reason the whole redesign carries almost no data risk.
+- **Look direction: use all three explored directions together (A+B+C)**, not pick one —
+  "cover as much ground with as few visual systems as possible without losing workload or
+  quality... too simple and users can't build muscle memory... too complicated and we get
+  a zoo of systems." This sentence is the actual rationale behind "one small kit of
+  reusable builders," which downstream docs state as a rule but don't attribute to this
+  reasoning.
+- **Rollback safety net:** the live production commit (`0fac006`) was noted as a restore
+  point; because the redesign is read-only on the backend, reverting the *frontend* alone
+  automatically preserves every transaction/payment/record accumulated in the meantime —
+  an "already free" rollback. The redesign was also slated to ride the existing `FEATURES`
+  flag for an instant runtime-toggle revert if users hate it.
+
+### 10. Funnel redesign specifics
+Jac's five corrections to the Funnel mockup (after saying "I LOVE IT") landed in the
+build but only partly made it into the spec's terse Funnel bullet:
+- **Icons instead of plain checkmarks** on stepper stage markers (pulled from the app's
+  own `GATE_ICON` set).
+- **Real estate to the right of each checkpoint holds that checkpoint's own actions** —
+  not a single generic action list below the stepper.
+- **Rename "Next Actions" → "More Actions"** (now explicitly the overflow bucket for
+  items with no stage tag).
+- **Inline action-adding, no popup** — the one tolerated exception is a small
+  calendar+time picker that appears just above whatever was clicked.
+- **Must use Jac's real funnel steps, never invented ones** — pulled verbatim from
+  `config.js`'s actual `FUNNELS` (Rental: Lead → Reserved → Rented, stacked with the
+  Member ladder Lead → Contacted → Not A No! → Payment Discussed → Signed; Equipment:
+  Lead → Contacted → Not A No! → Payment Discussed → Paid).
+- The **vertical** (not horizontal) stepper was chosen because a 5-stage horizontal
+  dated track got cramped at customer-section width.
+- The current-stage marker was made color-blind-safe **three separate ways** at once (a
+  diamond glyph in the dot, a matte offset ring, and literal text "· now") — a concrete,
+  reusable technique for "never color alone" that isn't written down as guidance
+  anywhere, only demonstrated once in this one mockup.
+
+---
+
+## Full ledger, by area
+
+Status tags: `[doc: …]` = already captured · `[⚠ NEW — captured here]` = rescued above,
+first written down in this ledger.
+
+### Design system — palette, type, contrast, components
+
+| # | Decision | Status |
+|---|---|---|
+| 1 | Dark palette hexes locked (steel surfaces, safety-orange accent, status colors) | [doc: wrangler-style §1] |
+| 2 | Light theme palette locked | [doc: wrangler-style §1] |
+| 3 | Filled red deepened `#ff4242→#d63636` (white text 3.44→4.73, AA-forced) | [doc: wrangler-style §1] |
+| 4 | Blue muted `#5b9dff→#6394cc` (softens vs. orange, keeps 5.93:1) | [doc: wrangler-style §1] |
+| 5 | Yellow dimmed twice: neon→`#ffe14d` (CVD sim, 103 sep.)→final `#eed44b` (dimmest point holding ≥90 from both orange and green) | [doc: wrangler-style §1] |
+| 6 | Jac is color-blind — CVD separation floor (≥90 under deuter+protan sim) is a hard gate, not a taste call | [doc: wrangler-style §1, style §4] |
+| 7 | Two type voices: stamped/mono for labels+chips, system sans for names/values; record names bold sentence-case | [doc: wrangler-style §2, style §2] |
+| 8 | One control height, one baseline, ≤3 weights, one size ladder (28·15·13·12·11·10·9.5) | [doc: style §1] |
+| 9 | Two radii only: pill(999) for actions, one chip radius for statuses | [doc: style §1] |
+| 10 | Signal · Gate · Stamp · Ref · Door named as the component vocabulary | [doc: wrangler-style §3] |
+| 11 | Signal: colour=state, fill=today, teleport-on-click, name-source-on-hover | [doc: wrangler-style §3] |
+| 12 | Gate: Signal + leading centered chevron hugging text, no orange dot, opens status picker | [doc: wrangler-style §3] |
+| 13 | Stamp: plain fact, no box/color, quiet sibling to Signal, `+N` overflow budget | [doc: wrangler-style §3] |
+| 14 | Ref: square accent-tinted backing + parent's Lucide icon + name, walks across cards | [doc: wrangler-style §3] |
+| 15 | Door: pill radius; commit=deep blue, money=green, destructive=red, cancel=ghost | [doc: wrangler-style §3] |
+| 16 | Toggle active segment = filled Signal chip of the option's status; falls back to plain orange only if no status; applies to every toggle incl. funnel tabs | [doc: wrangler-style §3] |
+| 17 | Contact affordance shows the real phone number/email as the `tel:`/`mailto:` link, not a verb like "Call" | [doc: wrangler-style §3] |
+| 18 | Honest-affordance rule: tappable ⇒ looks it, not ⇒ plain text (kills fake hover-underlines) | [doc: wrangler-style §3] |
+| 19 | "Keep where things are" — reinvent look & function only, never the map | [doc: wrangler-style §4] |
+| 20 | Plate grammar: left status-bar + stamped label + summary + chip + chevron → body; header colour = worst item inside | [doc: wrangler-style §4] |
+| 21 | Restrained wrangler/ranch voice; litmus = "western before industrial" means dial it back | [doc: wrangler-style §5] |
+| 22 | 60-30-10 accent budget adopted as a written rule | [doc: style §5] |
+| 23 | Never pure `#000`/`#fff` anywhere | [doc: style §5] |
+| 24 | `colour = taskState(record)` / `fill = triggeredToday(record, ctx)` — the two state functions, one owner each | [doc: style §6] |
+| 25 | Space-cowboy/"Duster Wrangler"/laser-lasso direction explored in depth, then explicitly rejected by Jac ("Nah. Toss this.") — app stays matte, no glow | [doc: wrangler-style intro] |
+| 26 | jactec-ui deleted at Jac's explicit request; replaced by the `style`/`wrangler-style` split, both mandatory together | [doc: wrangler-style intro, CLAUDE.md] |
+| 27 | The 5-part DNA: WORD · NUMBER · SIGNAL · DOOR · PLACE, and DOOR = the merge of the reachability + reversibility root problems | [⚠ NEW — captured here, §1] |
+| 28 | Full color semantics (Grey/Blue/Yellow/Red/Green meanings) and their origin in Jac's own pre-project R/Y/G system | [⚠ NEW — captured here, §2] |
+| 29 | Rollup precedence order: red > yellow > blue > green > grey | [⚠ NEW — captured here, §2] |
+| 30 | Buttons carry no status color, ever — a deliberate rule to stop blue double-duty | [⚠ NEW — captured here, §2] |
+| 31 | Group taxonomy: Attention groups (hidden when empty) vs. Lifecycle groups (always present, grey-until-triggered, no native color) | [⚠ NEW — captured here, §3] |
+| 32 | End Rent is inherently yellow by definition (closes finding #110 without a separate bucket) | [⚠ NEW — captured here, §3] |
+| 33 | The real per-card lifecycle group lists (Customers/Rentals/Units-staff/Units-office) | [⚠ NEW — captured here, §4] |
+| 34 | Groups must never be named after status; color and group naming are separate axes | [⚠ NEW — captured here, §4] |
+| 35 | Role-scoped group *order* on list cards (same set, reordered by role) — distinct from the section-order-by-role rule inside an expanded item | [⚠ NEW — captured here, §4] |
+| 36 | "Your Work" and "Done" quick-filter chips, and why 4 time-based chips were rejected in favor of one universal filter | [⚠ NEW — captured here, §5] |
+| 37 | Card-title toggle moved center→left-aligned to free header room for the quick-filter chips | [⚠ NEW — captured here, §5] |
+| 38 | The fill-bit's full debate (Blocking → Today → the final generous "curiosity magnet" rule) | [⚠ NEW — captured here, §6] |
+| 39 | The 3-tier hover contract for Signal/Gate chips (instant read → the word → hover/Tab/long-press for why) | [⚠ NEW — captured here, §6] |
+| 40 | The three-way color-role split principle organizing text/links/flags | [⚠ NEW — captured here, §7] |
+| 41 | The two-blues collision (status-Waiting vs. commit) and the pill-shape resolution | [⚠ NEW — captured here, §8] |
+| 42 | Chip radius unified to one value (7px) for Signal/Gate/Stamp-box/Ref-square, resolving an internal wrangler-style/style conflict | [doc: wrangler-style §3, confirmed consistent] |
+| 43 | Current-stage marker made CVD-safe three independent ways at once (glyph + ring + text), demonstrated on the Funnel | [⚠ NEW — captured here, §10] |
+
+### DNA & component vocabulary
+
+| # | Decision | Status |
+|---|---|---|
+| 44 | 5+1 card shape: every role keeps the five base cards (Units · Rentals · Customers · Trips · Categories) plus a 6th role-dependent Dashboard card | [doc: spec §5 RESOLVED] |
+| 45 | Dashboard is a landing, never a lockout — the base cards stay reachable; access-gating is a separate security call | [doc: spec §5] |
+| 46 | Drill = filter-in-place on single click, tab-on-double-click (mirrors the existing anchor discriminator) | [doc: spec §5] |
+| 47 | Yard Journey stays a Units section; driver routes stay on the Trips card — the dashboard drills TO them, never replaces them | [doc: spec §5] |
+| 48 | One colour law shared by chip and chart — a graph wedge is the same colour as the Signal chip it lands on | [doc: spec §5] |
+| 49 | The 5-part DNA framework itself (WORD/NUMBER/SIGNAL/DOOR/PLACE) as the conceptual ancestor of Signal/Gate/Stamp/Ref/Door | [⚠ NEW — captured here, §1] |
+
+### Interaction architecture
+
+| # | Decision | Status |
+|---|---|---|
+| 50 | Inline-expand replaces detail-view navigation; single-click/tap expands in place, no cascade | [doc: spec §1] |
+| 51 | Desktop expand animates with the mobile-swipe easing/timing, fixed target size, siblings push down | [doc: spec §1] |
+| 52 | Mobile expand opens a focused full-screen mode reusing the comms full-screen gesture system | [doc: spec §1] |
+| 53 | Multi-section cards page via section chips living in the item's own top row on expand | [doc: spec §2] |
+| 54 | Landing section = the Signal summary, labelled "To Do" on the section chips (internal name stays "Signal") | [doc: spec §2] |
+| 55 | Role sets the default landing + section order inside an expanded item; drag-resort persists per record-type | [doc: spec §2] |
+| 56 | Persistent History-search footer on every expanded item, all sections, not paged away | [doc: spec §2] |
+| 57 | Tall sections (e.g. Customers' Invoices) scroll internally, never blow out the card | [doc: spec §2] |
+| 58 | Hover-jump popover-above accelerator: emerges from the item's top edge with a tail/notch, one chip-line tall, flips below near the list top | [doc: spec §2] |
+| 59 | Hover-jump is instant/no-dwell, mis-click-safe by geometry (right-lane / whole-row hover), not by a timer | [doc: spec §2] |
+| 60 | Hover-jump left-stack alternative (hover the item name) as a fallback if "above" is too tight | [doc: spec §2] |
+| 61 | Rentals is the sections exception — one calendar-anchored view; the calendar itself never moves/resizes on expand | [doc: spec §3] |
+| 62 | Single-vs-double click discriminator (220ms) reused: single = inline-expand (no cascade), double = anchor (cascade + tab) | [doc: spec §4] |
+| 63 | Anchor icon top-right on an expanded item; becomes "+" on other expanded items if something's already anchored | [doc: spec §4] |
+| 64 | Cascade fires on anchor only, never on inline-expand | [doc: spec §4] |
+| 65 | Tabs are sessions, not just items — a tab holds the whole 3-card cascade/filter/scroll context | [doc: spec §4] |
+| 66 | Links jump precisely: reveal target card → scroll → inline-expand on the correct section; own taps land on Signal, links land on their subject | [doc: spec §4] |
+| 67 | Preview tool (hover-eye) retired — inline-expand is the new peek | [doc: spec §4] |
+| 68 | Inspection checklist becomes a live, in-place capture surface, not a separate form | [doc: spec §6] |
+| 69 | Yard Journey becomes its own Units section: vertical lifecycle timeline, "NOW + next" header doubles as field-role's To Do summary | [doc: spec §6] |
+| 70 | Funnel: concept kept, execution rebuilt on the locked components | [doc: spec §6] |
+| 71 | Comms: three altitudes — bell (alerts) / footer dock (quick-dock) / Inbox card (full workspace) | [doc: spec §7] |
+| 72 | Every comms thread is Ref-linked to the record it's about | [doc: spec §7] |
+| 73 | Unified triage (one Gmail-style list) + native conversation per medium (email=reading pane, texts=Messages bubbles, team=Messenger channels) | [doc: spec §7.1] |
+| 74 | Channel toggle top-right: ALL·TEAM·TEXTS·EMAIL·WRANGLER·CALLS, swipeable on mobile **[refined → NOT fully locked: the WRANGLER segment is still OPEN (Claude's recommendation only, per spec §7.1 and "Still open" below) — only ALL·TEAM·TEXTS·EMAIL·CALLS + the swipeable top-toggle placement are decided]** | [doc: spec §7.1] |
+| 75 | Mr. Wrangler is its own channel; stops clogging the bell, fires a loud distinct alert on reply/fix | [doc: spec §7.1] |
+| 76 | Inbox reuses the app's own search bar + Views&sort (not Gmail's chrome) | [doc: spec §7.2] |
+| 77 | Recent-search history popup opens ABOVE the bar app-wide, same principle as the hover-jump popover | [doc: spec §7.2] |
+| 78 | Compose docks at the footer (desktop, minimizable) or full-screen (mobile), never follows the pointer | [doc: spec §7.3] |
+| 79 | Right-click comms action opens compose in place with the record pre-attached; never teleports to the Inbox card | [doc: spec §7.3] |
+| 80 | Comms-rail tab popups rebuilt on the locked system, modeled on Messenger/Messages/Gmail rather than the current (undisclosed) design | [doc: spec §7.3] |
+| 81 | Responsive space model: Roomy (3 panes + draggable divider) / One-card (menu-list-email hamburger dance) / Narrow (fully mobile) | [doc: spec §7.4] |
+| 82 | Hamburger choreography: hover = overlay-covers-list; click = trades places with the email; list is the anchor, never pushed | [doc: spec §7.4] |
+| 83 | Customizable quick-actions (Hide/Mark-unread/Star/Snooze/Archive) surfaced identically as row actions and right-click | [doc: spec §7.4] |
+| 84 | Drag-to-resort threads and folders/labels | [doc: spec §7.4] |
+| 85 | "Sort" flagged as weak, parked for a future all-cards redesign | [doc: spec Open problems] |
+
+### Cards & Dashboard
+
+| # | Decision | Status |
+|---|---|---|
+| 86 | Sales card generalizes into the role Dashboard idea (chart-as-control, not a dead-end readout) | [doc: spec §5] |
+| 87 | Chart marks are links (pillTo + cascade fired from a wedge instead of text) | [doc: spec §5] |
+| 88 | Field roles get their live timeline (Yard Journey/route) as the analogous dashboard-shape; analytical roles get graphs — one pattern, two forms | [doc: spec §5] |
+| 89 | KPI-rings-to-left tradeoff resolved by the Dashboard-as-6th-card idea rather than measured directly | [doc: spec §5] |
+
+### Comms (see Interaction architecture above — comms items 71–85 are grouped there)
+
+### Process / workflow
+
+| # | Decision | Status |
+|---|---|---|
+| 90 | Two-skill split: `style` = measurable rulebook only; `wrangler-style` = hard decisions; both run on any UI change, decision moves when it conflicts with a rule | [doc: wrangler-style + style intros, CLAUDE.md] |
+| 91 | jactec-ui deleted outright at Jac's request (recoverable via git history only) | [doc: CLAUDE.md, wrangler-style intro] |
+| 92 | "Gmail's bones, RW's skin" — not a literal Gmail clone; flip only if Jac asks for the literal look | [doc: spec §7] |
+| 93 | Current comms rail screenshot deliberately withheld from Claude so the weak existing design can't bias the rebuild | [doc: spec §7.3] |
+| 94 | Critique-log tagging scheme: Rule / Decision / Surface / Gap × Everywhere / Just-here, judged by 4 lenses (job/ugly-state/motion/missing) | [doc: mockup-critique-log.md] |
+| 95 | Popup-first interaction rule (single-attempt, inline fallback, batched multiSelect) — reused throughout this whole session | [doc: CLAUDE.md] |
+| 96 | This is a VIEW-LAYER-ONLY redesign — same data/logic/workflows, only how they appear changes | [⚠ NEW — captured here, §9] |
+| 97 | Read-only-on-live-data architecture, chosen specifically so rollback needs zero data migration | [⚠ NEW — captured here, §9] |
+| 98 | Staging home = reuse staging-2 slot (not a dedicated repo), chosen so approved cards can merge to trunk piecemeal | [⚠ NEW — captured here, §9] |
+| 99 | Explored-all-three-visual-directions rationale (narrow-DNA vs. muscle-memory vs. zoo-of-systems tradeoff) | [⚠ NEW — captured here, §9] |
+| 100 | Rollback safety net: `0fac006` tagged as the live restore point; redesign to ride the existing `FEATURES` flag for instant runtime revert | [⚠ NEW — captured here, §9] |
+
+---
+
+## Still open (discussed, not decided — do not treat as locked)
+
+- **Backend data snapshot.** Claude offered to make a dated private Drive copy of the
+  Live Database (+ optionally the Daily Category Report) as an extra safety net. Jac
+  never said "go" on this in the session — it's an offered-but-unactioned safety step,
+  not a decision.
+- **Whether analytical-role dashboard charts (funnel trend, revenue trend) should carry
+  more Signal status color, or stay neutral blue as non-enum data.** Raised as an open
+  judgment call on the Dashboard mock; never answered.
+- **Mr. Wrangler's exact channel placement** — its own 6th toggle segment (Claude's
+  recommendation, since shipped in the mock) vs. living only inside ALL + the bell. Spec
+  itself already flags this OPEN. (See item 74's annotation above — the mock shipping it
+  is not the same as it being locked.)
+- **KPI Rings → left vertical rail** — superseded in practice by the Dashboard-card idea,
+  but the underlying measure-don't-guess tradeoff was never directly tested (mock
+  top-KPI vs. left-KPI side by side), per the spec's own note.
+- **Signature motif** — whether the app gets one bold signature beat now that jactec-ui's
+  hazard-stripe+rivets weren't re-adopted. Flagged open in `wrangler-style` §6.
+- **Commit-blue exact shade** — `#2f6fd0` chosen, but flagged for revisit if it ever reads
+  too close to status-blue. Flagged open in `wrangler-style` §6.
+- **Cross-user / transferable sessions / send-to-coworker linking model** — acknowledged
+  as needing the Teams/linking model firmed up first. Flagged open in the spec.
+- **"Sort" all-cards redesign** — parked explicitly as future work, not this slice.
+- **Fill rule's one remaining edge case** — whether a waiting-on-vendor gate (WO
+  closeable today but the part's on order) fills as "today's blocker you're tracking" or
+  stays outline until the part lands; superseded in spirit by the final generous-fill
+  rule but never explicitly re-confirmed for this specific case.
+
+---
+
+## Promotion recommendations — ledger-only decisions that should become enforced canon
+
+These are load-bearing rules this reconciliation pass found living **only** in this
+ledger's rescued sections — never actually written into `wrangler-style`/`style` — even
+though other locked decisions already depend on them (e.g. "header colour = worst item
+inside" needs a *worst* to be defined; it isn't, anywhere but here). Recommended only —
+**Jac promotes on his go**; this ledger is not the place to change `wrangler-style`/`style`
+themselves.
+
+### (a) Rollup precedence — `style` §6 (State & fill)
+
+Add as a new bullet after the `fill = triggeredToday(...)` line:
+
+```
+- **Rollup precedence, hottest wins.** When multiple task-states combine into one summary
+  (a group header, a card cap, a rolled-up count), the winner is fixed, never resolved ad
+  hoc per renderer: **red > yellow > blue > green > grey.**
+```
+
+### (b) No status colour on buttons, ever — already canon; recommend a cross-reference only
+
+This one is **already** stated verbatim in `style` §6 ("Buttons carry **no** status
+colour") and the §8 checklist ("no status colour on a button"). Nothing to promote there.
+The gap is that `wrangler-style` — the skill that actually defines Door's action colours —
+never says the negative rule out loud. Recommend appending to the **Door** bullet in
+`wrangler-style` §3:
+
+```
+  (Commit/money/destructive are action colours, never status colours — no Door, chip, or
+  button ever repurposes a status hue to mean "click me"; see `style` §6.)
+```
+
+### (c) The three-way colour-role split — `wrangler-style` §3 (Components), as a preamble
+
+Add before the component bullet list:
+
+```
+**The one rule underneath every component below:** status colour = *what* it is · orange
+= *touchable* · deep-blue `--commit` = *commit* · everything else = plain honest text.
+Nothing ever does two jobs — that's the whole reason Signal, Ref, and Door don't collide.
+```
+
+### (d) Group taxonomy — `wrangler-style` §4 (Layout & structure)
+
+Add as new bullets:
+
+```
+- **Group taxonomy.** Every card's list groups are one of two kinds: **Attention groups**
+  (e.g. Field Calls, Failed) exist and are coloured only because something is wrong —
+  hidden entirely when empty. **Lifecycle groups** (e.g. On Rent, Reserved, Available) are
+  always present, grey by default, and take colour only when a member inside triggers it —
+  no group ever carries a fixed/native colour.
+- **Groups are never named after status** ("Bad"/"To-Do") — that double-encodes what
+  colour already says; a group name says *where* in the workflow, colour says *how much*
+  it needs you.
+```
+
+### (e) The 3-tier Signal/Gate hover contract — `wrangler-style` §3, extend the Signal bullet
+
+Current Signal bullet only says "hover → explain + name the source." Extend it:
+
+```
+  Three-tier read: **(1) colour + fill** = the instant at-a-glance state, **(2) the word
+  on the chip** = what it is, **(3) hover / Tab-focus / long-press** = *why* and *what it
+  stops*. Click → teleport to source.
+```
+
+### (f) Internal vocabulary vs. user-facing labels — `wrangler-style` §5 (Voice)
+
+Add as a new bullet:
+
+```
+- **Component names are internal vocabulary, never user-facing.** Signal/Gate/Stamp/Ref/
+  Door are how *we* talk about the pieces; the person using the app always sees plain task
+  language (e.g. the Signal-summary landing tab reads **"To Do"**, never "Signal").
+```

--- a/docs/superpowers/specs/2026-07-20-mockup-critique-log.md
+++ b/docs/superpowers/specs/2026-07-20-mockup-critique-log.md
@@ -1,0 +1,78 @@
+# Mockup critique log — Phase 2 review
+
+**Opened:** 2026-07-20 · **Status:** open, receiving notes
+**Covers:** the Phase-2 mockups under review on staging — List Views v2, Yard Journey,
+Funnel, the three Detail views, and get-told (incoming). All run through `style` (numbers)
++ `wrangler-style` (decisions).
+
+## Purpose
+
+Jac reviews the mockups and gives notes; this log captures each note **tagged** so the fix
+lands in the right place and nothing is lost between review and build. The concepts are
+settled — critique now targets *does each surface do its job, and does it hold the system.*
+
+## How a note is tagged
+
+Every note gets a **type** (where the fix lives) and a **scope** (how far it reaches):
+
+**Type**
+- **Rule** — a number/law (a control height, a contrast floor, the CVD threshold). Rare;
+  moves only deliberately. Home: `style`.
+- **Decision** — a colour, font, component look, or word. Free to change. Home:
+  `wrangler-style` — and it propagates to every surface at once.
+- **Surface** — one screen's execution ("the funnel's action column is cramped"). Fixed in
+  that mockup only.
+- **Gap** — the surface doesn't do its job, or something's missing.
+
+**Scope**
+- **Everywhere** — a system change; one skill edit ripples to all surfaces.
+- **Just here** — a one-off on this surface.
+
+## The critique lenses (how a note is aimed)
+
+1. **Job test** — does a *tired* worker finish the surface's one job in ~3s? where does the
+   eye land first — is that the fire?
+2. **Ugly-state test** — what does it look like at its worst (40 red rows, an empty day, a
+   failed sync, 200 invoices)?
+3. **Motion test** — imagine the thumb: tap → expand → is the thing right there → get back fast?
+4. **Missing test** — walk a real day; where are you still stuck / still working outside the screen?
+
+## The one job each surface owes (the yardstick)
+
+| Surface | Its one job |
+|---|---|
+| List Views | Spot what's on fire without reading every row |
+| Yard Journey | Know my next move on this machine |
+| Funnel | Who's worth chasing, and what's the next touch |
+| Units / Rentals / Customers detail | Trust what the screen says |
+| get-told (incoming) | Hear about it when something needs me — without staring at the screen |
+
+## Log
+
+_Disposition: open → queued → done (with where it was fixed: skill / mockup / spec)._
+
+| # | Date | Surface | Note | Type | Scope | Disposition |
+|---|------|---------|------|------|-------|-------------|
+| 1 | 2026-07-20 | Intake | **Parked** — Jac isn't worried about intake as a feature until much later, if ever. Mock kept for reference; don't re-surface it as "the next gap." | Gap | Just here | Parked |
+| 2 | 2026-07-20 | Inbox chrome | **"VIEWS & SORT" button looks VERY out of place** in the top chrome. Jac drafting alternatives on paper — DON'T rebuild yet. Ties to the parked all-cards Sort redesign. | Surface | Just here | Open — Jac redrafting |
+| 3 | 2026-07-20 | Trips (dispatch) | **Overwhelming — trips blur together; a contrast/background problem.** Only the mobile "Next Up" focus felt right. Fix: stronger per-trip **separation** (distinct cards, breathing room, less uniform dark-on-dark) + borrow the driver "NOW / Next Up" focus. Don't rebuild until the Trips MODEL (§8) settles. | Surface | Just here | DONE — rebuilt as the **ETA-Tracker ledger** (`trips-ledger.html`, spec §8.5): register layout, soft-blue Gate chips, unit+customer Refs, `+MIN=ETA` line, departure-clock colour, numbered spine outside the card. Published. |
+
+## Canon-compliance audit — build-first surfaces (2026-07-21)
+
+Ran a canon-drift audit of `list-views.html` + `detail-views.html` (the surfaces slated to build first) against
+`style` + `wrangler-style`. **These feed the build writing-plan — the fixes land in the BUILT code, not necessarily the
+throwaway mockups.** Systemic patterns (fix everywhere at build):
+
+- **Ref drift (the Trips miss, repeated).** Card **titles/headers** and unit/invoice **sub-rows** render linked records as
+  **plain text**; a shared `ref()` **hardcodes the user icon** for every type. → Every linked record is a Ref with its
+  **type icon**, everywhere (canon tightened in `wrangler-style` §3).
+- **ONE chip radius, violated.** Ref/Signal/Gate carry 2–3 different radii (`6/8/5px`). → collapse to one shared chip-radius token.
+- **Yellow token drift (detail-views).** `--yellow:#ffe14d` is the **rejected neon** (fails CVD); locked value is **`#eed44b`**.
+  Footer even mislabels it. Every yellow Signal/Gate is off-canon. → swap to `#eed44b`.
+- **Pure `#fff` ink (detail-views, real — not just light blocks).** `.sig.f.red`/`.door.save` use pure white. → `--onRedFill`/`--onCommit #fdfdfd`.
+- **Number voice.** Dollar figures in body-sans instead of **mono/tabular**. → `var(--stamp)` + tabular-nums.
+- **Toggle colour law (detail-views).** Insured/Uninsured active option paints plain accent-orange, discarding good/risk **state**.
+  → route through state colour (orange fallback is only for no-status options).
+- **Dead light-mode blocks** on both. → strip on build (dark-only rule now in `wrangler-style` §1).
+- **Clean:** Gate chips (state colour + chevron, never `--commit`) and the two type voices are otherwise correct. Good sign —
+  most drift is old mockups predating settled canon, not gaps in the canon itself.


### PR DESCRIPTION
## Summary

Makes the Claude Design Labs redesign pipeline **durable in the repo** — it was living in an ephemeral session scratchpad that dies with the container. **Docs + design assets only: no app code, no served files, no behavior change.**

> **Note:** this branch was restarted from trunk after its earlier work merged, so this PR's contents are entirely new. (The old `style`-skill description it carried has long since shipped.)

### What's here

| Path | What it is |
|---|---|
| `docs/design/LABS-PIPELINE.md` | **The continuation doc.** How Labs, the kit, and the builder-rewrite implementation fit together; the North Star / anti-objectives / inherit prompt framework; the foundations-first build order; locked decisions; current ship state. Read this first in a new session. |
| `docs/design/rw-design-system/` | The **code-accurate design-system kit** — `tokens.css` + 12 `@dsCard` preview cards, built on the locked `html.dv2` redesign tokens. Vanilla HTML+CSS, dark-only. This is what gets `/design-sync`'d to Design Labs. |
| `docs/design/atoms-canvas.html` | All eight atom families on one editable page — the surface used to review and lock the atoms. |
| `docs/design/rw-consistency-pass.css` | The **approved** atom consistency pass from the Labs review. |
| `docs/design/prompts/` | The Labs prompts written so far (atoms · detail views · shell). |
| `docs/design/labs-build-order.md` | The framework + full build order. |

### Design decisions locked in this pass

- **Three control shapes, one per family** — state chips squared (`--chip-radius:2px`), records rounded (`--item-radius:8px`), actions pill (Doors only). ⚠️ This **supersedes** the older "two radii / one 7px chip radius" line in the `style` skill, which is now stale canon.
- **Body voice → Archivo** (mono unchanged). Fonts are CDN-loaded, so this is a one-line `<link>` change — no font files to bundle.
- **Outline chips are true outlines** — transparent background + 1px border in the status hue; the ten `--*-bg` tint backfills are retired (tokens stay, plates still use them). New `--red-line` keeps red legible on dark without the tint.
- **`.menu` dropped** — the status *picker* is now `.seg--stack`. A menu of unrelated **actions** is a different job, queued as a *container* rather than an atom.
- **New atom: Pin** — universal corner marker, colour=state / fill=today, 13px, zero layout footprint.

### Also rescued

Two specs existed **only** on the old branch head and had never been merged to trunk — carried forward so restarting the branch couldn't lose them:
- `docs/superpowers/specs/2026-07-20-decisions-ledger.md` (the locked-decision index)
- `docs/superpowers/specs/2026-07-20-mockup-critique-log.md`

### Follow-up

A further commit applies `rw-consistency-pass.css` to the kit files themselves (agent in flight at time of writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1EAY3d3fehnTBqoCQbjhc