### PR TITLE
Remotion logo-intro sample + skill research

### DIFF
--- a/video/logo-intro/.gitignore
+++ b/video/logo-intro/.gitignore
@@ -1,0 +1,6 @@
+# Remotion build + render artifacts — never commit
+node_modules/
+package-lock.json
+out/
+frames/
+.remotion/

--- a/video/logo-intro/package.json
+++ b/video/logo-intro/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rw-logo-intro",
+  "private": true,
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Rental Wrangler branded logo-reveal intro — Remotion sample",
+  "scripts": {
+    "studio": "remotion studio",
+    "render": "node render.mjs"
+  },
+  "dependencies": {
+    "@remotion/bundler": "4.0.494",
+    "@remotion/cli": "4.0.494",
+    "@remotion/renderer": "4.0.494",
+    "remotion": "4.0.494",
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
+  }
+}

--- a/video/logo-intro/prepare-logo.mjs
+++ b/video/logo-intro/prepare-logo.mjs
@@ -1,0 +1,21 @@
+// Extract the embedded PNG from the repo's jac-rentals-logo.svg (a Sketch export
+// that wraps a single raster) into public/logo.png so Remotion can <Img> it.
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+
+const SRC = '/home/user/rental-wrangler/assets/jac-rentals-logo.svg';
+const svg = readFileSync(SRC, 'utf8');
+
+const m = svg.match(/data:image\/png;base64,([A-Za-z0-9+/=\s]+)/);
+if (!m) {
+  console.error('no data:image/png found in', SRC);
+  process.exit(1);
+}
+const buf = Buffer.from(m[1].replace(/\s+/g, ''), 'base64');
+
+mkdirSync('public', { recursive: true });
+writeFileSync('public/logo.png', buf);
+
+// Parse the IHDR chunk for dimensions (sig 8 + len 4 + 'IHDR' 4 => w@16, h@20).
+const w = buf.readUInt32BE(16);
+const h = buf.readUInt32BE(20);
+console.log(`wrote public/logo.png ${buf.length} bytes, ${w}x${h}`);

--- a/video/logo-intro/render.mjs
+++ b/video/logo-intro/render.mjs
@@ -1,0 +1,72 @@
+// Shared render harness for the Rental Wrangler logo-intro sample.
+// Proven path (feasibility probe, Remotion 4.0.494): bundle() -> selectComposition()
+// -> renderMedia(), with browserExecutable pinned to the pre-installed headless
+// Chromium so there is ZERO network dependency at render time.
+//
+//   node render.mjs <entry.jsx> <CompId> <out.mp4>
+//
+import { bundle } from '@remotion/bundler';
+import { selectComposition, renderMedia } from '@remotion/renderer';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const [, , entryArg, compId, outArg] = process.argv;
+if (!entryArg || !compId || !outArg) {
+  console.error('usage: node render.mjs <entry.jsx> <CompId> <out.mp4>');
+  process.exit(1);
+}
+
+// The pre-installed headless-shell Chromium (guaranteed present per the environment
+// contract). Rendering against this avoids Remotion's ~92MB one-time shell download.
+const BROWSER = '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell';
+
+const entryPoint = path.resolve(__dirname, entryArg);
+const outputLocation = path.resolve(__dirname, outArg);
+
+console.log('[render] bundling', entryPoint);
+const serveUrl = await bundle({ entryPoint });
+
+console.log('[render] selecting composition', compId);
+const composition = await selectComposition({ serveUrl, id: compId, browserExecutable: BROWSER });
+
+console.log(
+  `[render] ${composition.width}x${composition.height} ${composition.durationInFrames}f @ ${composition.fps}fps`,
+);
+await renderMedia({
+  composition,
+  serveUrl,
+  codec: 'h264',
+  outputLocation,
+  browserExecutable: BROWSER,
+});
+console.log('RENDERED', outputLocation);
+
+// Best-effort review stills. Remotion's vendored ffmpeg is a MINIMAL build (only the
+// `scale` filter — no select/tile/fps), so we seek discrete timestamps with -ss and
+// grab one frame each rather than build a filter montage. (The pre-installed Playwright
+// ffmpeg is a stripped webm-only build and can't read h264 at all.)
+try {
+  const ffmpeg = path.join(__dirname, 'node_modules/@remotion/compositor-linux-x64-gnu/ffmpeg');
+  if (existsSync(ffmpeg)) {
+    const durSec = composition.durationInFrames / composition.fps;
+    const base = outputLocation.replace(/\.mp4$/, '');
+    const fracs = [0.02, 0.25, 0.5, 0.75, 0.98];
+    let ok = 0;
+    fracs.forEach((fr, i) => {
+      const t = (durSec * fr).toFixed(3);
+      const still = `${base}-s${i}.png`;
+      const r = spawnSync(
+        ffmpeg,
+        ['-y', '-ss', t, '-i', outputLocation, '-frames:v', '1', '-vf', 'scale=720:-1', still],
+        { encoding: 'utf8' },
+      );
+      if (r.status === 0 && existsSync(still)) ok++;
+    });
+    console.log('STILLS', ok, '->', `${base}-s0..4.png`);
+  }
+} catch (e) {
+  console.log('[render] stills error', e.message);
+}

