### PR TITLE
fix: name repo Codex marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "personal",
+  "name": "rental-wrangler",
   "interface": {
     "displayName": "Personal"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ once, then begin a new task so Codex discovers the skills:
 
 ```text
 codex plugin marketplace add .agents/plugins
-codex plugin add rental-wrangler-commands@personal
+codex plugin add rental-wrangler-commands@rental-wrangler
 ```
 
 In the Codex desktop marketplace UI, add `operations-jacrentals/rental-wrangler` at


### PR DESCRIPTION
Uses a repo-specific marketplace name so the corrected sparse paths can be added alongside the stale personal entry.