### PR TITLE
docs: Codex migration handoff + onboarding

### DIFF
--- a/docs/CODEX-HANDOFF.md
+++ b/docs/CODEX-HANDOFF.md
@@ -1,0 +1,165 @@
+# Rental Wrangler — Claude Code → OpenAI Codex migration handoff
+
+**Purpose:** everything Codex needs to take over this repo. Written to travel *with* the repo,
+so it works wherever Codex reads it.
+
+> **Two-doc handoff:** this file is the **setup mechanics** (repo, secrets, tooling, dual-agent).
+> Once set up, **study the project itself** via **`docs/CODEX-ONBOARDING.md`** — a guided reading
+> order for the current state, the research, the flaws, the design canon, what's been built, and
+> what's next.
+
+## TL;DR — most of this is agent-agnostic and already travels
+The project is mostly portable Node + markdown on a GitHub repo. There are **three real work
+items**, everything else just works if Codex runs on the same repo:
+
+1. **Create `AGENTS.md`** — Codex's instruction file (it does not read `CLAUDE.md`).
+2. **Re-provision secrets** in Codex's environment — *you* do this, never through chat or the repo.
+3. **Swap the two LLM-calling GitHub Actions** to OpenAI (`wrangler-fix.yml`, check `auto-promote.yml`).
+4. **If Claude + Codex run at once:** namespace branches (`codex/*`) + a `docs/WIP.md` ledger +
+   a cross-review skill (§8). The staging deck already isolates deploys for free.
+
+---
+
+## 1. Already portable — NO action (GitHub covers it)
+Your instinct was right: most "control gates" are a nonstarter because GitHub already holds them.
+- **CI gates** — `.github/workflows/ci.yml` runs the whole suite (`smoke`, `logic-test`,
+  `lease-test`, `lease-deploy-test`, `promote-test`, `cachebust-test`, `gen-rule-usage --check`,
+  `check-window-catalog`, `gen-code-map --check`, `check-cachebust`). GitHub-native → **any agent
+  on this repo inherits them**. **Branch protection** on `trunk`/`production` travels too.
+- **Release tooling** — `tools/*.mjs` (`deploy-staging`, `promote`, `staging-lease`,
+  `bump-cachebust`, `gen-code-map`, `gen-icons`) are plain Node, zero Claude dependencies.
+- **The repo brain** — `docs/CODE-MAP.md`, `MEMORY.md`, `docs/`, and `.claude/rules/` are all
+  markdown and travel automatically. Codex can **read** `.claude/skills/*` and `.claude/rules/*`
+  as plain files even though it can't "invoke" them as skills.
+
+## 2. Small adaptations
+### 2a. `AGENTS.md` (Codex's instruction file)
+Codex reads `AGENTS.md` at the repo root, not `CLAUDE.md`. Fastest path: seed `AGENTS.md` from
+`CLAUDE.md`, then graft in the essential runbooks below so the ship flow + design canon are inline.
+Keep `CLAUDE.md` too (harmless, and lets you run Claude again if ever needed).
+
+### 2b. Skills → runbooks (the knowledge travels; the `/invoke` mechanism doesn't)
+Every skill is a markdown file under `.claude/skills/<name>/SKILL.md`. Point `AGENTS.md` at these:
+
+| Skill | Action | Why |
+|---|---|---|
+| `build` · `deploy` · `merge` · `promote` · `live` | **PORT** | the ship flow — core release runbook. Tooling is portable; document the orchestration (see §6 npm scripts). |
+| `clasp` | **PORT** | backend (Google Apps Script) deploy runbook — the backend can't ship without it. |
+| `style` · `wrangler-style` | **PORT (critical)** | the design canon (palette, type voices, Signal·Gate·Stamp·Ref·Door, and the measurable spec — control height, size ladder, contrast floors). The reason the UI is one family. |
+| `wrangler-fix` | **PORT** | "prove the root cause with citations before changing code" — the debugging methodology. |
+| `atlas` | **PORT (as instruction)** | CODE-MAP-first navigation → the #2 token lever (§5). |
+| `start` | **ADAPT** | session orientation — keep the branch-flow parts, drop Claude-session bits. |
+| `run-live` · `lazy-audit` · `webapp-testing` | **ADAPT** | Playwright-based test/audit flows — portable, useful. |
+| `brainstorming` | **ADAPT** | the spec-first design dialogue — a useful pattern, not Claude-specific. |
+| `audit` | **DROP** | Claude token-efficiency audit — harness-specific. |
+| `end` · `skill-creator` | **DROP** | Claude session/skill management. |
+
+## 3. Secrets — YOU re-provision, never through the agent or the repo
+**Hard rule (unchanged): the repo is PUBLIC via Pages. No secret value ever goes in the repo, a
+commit, or a chat message.** This doc lists NAMES and PURPOSES only.
+
+Two homes for secrets:
+- **GitHub Actions secrets (CI):** already set on this repo. If Codex works on the **same repo**,
+  CI keeps working with no action.
+- **Codex's agent environment (interactive `deploy`/`clasp` runs):** recreate these env vars in
+  Codex's sandbox config, values pulled from **your** vault:
+
+| Env var / secret | Purpose | Source |
+|---|---|---|
+| `STAGING_DEPLOY_PAT` | GitHub PAT for the staging-deck push (`tools/deploy-staging.mjs`) | your GitHub PAT store |
+| `STAGING_DEPLOY_KEY_PATH` | alt deploy-key path (if used instead of the PAT) | your key store |
+| `GAS_SA_KEY_B64` | base64 Google service-account key for the `clasp` backend push | Google Cloud IAM |
+| backend/team + role passwords | login + role gates | live in the backend `Code.gs`/config (gitignored) — carry them with the backend, **never** the repo |
+| Google Maps / GPS · Twilio SMS · Stripe (if used) | maps, texts, payments | your provider dashboards |
+| `CLAUDE_CODE_SESSION_ID` | Claude-only | **drop** |
+
+## 4. The two GitHub Actions that call an LLM — swap to OpenAI
+- `.github/workflows/wrangler-fix.yml` — the auto-fix engine calls Claude to triage issues.
+  Swap the model call to OpenAI, or disable it until ported.
+- `.github/workflows/auto-promote.yml` — check for any Claude-action dependency. If it's just
+  `promote.mjs` on a trigger, it's fine as-is.
+- `ci.yml`, `branch-janitor.yml` are LLM-free → no change.
+
+## 5. Token levers (from the other session — encoded here)
+1. **Split `app.js` (27,812 lines) — the #1 win.** A read then pulls the right module, not 27k
+   lines. **Caution:** gates key off `app.js` — `gen-code-map` (chapter markers) and `smoke`/`logic`
+   (boot). Split along the **chapter boundaries CODE-MAP already names** and re-run the **full gate
+   suite after each move**. Best done as an early Codex task: clean, mechanical, high payoff — but
+   it must stay gate-green.
+2. **Use CODE-MAP hard.** `AGENTS.md` should tell Codex: open `docs/CODE-MAP.md` FIRST, jump to
+   `file:line`, never scan `app.js` blind. (That's the `/atlas` discipline.)
+3. **Codex model routing.** Route mechanical work to cheaper tiers; keep the hard reasoning up.
+
+## 6. Decisions needed from you
+1. **Same repo? — ✅ CONFIRMED (Jac).** Codex runs on this same GitHub repo, so CI (`ci.yml`),
+   branch protection on `trunk`/`production`, the GitHub Actions secrets, and all of `tools/`
+   carry over with **zero re-setup**.
+2. **Keep trunk → staging → production? — ✅ CONFIRMED (Jac).** The tooling is portable; only the
+   `/build /deploy /merge /promote` *invocation* was Claude-specific → wrap it in **npm scripts**
+   so the flow is agent-agnostic (first Codex chore):
+   - `npm run gates` → runs the full CI suite locally
+   - `npm run deploy:staging` → `node tools/deploy-staging.mjs`
+   - `npm run promote` → `node tools/promote.mjs`
+   - `npm run cachebust` → `node tools/bump-cachebust.mjs`
+3. **Backend (Google Apps Script):** keep the clasp service-account push (the only backend path) —
+   just re-provision `GAS_SA_KEY_B64`. Go-live stays your Apps Script editor deploy.
+4. **`app.js` split — ✅ CONFIRMED: Codex does it.** Split along the **chapter boundaries
+   `docs/CODE-MAP.md` already names** and **re-run the full gate suite after each move**
+   (`gen-code-map`/`smoke`/`logic` all key off `app.js`). Do it early — it's the #1 token lever (§5).
+5. **Cross-review — ✅ CONFIRMED: a tool, never a gate (Jac).** The `/cross-review` skill (§8b) is
+   something you run **on demand** for a second opinion; it never blocks a merge and is never a
+   required check.
+
+## 7. First-week Codex checklist
+- [ ] Confirm Codex on the **same** GitHub repo (inherits CI + branch protection + Actions secrets).
+- [ ] Create `AGENTS.md` (seed from `CLAUDE.md`; graft in `build`/`deploy`/`promote`/`clasp`/
+      `style`/`wrangler-style` runbooks; point it at `docs/CODE-MAP.md` as the nav entrypoint).
+- [ ] Add the §6 npm scripts so the ship flow is agent-agnostic.
+- [ ] Re-provision agent-env secrets from your vault (§3) — never via chat/repo.
+- [ ] Swap `wrangler-fix.yml` (and check `auto-promote.yml`) to OpenAI, or disable.
+- [ ] Split `app.js` by CODE-MAP chapters, re-running the full gate suite after each move.
+
+## 8. Running Claude + Codex on one repo — collisions & cross-review
+Both agents on one repo is safe *if* each stays in its own lane and the shared integration point
+(`trunk`, branch-protected) serializes them.
+
+### 9a. Collision avoidance — namespace by platform
+- **Branches:** prefix by platform. Claude already uses `claude/<slug>`; **Codex uses
+  `codex/<slug>`.** One glance says who owns a ref; the two never fight over the same branch.
+- **Deploys — already isolated, nothing to change.** The staging deck writes immutable
+  `d/<branch-slug>-<n>/` folders keyed by branch, so `codex/foo` → `codex-foo-1`, `claude/bar` →
+  `claude-bar-1`. No collision, and the `/d/` launcher + in-app **Staging ▾** switcher list both
+  agents' deploys side by side.
+- **Features:** keep **one `FEATURES` flag per feature** (not per platform); note the owning
+  platform + branch in the flag's comment so neither agent re-implements a flag the other owns.
+- **Integration:** both PR into `trunk` (branch-protected → writes serialize, no direct pushes).
+  Two PRs touching the same lines = an ordinary merge conflict, resolved at merge time.
+  **Production only moves via `/promote` — a human call — and that stays the single go-live gate
+  for BOTH agents.** Neither agent ever ships to production on its own.
+- **The catch-all = a work ledger.** Keep a tiny shared `docs/WIP.md`: one line per in-flight
+  feature — `owner (claude|codex) · branch · flag · one-line status`. Each agent **appends when it
+  starts** a feature and **removes on merge**. Before starting anything, an agent reads WIP.md so
+  the two never grab the same work. (`branch-janitor` can flag stale entries.)
+
+### 9b. Cross-review — "look at what the other one did and tell me what you think"
+A small skill on each side, both grounded in the SAME canon (`docs/CODE-MAP.md` +
+`style`/`wrangler-style` + the specs) so they judge by one standard. **It is a tool you reach for
+on demand — never a gate, never a merge block, never a required check.**
+- **Claude:** a `/cross-review <codex-branch-or-PR>` skill — fetch the diff, check it against the
+  gates and the design canon, then report **agree / disagree / risks** with `file:line` citations.
+  (It's the existing `/review` + `/code-review`, pointed at Codex's PR with a "measure against
+  canon" framing.)
+- **Codex:** a mirror command that does the same to a `claude/*` PR, pointed at the same canon files.
+- Production is `/promote`-gated by a human, so cross-review only ever **informs your call** — you
+  run it whenever you want a second opinion, and it never touches the merge.
+
+## 9. Current work-in-flight (context for whoever picks up the UI)
+The active branch `claude/rental-wrangler-ui-research-rhd74v` (PR #752) holds the **Phase-2
+`dv2` redesign**, gated behind `FEATURES.designV2` (off in production; auto-on on staging/local
+via the `html.dv2` class). Steps 1–2 of the inline-expand model are built: a single-click reveals
+a record **in the list** (row expands, height-capped to the column), reshaped to the section
+**plate-stack** (header-as-close, collapsed Inspection + History, swipe-easing reveal). Remaining:
+carry the reshape into Rentals + Customers, the History-search footer, links-land-on-section,
+mobile paged sections + To-Do, and retiring the legacy card-swap detail. Full plan:
+`docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md` and
+`docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md`.

--- a/docs/CODEX-ONBOARDING.md
+++ b/docs/CODEX-ONBOARDING.md
@@ -1,0 +1,126 @@
+# Codex onboarding — study this project before you build
+
+Welcome. You're taking over Rental Wrangler. Work in **two phases**: set up *with* Jac, then study
+the project *on your own*, then confirm your understanding with Jac before writing any feature code.
+
+---
+
+## Phase A — set up (walk Jac through it)
+Follow **`docs/CODEX-HANDOFF.md`** end to end: same GitHub repo, create `AGENTS.md`, add the npm
+scripts, and re-provision secrets. **Walk Jac through each secret** — he provisions the values from
+his own vault; you never handle or echo a secret value, and nothing secret ever enters the repo or
+chat. Swap the two LLM-calling GitHub Actions to OpenAI. **Do not touch feature code until
+`npm run gates` (the full CI suite) is green.**
+
+## Phase B — study & understand (before any feature code)
+Read the sources below **in order**, then **write Jac a short "here's my understanding of where the
+project is and what I'd do next"** and confirm it before building. The goal is to understand: the
+current state, the research, the flaws, the docs, the findings, Jac's ideas, the prior agent's
+ideas, what's been done, and what's next.
+
+### 1. What this project is
+Heavy-equipment rental-management **single-page app** for **JacRentals** (Sulphur, LA). Vanilla JS,
+single-file frontend: `app.js` (~27.8k lines), `style.css`, `index.html`, `config.js`, `data.js`.
+**Google Apps Script backend** (schema-less Google Sheets; gitignored `Code.gs`, deployed by clasp).
+Ships on a **trunk → staging → production** flow. Currently mid a **Phase-2 UI redesign**.
+
+### 2. The brain (read first)
+- **`CLAUDE.md`** — the project operating rules (seed your `AGENTS.md` from it).
+- **`MEMORY.md`** (repo root) — cross-session memory / durable context.
+- **`.claude/rules/`** — path-scoped rules (e.g. icons: never hand-draw, source from Lucide).
+- **`docs/CODE-MAP.md`** — the navigation map. **Open this FIRST before any code dive** and jump to
+  `file:line` rather than scanning `app.js` blind. (Regenerate with `node tools/gen-code-map.mjs`.)
+
+### 3. The design canon (the UI standard)
+- **`.claude/skills/style/`** — the measurable spec: one control height, one baseline, the size
+  ladder, contrast floors, colour-blind separation, and the two state functions (**colour = state**,
+  **fill = today**).
+- **`.claude/skills/wrangler-style/`** — the decisions: the locked steel palette, the two type
+  voices, the button taxonomy, the **Signal · Gate · Stamp · Ref · Door** component vocabulary, and
+  the restrained wrangler/ranch voice.
+- **`docs/superpowers/specs/2026-07-20-decisions-ledger.md`** — the running ledger of locked design
+  decisions (what was decided and why; newer decisions supersede older ones).
+- **CRITICAL sourcing rule:** design comes from the **canon + specs + mockups + research** —
+  **never reverse-engineered from the live `app.js`/`style.css`.** This is a hard rule from Jac
+  (a controlled design environment); honor it.
+
+### 4. The research & findings (why the design is what it is)
+- **`docs/specs/market-research.md`** — market research.
+- **`docs/handoffs/dispatch-ux-research-2026-07-06.md`** — dispatch UX research.
+- **`docs/superpowers/specs/2026-07-20-mockup-critique-log.md`** — the canon-compliance audit of the
+  redesign mockups: the concrete **flaws** found and their fixes.
+- **`docs/handoffs/audit-2026-07-19-rentals-dispatcher-remaining-work.md`** and
+  **`audit-2026-07-09-parked-findings.md`** — audit findings and parked work.
+- The broad UX-research corpus (a ~171-finding inventory + taxonomy) was worked *in a prior
+  session*; its conclusions are folded into the specs in §5. The raw inventory is **not in the
+  repo** — see §9.
+
+### 5. The CURRENT redesign (what we're building now) — read closely
+- **`docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md`** — **THE current spec.**
+  The whole Phase-2 model: inline-expand (detail is a reveal *in the list*, not a card-swap), the
+  section **plate-stack**, the Rentals calendar-anchor exception, links-land-on-section, mobile
+  paged sections, Comms/Inbox (§7), the **Trips ETA-Tracker ledger** (§8 — includes Jac's
+  hand-drawn ledger, described in detail at §8.5), and the role **Dashboard** (§5). Jac's ideas are
+  captured throughout; the §2.0 block records the plate-stack-vs-paging decision.
+- **`docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md`** — the build plan for the
+  list + detail views: the shared element layer, the phases, and a **running build log** of what's
+  been shipped slice by slice.
+
+### 6. What's been done so far (current build state)
+The Phase-2 **`dv2`** redesign is being built **incrementally on staging**, gated behind
+`FEATURES.designV2` (`config.js`) + the `html.dv2` class (set in `app.js`). It is **additive and
+scoped `html.dv2 …`** — auto-on on staging/local, **production frozen** until the flag flips, so the
+base look is byte-identical when off. On branch **`claude/rental-wrangler-ui-research-rhd74v`
+(PR #752)**:
+- **Palette/voice + element slices** — steel palette under `html.dv2`, section state stripes
+  (left-border, matte), Ref icon plates, unit names routed through the shared `unitPill` builder,
+  mono-tabular numbers, group-count voice.
+- **Inline-expand Step 1** — single-click **reveals a record IN the list** (the row expands),
+  **height-capped to the column** (the item scrolls internally, never blows out), full-width
+  **grid-row breakout**.
+- **Inline-expand Step 2** — reshaped to the **section plate-stack**: the header is the close
+  control (the ✕ was dropped), Inspection collapses to a one-line plate, History collapses to its
+  count chips, a swipe-easing reveal, and it scroll-anchors to the column top. **Units only so far.**
+- **Study the built design two ways:** open the live staging build (the `/d/` launcher → newest
+  deck, or the in-app **Staging ▾** switcher), and read the `html.dv2` blocks in `style.css` +
+  the inline-expand code in `app.js` (`rowEl` / `cardEl` / `openStandard`, and the
+  `INLINE_EXPAND_CARDS` / `dv2On` helpers).
+
+### 7. What's next (the roadmap)
+Immediate — finish the inline-expand rollout (agreed build order):
+3. role default landing + drag-resort section order
+4. Rentals calendar-anchor exception (no section tabs)
+5. persistent History-search footer (bring the log back on demand)
+6. single/double-click remap (largely done — single = expand, double = anchor)
+7. links land on the correct **section** (generalize the existing `pillTo`)
+8. mobile full-screen **paged** sections + a **To-Do** landing page
+9. hover-jump popover (lowest priority)
+10. retire the legacy card-swap detail once 1–7 cover all three cards
+Also: **carry the plate-stack reshape into Rentals + Customers** (Units is done).
+Then, per the spec: the **Trips ETA-Tracker ledger** (§8, mockup iterated with Jac), **Comms/Inbox**
+(§7), the role **Dashboard** (§5 — Jac: "after the staging builds"), the **all-cards Sort redesign**,
+and the extra-colour **palette collapse** into the frozen set.
+
+### 8. How work ships here
+Feature branch **`codex/<slug>`** → `npm run deploy:staging` (review on the deck URL) → **`/merge`**
+(PR → `trunk`, gates must pass) → **`/promote`** (`trunk` → production — **a human call, the only
+step that goes live**). **Never push to `trunk`/`production` directly** (branch-protected). Keep dv2
+changes additive and `html.dv2`-scoped so production stays byte-identical until Jac flips the flag.
+(If Claude is also running: see `CODEX-HANDOFF.md` §8 for branch namespacing + the `docs/WIP.md`
+work ledger so the two agents don't collide.)
+
+### 9. Gaps to close with Jac (NOT in the repo — you can't see these yet)
+- **The visual mockups + photos + artifacts.** The 3-detail-views mockup, the `list-views` /
+  `detail-views` HTML, Jac's hand-drawn sketches (e.g. the ETA-tracker), and the inspiration images
+  live in the **chat / on claude.ai — not the repo**. `scratchpad/` is empty. If you want them, ask
+  Jac to export the key ones into `docs/design/reference/`. The design is otherwise fully captured
+  in the spec (§5) + the **live staging build** + the canon skills — start there.
+- **The raw UX-research finding inventory (~171 findings + taxonomy)** was worked in a prior
+  session. Its conclusions are folded into the spec + the critique log (§4). Ask Jac whether the raw
+  inventory should be committed.
+
+### 10. Your first deliverable
+After reading the above and skimming the live staging build: **write Jac a short summary — "here's
+my understanding of the current state and what I'd do next" — and confirm it before building.** Then
+pick up the inline-expand rollout (step 3), the Rentals/Customers plate-stack reshape, or whatever
+Jac prioritizes.


### PR DESCRIPTION
Lands the two Codex handoff docs on `trunk` **independently of the dv2 redesign PR (#752)**, so Codex finds them on the default branch when it clones the repo — instead of being stranded behind the unfinished redesign.

## What's in it
- **`docs/CODEX-HANDOFF.md`** — setup mechanics: same repo (CI/branch-protection/Actions-secrets carry over), create `AGENTS.md`, add npm scripts for the ship flow, re-provision secrets (Jac provisions values from his vault — never in the repo/chat), swap the two LLM-calling Actions to OpenAI, dual-agent collision model (branch namespacing + `docs/WIP.md` ledger; the staging deck already isolates deploys), and an on-demand advisory cross-review (never a gate).
- **`docs/CODEX-ONBOARDING.md`** — the study-the-project brief: guided reading order for the current state, the research, the flaws, the design canon (`style`/`wrangler-style` + the decisions-ledger + the sourcing-boundary rule), what's shipped so far (dv2 inline-expand Steps 1–2, the section plate-stack), and what's next (the inline-expand rollout + the Rentals/Customers reshape, then Trips ledger / Comms / Dashboard / Sort).

## Notes
- **Docs-only** — no code, no served-file change, so no cache-bust bump needed; the `smoke`/gate suite should pass clean.
- Safe to squash-merge to `trunk` **before** starting Codex, so the handoff is on the branch Codex clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1EAY3d3fehnTBqoCQbjhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1EAY3d3fehnTBqoCQbjhc)_