--- a/video/logo-intro/src/concept-constellation-draw.jsx
+++ b/video/logo-intro/src/concept-constellation-draw.jsx
@@ -1,0 +1,487 @@
+import React from 'react';
+import {
+  registerRoot,
+  Composition,
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Easing,
+} from 'remotion';
+
+// ---------------------------------------------------------------------------
+// "Constellation Draw" — Rental Wrangler / JacRentals logo intro concept.
+// Yard data-plate design language: dark industrial steel, ONE safety-orange
+// accent, hazard-stripe signature, riveted steel shield badge, stamped
+// condensed uppercase type, restrained leather-tan touch. A cosmic western
+// sky nod (constellation) that resolves into the industrial badge.
+// ---------------------------------------------------------------------------
+
+const STEEL_BASE = '#14181d';
+const STEEL_PANEL = '#1b2027';
+const STEEL_PANEL_HI = '#20262d';
+const ORANGE = '#ff7a1a';
+const GOLD = '#f5c542';
+const TAN = '#c2925a';
+const RIVET_HI = '#3a4048';
+const RIVET_LO = '#0e1215';
+
+const FONT = '"Saira Condensed","Oswald","Arial Narrow",sans-serif';
+
+// 12 constellation points, arranged in a loose "dipper / shield-ish" scatter
+// around the center in a normalized -1..1 box, converted to px later. Kept
+// inside safe margins even at the widest spread.
+const POINTS = [
+  { x: -0.62, y: -0.58 },
+  { x: -0.30, y: -0.82 },
+  { x: 0.10, y: -0.86 },
+  { x: 0.46, y: -0.62 },
+  { x: 0.68, y: -0.28 },
+  { x: 0.58, y: 0.14 },
+  { x: 0.30, y: 0.48 },
+  { x: -0.06, y: 0.62 },
+  { x: -0.42, y: 0.46 },
+  { x: -0.66, y: 0.10 },
+  { x: -0.20, y: -0.16 },
+  { x: 0.14, y: -0.10 },
+];
+
+// Edges connecting the scatter into a single constellation figure (indices
+// into POINTS). Kept as a simple wandering path plus a couple of chords so
+// the "draw" reads as a real constellation, not a random mess.
+const EDGES = [
+  [0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7],
+  [7, 8], [8, 9], [9, 0], [10, 11], [1, 10], [6, 11],
+];
+
+const RIVET_POSITIONS = [
+  { top: 14, left: 14 },
+  { top: 14, right: 14 },
+  { bottom: 14, left: 14 },
+  { bottom: 14, right: 14 },
+];
+
+function Rivet({ style }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        background: `radial-gradient(circle at 35% 30%, ${RIVET_HI}, ${RIVET_LO} 70%)`,
+        boxShadow: '0 1px 1px rgba(0,0,0,0.6)',
+        ...style,
+      }}
+    />
+  );
+}
+
+function HazardEdge({ side }) {
+  // Thin hazard-stripe accent strip, used once along the bottom of the frame
+  // as the signature — restrained, not everywhere.
+  const isTop = side === 'top';
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        [isTop ? 'top' : 'bottom']: 0,
+        height: 8,
+        backgroundImage:
+          'repeating-linear-gradient(135deg, #f5c542 0 13px, #14181d 13px 26px)',
+        opacity: 0.85,
+      }}
+    />
+  );
+}
+
+function ShieldBadge({ scale, opacity }) {
+  // Rounded-hex / shield steel plate, riveted corners. Placeholder hero —
+  // real badge art comes from Jac later.
+  const w = 560;
+  const h = 560;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: '50%',
+        width: w,
+        height: h,
+        transform: `translate(-50%, -50%) scale(${scale})`,
+        opacity,
+      }}
+    >
+      <svg width={w} height={h} viewBox="0 0 560 560">
+        <defs>
+          <linearGradient id="shieldFace" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={STEEL_PANEL_HI} />
+            <stop offset="55%" stopColor={STEEL_PANEL} />
+            <stop offset="100%" stopColor="#171b21" />
+          </linearGradient>
+          <linearGradient id="shieldEdge" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#3a424c" />
+            <stop offset="100%" stopColor="#0b0e12" />
+          </linearGradient>
+          <radialGradient id="badgeGlow" cx="50%" cy="42%" r="60%">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.08)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </radialGradient>
+        </defs>
+        {/* shield / rounded-hex silhouette */}
+        <path
+          d="M280 18
+             L470 96
+             C490 104 502 122 502 144
+             L502 300
+             C502 392 440 462 280 542
+             C120 462 58 392 58 300
+             L58 144
+             C58 122 70 104 90 96
+             Z"
+          fill="url(#shieldEdge)"
+        />
+        <path
+          d="M280 34
+             L456 106
+             C472 112 482 128 482 146
+             L482 298
+             C482 380 426 444 280 518
+             C134 444 78 380 78 298
+             L78 146
+             C78 128 88 112 104 106
+             Z"
+          fill="url(#shieldFace)"
+          stroke={ORANGE}
+          strokeOpacity="0.35"
+          strokeWidth="2"
+        />
+        <path
+          d="M280 34
+             L456 106
+             C472 112 482 128 482 146
+             L482 298
+             C482 380 426 444 280 518
+             C134 444 78 380 78 298
+             L78 146
+             C78 128 88 112 104 106
+             Z"
+          fill="url(#badgeGlow)"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function Constellation({ frame, fps, w, h }) {
+  const cx = w / 2;
+  const cy = h / 2 - 40;
+  const spread = 300;
+
+  // Phase timing (frames):
+  // 0-40: dots twinkle in, staggered
+  // 18-56: lines draw between them
+  // 46-72: whole constellation converges + fades toward badge
+  const dotIn = (i) =>
+    spring({ frame, fps, config: { damping: 16, stiffness: 140, mass: 0.6 }, delay: i * 3 });
+
+  const convergeStart = 46;
+  const convergeEnd = 74;
+  const converge = interpolate(frame, [convergeStart, convergeEnd], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+  const groupOpacity = interpolate(frame, [convergeStart, convergeEnd], [1, 0], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+  const easedConverge = Easing.bezier(0.35, 0, 0.2, 1)(converge);
+
+  const pos = (i) => {
+    const p = POINTS[i];
+    const px = cx + p.x * spread * (1 - easedConverge);
+    const py = cy + p.y * spread * (1 - easedConverge);
+    return { px, py };
+  };
+
+  return (
+    <svg
+      width={w}
+      height={h}
+      style={{ position: 'absolute', left: 0, top: 0, opacity: groupOpacity }}
+    >
+      <g>
+        {EDGES.map(([a, b], i) => {
+          const lineStart = 16 + i * 2.6;
+          const lineDraw = interpolate(frame, [lineStart, lineStart + 16], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          });
+          const pa = pos(a);
+          const pb = pos(b);
+          const len = Math.hypot(pb.px - pa.px, pb.py - pa.py);
+          return (
+            <line
+              key={i}
+              x1={pa.px}
+              y1={pa.py}
+              x2={pb.px}
+              y2={pb.py}
+              stroke="rgba(255,255,255,0.55)"
+              strokeWidth={1.4}
+              strokeDasharray={len}
+              strokeDashoffset={len * (1 - lineDraw)}
+            />
+          );
+        })}
+        {POINTS.map((_, i) => {
+          const s = dotIn(i);
+          const { px, py } = pos(i);
+          const r = interpolate(s, [0, 1], [0, 3.4]);
+          const glow = interpolate(s, [0, 1], [0, 1]);
+          const isHero = i === 10 || i === 11; // two "brighter" stars near center
+          return (
+            <g key={i}>
+              {isHero && (
+                <circle
+                  cx={px}
+                  cy={py}
+                  r={r * 3.2}
+                  fill={GOLD}
+                  opacity={glow * 0.12}
+                />
+              )}
+              <circle
+                cx={px}
+                cy={py}
+                r={isHero ? r * 1.25 : r}
+                fill="#ffffff"
+                opacity={glow}
+              />
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+}
+
+function PulseRing({ frame, fps }) {
+  const start = 62;
+  const dur = 26;
+  const local = frame - start;
+  if (local < 0) return null;
+  const t = interpolate(local, [0, dur], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+  const eased = Easing.out(Easing.cubic)(t);
+  const size = interpolate(eased, [0, 1], [120, 620]);
+  const opacity = interpolate(t, [0, 0.15, 1], [0, 0.7, 0]);
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: '50%',
+        width: size,
+        height: size,
+        marginLeft: -size / 2,
+        marginTop: -size / 2,
+        borderRadius: '50%',
+        border: `2px solid ${ORANGE}`,
+        boxShadow: `0 0 24px 0 ${ORANGE}`,
+        opacity,
+        pointerEvents: 'none',
+      }}
+    />
+  );
+}
+
+function Main() {
+  const frame = useCurrentFrame();
+  const { fps, width, height } = useVideoConfig();
+
+  // Background: deep space-steel radial gradient, present throughout.
+  const bgOpacity = interpolate(frame, [0, 10], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  // Badge resolve: scale + fade in as constellation converges.
+  const badgeStart = 50;
+  const badgeSpring = spring({
+    frame,
+    fps,
+    delay: badgeStart,
+    config: { damping: 15, stiffness: 130, mass: 0.9 },
+  });
+  const badgeScale = interpolate(badgeSpring, [0, 1], [0.7, 1]);
+  const badgeOpacity = interpolate(frame, [badgeStart, badgeStart + 16], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  // Wordmark fades up inside the badge.
+  const wordStart = 66;
+  const wordOpacity = interpolate(frame, [wordStart, wordStart + 14], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+  const wordY = interpolate(frame, [wordStart, wordStart + 14], [16, 0], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.out(Easing.cubic),
+  });
+
+  // EST. 2099 settles last.
+  const estStart = 78;
+  const estOpacity = interpolate(frame, [estStart, estStart + 12], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  // Underline sweep beneath wordmark — the ONE orange accent usage as a
+  // deliberate underline (in addition to the pulse ring, which is the other
+  // sanctioned orange moment; kept restrained/sequential, not simultaneous
+  // busy-ness).
+  const underlineStart = 70;
+  const underlineW = interpolate(frame, [underlineStart, underlineStart + 14], [0, 132], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.out(Easing.cubic),
+  });
+
+  return (
+    <AbsoluteFill
+      style={{
+        background: STEEL_BASE,
+        overflow: 'hidden',
+      }}
+    >
+      {/* deep space-steel radial gradient */}
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity,
+          background:
+            'radial-gradient(ellipse at 50% 40%, #232a33 0%, #171c22 45%, #0e1215 100%)',
+        }}
+      />
+      {/* faint static starfield speckle, very subtle, industrial-night not fantasy */}
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity * 0.5,
+          backgroundImage:
+            'radial-gradient(1px 1px at 12% 22%, rgba(255,255,255,0.35) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 82% 15%, rgba(255,255,255,0.28) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 68% 78%, rgba(255,255,255,0.25) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 24% 82%, rgba(255,255,255,0.3) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 90% 60%, rgba(255,255,255,0.22) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 6% 55%, rgba(255,255,255,0.2) 0, transparent 60%)',
+        }}
+      />
+
+      {/* corner rivets on the frame itself, subtle plate framing */}
+      {RIVET_POSITIONS.map((p, i) => (
+        <Rivet key={i} style={{ ...p, opacity: bgOpacity }} />
+      ))}
+
+      <Constellation frame={frame} fps={fps} w={width} h={height} />
+
+      <PulseRing frame={frame} fps={fps} />
+
+      <ShieldBadge scale={badgeScale} opacity={badgeOpacity} />
+
+      {/* wordmark + est, layered above the badge center */}
+      <AbsoluteFill
+        style={{
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+        }}
+      >
+        <div
+          style={{
+            transform: `translateY(${wordY}px)`,
+            opacity: wordOpacity,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontFamily: FONT,
+              fontWeight: 700,
+              fontSize: 58,
+              letterSpacing: 4,
+              color: GOLD,
+              textTransform: 'uppercase',
+              textShadow: '0 2px 0 #6b4d16, 0 4px 10px rgba(0,0,0,0.55)',
+              lineHeight: 1.02,
+              textAlign: 'center',
+            }}
+          >
+            RENTAL
+          </div>
+          <div
+            style={{
+              fontFamily: FONT,
+              fontWeight: 700,
+              fontSize: 58,
+              letterSpacing: 4,
+              color: GOLD,
+              textTransform: 'uppercase',
+              textShadow: '0 2px 0 #6b4d16, 0 4px 10px rgba(0,0,0,0.55)',
+              lineHeight: 1.02,
+              textAlign: 'center',
+              marginTop: 2,
+            }}
+          >
+            WRANGLER
+          </div>
+          <div
+            style={{
+              marginTop: 12,
+              width: underlineW,
+              height: 3,
+              background: ORANGE,
+              boxShadow: `0 0 10px 1px ${ORANGE}`,
+              borderRadius: 2,
+            }}
+          />
+          <div
+            style={{
+              marginTop: 14,
+              fontFamily: FONT,
+              fontWeight: 500,
+              fontSize: 20,
+              letterSpacing: 6,
+              color: TAN,
+              textTransform: 'uppercase',
+              opacity: estOpacity,
+            }}
+          >
+            EST. 2099
+          </div>
+        </div>
+      </AbsoluteFill>
+
+      <HazardEdge side="bottom" />
+    </AbsoluteFill>
+  );
+}
+
+registerRoot(() => (
+  <Composition
+    id="constellation-draw"
+    component={Main}
+    durationInFrames={92}
+    fps={30}
+    width={1920}
+    height={1080}
+  />
+));

--- a/video/logo-intro/src/concept-data-plate-boot.jsx
+++ b/video/logo-intro/src/concept-data-plate-boot.jsx
@@ -1,0 +1,447 @@
+import React from 'react';
+import {
+  registerRoot,
+  Composition,
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Easing,
+} from 'remotion';
+
+// ---------------------------------------------------------------------------
+// "Data-Plate Boot" — Rental Wrangler / JacRentals logo intro concept.
+// A machine HUD booting up. Beat: cyan-white scanline sweeps top->bottom over
+// dark steel -> riveted steel panel slides in from the right + locks with a
+// soft bounce -> a circular KPI-ring sweep draws 0->360 around the badge ->
+// wordmark "RENTAL WRANGLER" reveals under a small "SYSTEM ONLINE" stamp ->
+// one safety-orange status blip pulses in a corner -> "EST. 2099" clicks in.
+// ---------------------------------------------------------------------------
+
+const STEEL_BASE = '#14181d';
+const STEEL_PANEL = '#1b2027';
+const STEEL_PANEL_HI = '#20262d';
+const ORANGE = '#ff7a1a';
+const GOLD = '#f5c542';
+const TAN = '#c2925a';
+const RIVET_HI = '#3a4048';
+const RIVET_LO = '#0e1215';
+const SCAN_CYAN = '#bff2ff';
+
+const FONT = '"Saira Condensed","Oswald","Arial Narrow",sans-serif';
+
+const clampOpts = { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' };
+
+function Rivet({ style }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 12,
+        height: 12,
+        borderRadius: '50%',
+        background: `radial-gradient(circle at 35% 30%, ${RIVET_HI}, ${RIVET_LO} 70%)`,
+        boxShadow: '0 1px 1px rgba(0,0,0,0.6)',
+        ...style,
+      }}
+    />
+  );
+}
+
+// Thin cyan-white HUD scanline sweeping top -> bottom over frames 0-20, then
+// fading out — the "booting up" beat.
+function Scanline({ frame }) {
+  const y = interpolate(frame, [0, 20], [-40, 1120], {
+    ...clampOpts,
+    easing: Easing.inOut(Easing.ease),
+  });
+  const opacity = interpolate(frame, [0, 4, 16, 24], [0, 0.9, 0.9, 0], clampOpts);
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: y,
+        height: 6,
+        opacity,
+        background: `linear-gradient(180deg, rgba(191,242,255,0) 0%, ${SCAN_CYAN} 50%, rgba(191,242,255,0) 100%)`,
+        boxShadow: `0 0 24px 6px rgba(191,242,255,0.55)`,
+      }}
+    />
+  );
+}
+
+// Riveted steel panel that slides in from the right and locks with a subtle
+// spring bounce (frames ~10-34), forming the backdrop for the badge + wordmark.
+function Panel({ frame, fps }) {
+  const x = spring({
+    frame,
+    fps,
+    delay: 10,
+    config: { damping: 13, stiffness: 110, mass: 1 },
+    from: 1400,
+    to: 0,
+  });
+  const opacity = interpolate(frame, [10, 24], [0, 1], clampOpts);
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: '50%',
+        width: 1160,
+        height: 760,
+        marginLeft: -580,
+        marginTop: -380,
+        transform: `translateX(${x}px)`,
+        opacity,
+        borderRadius: 18,
+        background: `linear-gradient(155deg, ${STEEL_PANEL_HI} 0%, ${STEEL_PANEL} 55%, #14181d 100%)`,
+        boxShadow: '0 24px 60px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.04)',
+        border: '1px solid rgba(255,255,255,0.05)',
+      }}
+    >
+      <Rivet style={{ top: 26, left: 26 }} />
+      <Rivet style={{ top: 26, right: 26 }} />
+      <Rivet style={{ bottom: 26, left: 26 }} />
+      <Rivet style={{ bottom: 26, right: 26 }} />
+    </div>
+  );
+}
+
+// Circular KPI-ring sweep drawing an arc from 0 -> 360 degrees around the
+// badge, frames ~24-56, via a conic-gradient masked to a ring.
+function KpiRing({ frame }) {
+  const opacity = interpolate(frame, [22, 30], [0, 1], clampOpts);
+  const sweep = interpolate(frame, [24, 58], [0, 360], {
+    ...clampOpts,
+    easing: Easing.out(Easing.cubic),
+  });
+  const size = 420;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: 316,
+        width: size,
+        height: size,
+        marginLeft: -size / 2,
+        opacity,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: '50%',
+          background: `conic-gradient(from -90deg, ${GOLD} 0deg, ${GOLD} ${sweep}deg, rgba(255,255,255,0.06) ${sweep}deg, rgba(255,255,255,0.06) 360deg)`,
+          WebkitMaskImage:
+            'radial-gradient(circle, transparent 0, transparent 191px, black 192px, black 200px, transparent 201px)',
+          maskImage:
+            'radial-gradient(circle, transparent 0, transparent 191px, black 192px, black 200px, transparent 201px)',
+        }}
+      />
+    </div>
+  );
+}
+
+// Riveted steel shield / rounded-hex plate placeholder badge, sitting inside
+// the KPI ring. Real badge art comes from Jac later.
+function ShieldBadge({ frame }) {
+  const scale = spring({
+    frame,
+    fps: 30,
+    delay: 18,
+    config: { damping: 14, stiffness: 150, mass: 0.8 },
+    from: 0.4,
+    to: 1,
+  });
+  const opacity = interpolate(frame, [18, 30], [0, 1], clampOpts);
+  const w = 300;
+  const h = 300;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: 316,
+        width: 420,
+        height: 420,
+        marginLeft: -210,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        opacity,
+        transform: `scale(${scale})`,
+      }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          width: w,
+          height: h,
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            clipPath:
+              'polygon(50% 0%, 88% 14%, 88% 56%, 50% 100%, 12% 56%, 12% 14%)',
+            background: `linear-gradient(155deg, ${STEEL_PANEL_HI} 0%, ${STEEL_PANEL} 55%, #14181d 100%)`,
+            boxShadow: '0 14px 32px rgba(0,0,0,0.5)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              background:
+                'radial-gradient(ellipse at 50% 34%, rgba(255,255,255,0.09) 0%, rgba(255,255,255,0) 60%)',
+            }}
+          />
+          {/* faint constellation dots on the plate face — on-brand texture */}
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              opacity: 0.6,
+              backgroundImage:
+                'radial-gradient(1.4px 1.4px at 22% 22%, rgba(255,255,255,0.5) 0, transparent 60%),' +
+                'radial-gradient(1.4px 1.4px at 76% 26%, rgba(255,255,255,0.4) 0, transparent 60%),' +
+                'radial-gradient(1.4px 1.4px at 66% 74%, rgba(255,255,255,0.35) 0, transparent 60%),' +
+                'radial-gradient(1.4px 1.4px at 28% 76%, rgba(255,255,255,0.4) 0, transparent 60%)',
+            }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: '40%',
+              textAlign: 'center',
+              fontFamily: FONT,
+              fontWeight: 800,
+              fontSize: 72,
+              letterSpacing: 2,
+              color: GOLD,
+              textShadow: '0 2px 0 #6b4d16, 0 5px 10px rgba(0,0,0,0.55)',
+              transform: 'translateY(-50%)',
+            }}
+          >
+            RW
+          </div>
+        </div>
+        <Rivet style={{ top: 58, left: 46 }} />
+        <Rivet style={{ top: 58, right: 46 }} />
+        <Rivet style={{ top: 146, left: 16 }} />
+        <Rivet style={{ top: 146, right: 16 }} />
+      </div>
+    </div>
+  );
+}
+
+function SystemOnlineStamp({ frame, fps }) {
+  const s = spring({
+    frame,
+    fps,
+    delay: 58,
+    config: { damping: 11, stiffness: 260, mass: 0.6 },
+    from: 1.3,
+    to: 1,
+  });
+  const opacity = interpolate(frame, [58, 65], [0, 1], clampOpts);
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '5px 14px',
+        borderRadius: 3,
+        border: `1px solid rgba(255,122,26,0.5)`,
+        background: 'rgba(255,122,26,0.08)',
+        opacity,
+        transform: `scale(${s})`,
+      }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          background: ORANGE,
+          boxShadow: `0 0 8px 2px ${ORANGE}`,
+        }}
+      />
+      <span
+        style={{
+          fontFamily: FONT,
+          fontWeight: 600,
+          fontSize: 19,
+          letterSpacing: 5,
+          color: ORANGE,
+          textTransform: 'uppercase',
+        }}
+      >
+        System Online
+      </span>
+    </div>
+  );
+}
+
+function Wordmark({ frame, fps }) {
+  const s = spring({
+    frame,
+    fps,
+    delay: 64,
+    config: { damping: 15, stiffness: 160, mass: 0.8 },
+    from: 0.9,
+    to: 1,
+  });
+  const opacity = interpolate(frame, [64, 74], [0, 1], clampOpts);
+  return (
+    <div
+      style={{
+        fontFamily: FONT,
+        fontWeight: 800,
+        letterSpacing: 1,
+        color: GOLD,
+        textTransform: 'uppercase',
+        lineHeight: 1.02,
+        textAlign: 'center',
+        opacity,
+        transform: `scale(${s})`,
+      }}
+    >
+      <div style={{ fontSize: 68 }}>RENTAL</div>
+      <div style={{ fontSize: 68 }}>WRANGLER</div>
+    </div>
+  );
+}
+
+// One safety-orange status blip pulsing in a corner — the single accent use.
+function StatusBlip({ frame }) {
+  const opacity = interpolate(frame, [72, 80], [0, 1], clampOpts);
+  const pulse = interpolate(frame % 20, [0, 10, 20], [0.55, 1, 0.55]);
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 138,
+        right: 138,
+        width: 16,
+        height: 16,
+        borderRadius: '50%',
+        background: ORANGE,
+        opacity: opacity * pulse,
+        boxShadow: `0 0 18px 5px rgba(255,122,26,${0.6 * opacity})`,
+      }}
+    />
+  );
+}
+
+function EstPlate({ frame, fps }) {
+  const s = spring({
+    frame,
+    fps,
+    delay: 80,
+    config: { damping: 10, stiffness: 300, mass: 0.6 },
+    from: 0,
+    to: 1,
+  });
+  return (
+    <div
+      style={{
+        marginTop: 14,
+        fontFamily: FONT,
+        fontWeight: 500,
+        fontSize: 20,
+        letterSpacing: 7,
+        color: TAN,
+        textTransform: 'uppercase',
+        transform: `scaleX(${s})`,
+        transformOrigin: 'center',
+      }}
+    >
+      EST. 2099
+    </div>
+  );
+}
+
+function Main() {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const bgOpacity = interpolate(frame, [0, 10], [0, 1], clampOpts);
+
+  return (
+    <AbsoluteFill style={{ background: STEEL_BASE, overflow: 'hidden' }}>
+      {/* dark steel base + vignette */}
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity,
+          background:
+            'radial-gradient(ellipse at 50% 42%, #232a33 0%, #171c22 48%, #0b0e12 100%)',
+        }}
+      />
+
+      {/* faint HUD grid texture, on-brand background */}
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity * 0.35,
+          backgroundImage:
+            'linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),' +
+            'linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px)',
+          backgroundSize: '64px 64px',
+        }}
+      />
+
+      <Scanline frame={frame} />
+
+      <Panel frame={frame} fps={fps} />
+
+      <KpiRing frame={frame} />
+      <ShieldBadge frame={frame} />
+
+      <AbsoluteFill
+        style={{
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          paddingBottom: 118,
+          flexDirection: 'column',
+        }}
+      >
+        <div style={{ marginBottom: 18 }}>
+          <SystemOnlineStamp frame={frame} fps={fps} />
+        </div>
+        <Wordmark frame={frame} fps={fps} />
+        <EstPlate frame={frame} fps={fps} />
+      </AbsoluteFill>
+
+      <StatusBlip frame={frame} />
+
+      {/* corner rivets framing the whole frame */}
+      <Rivet style={{ top: 24, left: 24, opacity: bgOpacity }} />
+      <Rivet style={{ top: 24, right: 24, opacity: bgOpacity }} />
+      <Rivet style={{ bottom: 24, left: 24, opacity: bgOpacity }} />
+      <Rivet style={{ bottom: 24, right: 24, opacity: bgOpacity }} />
+    </AbsoluteFill>
+  );
+}
+
+registerRoot(() => (
+  <Composition
+    id="data-plate-boot"
+    component={Main}
+    durationInFrames={92}
+    fps={30}
+    width={1920}
+    height={1080}
+  />
+));

--- a/video/logo-intro/src/concept-ignition-stamp.jsx
+++ b/video/logo-intro/src/concept-ignition-stamp.jsx
@@ -1,0 +1,332 @@
+import React from 'react';
+import {
+  registerRoot,
+  Composition,
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+} from 'remotion';
+
+// ---------------------------------------------------------------------------
+// "Ignition Stamp" — Rental Wrangler / JacRentals logo intro concept.
+// Yard data-plate design language: dark industrial steel, ONE safety-orange
+// accent, hazard-stripe signature, riveted steel shield badge, stamped
+// condensed uppercase type. Beat: plate fades up -> hazard bar wipes in ->
+// shield badge drops + settles with a metallic glint sweep -> wordmark
+// stamps in letter-by-letter -> orange underline snaps out -> EST. 2099.
+// ---------------------------------------------------------------------------
+
+const STEEL_BASE = '#14181d';
+const STEEL_PANEL = '#1b2027';
+const STEEL_PANEL_HI = '#20262d';
+const ORANGE = '#ff7a1a';
+const GOLD = '#f5c542';
+const TAN = '#c2925a';
+const RIVET_HI = '#3a4048';
+const RIVET_LO = '#0e1215';
+
+const FONT = '"Saira Condensed","Oswald","Arial Narrow",sans-serif';
+
+const clampOpts = { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' };
+
+const WORD_1 = 'RENTAL';
+const WORD_2 = 'WRANGLER';
+
+function Rivet({ style }) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 12,
+        height: 12,
+        borderRadius: '50%',
+        background: `radial-gradient(circle at 35% 30%, ${RIVET_HI}, ${RIVET_LO} 70%)`,
+        boxShadow: '0 1px 1px rgba(0,0,0,0.6)',
+        ...style,
+      }}
+    />
+  );
+}
+
+function HazardBar({ frame }) {
+  // Wipes in from the left across the lower third — a reveal mask, the
+  // fixed-size pattern behind it never stretches.
+  const progress = interpolate(frame, [6, 30], [0, 1], clampOpts);
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 0,
+        bottom: 0,
+        width: `${progress * 100}%`,
+        height: 132,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          width: 1920,
+          height: 132,
+          backgroundImage:
+            'repeating-linear-gradient(135deg, #f5c542 0 13px, #14181d 13px 26px)',
+          opacity: 0.9,
+        }}
+      />
+    </div>
+  );
+}
+
+function ShieldBadge({ frame, fps }) {
+  const dropSpring = spring({
+    frame,
+    fps,
+    delay: 8,
+    config: { damping: 14, stiffness: 120, mass: 1 },
+    from: -480,
+    to: 0,
+  });
+  const opacity = interpolate(frame, [8, 22], [0, 1], clampOpts);
+
+  // Diagonal white metallic glint sweeping across the settled badge.
+  const glintX = interpolate(frame, [24, 48], [-70, 170], clampOpts);
+
+  const w = 372;
+  const h = 412;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: 96,
+        width: w,
+        height: h,
+        marginLeft: -w / 2,
+        transform: `translateY(${dropSpring}px)`,
+        opacity,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          clipPath:
+            'polygon(50% 0%, 88% 14%, 88% 56%, 50% 100%, 12% 56%, 12% 14%)',
+          background: `linear-gradient(155deg, ${STEEL_PANEL_HI} 0%, ${STEEL_PANEL} 55%, #14181d 100%)`,
+          boxShadow: '0 18px 40px rgba(0,0,0,0.55)',
+          overflow: 'hidden',
+        }}
+      >
+        {/* subtle radial sheen on the plate face */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background:
+              'radial-gradient(ellipse at 50% 34%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0) 60%)',
+          }}
+        />
+        {/* metallic glint sweep, clipped to the shield silhouette */}
+        <div
+          style={{
+            position: 'absolute',
+            top: '-40%',
+            left: `${glintX}%`,
+            width: '26%',
+            height: '180%',
+            background:
+              'linear-gradient(100deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.75) 50%, rgba(255,255,255,0) 100%)',
+            transform: 'rotate(18deg)',
+            filter: 'blur(2px)',
+          }}
+        />
+        {/* monogram placeholder */}
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: '38%',
+            textAlign: 'center',
+            fontFamily: FONT,
+            fontWeight: 800,
+            fontSize: 96,
+            letterSpacing: 2,
+            color: GOLD,
+            textShadow: '0 2px 0 #6b4d16, 0 5px 12px rgba(0,0,0,0.55)',
+            transform: 'translateY(-50%)',
+          }}
+        >
+          RW
+        </div>
+      </div>
+      <Rivet style={{ top: 78, left: 66 }} />
+      <Rivet style={{ top: 78, right: 66 }} />
+      <Rivet style={{ top: 190, left: 30 }} />
+      <Rivet style={{ top: 190, right: 30 }} />
+    </div>
+  );
+}
+
+function StampLetter({ ch, i, frame, fps }) {
+  const delay = 36 + i * 2;
+  const s = spring({
+    frame,
+    fps,
+    delay,
+    config: { damping: 12, stiffness: 220, mass: 0.7 },
+    from: 1.18,
+    to: 1,
+  });
+  const opacity = interpolate(frame, [delay, delay + 5], [0, 1], clampOpts);
+  const impact = interpolate(s, [1, 1.18], [0, 1], clampOpts);
+  const shadowOffset = interpolate(impact, [0, 1], [1, 7]);
+  const shadowBlur = interpolate(impact, [0, 1], [2, 16]);
+
+  if (ch === ' ') {
+    return <span style={{ display: 'inline-block', width: 22 }} />;
+  }
+
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        transform: `scale(${s})`,
+        opacity,
+        textShadow: `0 ${shadowOffset}px ${shadowBlur}px rgba(0,0,0,0.65)`,
+      }}
+    >
+      {ch}
+    </span>
+  );
+}
+
+function Wordmark({ frame, fps }) {
+  const letters = `${WORD_1} ${WORD_2}`.split('');
+  return (
+    <div
+      style={{
+        fontFamily: FONT,
+        fontWeight: 800,
+        fontSize: 104,
+        letterSpacing: 1,
+        color: GOLD,
+        textTransform: 'uppercase',
+        lineHeight: 1,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {letters.map((ch, i) => (
+        <StampLetter key={i} ch={ch} i={i} frame={frame} fps={fps} />
+      ))}
+    </div>
+  );
+}
+
+function Underline({ frame, fps }) {
+  const s = spring({
+    frame,
+    fps,
+    delay: 68,
+    config: { damping: 10, stiffness: 280, mass: 0.6 },
+    from: 0,
+    to: 1,
+  });
+  return (
+    <div
+      style={{
+        width: 560,
+        height: 7,
+        marginTop: 20,
+        background: ORANGE,
+        boxShadow: `0 0 16px 1px ${ORANGE}`,
+        borderRadius: 3,
+        transform: `scaleX(${s})`,
+        transformOrigin: 'center',
+      }}
+    />
+  );
+}
+
+function Main() {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const bgOpacity = interpolate(frame, [0, 16], [0, 1], clampOpts);
+  const estOpacity = interpolate(frame, [78, 90], [0, 1], clampOpts);
+
+  return (
+    <AbsoluteFill style={{ background: STEEL_BASE, overflow: 'hidden' }}>
+      {/* dark steel plate + vignette */}
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity,
+          background:
+            'radial-gradient(ellipse at 50% 42%, #232a33 0%, #171c22 48%, #0b0e12 100%)',
+        }}
+      />
+
+      {/* faint constellation dots, on-brand background texture */}
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity * 0.5,
+          backgroundImage:
+            'radial-gradient(1.5px 1.5px at 14% 20%, rgba(255,255,255,0.35) 0, transparent 60%),' +
+            'radial-gradient(1.5px 1.5px at 84% 18%, rgba(255,255,255,0.28) 0, transparent 60%),' +
+            'radial-gradient(1.5px 1.5px at 70% 76%, rgba(255,255,255,0.22) 0, transparent 60%),' +
+            'radial-gradient(1.5px 1.5px at 22% 80%, rgba(255,255,255,0.28) 0, transparent 60%),' +
+            'radial-gradient(1.5px 1.5px at 92% 58%, rgba(255,255,255,0.2) 0, transparent 60%)',
+        }}
+      />
+
+      {/* corner rivets framing the whole plate */}
+      <Rivet style={{ top: 24, left: 24, opacity: bgOpacity }} />
+      <Rivet style={{ top: 24, right: 24, opacity: bgOpacity }} />
+      <Rivet style={{ bottom: 24, left: 24, opacity: bgOpacity }} />
+      <Rivet style={{ bottom: 24, right: 24, opacity: bgOpacity }} />
+
+      <HazardBar frame={frame} />
+
+      <ShieldBadge frame={frame} fps={fps} />
+
+      <AbsoluteFill
+        style={{
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          paddingBottom: 176,
+          flexDirection: 'column',
+        }}
+      >
+        <Wordmark frame={frame} fps={fps} />
+        <Underline frame={frame} fps={fps} />
+        <div
+          style={{
+            marginTop: 16,
+            fontFamily: FONT,
+            fontWeight: 500,
+            fontSize: 22,
+            letterSpacing: 7,
+            color: TAN,
+            textTransform: 'uppercase',
+            opacity: estOpacity,
+          }}
+        >
+          EST. 2099
+        </div>
+      </AbsoluteFill>
+    </AbsoluteFill>
+  );
+}
+
+registerRoot(() => (
+  <Composition
+    id="ignition-stamp"
+    component={Main}
+    durationInFrames={92}
+    fps={30}
+    width={1920}
+    height={1080}
+  />
+));

--- a/video/logo-intro/src/concept-weld-forge.jsx
+++ b/video/logo-intro/src/concept-weld-forge.jsx
@@ -1,0 +1,445 @@
+import React from 'react';
+import {
+  registerRoot,
+  Composition,
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Easing,
+} from 'remotion';
+
+// ---------------------------------------------------------------------------
+// "Weld / Forge" — Rental Wrangler / JacRentals logo intro concept.
+// A weld spark travels the perimeter of the steel shield badge, leaving a
+// glowing molten-orange edge behind it. When the loop closes the seam cools
+// to brushed steel, rivets pop into the frame corners with a tiny shake, the
+// wordmark heats from dark to gold, and a hazard-stripe underline slides in.
+// Yard data-plate design language: dark industrial steel, ONE safety-orange
+// accent (used as the weld itself), hazard-stripe signature, riveted plate,
+// stamped condensed uppercase type, restrained leather-tan touch.
+// ---------------------------------------------------------------------------
+
+const STEEL_BASE = '#14181d';
+const STEEL_PANEL = '#1b2027';
+const STEEL_PANEL_HI = '#20262d';
+const ORANGE = '#ff7a1a';
+const GOLD = '#f5c542';
+const TAN = '#c2925a';
+const RIVET_HI = '#3a4048';
+const RIVET_LO = '#0e1215';
+const STEEL_EDGE_COOL = '#b7c1cb'; // brushed-steel highlight the weld seam cools to
+const WORD_COLD = '#2b3138'; // dark unheated steel the wordmark starts as
+
+const FONT = '"Saira Condensed","Oswald","Arial Narrow",sans-serif';
+
+const clamp01 = (t) => Math.max(0, Math.min(1, t));
+
+function hexToRgb(hex) {
+  const clean = hex.replace('#', '');
+  const full = clean.length === 3 ? clean.split('').map((c) => c + c).join('') : clean;
+  const int = parseInt(full, 16);
+  return { r: (int >> 16) & 255, g: (int >> 8) & 255, b: int & 255 };
+}
+
+function lerpColor(a, b, t) {
+  const tt = clamp01(t);
+  const ca = hexToRgb(a);
+  const cb = hexToRgb(b);
+  const r = Math.round(ca.r + (cb.r - ca.r) * tt);
+  const g = Math.round(ca.g + (cb.g - ca.g) * tt);
+  const bl = Math.round(ca.b + (cb.b - ca.b) * tt);
+  return `rgb(${r},${g},${bl})`;
+}
+
+// ---------------------------------------------------------------------------
+// Shield outline geometry — same silhouette as the badge fill, expressed as
+// line/cubic segments so we can sample it into a dense polyline. The weld
+// spark travels this polyline at (approximately) constant speed, and the
+// same polyline is drawn back with stroke-dasharray for the "traced" glow —
+// so the dash length always matches the sampled arc length exactly.
+// ---------------------------------------------------------------------------
+const A = {
+  p0: { x: 280, y: 34 },
+  p1: { x: 456, y: 106 },
+  c1a: { x: 472, y: 112 },
+  c1b: { x: 482, y: 128 },
+  p2: { x: 482, y: 146 },
+  p3: { x: 482, y: 298 },
+  c2a: { x: 482, y: 380 },
+  c2b: { x: 426, y: 444 },
+  p4: { x: 280, y: 518 },
+  c3a: { x: 134, y: 444 },
+  c3b: { x: 78, y: 380 },
+  p5: { x: 78, y: 298 },
+  p6: { x: 78, y: 146 },
+  c4a: { x: 78, y: 128 },
+  c4b: { x: 88, y: 112 },
+  p7: { x: 104, y: 106 },
+};
+
+const SHIELD_SEGMENTS = [
+  { type: 'L', from: A.p0, to: A.p1 },
+  { type: 'C', from: A.p1, c1: A.c1a, c2: A.c1b, to: A.p2 },
+  { type: 'L', from: A.p2, to: A.p3 },
+  { type: 'C', from: A.p3, c1: A.c2a, c2: A.c2b, to: A.p4 },
+  { type: 'C', from: A.p4, c1: A.c3a, c2: A.c3b, to: A.p5 },
+  { type: 'L', from: A.p5, to: A.p6 },
+  { type: 'C', from: A.p6, c1: A.c4a, c2: A.c4b, to: A.p7 },
+  { type: 'L', from: A.p7, to: A.p0 },
+];
+
+function cubicPt(p0, p1, p2, p3, t) {
+  const mt = 1 - t;
+  const a = mt * mt * mt;
+  const b = 3 * mt * mt * t;
+  const c = 3 * mt * t * t;
+  const d = t * t * t;
+  return { x: a * p0.x + b * p1.x + c * p2.x + d * p3.x, y: a * p0.y + b * p1.y + c * p2.y + d * p3.y };
+}
+
+function buildPolyline(segments, samplesPerSeg) {
+  const pts = [];
+  segments.forEach((seg) => {
+    for (let i = 0; i < samplesPerSeg; i++) {
+      const t = i / samplesPerSeg;
+      if (seg.type === 'L') {
+        pts.push({ x: seg.from.x + (seg.to.x - seg.from.x) * t, y: seg.from.y + (seg.to.y - seg.from.y) * t });
+      } else {
+        pts.push(cubicPt(seg.from, seg.c1, seg.c2, seg.to, t));
+      }
+    }
+  });
+  pts.push({ ...segments[0].from });
+  return pts;
+}
+
+const SHIELD_POLY = buildPolyline(SHIELD_SEGMENTS, 26);
+const SHIELD_CUM = [0];
+for (let i = 1; i < SHIELD_POLY.length; i++) {
+  const prev = SHIELD_POLY[i - 1];
+  const cur = SHIELD_POLY[i];
+  SHIELD_CUM.push(SHIELD_CUM[i - 1] + Math.hypot(cur.x - prev.x, cur.y - prev.y));
+}
+const SHIELD_TOTAL_LEN = SHIELD_CUM[SHIELD_CUM.length - 1];
+const SHIELD_D = SHIELD_POLY.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(' ') + ' Z';
+
+function pointAtProgress(p) {
+  const target = clamp01(p) * SHIELD_TOTAL_LEN;
+  for (let i = 1; i < SHIELD_CUM.length; i++) {
+    if (SHIELD_CUM[i] >= target) {
+      const segLen = SHIELD_CUM[i] - SHIELD_CUM[i - 1];
+      const segT = segLen === 0 ? 0 : (target - SHIELD_CUM[i - 1]) / segLen;
+      const a = SHIELD_POLY[i - 1];
+      const b = SHIELD_POLY[i];
+      return { x: a.x + (b.x - a.x) * segT, y: a.y + (b.y - a.y) * segT };
+    }
+  }
+  return SHIELD_POLY[SHIELD_POLY.length - 1];
+}
+
+// ---------------------------------------------------------------------------
+// Timeline (frames @ 30fps, 92 total ~= 3.07s)
+// ---------------------------------------------------------------------------
+const FADE_IN_END = 10;
+const TRACE_START = 10;
+const TRACE_END = 56; // weld spark closes the loop here
+const SPARK_FADE_START = TRACE_START;
+const SPARK_FADE_IN_END = TRACE_START + 3;
+const SPARK_FADE_OUT_START = TRACE_END - 2;
+const SPARK_FADE_OUT_END = TRACE_END + 6;
+const PANEL_FADE_START = 40;
+const PANEL_FADE_END = 70;
+const COOL_START = TRACE_END;
+const COOL_END = COOL_START + 15;
+const RIVET_BASE = 60;
+const RIVET_STAGGER = 4;
+const WORD_HEAT_START = 66;
+const WORD_HEAT_END = WORD_HEAT_START + 20;
+const EST_START = 84;
+const EST_END = 92;
+const UNDERLINE_START = 78;
+const UNDERLINE_END = 92;
+const UNDERLINE_W = 176;
+
+const RIVET_POSITIONS = [
+  { top: 40, left: 40 },
+  { top: 40, right: 40 },
+  { bottom: 40, left: 40 },
+  { bottom: 40, right: 40 },
+];
+
+function Rivet({ frame, delay }) {
+  const local = frame - delay;
+  if (local < -1) return null;
+  const s = spring({ frame, fps: 30, delay, config: { damping: 11, stiffness: 190, mass: 0.55 } });
+  const scale = interpolate(s, [0, 1], [0, 1]);
+  const shakeEnv = interpolate(local, [0, 10], [1, 0], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' });
+  const shakeX = Math.sin(local * 2.4) * 2.4 * shakeEnv;
+  const shakeY = Math.cos(local * 3.1) * 1.6 * shakeEnv;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: 14,
+        height: 14,
+        borderRadius: '50%',
+        background: `radial-gradient(circle at 35% 30%, ${RIVET_HI}, ${RIVET_LO} 70%)`,
+        boxShadow: '0 1px 2px rgba(0,0,0,0.7), 0 0 6px rgba(255,122,26,0.15)',
+        transform: `translate(${shakeX}px, ${shakeY}px) scale(${scale})`,
+      }}
+    />
+  );
+}
+
+function HazardEdge() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: 8,
+        backgroundImage: 'repeating-linear-gradient(135deg, #f5c542 0 13px, #14181d 13px 26px)',
+        opacity: 0.85,
+      }}
+    />
+  );
+}
+
+function ShieldBadge({ frame, fps }) {
+  const w = 560;
+  const h = 560;
+
+  const traceProgress = interpolate(frame, [TRACE_START, TRACE_END], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  const sparkOpacity = interpolate(
+    frame,
+    [SPARK_FADE_START, SPARK_FADE_IN_END, SPARK_FADE_OUT_START, SPARK_FADE_OUT_END],
+    [0, 1, 1, 0],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' },
+  );
+  const sparkPos = pointAtProgress(traceProgress);
+
+  const panelOpacity = interpolate(frame, [PANEL_FADE_START, PANEL_FADE_END], [0.05, 0.92], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.out(Easing.cubic),
+  });
+
+  const coolT = interpolate(frame, [COOL_START, COOL_END], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.inOut(Easing.cubic),
+  });
+  const edgeColor = lerpColor(ORANGE, STEEL_EDGE_COOL, coolT);
+  const edgeWidth = interpolate(coolT, [0, 1], [6, 3]);
+  const hotGlow = interpolate(frame, [COOL_START, COOL_END], [0.9, 0], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+  const sheenGlow = interpolate(coolT, [0, 1], [0, 0.4]);
+
+  // Before the loop closes, keep the traced portion hot orange with a strong
+  // glow (the "leaving a glowing molten-orange edge behind it" beat).
+  const preCloseGlow = traceProgress > 0 && traceProgress < 1 ? 0.9 : hotGlow;
+  const strokeColor = traceProgress < 1 ? ORANGE : edgeColor;
+  const strokeGlowOrange = traceProgress < 1 ? 0.9 : hotGlow;
+  const strokeWidth = traceProgress < 1 ? 6 : edgeWidth;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: '50%',
+        width: w,
+        height: h,
+        transform: 'translate(-50%, -50%)',
+      }}
+    >
+      <svg width={w} height={h} viewBox="0 0 560 560" style={{ overflow: 'visible' }}>
+        <defs>
+          <linearGradient id="wfShieldFace" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={STEEL_PANEL_HI} />
+            <stop offset="55%" stopColor={STEEL_PANEL} />
+            <stop offset="100%" stopColor="#171b21" />
+          </linearGradient>
+          <radialGradient id="wfBadgeGlow" cx="50%" cy="42%" r="60%">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.07)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </radialGradient>
+        </defs>
+
+        {/* interior plate fill — a faint ghost while welding, solid once cooled */}
+        <path d={SHIELD_D} fill="url(#wfShieldFace)" opacity={panelOpacity} />
+        <path d={SHIELD_D} fill="url(#wfBadgeGlow)" opacity={panelOpacity} />
+
+        {/* the traced / cooled seam itself */}
+        <path
+          d={SHIELD_D}
+          fill="none"
+          stroke={strokeColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeDasharray={SHIELD_TOTAL_LEN}
+          strokeDashoffset={SHIELD_TOTAL_LEN * (1 - traceProgress)}
+          style={{
+            filter:
+              `drop-shadow(0 0 ${10 * strokeGlowOrange}px rgba(255,122,26,${strokeGlowOrange}))` +
+              ` drop-shadow(0 0 ${6 * sheenGlow}px rgba(255,255,255,${sheenGlow}))`,
+          }}
+        />
+
+        {/* the traveling weld spark */}
+        {sparkOpacity > 0.001 && (
+          <g opacity={sparkOpacity}>
+            <circle cx={sparkPos.x} cy={sparkPos.y} r={17} fill="rgba(255,140,40,0.28)" />
+            <circle cx={sparkPos.x} cy={sparkPos.y} r={9} fill="rgba(255,190,110,0.7)" />
+            <circle cx={sparkPos.x} cy={sparkPos.y} r={4.2} fill="#fff7e6" />
+          </g>
+        )}
+      </svg>
+    </div>
+  );
+}
+
+function Main() {
+  const frame = useCurrentFrame();
+  const { fps, width, height } = useVideoConfig();
+
+  const bgOpacity = interpolate(frame, [0, FADE_IN_END], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  const wordHeatT = interpolate(frame, [WORD_HEAT_START, WORD_HEAT_END], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.inOut(Easing.cubic),
+  });
+  const wordColor = lerpColor(WORD_COLD, GOLD, wordHeatT);
+  const wordGlow = interpolate(
+    frame,
+    [WORD_HEAT_START, WORD_HEAT_START + 10, WORD_HEAT_END],
+    [0, 0.75, 0.12],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' },
+  );
+  const wordOpacity = interpolate(frame, [WORD_HEAT_START - 4, WORD_HEAT_START + 4], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  const estOpacity = interpolate(frame, [EST_START, EST_END], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  const underlineW = interpolate(frame, [UNDERLINE_START, UNDERLINE_END], [0, UNDERLINE_W], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.out(Easing.cubic),
+  });
+
+  return (
+    <AbsoluteFill style={{ background: STEEL_BASE, overflow: 'hidden' }}>
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity,
+          background: 'radial-gradient(ellipse at 50% 42%, #202730 0%, #171c22 45%, #0d1013 100%)',
+        }}
+      />
+      {/* a few white constellation dots — restrained, industrial-night accent */}
+      <AbsoluteFill
+        style={{
+          opacity: bgOpacity * 0.4,
+          backgroundImage:
+            'radial-gradient(1px 1px at 14% 20%, rgba(255,255,255,0.3) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 84% 18%, rgba(255,255,255,0.25) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 88% 66%, rgba(255,255,255,0.22) 0, transparent 60%),' +
+            'radial-gradient(1px 1px at 9% 72%, rgba(255,255,255,0.24) 0, transparent 60%)',
+        }}
+      />
+
+      <ShieldBadge frame={frame} fps={fps} />
+
+      {RIVET_POSITIONS.map((p, i) => (
+        <div key={i} style={{ position: 'absolute', ...p }}>
+          <Rivet frame={frame} delay={RIVET_BASE + i * RIVET_STAGGER} />
+        </div>
+      ))}
+
+      <AbsoluteFill style={{ alignItems: 'center', justifyContent: 'center', flexDirection: 'column' }}>
+        <div style={{ opacity: wordOpacity, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <div
+            style={{
+              fontFamily: FONT,
+              fontWeight: 700,
+              fontSize: 58,
+              letterSpacing: 4,
+              color: wordColor,
+              textTransform: 'uppercase',
+              textShadow: `0 2px 0 rgba(0,0,0,0.45), 0 0 ${18 * wordGlow}px rgba(255,122,26,${wordGlow})`,
+              lineHeight: 1.02,
+              textAlign: 'center',
+            }}
+          >
+            RENTAL
+          </div>
+          <div
+            style={{
+              fontFamily: FONT,
+              fontWeight: 700,
+              fontSize: 58,
+              letterSpacing: 4,
+              color: wordColor,
+              textTransform: 'uppercase',
+              textShadow: `0 2px 0 rgba(0,0,0,0.45), 0 0 ${18 * wordGlow}px rgba(255,122,26,${wordGlow})`,
+              lineHeight: 1.02,
+              textAlign: 'center',
+              marginTop: 2,
+            }}
+          >
+            WRANGLER
+          </div>
+          <div
+            style={{
+              marginTop: 12,
+              width: underlineW,
+              height: 6,
+              backgroundImage: 'repeating-linear-gradient(135deg, #f5c542 0 8px, #14181d 8px 16px)',
+              borderRadius: 2,
+              boxShadow: underlineW > 4 ? '0 0 8px 0 rgba(245,197,66,0.35)' : 'none',
+            }}
+          />
+          <div
+            style={{
+              marginTop: 14,
+              fontFamily: FONT,
+              fontWeight: 500,
+              fontSize: 20,
+              letterSpacing: 6,
+              color: TAN,
+              textTransform: 'uppercase',
+              opacity: estOpacity,
+            }}
+          >
+            EST. 2099
+          </div>
+        </div>
+      </AbsoluteFill>
+
+      <HazardEdge />
+    </AbsoluteFill>
+  );
+}
+
+registerRoot(() => (
+  <Composition id="weld-forge" component={Main} durationInFrames={92} fps={30} width={1920} height={1080} />
+));


### PR DESCRIPTION
## What & why

Research spike into **Remotion** (the React framework for making videos programmatically) and a first working sample: a branded **Rental Wrangler logo-reveal** intro rendered to MP4. Goal is a reusable `remotion` skill + a runnable sample, so Claude can generate branded videos on demand.

**Status: draft / work-in-progress.** This commit lands the render harness only; the animation concepts and the skill itself are still being built.

## Feasibility — confirmed working in the cloud sandbox

- Remotion **4.0.494** (+ React 19) installs and renders real **1920×1080 h264 MP4** end-to-end.
- Render path: `bundle()` → `selectComposition()` → `renderMedia()` with `browserExecutable` pinned to the **pre-installed headless Chromium** (`/opt/pw-browsers/...`) — so renders have **zero network dependency** and skip Remotion's ~92 MB shell download.
- Review stills are pulled with Remotion's own vendored ffmpeg (the Playwright ffmpeg is a stripped webm-only build).

## In this commit

- `video/logo-intro/render.mjs` — shared render harness (bundle → select → render + still extraction).
- `video/logo-intro/package.json` — pinned deps (remotion / cli / renderer / bundler 4.0.494, react 19).
- `video/logo-intro/prepare-logo.mjs` — helper to extract an embedded raster from an SVG asset.
- `video/logo-intro/.gitignore` — keeps `node_modules` / `out` / `frames` / cache out of git.

Nothing here touches the served SPA (`app.js` / `style.css` / `index.html`) or the backend.

## Next

- Four on-brand motion concepts (Ignition Stamp / Constellation Draw / Weld-Forge / Data-Plate Boot) rendering now for a pick.
- Swap in the real Rental Wrangler badge art once provided.
- Author the reusable `remotion` skill grounded in the proven harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KUDAq6MW1BiXRZZk1koXh

---
_Generated by [Claude Code](https://claude.ai/code/session_019KUDAq6MW1BiXRZZk1koXh)_