### PR TITLE
docs: design mockups + UX research corpus + WIP ledger

### DIFF
--- a/docs/WIP.md
+++ b/docs/WIP.md
@@ -1,0 +1,14 @@
+# Work in flight — the dual-agent ledger
+
+One line per in-flight feature, so Claude and Codex don't collide (see `docs/CODEX-HANDOFF.md`
+§8a). Each agent **appends** a line when it starts a feature and **removes** it on merge. Read this
+before starting anything, so the two agents never grab the same work.
+
+**Format:** `owner (claude | codex) · branch · flag · one-line status`
+
+---
+
+- **claude** · `claude/rental-wrangler-ui-research-rhd74v` (PR #752) · `FEATURES.designV2` · dv2
+  inline-expand redesign — Steps 1–2 built (inline-expand rendering seam + section plate-stack,
+  Units done). Pending: land on trunk behind the flag, then carry the plate-stack into Rentals +
+  Customers and finish rollout steps 3–10 (`docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md`).

--- a/docs/design/reference/README.md
+++ b/docs/design/reference/README.md
@@ -1,0 +1,34 @@
+# Design reference — mockups & artifacts
+
+These are the **design-authority mockups** for Rental Wrangler's Phase-2 redesign — the visual
+source of truth for each surface, preserved from the design sessions. Read the relevant one before
+building or reshaping that surface. Where a mockup and the spec / decisions-ledger disagree, the
+**newer decision wins** (`docs/superpowers/specs/2026-07-20-decisions-ledger.md`).
+
+**Sourcing rule:** design comes from these mockups + the `style`/`wrangler-style` canon + the specs
+— never reverse-engineered from the live `app.js` / `style.css`.
+
+| Mockup | Surface / spec section |
+|---|---|
+| `detail-views.html` | The three detail views (Units / Rentals / Customers) — the section plate-stack (§2) |
+| `list-views.html` | The list / card views — "spot what's on fire" (§1–2) |
+| `text-links-flags.html` | The "Words, links & flags" element vocabulary (Signal · Gate · Stamp · Ref · Door) |
+| `trips-ledger.html` | Trips ETA-Tracker ledger (§8.5) |
+| `trips-schedule.html` | Trips scheduling surface (§8.4) |
+| `trips-card.html` | Trips card (§8) |
+| `inbox-card.html` | Comms / Inbox workspace (§7) |
+| `compose-dock.html` | Comms compose dock (§7.3) |
+| `get-told.html` | The bell / notifications (§7) |
+| `dashboard-card.html` | Role Dashboard (§5) |
+| `funnel.html` | Customers funnel (§6) |
+| `inspection.html` | Inspection checklist takeover (§6) |
+| `yard-journey.html` | Yard-journey lifecycle timeline (§6) |
+| `intake.html` | Intake flow |
+| `decision-notes.md` | Running design-decision notes from the sessions |
+
+The distilled UX research behind these decisions — the ~171-finding inventory, the job taxonomy,
+and the flaws that drove the redesign — lives in `docs/research/`.
+
+> Not captured here: Jac's hand-drawn sketches (the ETA-tracker, inspiration shots) were images in
+> chat, not files, so they aren't in the repo. The spec describes them in words (e.g. the ledger at
+> §8.5) and these mockups render the settled result.

--- a/docs/design/reference/compose-dock.html
+++ b/docs/design/reference/compose-dock.html
@@ -1,0 +1,508 @@
+<title>Compose &amp; comms-dock — the quick-dock tier</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --gray:#8b94a3;
+    --tan:#c2925a;
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  @media (prefers-color-scheme:light){ :root{
+    --bg:#e6e8ea; --bg2:#dfe3ea; --panel:#fff; --panel2:#eef1f6; --card:#fff; --cardh:#eef1f6;
+    --line:#cfd6e1; --lineSoft:#e1e6ee; --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#fff;
+    --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  } }
+  :root[data-theme="light"]{
+    --bg:#e6e8ea; --bg2:#dfe3ea; --panel:#fff; --panel2:#eef1f6; --card:#fff; --cardh:#eef1f6; --line:#cfd6e1; --lineSoft:#e1e6ee;
+    --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#fff; --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  }
+  :root[data-theme="dark"]{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b; --line:#2c343f; --lineSoft:#212834;
+    --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89; --onAcc:#1a1205; --accent:#ff7e1f; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --green:#34d399; --gray:#8b94a3; --tan:#c2925a;
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1180px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:92ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600}
+  .key{display:flex; flex-wrap:wrap; gap:6px 12px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+  h2.sec{font-family:var(--stamp); font-weight:800; font-size:13px; letter-spacing:.06em; text-transform:uppercase; color:var(--txt); margin:32px 0 4px; display:flex; align-items:center; gap:8px}
+  h2.sec .n{color:var(--accent)}
+  .secnote{font-size:12px; color:var(--txt3); margin:0 0 12px; max-width:88ch}
+  .secnote b{color:var(--txt2)}
+
+  /* ---------- the five parts (kept identical to the approved reference mockups) ---------- */
+  .ctl{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .sig{padding:0 8px; border-radius:7px}
+  .sig.f.red{background:var(--redStrong);color:#fff} .sig.o.red{color:var(--red);box-shadow:inset 0 0 0 1.3px var(--red)}
+  .sig.f.yellow{background:var(--yellow);color:#211a05} .sig.o.yellow{color:var(--yellow);box-shadow:inset 0 0 0 1.3px var(--yellow)}
+  .sig.f.blue{background:var(--blue);color:#0a1220} .sig.o.blue{color:var(--blue);box-shadow:inset 0 0 0 1.3px var(--blue)}
+  .sig.f.green{background:var(--green);color:#04140d} .sig.o.green{color:var(--green);box-shadow:inset 0 0 0 1.3px var(--green)}
+  .sig.o.grey{color:var(--gray);box-shadow:inset 0 0 0 1.3px var(--gray)}
+  .stamp{font-family:var(--stamp); font-size:10.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap}
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:700; cursor:pointer; text-decoration:none; white-space:nowrap}
+  .ref .ty{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .ref .ty svg{width:11px;height:11px}
+  .ref small{color:var(--gray); font-family:var(--stamp); font-size:9px; font-weight:600; margin-left:1px}
+  .door{height:var(--h); display:inline-flex; align-items:center; gap:6px; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; cursor:pointer; border-radius:999px; padding:0 13px; border:0}
+  .door svg{width:13px;height:13px}
+  .door.send{background:var(--commit); color:#fff}
+  .door.ghost{background:transparent; color:var(--txt2); border:1px solid var(--line)}
+  .iconbtn{width:22px;height:22px;flex:none;display:inline-flex;align-items:center;justify-content:center;border-radius:6px;color:var(--txt3);cursor:pointer;background:transparent;border:0}
+  .iconbtn:hover{background:var(--lineSoft); color:var(--txt2)}
+  .iconbtn svg{width:14px;height:14px}
+  .clink{display:inline-flex; align-items:center; gap:6px; color:var(--txt); font-size:12.5px; text-decoration:none; font-family:var(--font)}
+  .clink svg{color:var(--accent); width:13px; height:13px} .clink .v{border-bottom:1.4px solid transparent} .clink:hover .v{border-bottom-color:var(--accent)}
+
+  .tip{position:relative; display:inline-block}
+  .tip .bub{position:absolute; bottom:calc(100% + 8px); left:0; width:max-content; max-width:min(70vw,230px); background:#05070a; color:#eef2f7; border:1px solid #3a444e; border-radius:7px; padding:8px 10px; font-family:var(--font); font-size:11.5px; line-height:1.42; text-transform:none; letter-spacing:0; box-shadow:0 12px 30px rgba(0,0,0,.6); opacity:0; transform:translateY(4px); pointer-events:none; transition:opacity .12s, transform .12s; z-index:60}
+  @media (prefers-color-scheme:light){ .tip .bub{background:#fff; color:#141821; border-color:#c7ccd2} } :root[data-theme="light"] .tip .bub{background:#fff; color:#141821; border-color:#c7ccd2}
+  .tip:hover .bub, .tip:focus-within .bub{opacity:1; transform:translateY(0)}
+  .tip .bub .t{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--accent); display:block; margin-bottom:3px}
+
+  /* ---------- callout (bridging annotation) ---------- */
+  .callout{padding:10px 12px; background:var(--bg2); border:1.4px dashed var(--accLine); border-radius:9px; font-size:11.5px; color:var(--txt2); line-height:1.5; position:relative}
+  .callout.tail-l::before{content:""; position:absolute; top:16px; left:-7px; width:12px; height:12px; background:var(--bg2); border-left:1.4px dashed var(--accLine); border-bottom:1.4px dashed var(--accLine); transform:rotate(45deg)}
+  .callout.tail-t::before{content:""; position:absolute; top:-7px; left:26px; width:12px; height:12px; background:var(--bg2); border-left:1.4px dashed var(--accLine); border-top:1.4px dashed var(--accLine); transform:rotate(45deg)}
+  .callout .lab{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; color:var(--accent); display:block; margin-bottom:4px}
+  .callout b{color:var(--txt)}
+
+  /* ================= STAGE — the app window standing in for "the card you're on" ================= */
+  .stage-row{display:flex; gap:16px; align-items:flex-start; margin-top:14px}
+  .stage-col{flex:1; min-width:0; max-width:760px}
+  .stage{position:relative; background:var(--bg2); border:1px solid var(--line); border-radius:14px; height:600px; display:flex; flex-direction:column; overflow:hidden; box-shadow:0 1px 0 var(--lineSoft) inset}
+  .stage-head{display:flex; align-items:center; gap:10px; height:46px; flex:none; padding:0 14px; border-bottom:1px solid var(--line); background:var(--panel)}
+  .stage-title{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.09em; text-transform:uppercase; color:var(--txt)}
+  .stage-search{flex:1; max-width:220px; height:24px; display:flex; align-items:center; gap:6px; padding:0 9px; border:1px solid var(--line); border-radius:7px; background:var(--card); color:var(--txt3); font-size:12px}
+  .stage-search svg{width:13px;height:13px}
+  .stage-hint{margin-left:auto; font-size:10.5px; color:var(--txt3); font-family:var(--stamp); letter-spacing:.03em; text-transform:uppercase}
+  .stage-hint b{color:var(--accent)}
+
+  .clist{flex:1; overflow-y:auto; position:relative}
+  .crow{display:flex; align-items:center; gap:10px; min-height:56px; padding:8px 14px; border-bottom:1px solid var(--lineSoft); border-left:3px solid transparent; position:relative}
+  .crow.sel{border-left-color:var(--accent); background:var(--cardh)}
+  .crow .cav{width:30px;height:30px;flex:none;border-radius:7px;background:var(--accSoft);color:var(--accent);display:flex;align-items:center;justify-content:center}
+  .crow .cav svg{width:16px;height:16px}
+  .crow .cnames{display:flex; flex-direction:column; gap:1px; min-width:0}
+  .crow .cname{font-size:13px; font-weight:700; color:var(--txt); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .crow .ccontact{font-size:12px; color:var(--txt2); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .crow .cmeta{display:flex; align-items:center; gap:8px; margin-left:auto; flex:none}
+  .crow .cstamp{font-size:10.5px}
+
+  /* ---------- R20 right-click context menu ---------- */
+  .ctxmenu{position:absolute; z-index:40; width:222px; background:var(--panel2); border:1px solid var(--line); border-radius:11px; padding:6px; box-shadow:0 18px 40px rgba(0,0,0,.5)}
+  .ctxmenu .mi{display:flex; align-items:center; gap:9px; padding:7px 9px; border-radius:8px; font-size:12px; color:var(--txt2); cursor:pointer; user-select:none}
+  .ctxmenu .mi:hover{background:var(--panel); color:var(--txt)}
+  .ctxmenu .mi svg{width:14px;height:14px; opacity:.75; flex:none}
+  .ctxmenu .mi.hi svg{color:var(--accent); opacity:1}
+  .ctxmenu .mi .nm{font-weight:700}
+  .ctxmenu .sep{height:1px; background:var(--line); margin:5px 3px}
+  .ctxmenu .grp{font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; color:var(--txt2); padding:5px 9px 3px}
+
+  /* ================= FOOTER COMMS DOCK ================= */
+  .dock-wrap{position:absolute; left:0; right:0; bottom:0; display:flex; justify-content:flex-end; align-items:flex-end; gap:8px; padding:0 12px; pointer-events:none}
+  .dock-item{pointer-events:auto; background:var(--panel); border:1px solid var(--line); border-bottom:none; border-radius:11px 11px 0 0; box-shadow:0 -6px 24px rgba(0,0,0,.35); display:flex; flex-direction:column; overflow:hidden}
+  .dock-item{width:352px; max-height:420px}
+  .dock-item.is-min{width:196px; max-height:none}
+  .dock-item.is-min .item-body{display:none}
+  .item-bar{display:flex; align-items:center; gap:8px; height:40px; flex:none; padding:0 10px; background:var(--panel2); border-bottom:1px solid var(--line)}
+  .dock-item.is-min .item-bar{border-bottom:none; cursor:pointer}
+  .item-bar .ico{width:18px;height:18px;flex:none;display:flex;align-items:center;justify-content:center;color:var(--txt2)}
+  .item-bar .ico svg{width:15px;height:15px}
+  .item-bar .tt{flex:1; min-width:0; font-size:12px; font-weight:700; color:var(--txt); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .dock-item:not(.is-min) .item-bar .tt{font-size:13px}
+  .item-bar .updot{width:7px;height:7px;border-radius:50%;flex:none}
+  .item-bar .updot.y{background:var(--yellow)} .item-bar .updot.r{background:var(--redStrong)}
+  .item-bar .acts{display:flex; align-items:center; gap:2px; flex:none}
+  .dock-item.is-min .acts{display:none}
+  .expand-chev{display:none}
+  .dock-item.is-min .expand-chev{display:flex; width:16px;height:16px; color:var(--txt3); align-items:center; justify-content:center; flex:none}
+  .dock-item.is-min .expand-chev svg{width:13px;height:13px}
+
+  .item-body{flex:1; min-height:0; display:flex; flex-direction:column}
+
+  /* -- email (Gmail-style) -- */
+  .efield{display:flex; align-items:center; gap:8px; padding:7px 12px; border-bottom:1px solid var(--lineSoft); flex:none}
+  .efield .ek{font-family:var(--stamp); font-size:10px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt2); width:50px; flex:none}
+  .efield .ev{font-size:12.5px; color:var(--txt); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex:1}
+  .efield .ev.ph{color:var(--txt3)} .efield .ev.blank{display:none}
+  .dock-item.is-blank .efield .ev.filled{display:none} .dock-item.is-blank .efield .ev.blank{display:block}
+  .ref-mini{display:inline-flex; align-items:center; gap:5px; padding:2px 8px 2px 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); font-size:11px; font-weight:700; color:var(--txt); flex:none}
+  .ref-mini .ty{width:15px;height:15px;border-radius:4px;background:var(--accSoft);color:var(--accent);display:flex;align-items:center;justify-content:center}
+  .ref-mini .ty svg{width:9px;height:9px}
+  .ebody{flex:1; min-height:70px; padding:10px 12px; font-size:13px; color:var(--txt2); line-height:1.55; overflow-y:auto}
+  .efoot{display:flex; align-items:center; gap:6px; padding:8px 10px; border-top:1px solid var(--line); flex:none}
+  .efoot .spacer{flex:1}
+
+  /* -- text (Apple Messages-style) -- */
+  .tx-head{padding:8px 12px; border-bottom:1px solid var(--lineSoft); flex:none; display:flex; flex-direction:column; gap:3px}
+  .tx-head .row1{display:flex; align-items:center; gap:8px}
+  .tx-head .who{font-size:12.5px; font-weight:700; color:var(--txt)}
+  .tx-head .ph{font-size:10.5px; color:var(--txt3); font-family:var(--stamp)}
+  .bubbles{flex:1; display:flex; flex-direction:column; gap:6px; padding:10px 12px; overflow-y:auto}
+  .brow{display:flex; flex-direction:column}
+  .brow.out{align-items:flex-end}
+  .brow.in{align-items:flex-start}
+  .bubble{max-width:78%; padding:7px 11px; border-radius:15px; font-size:12.5px; line-height:1.4}
+  .brow.in .bubble{background:var(--panel2); color:var(--txt); border-bottom-left-radius:4px}
+  .brow.out .bubble{background:var(--commit); color:#fff; border-bottom-right-radius:4px}
+  .brow .rcpt{font-family:var(--stamp); font-size:9px; color:var(--txt3); margin-top:3px; letter-spacing:.03em; text-transform:uppercase}
+  .imrow{display:flex; align-items:center; gap:8px; padding:9px 11px; border-top:1px solid var(--line); flex:none}
+  .impill{flex:1; height:30px; border-radius:999px; background:var(--card); border:1px solid var(--line); display:flex; align-items:center; padding:0 12px; color:var(--txt3); font-size:12.5px}
+  .sendcirc{width:28px;height:28px;border-radius:50%;background:var(--commit); color:#fff; display:flex; align-items:center; justify-content:center; flex:none; cursor:pointer}
+  .sendcirc svg{width:14px;height:14px}
+
+  /* -- team (Messenger-style) -- */
+  .tm-head{padding:8px 12px; border-bottom:1px solid var(--lineSoft); flex:none; display:flex; flex-direction:column; gap:3px}
+  .tm-head .row1{display:flex; align-items:center; gap:7px}
+  .tm-head .chn{font-size:12.5px; font-weight:700; color:var(--txt)}
+  .tm-head .pres{display:flex; align-items:center; gap:5px; font-size:10.5px; color:var(--txt2)}
+  .pdot{width:7px;height:7px;border-radius:50%; background:var(--green); flex:none}
+  .msgblock{display:flex; flex-direction:column; gap:2px}
+  .msgblock .snd{font-size:11px; font-weight:700; color:var(--txt2)}
+  .reacts{display:flex; gap:4px; margin-top:2px}
+  .reactchip{display:inline-flex; align-items:center; gap:4px; padding:2px 7px; border-radius:999px; background:var(--card); border:1px solid var(--line); font-size:10px; color:var(--txt2)}
+
+  /* ================= reference row — the three skins, statically side by side ================= */
+  .refrow{display:grid; grid-template-columns:repeat(3,1fr); gap:14px; margin-top:6px}
+  @media (max-width:900px){ .refrow{grid-template-columns:1fr} }
+  .refcard{background:var(--panel); border:1px solid var(--line); border-radius:12px; overflow:hidden; display:flex; flex-direction:column; height:340px}
+  .refcap{font-family:var(--stamp); font-size:9.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--txt3); padding:8px 12px 0}
+
+  /* ================= PHONE ================= */
+  .mobile-row{display:flex; gap:22px; align-items:flex-start; margin-top:14px; flex-wrap:wrap}
+  .phone{width:284px; flex:none; border-radius:32px; background:var(--card); border:10px solid var(--card); box-shadow:0 0 0 1.5px var(--line), 0 24px 50px rgba(0,0,0,.4); position:relative; overflow:hidden; height:580px}
+  .phone-notch{position:absolute; top:0; left:50%; transform:translateX(-50%); width:110px; height:20px; background:var(--card); border-radius:0 0 14px 14px; z-index:5}
+  .phone-status{display:flex; justify-content:space-between; padding:8px 16px 2px; font-family:var(--font); font-size:10.5px; color:var(--txt2); font-variant-numeric:tabular-nums; position:relative; z-index:2}
+  .phone-screen{position:relative; height:calc(100% - 22px); background:var(--bg); border-radius:22px; overflow:hidden}
+  .phone-behind{padding:8px 12px; opacity:.32; filter:saturate(.6); pointer-events:none}
+  .phone-behind .stage-head{border-radius:0}
+  .phone-compose{position:absolute; inset:0; background:var(--panel); display:flex; flex-direction:column}
+  .pc-head{display:flex; align-items:center; gap:9px; padding:10px 12px 8px; border-bottom:1px solid var(--line); flex:none}
+  .pc-back{width:26px;height:26px;border-radius:50%;background:var(--card); border:1px solid var(--line); color:var(--txt2); display:flex; align-items:center; justify-content:center; flex:none}
+  .pc-back svg{width:14px;height:14px}
+  .pc-names{display:flex; flex-direction:column; gap:2px; min-width:0}
+  .pc-names .who{font-size:13px; font-weight:700; color:var(--txt)}
+  .pc-thread{flex:1; overflow-y:auto; padding:12px}
+  .pc-input{display:flex; align-items:center; gap:8px; padding:10px 12px 16px; border-top:1px solid var(--line); flex:none}
+
+  .foot{margin-top:26px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:88ch} .foot b{color:var(--txt)}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Compose &amp; comms rail · spec §7.3 · matte, no glow · first draft for reaction</p>
+  <h1>Compose docks — <span class="hl">it never teleports you</span></h1>
+  <p class="lede">A comms action fired from a record — right-click, <b>+Team</b>, <b>+Gmail</b>, <b>Text…</b>, <b>Email…</b> — opens the new message <b>where you are</b>: a minimizable footer tab on desktop (Gmail-desktop's docked compose, several at once), a full-screen sheet on mobile. It never navigates you to the Inbox card. Three compose types duplicate three best-in-class feels in RW's own skin: <b>Gmail</b> (email), <b>Apple Messages</b> (text), <b>Facebook Messenger</b> (team) — not the incumbent comms rail.</p>
+  <div class="key"><span><b>Signal</b> state chip</span><span><b>Ref</b> record link</span><span><b>Stamp</b> fact</span><span><b>Door</b> action</span><span>· fill = today · colour = state</span></div>
+
+  <h2 class="sec"><span class="n">1</span> Desktop — right-click a record, the dock catches it</h2>
+  <p class="secnote">Right-click (or long-press) <b>Boudreaux Marine</b> below — a live R20 menu opens. Every other row works the same way. Click a comms item and watch the footer dock respond: it expands that compose and minimizes the rest, exactly like clicking a different Gmail compose bar.</p>
+
+  <div class="stage-row">
+    <div class="stage-col">
+      <div class="stage" id="stage">
+        <div class="stage-head">
+          <span class="stage-title">Customers</span>
+          <span class="stage-search"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>Search customers…</span>
+          <span class="stage-hint">right-click a row <b>&rarr;</b></span>
+        </div>
+        <div class="clist" id="clist">
+
+          <div class="crow sel" id="row-boudreaux" oncontextmenu="return openMenuForRow(this,event)">
+            <span class="cav"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>
+            <div class="cnames">
+              <span class="cname">Boudreaux Marine</span>
+              <span class="ccontact">Denny Boudreaux · <a class="clink" href="tel:+13375550142" onclick="return false"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2a9 9 0 0 1 9 9M13 6a5 5 0 0 1 5 5"/><path d="M21.3 18.7a1 1 0 0 1-.8 1.8C12.5 20.5 6 14 6 6.5a1 1 0 0 1 1.8-.8l1.9 1.9a1 1 0 0 1 .2 1.13c-.3.6-.53 1.28-.53 1.87 0 3.5 4.5 8 8 8 .58 0 1.26-.23 1.86-.53a1 1 0 0 1 1.13.2z"/></svg><span class="v">(337) 555-0142</span></a></span>
+            </div>
+            <div class="cmeta">
+              <span class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.6-3.6a6 6 0 0 1-7.9 7.9l-6.8 6.8a2.1 2.1 0 1 1-3-3l6.8-6.8a6 6 0 0 1 7.9-7.9z"/></svg></span>Gator<small>RC-4700</small></span>
+              <span class="tip"><span class="ctl sig f yellow">Field call</span><span class="bub"><span class="t">Signal · units</span>Boom hydraulics reported slow — a WO opened on RC-4700 today. Click to jump to the unit.</span></span>
+            </div>
+          </div>
+
+          <div class="crow">
+            <span class="cav"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>
+            <div class="cnames"><span class="cname">Guidry Construction</span><span class="ccontact">Trey Guidry · (337) 555-0188</span></div>
+            <div class="cmeta"><span class="ctl sig o blue">Quoted</span></div>
+          </div>
+
+          <div class="crow">
+            <span class="cav"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>
+            <div class="cnames"><span class="cname">Landry Site Services</span><span class="ccontact">Paul Landry · (337) 555-0173</span></div>
+            <div class="cmeta"><span class="ctl sig f green">Delivered today</span></div>
+          </div>
+
+          <div class="crow">
+            <span class="cav"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>
+            <div class="cnames"><span class="cname">Fontenot Paving</span><span class="ccontact">Renee Fontenot · (337) 555-0206</span></div>
+            <div class="cmeta"><span class="ctl sig o red">Past due</span></div>
+          </div>
+
+          <div class="crow">
+            <span class="cav"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>
+            <div class="cnames"><span class="cname">Thibodaux Crane Co.</span><span class="ccontact">Wayne Thibodaux · (337) 555-0119</span></div>
+            <div class="cmeta"><span class="ctl sig o grey">Inactive</span></div>
+          </div>
+
+          <!-- R20 context menu — pre-opened on Boudreaux Marine for the first paint; also wired to real right-click -->
+          <div class="ctxmenu" id="ctxmenu" style="top:76px;left:250px">
+            <div class="mi" onclick="closeMenu()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg><span class="nm">Copy</span></div>
+            <div class="mi" onclick="closeMenu()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg><span class="nm">Global Search</span></div>
+            <div class="sep"></div>
+            <div class="grp">Comms · re Gator / RC-4700</div>
+            <div class="mi hi" onclick="openDock('text')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg><span class="nm">Text Denny…</span></div>
+            <div class="mi hi" onclick="openDock('email')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg><span class="nm">Email Denny…</span></div>
+            <div class="sep"></div>
+            <div class="mi hi" onclick="openDock('team')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" x2="20" y1="9" y2="9"/><line x1="4" x2="20" y1="15" y2="15"/><line x1="10" x2="8" y1="3" y2="21"/><line x1="16" x2="14" y1="3" y2="21"/></svg><span class="nm">+ Team</span></div>
+            <div class="mi hi" onclick="openDock('emailblank')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg><span class="nm">+ Gmail</span></div>
+          </div>
+
+          <!-- ============= THE FOOTER DOCK — 3 docked, 1 expanded ============= -->
+          <div class="dock-wrap" id="dockwrap">
+
+            <div class="dock-item is-min" data-item="team" onclick="tabClick(this,event)">
+              <div class="item-bar">
+                <span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" x2="20" y1="9" y2="9"/><line x1="4" x2="20" y1="15" y2="15"/><line x1="10" x2="8" y1="3" y2="21"/><line x1="16" x2="14" y1="3" y2="21"/></svg></span>
+                <span class="tt">On Rent · Delivery</span>
+                <span class="updot y"></span>
+                <span class="acts">
+                  <span class="iconbtn" title="Open in Inbox (opt-in)" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6M10 14 21 3"/></svg></span>
+                  <span class="iconbtn" title="Minimize" onclick="minimizeItem(this,event)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg></span>
+                </span>
+                <span class="expand-chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg></span>
+              </div>
+              <div class="item-body">
+                <div class="tm-head">
+                  <div class="row1"><span class="chn"># On Rent · Delivery · Recovery</span><span class="ref-mini"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.6-3.6a6 6 0 0 1-7.9 7.9l-6.8 6.8a2.1 2.1 0 1 1-3-3l6.8-6.8a6 6 0 0 1 7.9-7.9z"/></svg></span>Gator · RC-4700</span></div>
+                  <div class="pres"><span class="pdot"></span>Trey Guidry · online</div>
+                </div>
+                <div class="bubbles">
+                  <div class="brow in"><div class="msgblock"><span class="snd">Trey Guidry</span><div class="bubble">Pulling up to Boudreaux now — RC-4700's the gator, right?</div>
+                    <div class="reacts"><span class="reactchip">👍 2</span></div></div></div>
+                  <div class="brow out"><div class="bubble">Yep — boom hydraulics, Denny said it's slow to raise. Take a look before you touch anything.</div></div>
+                </div>
+                <div class="imrow"><span class="impill">Message #on-rent…</span>
+                  <span class="iconbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg></span>
+                  <span class="sendcirc"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg></span>
+                </div>
+              </div>
+            </div>
+
+            <div class="dock-item is-min" data-item="text" onclick="tabClick(this,event)">
+              <div class="item-bar">
+                <span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg></span>
+                <span class="tt">Denny Boudreaux</span>
+                <span class="updot r"></span>
+                <span class="acts">
+                  <span class="iconbtn" title="Open in Inbox (opt-in)" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6M10 14 21 3"/></svg></span>
+                  <span class="iconbtn" title="Minimize" onclick="minimizeItem(this,event)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg></span>
+                </span>
+                <span class="expand-chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg></span>
+              </div>
+              <div class="item-body">
+                <div class="tx-head"><div class="row1"><span class="who">Denny Boudreaux</span><span class="ref-mini"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.6-3.6a6 6 0 0 1-7.9 7.9l-6.8 6.8a2.1 2.1 0 1 1-3-3l6.8-6.8a6 6 0 0 1 7.9-7.9z"/></svg></span>Gator · RC-4700</span></div><span class="ph">(337) 555-0142</span></div>
+                <div class="bubbles">
+                  <div class="brow in"><div class="bubble">Hey — when's Trey coming by? Machine's acting up again.</div></div>
+                  <div class="brow out"><div class="bubble">On it — he's wrapping a job in Iowa, should be at y'all's by 2.</div><span class="rcpt">Delivered · 1:47 PM</span></div>
+                </div>
+                <div class="imrow"><span class="impill">Text Message</span><span class="sendcirc"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg></span></div>
+              </div>
+            </div>
+
+            <div class="dock-item" data-item="email" onclick="tabClick(this,event)">
+              <div class="item-bar">
+                <span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg></span>
+                <span class="tt">Email Denny — re: Gator / RC-4700</span>
+                <span class="acts">
+                  <span class="iconbtn" title="Open in Inbox (opt-in)" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6M10 14 21 3"/></svg></span>
+                  <span class="iconbtn" title="Minimize" onclick="minimizeItem(this,event)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg></span>
+                </span>
+                <span class="expand-chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg></span>
+              </div>
+              <div class="item-body">
+                <div class="efield"><span class="ek">To</span><span class="ev filled">Denny Boudreaux &lt;denny@boudreauxmarine.com&gt;</span><span class="ev ph blank">Recipients…</span></div>
+                <div class="efield"><span class="ek">Subject</span><span class="ev filled">re: Gator / RC-4700 — field call follow-up</span><span class="ev ph blank">Subject</span><span class="ref-mini" style="margin-left:6px"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.6-3.6a6 6 0 0 1-7.9 7.9l-6.8 6.8a2.1 2.1 0 1 1-3-3l6.8-6.8a6 6 0 0 1 7.9-7.9z"/></svg></span>Gator</span></div>
+                <div class="ebody">Denny — following up on the Gator (RC-4700) out at the Sulphur site. Trey's headed over this afternoon to look at the boom hydraulics call. I'll text when he's en route.</div>
+                <div class="efoot">
+                  <span class="door send"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg>Send</span>
+                  <span class="spacer"></span>
+                  <span class="iconbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></span>
+                  <span class="iconbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.1-3.1a2 2 0 0 0-2.8 0L6 21"/></svg></span>
+                  <span class="iconbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></svg></span>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div style="width:246px; flex:none; display:flex; flex-direction:column; gap:12px; margin-top:52px">
+      <div class="callout tail-l">
+        <span class="lab">The rule</span>
+        Comms fired <b>from a record</b> → the compose <b>docks here</b>, you stay on your card. The full <b>Inbox card is opt-in</b> — you go there for the workspace, it's never a side effect of starting a message.
+      </div>
+      <div class="callout tail-l">
+        <span class="lab">Why the rail catches it</span>
+        The dock only ever shows <b>one expanded</b> compose at a time — click a minimized tab (or a menu item) and it swaps places with whatever was open, same as switching Gmail compose windows.
+      </div>
+    </div>
+  </div>
+
+  <h2 class="sec"><span class="n">2</span> The three docked skins, side by side</h2>
+  <p class="secnote">Same footer-dock mechanic, three native forms — <b>never one generic "message" box wearing three hats.</b> Email reads like Gmail; text reads like Messages; team reads like Messenger. Only channel + Ref differ from what's docked above.</p>
+  <div class="refrow">
+    <div class="refcard">
+      <div class="refcap">✉ Email · Gmail-style</div>
+      <div class="item-body">
+        <div class="efield"><span class="ek">To</span><span class="ev filled">Denny Boudreaux &lt;denny@boudreauxmarine.com&gt;</span></div>
+        <div class="efield"><span class="ek">Subject</span><span class="ev filled">re: Gator / RC-4700 — field call follow-up</span></div>
+        <div class="ebody">Denny — following up on the Gator (RC-4700)…</div>
+        <div class="efoot"><span class="door send"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg>Send</span><span class="spacer"></span>
+          <span class="iconbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></span>
+        </div>
+      </div>
+    </div>
+    <div class="refcard">
+      <div class="refcap">SMS · Apple Messages-style</div>
+      <div class="item-body">
+        <div class="tx-head"><div class="row1"><span class="who">Denny Boudreaux</span></div><span class="ph">(337) 555-0142</span></div>
+        <div class="bubbles">
+          <div class="brow in"><div class="bubble">Hey — when's Trey coming by?</div></div>
+          <div class="brow out"><div class="bubble">Should be there by 2.</div><span class="rcpt">Delivered</span></div>
+        </div>
+        <div class="imrow"><span class="impill">Text Message</span><span class="sendcirc"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg></span></div>
+      </div>
+    </div>
+    <div class="refcard">
+      <div class="refcap"># Team · Messenger-style</div>
+      <div class="item-body">
+        <div class="tm-head"><div class="row1"><span class="chn"># On Rent · Delivery · Recovery</span></div><div class="pres"><span class="pdot"></span>Trey Guidry · online</div></div>
+        <div class="bubbles">
+          <div class="brow in"><div class="msgblock"><span class="snd">Trey Guidry</span><div class="bubble">Pulling up now.</div><div class="reacts"><span class="reactchip">👍 2</span></div></div></div>
+          <div class="brow out"><div class="bubble">Boom hydraulics — check before you touch it.</div></div>
+        </div>
+        <div class="imrow"><span class="impill">Message #on-rent…</span><span class="iconbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></svg></span><span class="sendcirc"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg></span></div>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="sec"><span class="n">3</span> Mobile — full-screen, no dock, no tabs</h2>
+  <p class="secnote">Same action, coarse-pointer target: the composer takes the <b>whole screen</b> instead of a footer sliver (a 350px docked panel doesn't fit a phone, and stacking tabs would fight the keyboard). One ✕ takes you back to exactly the card + row you were on — never the Inbox.</p>
+  <div class="mobile-row">
+    <div class="phone">
+      <div class="phone-notch"></div>
+      <div class="phone-status"><span>9:41</span><span>JacRentals</span></div>
+      <div class="phone-screen">
+        <div class="phone-behind">
+          <div class="stage-head" style="border-radius:10px 10px 0 0"><span class="stage-title">Customers</span></div>
+          <div class="crow sel" style="min-height:46px">
+            <span class="cav"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>
+            <div class="cnames"><span class="cname">Boudreaux Marine</span><span class="ccontact">Denny Boudreaux</span></div>
+          </div>
+          <div class="crow" style="min-height:46px"><div class="cnames"><span class="cname">Guidry Construction</span><span class="ccontact">Trey Guidry</span></div></div>
+        </div>
+        <div class="phone-compose">
+          <div class="pc-head">
+            <span class="pc-back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg></span>
+            <div class="pc-names"><span class="who">Denny Boudreaux</span><span class="ref-mini" style="align-self:flex-start"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.6-3.6a6 6 0 0 1-7.9 7.9l-6.8 6.8a2.1 2.1 0 1 1-3-3l6.8-6.8a6 6 0 0 1 7.9-7.9z"/></svg></span>Gator · RC-4700</span></div>
+          </div>
+          <div class="pc-thread">
+            <div class="bubbles">
+              <div class="brow in"><div class="bubble">Hey — when's Trey coming by? Machine's acting up again.</div></div>
+              <div class="brow out"><div class="bubble">On it — he's wrapping a job in Iowa, should be at y'all's by 2.</div><span class="rcpt">Delivered · 1:47 PM</span></div>
+              <div class="brow in"><div class="bubble">Copy that, thanks.</div></div>
+            </div>
+          </div>
+          <div class="pc-input"><span class="impill">Text Message</span><span class="sendcirc"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg></span></div>
+        </div>
+      </div>
+    </div>
+    <div style="flex:1; min-width:240px; display:flex; flex-direction:column; gap:12px">
+      <div class="callout tail-t"><span class="lab">Mobile rule</span>The composer <b>reuses the comms full-screen gesture</b> — the same surface the app already uses elsewhere for a focused mobile mode, not a bespoke overlay. Closing (✕) always returns to <b>the record you were on</b>, mid-scroll-position intact.</div>
+      <div class="callout tail-t"><span class="lab">No stacking on phone</span>Only one compose lives at a time on mobile — there's no room for docked tabs, so starting a second message replaces the first (draft kept, resumable from its record or the Inbox).</div>
+    </div>
+  </div>
+
+  <div class="foot">
+    <b>Judgment calls in this draft:</b> the R20 menu keeps the generic Copy/Global-Search items above a divider so this reads as the real menu, not a stripped demo, with the four comms actions grouped under a "re: Gator / RC-4700" heading that names what's riding along. "+Gmail" is wired to a blank To/Subject (the generic compose) while "Text/Email Denny…" pre-fill — showing both compose starts side by side. Only <b>one</b> dock item is ever expanded at once (Gmail's multi-window compose was intentionally simplified) — a minimized tab's unread dot borrows Signal's fill=today colour logic. The pop-out icon in each dock header is inert here (title-only) — it's the pointer to "open in Inbox," not built out since the Inbox card is a separate mock.
+  </div>
+
+</div></div>
+
+<script>
+(function(){
+  var stage = document.getElementById('stage');
+  var clist = document.getElementById('clist');
+  var menu = document.getElementById('ctxmenu');
+
+  function positionMenu(anchorRect){
+    var sr = stage.getBoundingClientRect();
+    var mw = 222, mh = menu.offsetHeight || 250;
+    var top = anchorRect.bottom - sr.top + 4;
+    var left = anchorRect.left - sr.left + 40;
+    if (left + mw > sr.width - 8) left = sr.width - mw - 8;
+    if (top + mh > sr.height - 8) top = anchorRect.top - sr.top - mh - 4;
+    if (top < 4) top = 4;
+    menu.style.top = top + 'px';
+    menu.style.left = left + 'px';
+  }
+
+  window.openMenuForRow = function(rowEl, evt){
+    if (evt) evt.preventDefault();
+    document.querySelectorAll('.crow.sel').forEach(function(r){ r.classList.remove('sel'); });
+    rowEl.classList.add('sel');
+    positionMenu(rowEl.getBoundingClientRect());
+    menu.style.display = 'block';
+    return false;
+  };
+
+  window.closeMenu = function(){ menu.style.display = 'none'; };
+
+  window.openDock = function(kind){
+    var type = kind === 'emailblank' ? 'email' : kind;
+    var items = document.querySelectorAll('.dock-item');
+    items.forEach(function(it){
+      if (it.getAttribute('data-item') === type){
+        it.classList.remove('is-min');
+        if (kind === 'emailblank') it.classList.add('is-blank'); else it.classList.remove('is-blank');
+      } else {
+        it.classList.add('is-min');
+      }
+    });
+    closeMenu();
+  };
+
+  window.tabClick = function(el, evt){
+    if (!el.classList.contains('is-min')) return; // already expanded — header clicks do nothing extra
+    document.querySelectorAll('.dock-item').forEach(function(it){
+      if (it === el) it.classList.remove('is-min'); else it.classList.add('is-min');
+    });
+  };
+
+  window.minimizeItem = function(btn, evt){
+    if (evt) evt.stopPropagation();
+    var item = btn.closest('.dock-item');
+    if (item) item.classList.add('is-min');
+  };
+
+  // clicking elsewhere in the stage (not a row, not the menu) closes the menu
+  clist.addEventListener('click', function(e){
+    if (!e.target.closest('.ctxmenu') && !e.target.closest('.crow')) closeMenu();
+  });
+  document.addEventListener('keydown', function(e){ if (e.key === 'Escape') closeMenu(); });
+
+  // initial paint: menu already open on Boudreaux Marine (no JS required to see the concept,
+  // this just fine-tunes the position against the real row's measured box)
+  var firstRow = document.getElementById('row-boudreaux');
+  if (firstRow) positionMenu(firstRow.getBoundingClientRect());
+})();
+</script>

--- a/docs/design/reference/dashboard-card.html
+++ b/docs/design/reference/dashboard-card.html
@@ -1,0 +1,389 @@
+<title>Dashboard card — first draft (6th card, role-dependent)</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --gray:#8b94a3;
+    --tan:#c2925a;
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  @media (prefers-color-scheme:light){ :root{
+    --bg:#e6e8ea; --bg2:#dfe3ea; --panel:#fff; --panel2:#eef1f6; --card:#fff; --cardh:#eef1f6;
+    --line:#cfd6e1; --lineSoft:#e1e6ee; --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#1a1205;
+    --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  } }
+  :root[data-theme="light"]{
+    --bg:#e6e8ea; --panel:#fff; --card:#fff; --cardh:#eef1f6; --line:#cfd6e1; --lineSoft:#e1e6ee;
+    --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#1a1205; --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  }
+  :root[data-theme="dark"]{
+    --bg:#0a0d11; --panel:#171d25; --card:#12171e; --cardh:#1a212b; --line:#2c343f; --lineSoft:#212834;
+    --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89; --onAcc:#1a1205; --accent:#ff7e1f; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --green:#34d399; --gray:#8b94a3; --tan:#c2925a;
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1180px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:92ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600}
+  .key{display:flex; flex-wrap:wrap; gap:6px 14px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+
+  /* ---------- 5+1 card rail ---------- */
+  .railwrap{margin:20px 0 22px}
+  .cardrail{display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .crail{height:var(--h); display:inline-flex; align-items:center; gap:7px; padding:0 11px 0 4px; border-radius:7px; background:var(--card); border:1px solid var(--line); font-family:var(--font); font-weight:700; font-size:12px; color:var(--txt2); cursor:default; white-space:nowrap}
+  .crail .ty{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;color:var(--txt3);background:var(--lineSoft);border-radius:5px;flex:none}
+  .crail .ty svg{width:11px;height:11px}
+  .crail.active{background:var(--accent); color:var(--onAcc); border-color:var(--accent); cursor:pointer}
+  .crail.active .ty{background:rgba(0,0,0,.2); color:var(--onAcc)}
+  .crail .n6{font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.05em; margin-left:1px; opacity:.85}
+  .raildiv{width:1px; align-self:stretch; background:var(--line); margin:0 2px}
+  .railcap{font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3); margin-top:8px}
+  .railcap b{color:var(--txt2)}
+
+  /* ---------- dashboard card shell ---------- */
+  .dcard{background:var(--panel); border:1px solid var(--line); border-radius:14px; overflow:hidden}
+  .dcap{font-family:var(--stamp); font-size:9.5px; letter-spacing:.13em; text-transform:uppercase; color:var(--txt3); padding:10px 15px 0}
+  .dhead{padding:2px 15px 12px; border-bottom:1px solid var(--line); display:flex; align-items:center; justify-content:space-between; gap:14px; flex-wrap:wrap}
+  .dtitle{display:flex; align-items:center; gap:9px; flex-wrap:wrap}
+  .dtitle .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:13px; font-weight:700; white-space:nowrap}
+  .dtitle .ref .ty{width:20px;height:20px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .dtitle .ref .ty svg{width:12px;height:12px}
+  .dsub{font-size:11px; color:var(--txt3)}
+  .rolewrap{display:flex; align-items:center; gap:9px}
+  .rolewrap .rlabel{font-family:var(--stamp); font-size:9.5px; letter-spacing:.05em; text-transform:uppercase; color:var(--txt3)}
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:7px; overflow:hidden; flex:none}
+  .seg b{display:inline-flex; align-items:center; gap:5px; padding:0 12px; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3); border-right:1px solid var(--line); cursor:pointer}
+  .seg b svg{width:11px;height:11px}
+  .seg b:last-child{border-right:0} .seg b.on{background:var(--accent); color:var(--onAcc)}
+
+  .dnote{padding:9px 15px 0; font-family:var(--stamp); font-size:9.5px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3); display:flex; gap:14px; flex-wrap:wrap}
+  .dnote b{color:var(--accent)}
+
+  .dbody{padding:13px 15px 14px}
+  .roleview{display:none} .roleview.on{display:block}
+  .chartgrid{display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:12px}
+
+  /* ---------- chart panel shell ---------- */
+  .cpanel{background:var(--card); border:1px solid var(--line); border-radius:10px; padding:10px 12px 11px; display:flex; flex-direction:column}
+  .cpanel.wide{grid-column:span 2}
+  @media (max-width:640px){ .cpanel.wide{grid-column:span 1} }
+  .cphead{display:flex; align-items:flex-start; justify-content:space-between; gap:8px}
+  .ceyebrow{font-family:var(--stamp); font-size:9.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--txt3)}
+  .ctarget{font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--onAcc); background:var(--accent); border-radius:5px; padding:1px 6px; white-space:nowrap; flex:none; line-height:1.6}
+  .ctitle{font-family:var(--font); font-weight:700; font-size:13px; color:var(--txt); margin:1px 0 8px; letter-spacing:-.01em}
+  .cnote{font-size:10px; color:var(--txt3); margin-top:8px; line-height:1.4}
+  .cnote b{color:var(--txt2)}
+  .clickable{cursor:pointer; transition:filter .12s, opacity .12s}
+  .clickable:hover{filter:brightness(1.18)}
+  .clickable:active{filter:brightness(.92)}
+
+  /* ---------- funnel ---------- */
+  .funnel{display:flex; flex-direction:column; gap:8px; margin-top:2px}
+  .frow{display:flex; align-items:center; gap:8px}
+  .flabel{font-family:var(--stamp); font-size:9.5px; font-weight:800; text-transform:uppercase; color:var(--txt3); width:66px; flex:none}
+  .ftrack{flex:1; height:16px; border-radius:4px; background:var(--lineSoft); position:relative; overflow:hidden}
+  .fbar{height:100%; border-radius:4px; background:var(--blue)}
+  .fbar.won{background:var(--green)}
+  .fval{font-family:var(--font); font-size:11px; font-weight:800; color:var(--txt); font-variant-numeric:tabular-nums; width:24px; text-align:right; flex:none}
+
+  /* ---------- donut ---------- */
+  .donutwrap{display:flex; align-items:center; gap:14px; margin-top:2px}
+  .donutwrap svg{width:112px; height:112px; flex:none}
+  .dcenter-n{font-family:var(--font); font-weight:800; font-size:15px; fill:var(--txt)}
+  .dcenter-l{font-family:var(--stamp); font-weight:800; font-size:9.5px; letter-spacing:.02em; fill:var(--txt3)}
+  .wedge{transition:filter .12s, stroke-width .12s} .wedge:hover{filter:brightness(1.15)}
+  .wedge.sel{stroke-width:20}
+  .donutlegend{display:flex; flex-direction:column; gap:7px; font-size:11px; flex:1; min-width:0}
+  .dli{display:flex; align-items:center; gap:7px; padding:2px 4px; border-radius:5px; border:1px solid transparent}
+  .dli.sel{border-color:var(--red); background:rgba(214,54,54,.12)}
+  .sw{width:9px;height:9px;border-radius:2px;flex:none}
+  .dlv{font-family:var(--stamp); font-weight:800; color:var(--txt); font-variant-numeric:tabular-nums; flex:none}
+  .dlk{color:var(--txt2); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .dlbadge{font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.03em; color:var(--red); border:1px solid var(--red); border-radius:4px; padding:0 4px; margin-left:auto; flex:none}
+
+  /* ---------- Signal chip (colour = state; dark ink on fill, white only on redStrong) ---------- */
+  .sig{display:inline-flex; align-self:flex-start; align-items:center; height:20px; padding:0 8px; border-radius:7px; font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase}
+  .sig.red{background:var(--redStrong); color:#fff}
+  .sig.yellow{background:var(--yellow); color:#211a05}
+
+  /* ---------- callout ---------- */
+  .callout{margin-top:9px; border-left:3px solid var(--red); background:var(--bg2); border-radius:0 8px 8px 0; padding:8px 10px}
+  .callout .ct-t{font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; color:var(--txt2); display:flex; align-items:center; gap:5px}
+  .callout .ct-t svg{width:10px;height:10px; color:var(--red); flex:none}
+  .callout .ct-b{font-size:11px; color:var(--txt2); margin-top:4px; line-height:1.45}
+  .callout .ct-b b{color:var(--txt)}
+  .callout .ct-b .k{font-family:var(--stamp); font-size:9.5px; font-weight:800; text-transform:uppercase; color:var(--txt); background:var(--lineSoft); border-radius:4px; padding:1px 5px}
+
+  /* ---------- vertical bars (WO backlog) ---------- */
+  .vbars{display:flex; align-items:flex-end; gap:14px; height:82px; border-bottom:1px solid var(--lineSoft); padding-top:4px; margin-top:2px}
+  .vbar{flex:1; display:flex; flex-direction:column; align-items:center; justify-content:flex-end; height:100%}
+  .vbar .bn{font-family:var(--font); font-size:12px; font-weight:800; color:var(--txt); margin-bottom:4px; font-variant-numeric:tabular-nums}
+  .vbar .bar{width:100%; max-width:36px; border-radius:4px 4px 0 0; background:var(--blue)}
+  .vbar.hot .bar{background:var(--yellow)}
+  .vbar .bl{font-family:var(--stamp); font-size:9.5px; letter-spacing:.02em; text-transform:uppercase; color:var(--txt3); margin-top:6px; text-align:center}
+  .vbar.hot .bl{color:var(--txt)}
+
+  /* ---------- area / trend ---------- */
+  .areawrap{margin-top:2px}
+  .areawrap svg{width:100%; height:auto; display:block}
+  .axweeks{display:flex; justify-content:space-between; margin-top:2px; padding:0 3px}
+  .axweeks span{font-family:var(--stamp); font-size:9.5px; letter-spacing:.02em; color:var(--txt3)}
+  .endlabel{font-family:var(--font); font-weight:800; font-size:11px; fill:var(--green)}
+
+  /* ---------- stat tile (status carried by the .sig chip, not by colouring the big digit —
+     plain yellow/red text on a big number fails the AA floor in light mode; a filled chip
+     with dark/white ink per the locked rule never does) ---------- */
+  .stat{display:flex; flex-direction:column; gap:5px}
+  .stat .sbig{font-family:var(--font); font-weight:800; font-size:28px; letter-spacing:-.02em; font-variant-numeric:tabular-nums; line-height:1; color:var(--txt)}
+  .stat .ssub{font-size:11px; color:var(--txt2)}
+  .stat .ssub b{color:var(--txt)}
+
+  /* ---------- action log ---------- */
+  .actionlog{margin-top:12px; padding:8px 12px; background:var(--bg2); border:1px dashed var(--line); border-radius:8px; font-family:var(--stamp); font-size:10px; letter-spacing:.02em; color:var(--txt3); display:flex; align-items:center; gap:6px}
+  .actionlog b{color:var(--accent); text-transform:uppercase}
+  .actionlog .go{color:var(--commit); font-weight:800}
+
+  .foot{margin-top:22px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:88ch}
+  .foot b{color:var(--txt)}
+  .foot ul{margin:8px 0 0; padding-left:18px} .foot li{margin:4px 0}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">First draft · react-to, not final · role Dashboard card</p>
+  <h1>The Dashboard <span class="hl">card</span></h1>
+  <p class="lede">Every role already keeps the same five cards — <b>Units · Rentals · Customers · Trips ·
+  Categories</b>. This adds a <b>6th: Dashboard</b>, shaped to whoever's looking at it. The Sales card already
+  <i>is</i> a dashboard — the sales job laid out as graphs — so this generalises that idea to every role. Two
+  variants below (<b>Sales</b> and <b>Mechanic</b>) so the role-dependent point is concrete. <b>Nothing here
+  replaces a base card</b> — Yard Journey stays on Units, routes stay on Trips; the charts only <b>drill into</b>
+  those cards with a filter already applied.</p>
+  <div class="key"><span><b>Signal</b> colour = state</span><span><b>Ref</b> linked record</span><span>chart wedge colour = the Signal chip it lands on</span><span>single-click = filter · double-click = open tab</span></div>
+
+  <!-- ================= 5+1 card rail ================= -->
+  <div class="railwrap">
+    <div class="cardrail">
+      <span class="crail"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4a2 2 0 0 0 1-1.73Z"/><path d="M3.3 7 12 12l8.7-5"/><path d="M12 22V12"/></svg></span>Units</span>
+      <span class="crail"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg></span>Rentals</span>
+      <span class="crail"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>Customers</span>
+      <span class="crail"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg></span>Trips</span>
+      <span class="crail"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m22 17.65-9.17 4.16a2 2 0 0 1-1.66 0L2 17.65"/><path d="m22 12.65-9.17 4.16a2 2 0 0 1-1.66 0L2 12.65"/></svg></span>Categories</span>
+      <span class="raildiv"></span>
+      <span class="crail active"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg></span>Dashboard<span class="n6">6TH</span></span>
+    </div>
+    <p class="railcap"><b>5 base cards</b>, shared by every role &nbsp;+&nbsp; <b>1 Dashboard</b>, shaped to the role looking at it.</p>
+  </div>
+
+  <!-- ================= Dashboard card ================= -->
+  <div class="dcard">
+    <p class="dcap">Card 6 of 6 · role-dependent · added card, not a landing page</p>
+    <div class="dhead">
+      <div class="dtitle">
+        <span class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg></span>Dashboard</span>
+        <span class="dsub">this role's job, laid out as graphs — every mark below is a link</span>
+      </div>
+      <div class="rolewrap">
+        <span class="rlabel">Viewing as</span>
+        <div class="seg">
+          <b id="segSales" onclick="setRole('sales')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>Sales</b>
+          <b id="segMech" class="on" onclick="setRole('mech')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Mechanic</b>
+        </div>
+      </div>
+    </div>
+    <div class="dnote"><span><b>single-click</b> a mark → filters the target card in place</span><span><b>double-click</b> → opens that filtered view as a session tab</span></div>
+
+    <div class="dbody">
+
+      <!-- ---------------- SALES VIEW ---------------- -->
+      <div class="roleview" id="viewSales">
+        <div class="chartgrid">
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Pipeline · this month</span><span class="ctarget">→ Customers</span></div>
+            <div class="ctitle">Lead → Signed funnel</div>
+            <div class="funnel">
+              <div class="frow clickable" onclick="act(this,'single-click','Customers','stage = Lead · 38 accounts')" ondblclick="act(this,'double-click','Customers','opens tab · stage = Lead · 38 accounts')">
+                <span class="flabel">Lead</span><span class="ftrack"><span class="fbar" style="width:100%"></span></span><span class="fval">38</span></div>
+              <div class="frow clickable" onclick="act(this,'single-click','Customers','stage = Quoted · 24 accounts')" ondblclick="act(this,'double-click','Customers','opens tab · stage = Quoted · 24 accounts')">
+                <span class="flabel">Quoted</span><span class="ftrack"><span class="fbar" style="width:63%"></span></span><span class="fval">24</span></div>
+              <div class="frow clickable" onclick="act(this,'single-click','Customers','stage = Site Visit · 15 accounts')" ondblclick="act(this,'double-click','Customers','opens tab · stage = Site Visit · 15 accounts')">
+                <span class="flabel">Site Visit</span><span class="ftrack"><span class="fbar" style="width:39%"></span></span><span class="fval">15</span></div>
+              <div class="frow clickable" onclick="act(this,'single-click','Customers','stage = Signed · 9 accounts')" ondblclick="act(this,'double-click','Customers','opens tab · stage = Signed · 9 accounts')">
+                <span class="flabel">Signed</span><span class="ftrack"><span class="fbar won" style="width:24%"></span></span><span class="fval">9</span></div>
+            </div>
+            <div class="cnote">each bar is a stage — <b>click Signed</b> to see the 9 closed-won accounts on Customers.</div>
+          </div>
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Account standing</span><span class="ctarget">→ Customers</span></div>
+            <div class="ctitle">Customer split</div>
+            <div class="donutwrap">
+              <svg viewBox="0 0 120 120">
+                <circle cx="60" cy="60" r="46" fill="none" stroke="var(--lineSoft)" stroke-width="16"/>
+                <g transform="rotate(-90 60 60)">
+                  <circle class="wedge clickable" cx="60" cy="60" r="46" fill="none" stroke="var(--green)" stroke-width="16" stroke-dasharray="185 104" stroke-dashoffset="0" onclick="act(this,'single-click','Customers','standing = Current · 30 accounts')" ondblclick="act(this,'double-click','Customers','opens tab · standing = Current · 30 accounts')"/>
+                  <circle class="wedge clickable" cx="60" cy="60" r="46" fill="none" stroke="var(--yellow)" stroke-width="16" stroke-dasharray="40 249" stroke-dashoffset="-185" onclick="act(this,'single-click','Customers','standing = Due Today · 7 accounts, incl. Duhon Contracting')" ondblclick="act(this,'double-click','Customers','opens tab · standing = Due Today · 7 accounts')"/>
+                  <circle class="wedge clickable" cx="60" cy="60" r="46" fill="none" stroke="var(--red)" stroke-width="16" stroke-dasharray="64 225" stroke-dashoffset="-225" onclick="act(this,'single-click','Customers','standing = Overdue · 11 accounts')" ondblclick="act(this,'double-click','Customers','opens tab · standing = Overdue · 11 accounts')"/>
+                </g>
+                <text x="60" y="55" text-anchor="middle" class="dcenter-n">48</text>
+                <text x="60" y="71" text-anchor="middle" class="dcenter-l">ACCOUNTS</text>
+              </svg>
+              <div class="donutlegend">
+                <div class="dli clickable" onclick="act(this,'single-click','Customers','standing = Current · 30 accounts')"><span class="sw" style="background:var(--green)"></span><span class="dlv">64%</span><span class="dlk">Current · 30</span></div>
+                <div class="dli clickable" onclick="act(this,'single-click','Customers','standing = Due Today · 7 accounts')"><span class="sw" style="background:var(--yellow)"></span><span class="dlv">14%</span><span class="dlk">Due Today · 7 (Duhon Contracting)</span></div>
+                <div class="dli clickable" onclick="act(this,'single-click','Customers','standing = Overdue · 11 accounts')"><span class="sw" style="background:var(--red)"></span><span class="dlv">22%</span><span class="dlk">Overdue · 11</span></div>
+              </div>
+            </div>
+            <div class="cnote">same red/yellow/green as every Customers Signal chip — this is just those chips, counted.</div>
+          </div>
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Revenue · 8-wk trend</span><span class="ctarget">→ Rentals</span></div>
+            <div class="ctitle">Weekly billed revenue</div>
+            <div class="areawrap clickable" onclick="act(this,'single-click','Rentals','week = W8 · $35.1k billed')" ondblclick="act(this,'double-click','Rentals','opens tab · week = W8 · $35.1k billed')">
+              <svg viewBox="0 0 300 100" preserveAspectRatio="none">
+                <line x1="10" y1="90" x2="290" y2="90" stroke="var(--lineSoft)" stroke-width="1" stroke-dasharray="2 3"/>
+                <path d="M10,90 L10,72.7 L50,63 L90,74 L130,51.2 L170,41 L210,52.4 L250,33.5 L290,26.3 L290,90 Z" fill="var(--blue)" opacity=".16" stroke="none"/>
+                <polyline points="10,72.7 50,63 90,74 130,51.2 170,41 210,52.4 250,33.5 290,26.3" fill="none" stroke="var(--blue)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+                <circle cx="290" cy="26.3" r="4" fill="var(--green)"/>
+                <text x="238" y="18" class="endlabel">$35.1k</text>
+              </svg>
+              <div class="axweeks"><span>W1</span><span>W2</span><span>W3</span><span>W4</span><span>W5</span><span>W6</span><span>W7</span><span>W8</span></div>
+            </div>
+            <div class="cnote">endpoint is this week — <b>click the line</b> to see this week's rentals on Rentals.</div>
+          </div>
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Receivables</span><span class="ctarget">→ Customers</span></div>
+            <div class="ctitle">Overdue AR</div>
+            <div class="stat clickable" onclick="act(this,'single-click','Customers','A/R overdue · 6 accounts')" ondblclick="act(this,'double-click','Customers','opens tab · A/R overdue · 6 accounts')">
+              <span class="sig red">Overdue</span>
+              <span class="sbig">$18,420</span>
+              <span class="ssub"><b>6</b> accounts overdue · 3 past 30 days</span>
+            </div>
+            <div class="cnote">same red as the Overdue Signal — click to open those 6 accounts.</div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ---------------- MECHANIC VIEW ---------------- -->
+      <div class="roleview on" id="viewMech">
+        <div class="chartgrid">
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Fleet state</span><span class="ctarget">→ Units</span></div>
+            <div class="ctitle">Down vs rented vs available</div>
+            <div class="donutwrap">
+              <svg viewBox="0 0 120 120">
+                <circle cx="60" cy="60" r="46" fill="none" stroke="var(--lineSoft)" stroke-width="16"/>
+                <g transform="rotate(-90 60 60)">
+                  <circle class="wedge clickable" cx="60" cy="60" r="46" fill="none" stroke="var(--green)" stroke-width="16" stroke-dasharray="191 98" stroke-dashoffset="0" onclick="act(this,'single-click','Units','status = Rented · 31 units')" ondblclick="act(this,'double-click','Units','opens tab · status = Rented · 31 units')"/>
+                  <circle class="wedge clickable" cx="60" cy="60" r="46" fill="none" stroke="var(--gray)" stroke-width="16" stroke-dasharray="74 215" stroke-dashoffset="-191" onclick="act(this,'single-click','Units','status = Available · 12 units')" ondblclick="act(this,'double-click','Units','opens tab · status = Available · 12 units')"/>
+                  <circle id="wedgeDown" class="wedge sel clickable" cx="60" cy="60" r="46" fill="none" stroke="var(--red)" stroke-width="20" stroke-dasharray="24 265" stroke-dashoffset="-265" onclick="act(this,'single-click','Units','status = Down · 4 units — RC-4700 Gator, SS-14 Scout +2')" ondblclick="act(this,'double-click','Units','opens tab · status = Down · 4 units')"/>
+                </g>
+                <text x="60" y="55" text-anchor="middle" class="dcenter-n">47</text>
+                <text x="60" y="71" text-anchor="middle" class="dcenter-l">UNITS</text>
+              </svg>
+              <div class="donutlegend">
+                <div class="dli clickable" onclick="act(this,'single-click','Units','status = Rented · 31 units')"><span class="sw" style="background:var(--green)"></span><span class="dlv">66%</span><span class="dlk">Rented · 31</span></div>
+                <div class="dli clickable" onclick="act(this,'single-click','Units','status = Available · 12 units')"><span class="sw" style="background:var(--gray)"></span><span class="dlv">26%</span><span class="dlk">Available · 12</span></div>
+                <div class="dli sel clickable" onclick="act(this,'single-click','Units','status = Down · 4 units')"><span class="sw" style="background:var(--red)"></span><span class="dlv">8%</span><span class="dlk">Down · 4</span><span class="dlbadge">SEL</span></div>
+              </div>
+            </div>
+            <div class="callout">
+              <div class="ct-t"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>Selected mark</div>
+              <div class="ct-b"><b>→ Units</b> card · <b>4 down units</b> (RC-4700 "Gator" + SS-14 "Scout" + 2 more) ·
+              <span class="k">single-click</span> filters here · <span class="k">double-click</span> opens a tab</div>
+            </div>
+          </div>
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Open WOs · by phase</span><span class="ctarget">→ Units</span></div>
+            <div class="ctitle">Work-order backlog</div>
+            <div class="vbars">
+              <div class="vbar clickable" onclick="act(this,'single-click','Units','WO phase = Diagnose · 3 open')" ondblclick="act(this,'double-click','Units','opens tab · WO phase = Diagnose · 3 open')">
+                <span class="bn">3</span><span class="bar" style="height:42px"></span><span class="bl">Diagnose</span></div>
+              <div class="vbar hot clickable" onclick="act(this,'single-click','Units','WO phase = Parts Wait · 5 open, bottleneck')" ondblclick="act(this,'double-click','Units','opens tab · WO phase = Parts Wait · 5 open')">
+                <span class="bn">5</span><span class="bar" style="height:70px"></span><span class="bl">Parts Wait</span></div>
+              <div class="vbar clickable" onclick="act(this,'single-click','Units','WO phase = In Repair · 4 open')" ondblclick="act(this,'double-click','Units','opens tab · WO phase = In Repair · 4 open')">
+                <span class="bn">4</span><span class="bar" style="height:56px"></span><span class="bl">In Repair</span></div>
+              <div class="vbar clickable" onclick="act(this,'single-click','Units','WO phase = QC · 2 open')" ondblclick="act(this,'double-click','Units','opens tab · WO phase = QC · 2 open')">
+                <span class="bn">2</span><span class="bar" style="height:28px"></span><span class="bl">QC</span></div>
+            </div>
+            <div class="cnote"><b>Parts Wait</b> is the bottleneck (yellow = aging 3+ days) — 14 open WOs total.</div>
+          </div>
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Compliance</span><span class="ctarget">→ Units</span></div>
+            <div class="ctitle">Inspections due</div>
+            <div class="stat clickable" onclick="act(this,'single-click','Units','inspection due · 7 units, this week')" ondblclick="act(this,'double-click','Units','opens tab · inspection due · 7 units')">
+              <span class="sig yellow">Due today</span>
+              <span class="sbig">7</span>
+              <span class="ssub">due <b>this week</b> · 2 already past their window</span>
+            </div>
+            <div class="cnote">same yellow as a Due-Today Signal — click to see the 7 units on Units.</div>
+          </div>
+
+          <div class="cpanel">
+            <div class="cphead"><span class="ceyebrow">Returns</span><span class="ctarget">→ Rentals</span></div>
+            <div class="ctitle">Overdue returns</div>
+            <div class="stat clickable" onclick="act(this,'single-click','Rentals','return overdue · 3 units, incl. Duhon Contracting')" ondblclick="act(this,'double-click','Rentals','opens tab · return overdue · 3 units')">
+              <span class="sig red">Overdue</span>
+              <span class="sbig">3</span>
+              <span class="ssub">overdue, incl. <b>Duhon Contracting</b> — 2 days late</span>
+            </div>
+            <div class="cnote">same red as the Overdue Signal — click to open those 3 rentals.</div>
+          </div>
+
+        </div>
+      </div>
+
+      <div class="actionlog" id="actionlog">› click any mark above — a chart segment is a link, not a picture.</div>
+
+    </div>
+  </div>
+
+  <div class="foot">
+    <b>First draft — react to it, not final.</b> A few calls made to get this concrete:
+    <ul>
+      <li>Toggle defaults to <b>Mechanic</b> on load (not Sales) so the one fully-legible drill — the Down wedge
+      callout — is visible without clicking anything.</li>
+      <li>The funnel and revenue-trend charts stay <b>blue/neutral</b> rather than status colour, since a pipeline
+      stage or a dollar trend isn't a status enum — only charts that directly split a status field (account
+      standing, fleet state) use the locked red/yellow/green/gray Signal palette. Worth confirming that split
+      reads right to you.</li>
+      <li>"Selected" on the Down wedge is shown as a thicker stroke + a bordered legend row + a static callout,
+      not a blurred glow (matte constraint) — real build would likely add this on hover/click, shown here baked
+      in so it's visible at rest.</li>
+      <li>Click and double-click on every mark are wired to the log line at the bottom, so you can click around
+      and see exactly what would filter vs. what would open a tab.</li>
+      <li>Work-order backlog drills to <b>Units</b> (that's where WOs live today) — flag if you want it split
+      differently, e.g. its own view.</li>
+      <li>Not addressed here on purpose: which roles get which numbers at all (money visibility, etc.) — that's
+      the separate <b>keep-the-keys</b> access-gate call, not a design decision.</li>
+    </ul>
+  </div>
+
+</div></div>
+
+<script>
+  function setRole(role){
+    document.getElementById('viewSales').classList.toggle('on', role==='sales');
+    document.getElementById('viewMech').classList.toggle('on', role==='mech');
+    document.getElementById('segSales').classList.toggle('on', role==='sales');
+    document.getElementById('segMech').classList.toggle('on', role==='mech');
+    document.getElementById('actionlog').innerHTML = '› switched dashboard to <b>' + (role==='sales'?'Sales':'Mechanic') + '</b> — same card, reshaped to the role.';
+  }
+  function act(el, kind, card, detail){
+    var verb = kind === 'single-click' ? 'filters' : 'opens tab ·';
+    document.getElementById('actionlog').innerHTML =
+      '<b>' + kind + '</b> → <span class="go">' + card + '</span> card · ' + verb + ' ' + detail;
+  }
+</script>

--- a/docs/design/reference/decision-notes.md
+++ b/docs/design/reference/decision-notes.md
@@ -1,0 +1,342 @@
+# Running decision notes (lines 1-2000 of transcript)
+
+## Phase 0 — research (lines 1-1390): no design decisions, pure audit gathering.
+- 171 findings -> 25-job taxonomy -> ~399 findings total across list/phone/surfaces/traces/detail waves.
+- Not relevant to ledger except as backdrop.
+
+## Phase 1 — brainstorming begins (msg 93/94, line 1391+)
+- Jac's ask: plot mockup of app's needs, "narrow DNA" - fewest builder functions/design elements to cover the ground.
+- 5-part DNA proposed: WORD / NUMBER / SIGNAL / DOOR / PLACE (early names, from Bill-of-Materials artifact)
+  - SIGNAL = urgency that climbs row->group->tab->yard count, ranks by severity
+  - NUMBER = one honest owned figure, provenance/drill-through
+  - DOOR = verb-first action + its own guards (reachability R5 + reversibility R4 merged into one part)
+  - WORD = durable, addressed inbox (messaging)
+  - PLACE = one grammar/kept-structure across cards
+- Q&A (msg 102): Jac never explicitly answered Q1/Q2/Q3 directly via popup (dropped) - conversation moved on organically (kept 5 parts implicitly, confirmed via later "5+1" resolution documented in spec §5).
+- DECISION (msg 117, Jac): "Keep the WHERE, reinvent the HOW" - do not redesign layout/structure (3 columns, mini-calendar rentals view, toggleable cards) but DO discard current colors/hierarchy/pills/buttons/text/components entirely. [DOCUMENTED - wrangler-style §4 "Keep where things are" + intro]
+- DECISION (msg 117/123): Need isolated staging build wired to real backend data, read-only, must NOT touch trunk/live, must be revertible.
+  - Q1 Home: Jac picked **B - reuse staging-2 slot** (not a dedicated new repo) "because we're going to merge cards we like into trunk possibly as we go" - hope is redesign simple enough to push to production piecemeal. [NOT in the 4 docs read]
+  - Q2 Backend data: Jac picked **B - read-only on live data**, no separate sandbox copy/backend needed. "We're not changing the business/app or workflows. We're improving how workflows appear... We shouldn't need to write to the backend." [NOT documented in the 4 docs]
+  - Q3 Look direction: Jac picked **ALL THREE (A+B+C combined)** - "cover as much ground with as few visual systems as possible without losing workload or quality... Too simple and users can't build muscle memory... too complicated = zoo of systems... Visuals should be recognizable across cards. Structures, popups, menus, toggles, pills, everything should be reusable... call on the same builders, references, tools, functions." [Partially documented as design philosophy generally, but this specific process decision/rationale is NOT captured]
+- DECISION (msg 129/130): Rollback safety net -
+  - Frontend: live production commit 0fac006 tagged/noted as restore point (revert = point production branch back at 0fac006)
+  - Since view-layer only reads backend (no writes), reverting frontend automatically preserves all backend data (transactions/payments/history) - "already free" rollback
+  - Redesign should ride behind existing FEATURES flag for instant runtime-toggle revert (generic FEATURES-flag practice IS documented in CLAUDE.md - but the SPECIFIC decision to apply it to THIS redesign is not written anywhere)
+  - Backend data snapshot (private Drive copy of Live Database + Daily Category Report) - offered, pending Jac go [check later msgs for resolution]
+- Visual direction chosen (msg 128, Jac): "Field Steel has the best text and shapes. The solid fills are good but maybe consider also using the no-fills of C [Signal]." + "I do like organizing by work like C. Using color for attention is a good move."
+  -> synthesized as V3 Hybrid (msg 131): only the single WORST thing per card is solid; everything else needing attention is outlined. [DOCUMENTED conceptually via style.css fill=today function + wrangler-style Signal/Gate defs, but the ORIGIN story / the V1/V2/V3 hybrid naming is not captured]
+- DECISION (msg 133, Jac corrections applied verbatim, all accepted by Claude):
+  1. Customers = strict ONE-LINE row rule (kept, not 2-line) [existing structural fact, arguably "keep-the-map" already covers implicitly, not explicit]
+  2. Units & Rentals KEEP their mini-cards (week-grid calendar for Rentals w/ route rail; tiles w/flags for Units) - restated/reconfirmed
+  3. Card titles ARE toggles (Units<->Categories, Rentals<->Calendar, Customers<->Sales) - kept
+  4. "Chip" made an explicit, unmistakable component (predecessor of Signal/Gate/Stamp)
+  5. COLOR RULE LOCKED: "color = attention only." Red = needs-you-now, amber = needs-you-soon (real time-sensitive, e.g. wash due). Healthy/neutral states (reserved, new lead, on-rent, current) are neutral/monochrome/grey, NEVER orange/amber. This directly kills "amber meaning 3 unrelated things." [This is essentially the ancestor of style §6 colour=state / fill=today, but the explicit LOCK MOMENT and the "amber ban on healthy states" phrasing / examples aren't in the docs]
+
+## Section: color/groups system (lines 2000-2570) — MAJOR undocumented area
+This entire "Groups + Color + Role + Quick-filter" design thread is NOT in any of the 4 read docs
+(confirmed: only 2026-07-20-list-views-inline-expand-design.md + critique-log exist for 07-20; neither
+mentions groups/color-semantics/Your-Work/Done chips). Style.md's §6 taskState/triggeredToday is the
+generic MECHANISM (documented) but the actual CONTENT of the decision (which color means what, the
+group taxonomy, the filter chips) is not written anywhere.
+
+- Jac revealed HIS ORIGINAL R/Y/G system predates this project: Red=blocking/gates, Yellow=needs doing,
+  Green=nothing to do. Considered launching a whole separate project around it (msg 142/144).
+- Claude's research-grounded critique: red wasn't rationed (finding #31, 44/60 rows red) and green lied
+  by being assigned via lifecycle not health (findings #54/#102/#53, e.g. 1,139hr-overdue machine shown
+  green "Available"). Fix = SIGNAL rollup (a group is only green if truly all-clear).
+- FINAL LOCKED COLOR SEMANTICS (evolved over msgs 144-193, superseding several intermediate proposals):
+  - Grey = N/A / nothing (silent, quiet default)
+  - Blue = **Waiting** — "the ball's not in your court" (someone else's move: vendor, customer, clock,
+    another dept). Explicitly chosen over "routine/do-later" (msg 167-170) because the app had NO
+    representation for in-flight/pending states (ACH mid-settlement rendering identically to overdue —
+    S13/S14; part-on-order; quote awaiting signature). Confirmed via "Reserved = Waiting" (waiting on
+    pickup) and proven on all 3 cards (part-on-order/Units, awaiting-sign/Rentals, ACH-processing/Customers).
+  - Yellow = **your move, now** (do-now / needs action) — kept clean/singular meaning once blue absorbed
+    "waiting" and routine work; this fixed Jac's "does yellow feel negative" worry.
+  - Red = **Bad** (expanded from Jac's original "blocked only" to general "bad/wrong") — Jac explicitly
+    widened it in msg 146: "Red = Bad, Yellow = Need To Do, Green = Done, Grey = N/A." Blocking-specific
+    meaning was recovered via the FILL bit instead of spending a 6th hue (see below).
+  - Green = **Done (today)** — a completion/recency state, not a permanent badge. Ages to Grey the next
+    day ("settles," "handled, ambient"). "Done re-alarms": if a completed item reverts to bad, it snaps
+    back to Red directly (not amber/yellow first). Recency window = calendar-day ("Done today"), same
+    rule on every card (serviced unit / returned rental / called customer all "settle" identically).
+  - ONE function assigns color: no renderer improvises its own color (root cause of the original R/Y/G
+    system's failure per the research — each card/renderer computed its own color independently).
+  - Rollup precedence, hottest wins: **red > yellow > blue > green > grey** (msg 162/164) — EXPLICIT
+    ORDER, not written in style.md (style.md only lists bucket names, no explicit precedence order).
+  - Buttons carry NO status color — made neutral (white/ink primary "click me," ghost secondary,
+    "never a status color") specifically to stop blue doing double duty as both a button-affirm color
+    AND a status color (msg 152-153, "Status is a thermometer, actions are neutral" artifact). This is
+    the origin story for wrangler-style §3 Door's "no status colour on a button" rule.
+- GROUP TAXONOMY (two flavors of ONE rule: header color = worst item inside, i.e. rollup) — msg 162:
+  - **Attention groups** (e.g. Field Calls, Failed) — exist/appear ONLY when something's wrong; HIDDEN
+    WHEN EMPTY. Colored because membership itself IS the bad state.
+  - **Lifecycle groups** (e.g. On Rent, Reserved, Available, End Rent) — ALWAYS present, grey-by-default,
+    take color only when a member inside triggers it. NO group has a fixed/native color (explicitly
+    rejected a "native color" for On Rent, msg 162, to prevent green-lying repeat of findings #102/#54).
+  - **End Rent is inherently yellow** (its membership = due-back-today by definition) until a red inside
+    overtakes it — this is how finding #110 (no forward-looking "due-back" bucket) got fully solved,
+    replacing an earlier idea of encoding "due back" only via color inside On Rent (msg 163-164 correction).
+  - Initially explored "first-match cascade" (a record could match multiple groups, land in first match)
+    — Jac clarified this was a misunderstanding: Today/Tomorrow/This Week are RESERVATION START dates,
+    not return dates, so it's a clean single-stage lifecycle timeline, NO cascade logic needed (msg 165).
+  - Real group lists Jac supplied as the starting point (msg 154), to be used as the actual per-card
+    lifecycle groups:
+    - Customers: Past Due, Not Due, Reserved, On Rent, Members, Non-Members
+    - Rentals: Today, Tomorrow, This Week, On Rent, Off Rent, End Rent, Returned, Quote, No Show, Cancelled
+    - Units (Staff/mechanic view): Field Calls, Not Ready/Failed+Reserved, Not Ready, Failed, Transport,
+      Reserved, On Rent, End Rent, Available, Incomplete (Office Work Needed)
+    - Units (Office+ view): Field Calls, Not Ready/Failed+Reserved, Transport, Reserved, On Rent,
+      End Rent, Available, Incomplete, Not Ready, Failed
+  - "Not Ready/Failed+Reserved" as its OWN top bucket = the broken-machine-promised-to-a-customer
+    collision (finding #51) getting a dedicated home.
+  - Groups must NOT be named after status ("Bad"/"To-Do") — that double-encodes what color already
+    says. Groups say WHERE in the workflow; color says HOW MUCH it needs you (msg 154-155 correction
+    of Claude's own earlier "Bad/To-Do" group naming mistake).
+  - Role-scoped group ORDER (not different groups, same set reordered): mechanic floats Not-Ready/
+    Failed to top; Office sinks them, floats dispatch/billing to top instead — proven via a live "Units,
+    two roles" artifact (msg 155-156). General principle stated: **"Your Work" grouping/filter engine is
+    universal; role supplies the priority/definition — role sets defaults, never walls off** (a mechanic
+    must still get pinged if a rental he's on goes overdue — cross-role taps still fire). This is a
+    DIFFERENT "role sets order" decision than the one already documented in the inline-expand spec §2
+    (which is about SECTION order inside an EXPANDED item) — this one is about LIST-CARD GROUP order.
+- QUICK-FILTER CHIPS (header-level, not a group) — msg 146-160:
+  - **"Your Work"** chip: hides any group holding only Green/Grey (all-clear); shows only groups
+    containing Red/Yellow/Blue. Does NOT re-bucket items — only hides/shows whole groups. Carries a
+    rolled-up count. The ONE filter that means the same thing on every card ("hide what's handled, show
+    what needs me") — deliberately chosen over 4 separate time-based chips (Today/Tomorrow/Week/Done)
+    because those are Rentals/Calendar-specific words that don't fit Units (service-language) or
+    Customers (money/lead-language) — would have broken "same builder everywhere."
+  - **"Done"** chip: a sibling/opposite filter — shows only items in the Green "done today" state (so a
+    user can re-touch what they just did). Explicitly NOT a group (would require listing an item in
+    multiple groups, which Jac called "just wrong for our system") — it's a FILTER over the existing
+    single-group placement, same mechanism as Your Work, opposite end.
+  - Card-title toggle moves from CENTER to LEFT-ALIGNED specifically to free header space for these
+    chips (+ graph + search + sort) — Jac's own proposal (msg 146), confirmed useful for mobile too
+    (frees room even for one chip).
+- FILL BIT — separate axis from hue, extensive back-and-forth, ENDED IN A DIFFERENT PLACE than either
+  of Jac's two proposals, msg 171-193:
+  1st proposal (Jac, msg 171): filled=Blocking / outline=Fix-it (soft), generalized by Claude across
+    all 5 hues (filled=hard/binding/gating, outline=soft/advisory) — built out with an 11-example
+    "real gates" artifact (failed inspection, no card on file [94.5% of the book has none], unsigned
+    agreement, PO-required, ACH-in-flight, blacklist, part-on-order, overbook, etc.) plus a "look-alike
+    that stays outline" companion column.
+  2nd proposal (Jac, msg 174/179/186): filled=**Today** instead — Claude compared "ground covered" by
+    each rule side by side; recommended keeping Blocking (novel signal) over Today (redundant with
+    groups+color) but Jac overruled, locking **Fill = Today**.
+  FINAL correction (Jac, msg 189, overriding Claude's own narrower first cut of "Fill=Today"): fill
+    should be a **generous "look here" / curiosity magnet** — Jac explicitly rejected Claude's proposed
+    outline-list (future-dated, in-flight/self-resolving, dormant flags, done-today) and said ALL of
+    those should ALSO fill because they "touch Today" in some live-thread sense — "I want users' eyes
+    to trigger special curiosity upon seeing a filled." Only genuine steady-state/at-rest records (idle
+    unit, mid-rental with nothing due, plain member) stay hollow/outline.
+  RESULT matches style.md §6's trigger list (due/overdue/gating-now/needs-hands/near-clock/in-flight/
+    flagged-live/closed-today) — so the MECHANISM is documented, but the DECISION NARRATIVE (why fill
+    ended up this generous, the Blocking-vs-Today debate, the two rejected intermediate designs) is not.
+  - Fill correctly framed as a MEANING bit, not a loudness bit — priority still comes from color +
+    sort order (already in style.md, confirmed origin here).
+  - **Hover layer locked** (msg 186/188): three-tier read — (1) color+fill = instant read, (2) the
+    word on the chip = what it is (Signal already verbalizes), (3) hover/Tab/long-press = why & what
+    it stops. This 3-tier hover contract for Signal chips is NOT spelled out anywhere in the 4 docs
+    (wrangler-style just says "hover -> explain + name the source" for Signal, missing the 3-tier
+    breakdown and the Tab/long-press keyboard-touch equivalents).
+  - One item Claude flagged as still open and never explicitly re-confirmed: whether a
+    waiting-on-vendor gate (WO closeable today but part on order) should fill as "today's blocker
+    you're tracking" or stay outline until the part lands — superseded by the msg 189 generous-fill
+    rule (everything touching today fills), so likely resolved as FILLED, but not explicitly re-stated.
+
+## Detail-view extraction (msg 193-194, line 2570+): Claude pulled real code structure of
+Units/Rentals/Customers detail views via subagent, to keep "where things are" while laying the new
+system on. This grounds the later spec's §2/§3/§6 sections.
+
+## Section: fill-rule finalization + detail views + button taxonomy (lines 2660-2770)
+- fill rule tightened one more notch (msg 196-198): "eligible categories are many, but each stays
+  hollow until its trigger actually FIRES (or is actively expected)" — a category being eligible isn't
+  enough. Re-locked as `fill = triggeredToday(record)`. [Mechanism documented in style.md §6, this
+  narrative/refinement moment is not]
+- Button taxonomy locked precisely (msg 200, confirming/refining the earlier msg 200 note): **toggle-
+  active = ORANGE (accent)**, white reserved for confirm/save ONLY, ghost neutral verbs, status gates
+  keep status color. [NOTE: this literally conflicts with the CURRENT wrangler-style §3 Door rule
+  "Toggle active segment -> the filled Signal chip of the selected option's status ... Falls back to
+  orange when the option carries no status" — i.e., the doc's current rule is a LATER refinement
+  (status-colored toggles, orange only as fallback) that supersedes this simpler "always orange" rule.
+  Both are real decisions at different points in time; only the latest (already in wrangler-style) is
+  binding, so no ledger action needed except noting the evolution exists.]
+- Kept/confirmed, not touched: Rentals' condensed TWO-WEEK calendar (Jac: "that's all the window ever
+  needs"), the `+Unit` line style, Customers' collapsed-section stack. [general "kept structure"
+  principle documented; the specific "two-week is enough" observation is a minor undocumented detail]
+- Pressure-test done on Customers (densest card, all 7 sections open = ~5 phone-screens tall) —
+  validated the need for one-section-at-a-time paging idea. Landing section must be a SIGNAL summary
+  (now in spec §2). The "~70% of viewport" expand-height number Jac proposed (msg 199.3) evolved into
+  the shipped mockup's `clamp(260px, 70vh, 680px)` — the spec doc itself doesn't state a percentage,
+  just "grows downward... fixed target size" — so the concrete size formula is a minor undocumented detail.
+
+## Section: the "connective layer" — text/links/flags/naming (lines 2727-2930) — MOSTLY DOCUMENTED
+via wrangler-style, with these narrative/process points NOT captured anywhere:
+- Three-way color-role split that unlocked the whole layer (msg 208): **"status colors = what ·
+  orange = touchable · white = commit · everything else = plain honest text."** This explicit rule
+  statement (the organizing principle behind Signal/Ref/Door separation) is not written as such in
+  wrangler-style — it only shows the resulting components, not this unifying one-liner.
+  [NEW-CAPTURE CANDIDATE]
+  - The trace-across-cards demo (Duhon -> Rental #4471 -> Skid Steer -> Invoice #4460, overdue chip
+    lights at the end) proving Ref "walks across cards" — illustrative example, minor.
+- The blue collision + resolution (msg 209-213): blue already = Waiting (status), so a commit button
+  can't reuse status-blue. Resolution: commit gets its OWN deep, more-saturated blue (`#2f6fd0`,
+  distinct from status blue `#6394cc`), rendered ALWAYS as a solid pill shape, so the two blues never
+  read as the same control even though both are "blue." Jac confirmed: "I like the new blue save
+  button. The shape helped too. Maybe consider a true pill to differentiate it even more" -> pill
+  shape adopted for Doors generally. [The specific two-blues collision/resolution NARRATIVE is a
+  genuine NEW-CAPTURE candidate — wrangler-style states the two hex values and that they're "revisit
+  if it reads too close" but doesn't explain WHY two blues exist or the pill-shape-as-differentiator
+  reasoning.]
+- Jac Q (msg 212.5) re: "the blue DOOR we had before helped the eye see where to create new stuff or
+  add... understand if research found it overkill" -> Claude's answer (msg 215): NOT overkill — blue
+  dashed +Add is canon (R5b), confirmed sanctioned, kept. [minor, implicitly covered by Door's "+Add
+  dashed outline" in wrangler-style]
+- Signal/Gate/Stamp/Ref/Door NAMED here for the first time (msg 211, "I named the pieces... Signal
+  Gate Stamp Ref Door") — already fully documented in wrangler-style §3.
+- Gate visual settled: NO orange dot (Jac rejected it, msg 212.1 "orange thing on gates is weird");
+  leading centered chevron, hugging text, no gap, chevron sits in FRONT of text not behind (Jac's
+  explicit correction) — [DOCUMENTED: wrangler-style §3 Gate "leading, optically-centred SVG chevron
+  that hugs the text (<=2px gap). No orange dot."] Good, already captured.
+- Cancel button = the one quiet ghost (answers Jac's msg 212.7 "what does a cancel button look like")
+  [DOCUMENTED].
+- Signal hover = teleport to source + name it (confirmed, msg 217/188) [DOCUMENTED].
+
+## Section: jactec-ui replaced by style + wrangler-style (lines 3268-3707) — CONFIRMED ALREADY DOCUMENTED
+- Reference-material critique session (msg 228-241): Jac shared external UI-inspiration screenshots;
+  Claude extracted 3 real changes (deepen red to `#d63636` for AA, mute blue to `#6394cc` vs orange,
+  adopt 60-30-10) - all now in wrangler-style/style. The "space-cowboy / Duster Wrangler / laser lasso
+  cyborg horse" direction was explored in depth (msg 230-236: intro-video character described in
+  detail — orange laser rim-lighting, matte-serious steel, "only the laser glows" rule, three visual
+  families mocked: Field Steel / Duster Wrangler / Dispatch) then explicitly TOSSED by Jac (msg 238,
+  "Nah. Toss this. Let's get back to work.") [ALREADY DOCUMENTED — wrangler-style intro provenance
+  note: "The space-cowboy / laser direction was explored and dropped: the app is matte, no glow."
+  Confirmed accurate, no new capture needed, though the ledger should note this explored-and-rejected
+  direction explicitly per instructions on "not inventing" — this IS a real decision (to reject) so
+  it's fine to list as documented.]
+- CVD/colorblind methodology (msg 256-266): Jac disclosed being colorblind; Claude ran deuteranopia+
+  protanopia simulation math; picked `#ffe14d` (103 separation) over `#f5c542`(77) initially, later
+  further dimmed to final `#eed44b` per wrangler-style (a later request "dimmed... on request" per
+  wrangler-style's own note — the FURTHER dimming below ffe14d must happen later in transcript, watch
+  for it in remaining unread lines). [DOCUMENTED in wrangler-style + style CVD rule]
+- Skill split finalized: `style` = numerical rulebook only, hard decisions stripped out (Saira/Geist
+  mandate, hex table removed); `wrangler-style` created as the NEW decisions-home, explicitly "the true
+  replacement to jactec-ui," both to be run together on any UI change (msg 286-290). jactec-ui DELETED
+  from the working tree (recoverable via git history) per Jac's explicit instruction (msg 279, "delete
+  it please"). CLAUDE.md repointed from jactec-ui to style+wrangler-style. [ALL ALREADY DOCUMENTED —
+  wrangler-style intro provenance note + CLAUDE.md "Design language" section confirm this exact
+  history.]
+- Jac also asked (msg 256) to make the rental mini-calendar colored ORANGE like the toggle — small
+  surface tweak, applied; not really ledger-worthy on its own (folded into general "calendar keeps its
+  shape" observations already covered).
+
+## Section: inline-expand refinements + anchoring/rail/cascade recon (lines 3709-3945)
+Jac's 6-point note (msg 293) + Claude's response (msg 294-296) — ALL folded into the spec doc I
+already read (2026-07-20-list-views-inline-expand-design.md §1-§4) essentially verbatim:
+- Persistent History-search footer (spec §2) - DOCUMENTED
+- Swipe-smooth fixed-target expand animation (spec §1) - DOCUMENTED
+- Rentals de-paged to calendar-anchored single view, calendar itself never resizes (spec §3) -
+  DOCUMENTED
+- Transferable sessions / send-to-coworker open problem (spec "Open problems") - DOCUMENTED
+- Tall sections (Invoices) scroll internally (spec §2) - DOCUMENTED
+- Mobile gesture-tolerance fear -> resolved as focused full-screen mode reusing comms gestures (spec
+  §1) - DOCUMENTED
+- Anchoring/rail/cascade recon (msg 305, the deep code-grounded doc) -> folded into spec §4 nearly
+  verbatim (deferOrAnchor 220ms, anchorRecord, cascade.js FK-walk, tabStrip, pillTo, openInvoice special
+  case) - DOCUMENTED
+- Tabs-as-sessions (a tab = the whole 3-card cascade/filter/scroll context, not just one record) -
+  DOCUMENTED (spec §4)
+- Hover-jump / dwell-delay accelerator (msg 312): THREE explicit guards proposed — (1) ~300ms dwell
+  delay before chips appear (the "main fix" separating fast-open from deliberate-pick gestures),
+  (2) reserved lane / chips slide in from a dedicated edge zone, never under the name/primary body,
+  (3) desktop-only (no touch mis-tap risk). Bonus: chips can be "signal-forward" (colored by which
+  section is lit) turning hover into a triage glance, not just a shortcut. [PARTIALLY DOCUMENTED — spec
+  §2 hover-jump bullet covers the geometry/reserved-lane/desktop-only guards well, but the SPECIFIC
+  ~300ms DWELL-DELAY NUMBER and the "two gestures separated by time" framing is NOT in the spec (spec
+  only says "Instant, no dwell" for the FINAL shipped version — wait, let me double check: spec says
+  "Instant, no dwell. Mis-click-safe by geometry" — this literally CONTRADICTS the 300ms dwell-delay
+  proposal! Need to check later transcript for whether dwell was explicitly dropped in favor of
+  pure-geometry mis-click-safety. FLAG for verification in remaining read.]
+- Yard Journey becoming its own Units section (msg 309-310) - DOCUMENTED (spec §6, "chosen 2026-07-20")
+- Role-default landing severed correctly: field roles (driver/mech) land on Journey (doubles as their
+  Signal summary); office roles get generic rollup - DOCUMENTED (spec §6)
+- Funnel flagged as "concept loved, execution poor," to be rebuilt on locked components - DOCUMENTED
+  (spec §6)
+- KPI Rings -> left vertical rail tradeoff flagged OPEN/dangerous, to be measured not felt - DOCUMENTED
+  (spec §5, later superseded/resolved by the Dashboard-as-6th-card idea also in spec §5 "RESOLVED")
+
+## IMPORTANT DISCREPANCY TO VERIFY: hover-jump dwell timing
+Spec doc §2 says: "Instant, no dwell. Mis-click-safe by geometry" — but msg 312 (this section)
+proposed ~300ms dwell AS the main mis-click guard. These read as contradictory. Need to find where/if
+Jac or Claude walked back the dwell-delay to "instant + geometry-only" — search forward in remaining
+transcript (lines 3945-5295).
+
+## RESOLVED: hover-jump dwell discrepancy
+Confirmed NOT a discrepancy — full evolution, all now matching the spec doc:
+1. Jac (msg 321): "Drop the 300ms thing... let's see if we can solve without the pause" — power
+   users want chips instantly.
+2. Claude's geometry-only fix (msg 322): absolutely-positioned right-lane strip, zero layout shift,
+   never covers name/body; graceful degradation backstop (worst case = opens on the wrong-but-
+   adjacent section, never destructive); lit-sections-first keeps the strip short. [Reasoning/
+   narrative NOT in spec, but the resulting rule IS: spec §2 "Instant, no dwell. Mis-click-safe by
+   geometry"]
+3. Jac (msg 324): flagged that hovering the row for the strip conflicts with hovering individual
+   row elements for THEIR OWN tooltips.
+4. Claude's fix attempt (msg 325): trigger only from the summary-Signal zone, not the whole row —
+   REJECTED by Jac (msg 327): "aiming for a certain element is slower and more annoying than just
+   clicking."
+5. FINAL (msg 328-329, Jac-steered): popover emerges from BEHIND the card, above it, on WHOLE-ROW
+   hover (nothing to aim at) — off the click-path entirely, so element tooltips AND click-to-open
+   both stay intact. Refinements: emerges from the item's TOP EDGE with a small tail/notch (shows
+   ownership + keeps one contiguous hover zone so moving up into it doesn't dismiss it — solves the
+   classic hover-menu "dead gap" problem), one chip-line tall, flips to appear below near the list
+   top. [FULLY DOCUMENTED — spec §2 hover-jump bullets match this almost verbatim]
+
+## Section: Funnel redesign details + toggle/label locks (lines 4137-4247)
+- Funnel v1 built by subagent, reviewed, Jac: "I LOVE IT" but gave 5 corrections (msg 343), of which
+  only some made it into the terse spec §6 Funnel bullet ("keep toggle + dated funnel + next-actions
+  list + action log, rebuilt on locked components... Mock + review") — the SPECIFICS below are
+  NOT reflected in the current spec doc:
+  - **Icons instead of plain checkmarks** for stepper stage markers. [NOT in spec §6]
+  - **Real estate to the right of checkpoints should hold PER-CHECKPOINT ACTIONS** (not just a
+    generic list below). [NOT in spec §6]
+  - **Rename "Next Actions" -> "More Actions."** [NOT in spec §6 — spec still says "next-actions list"]
+  - **Inline action-adding, no popup** — the ONE tolerated exception is a small calendar+time popup
+    that appears just above whatever was clicked (for date/time entry specifically). [NOT in spec §6]
+  - Funnel must use **Jac's actual real funnel steps**, not invented ones (Rental: Lead -> Quoted ->
+    Reserved -> On Rent -> Member; Equipment Sales: Lead -> Quoted -> Demo -> Negotiation -> Won) —
+    these exact step names given to the rebuild agent. [NOT captured anywhere in the 4 docs]
+  - Current-stage marker made color-blind-safe THREE ways deliberately (not color alone): a diamond
+    glyph in the dot (vs check for done, empty for upcoming), a matte offset ring (no glow/blur), and
+    literal text "· now" — Jac didn't ask for this explicitly but praised it when he saw it applied.
+    [NOT captured in docs — a good concrete illustration of the "never colour alone" style.md rule
+    but the specific 3-way technique isn't written down anywhere as reusable guidance]
+  - Vertical (not horizontal) stepper chosen because a 5-stage horizontal dated track got cramped at
+    customer-section width — vertical scales without forcing sideways scroll. [NOT documented]
+  - Chip radius unified to ONE value (7px) for Signal/Gate/Stamp-box/Ref-square, resolving an
+    internal conflict where wrangler-style had listed Signal-radius 8 and Ref-radius 6 separately —
+    "the decision moves, not the rule" (style's one-chip-radius rule wins). [DOCUMENTED — current
+    wrangler-style §3 already says "radius 7 (the ONE chip radius — see note)" for Signal and
+    matches for Ref too, so this got folded in; good, no new capture needed, confirms consistency]
+- **"To Do" label locked** (msg 343.2/351.1): the Signal-summary tab is user-facing-labeled "To Do"
+  on section chips; "Signal" remains the internal/dev name only. [DOCUMENTED — spec §2]
+- **Toggle rule, FINAL, locked** (msg 343.4/351.4): every toggle's active segment = the FILLED Signal
+  chip of the selected option's status (colour=state); falls back to plain orange only when the
+  option carries no status. Explicitly stated to apply to "every toggle, funnels included" — later
+  generalized in wrangler-style to "every toggle, incl. funnel tabs and the yard/staff segmented
+  controls." [DOCUMENTED — wrangler-style §3 Door]
+- **Yellow dimming tension discovered and resolved with real math** (msg 344-347): dimming yellow by
+  DARKENING (lightness) shrinks its CVD separation from ORANGE; dimming by DESATURATING (softening)
+  shrinks its CVD separation from GREEN. `#ffe14d` was the "vivid corner" scoring 103 from both.
+  `#eed44b` is the dimmest point on the frontier that still holds ≥90 from BOTH (93 vs orange, 95 vs
+  green) — established as the honest ceiling / floor, "don't dim past it." [DOCUMENTED in wrangler-
+  style §1 forced-picks note — matches well, though the SPECIFIC discovery narrative (darken-hurts-
+  orange vs desaturate-hurts-green trade-off) is a nice piece of reasoning not spelled out, low
+  priority to add]
+- Housekeeping principle stated (msg 351): when a locked value changes (like the yellow), do NOT
+  hand-recolor every already-published mockup on the main thread — let each pick up the new value
+  next time it's naturally revised. [process habit, not really a design decision — skip]
+
+## Continue reading from line 4247 to end (5295).
+

--- a/docs/design/reference/detail-views.html
+++ b/docs/design/reference/detail-views.html
@@ -1,0 +1,270 @@
+<title>Detail views — built to the style skill</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --gray:#8b94a3;
+    --tan:#c2925a; --rivet:#4a525e; --rivetPit:#0b0f14;
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1180px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:84ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600}
+  .key{display:flex; flex-wrap:wrap; gap:6px 12px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+
+  .board{display:grid; grid-template-columns:repeat(auto-fit,minmax(330px,1fr)); gap:14px; margin-top:18px; align-items:start}
+
+  .panel{background:var(--panel); border:1px solid var(--line); border-radius:14px; overflow:visible}
+  .pcap{font-family:var(--stamp); font-size:9.5px; letter-spacing:.13em; text-transform:uppercase; color:var(--txt3); padding:9px 13px 0}
+  .ptitle{padding:1px 13px 11px; border-bottom:1px solid var(--line)}
+  .pt-name{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt); letter-spacing:-.01em; display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .pt-sub{font-size:11px; color:var(--txt3); margin-top:2px}
+  .stamps{display:flex; align-items:center; gap:7px; flex-wrap:wrap; margin-top:8px}
+  .contact{display:flex; align-items:center; gap:14px; flex-wrap:wrap; margin-top:9px}
+
+  /* ---------- yard rail (units) ---------- */
+  .rail{display:flex; align-items:center; gap:0; padding:9px 12px; border-bottom:1px solid var(--line); overflow-x:auto}
+  .rnode{font-family:var(--stamp); font-size:9px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap; display:inline-flex; align-items:center; gap:5px}
+  .rnode .dot{width:7px;height:7px;border-radius:50%;background:var(--gray)} .rnode.done .dot{background:var(--green)}
+  .rline{flex:1; min-width:14px; height:1px; background:var(--line); margin:0 6px}
+  .rnext{font-family:var(--stamp); font-size:9px; font-weight:700; text-transform:uppercase; color:var(--commit); border:1.4px dashed var(--commit); border-radius:6px; padding:2px 7px; white-space:nowrap}
+
+  /* ---------- plate grammar ---------- */
+  .plate{border-bottom:1px solid var(--line); border-left:3px solid transparent}
+  .plate:last-child{border-bottom:0}
+  .plate.bad{border-left-color:var(--red)} .plate.now{border-left-color:var(--yellow)} .plate.wait{border-left-color:var(--blue)} .plate.done{border-left-color:var(--green)} .plate.none{border-left-color:var(--gray)}
+  .phead{display:flex; align-items:center; gap:9px; min-height:36px; padding:6px 12px}
+  .plabel{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt); flex:none}
+  .psum{flex:1; min-width:0; font-size:11px; color:var(--txt2); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .chev{font-size:12px; color:var(--txt3); flex:none; display:inline-flex; align-items:center; width:12px; height:12px}
+  .chev svg{width:12px;height:12px} .chev.open{color:var(--accent)}
+
+  /* ---------- the five parts ---------- */
+  .ctl{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  /* Signal */
+  .sig{padding:0 8px; border-radius:8px}
+  .sig.f.red{background:var(--redStrong);color:#fdfdfd} .sig.o.red{color:var(--red);box-shadow:inset 0 0 0 1.3px var(--red)}
+  .sig.f.yellow{background:var(--yellow);color:#211a05} .sig.o.yellow{color:var(--yellow);box-shadow:inset 0 0 0 1.3px var(--yellow)}
+  .sig.f.blue{background:var(--blue);color:#0a1220} .sig.o.blue{color:var(--blue);box-shadow:inset 0 0 0 1.3px var(--blue)}
+  .sig.f.green{background:var(--green);color:#04140d} .sig.o.green{color:var(--green);box-shadow:inset 0 0 0 1.3px var(--green)}
+  .sig.o.grey{color:var(--gray);box-shadow:inset 0 0 0 1.3px var(--gray)}
+  /* Gate = Signal + leading chevron */
+  .gate{padding:0 8px 0 6px; border-radius:8px; gap:2px; cursor:pointer}
+  .gate .cv{display:inline-flex;align-items:center;justify-content:center;width:11px;height:11px} .gate .cv svg{width:11px;height:11px;display:block}
+  .gate.yellow{background:var(--yellow);color:#211a05} .gate.blue{background:var(--blue);color:#0a1220}
+  /* Stamp = plain fact */
+  .stamp{font-family:var(--stamp); font-size:10.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap}
+  .dot{color:var(--line); font-family:var(--stamp); font-size:10px} .stamp.more{color:var(--accent)}
+  /* Ref = parent icon + name */
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 8px 0 3px; border-radius:6px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:600; cursor:pointer; text-decoration:none; white-space:nowrap}
+  .ref .ty{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .ref .ty svg{width:11px;height:11px}
+  .ref small{color:var(--gray); font-family:var(--stamp); font-size:9px; font-weight:600}
+  /* Doors */
+  .door{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:10px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; cursor:pointer; border-radius:999px; padding:0 12px}
+  .door.save{background:var(--commit); color:#fdfdfd; border:0}
+  .door.add{background:transparent; color:var(--commit); border:1.4px dashed var(--commit); padding:0 10px}
+  .door.ghost{background:transparent; color:var(--txt2); border:1px solid var(--line)}
+  .door.gated{background:transparent; color:var(--txt3); border:1px solid var(--line); cursor:help; gap:5px}
+  .door .lk{opacity:.8}
+  /* contact = the number IS the link */
+  .clink{display:inline-flex; align-items:center; gap:6px; color:var(--txt); font-size:12.5px; text-decoration:none; font-family:var(--font)}
+  .clink svg{color:var(--accent); width:14px; height:14px} .clink .v{border-bottom:1.4px solid transparent} .clink:hover .v{border-bottom-color:var(--accent)}
+
+  /* segmented toggle */
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:7px; overflow:hidden}
+  .seg b{display:inline-flex;align-items:center;padding:0 9px;font-family:var(--stamp);font-size:9.5px;font-weight:800;letter-spacing:.03em;text-transform:uppercase;color:var(--txt3);border-right:1px solid var(--line)}
+  .seg b:last-child{border-right:0} .seg b.on{background:var(--accent);color:var(--onAcc)}
+
+  /* expanded body */
+  .pbody{padding:3px 12px 12px; background:var(--bg2); border-top:1px solid var(--line)}
+  .kv{display:flex; justify-content:space-between; gap:10px; padding:5px 0; border-bottom:1px solid var(--lineSoft); font-size:12px; align-items:center}
+  .kv:last-child{border-bottom:0}
+  .kv .k{font-family:var(--stamp); font-size:9.5px; letter-spacing:.05em; text-transform:uppercase; color:var(--txt3); flex:none}
+  .kv .v{color:var(--txt); text-align:right} .kv .v.ed{border-bottom:1px dashed var(--line)} .kv .v.lock{color:var(--txt3)}
+  .num{margin:9px 0 8px; padding:10px 11px; background:var(--card); border:1px solid var(--line); border-radius:9px}
+  .num .big{font-family:var(--font); font-size:22px; font-weight:800; letter-spacing:-.02em; color:var(--txt); line-height:1; font-variant-numeric:tabular-nums}
+  .num .big .roi{font-size:12px; color:var(--green); margin-left:8px} .num.owe .big{color:var(--red)}
+  .num .prov{font-size:10.5px; color:var(--txt3); margin-top:4px} .num .prov b{color:var(--txt)}
+  .prow{display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-top:9px}
+  .subrow{display:flex; align-items:center; gap:8px; padding:6px 0; border-bottom:1px solid var(--lineSoft); font-size:12px}
+  .subrow:last-child{border-bottom:0}
+  .subrow .sn{flex:1; min-width:0; color:var(--txt); font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .subrow .sn small{color:var(--gray); font-family:var(--stamp); font-size:9px; font-weight:600; margin-left:5px}
+  .subrow .amt{font-family:var(--font); font-size:11px; color:var(--txt); font-weight:700; font-variant-numeric:tabular-nums}
+  .kpis{display:grid; grid-template-columns:repeat(4,1fr); gap:1px; background:var(--line); border:1px solid var(--line); border-radius:8px; overflow:hidden; margin:9px 0}
+  .kpi{background:var(--card); padding:7px 8px}
+  .kpi .kl{font-family:var(--stamp); font-size:8px; letter-spacing:.06em; text-transform:uppercase; color:var(--txt3)}
+  .kpi .kn{font-family:var(--font); font-size:14px; font-weight:800; color:var(--txt); margin-top:1px; font-variant-numeric:tabular-nums} .kpi .kn.owe{color:var(--red)}
+  .cal{margin:9px 0; padding:8px; background:var(--card); border:1px solid var(--line); border-radius:9px}
+  .calh{font-family:var(--stamp); font-size:9px; letter-spacing:.06em; text-transform:uppercase; color:var(--txt3); margin-bottom:6px; display:flex; justify-content:space-between}
+  .calg{display:grid; grid-template-columns:repeat(7,1fr); gap:3px}
+  .calg i{font-style:normal; font-family:var(--font); font-size:9.5px; text-align:center; padding:4px 0; border-radius:3px; color:var(--txt3)}
+  .calg i.in{background:var(--accSoft); color:var(--txt)} .calg i.s{background:var(--accent); color:var(--onAcc); font-weight:800} .calg i.e{background:var(--accent); color:var(--onAcc); font-weight:800}
+  .ent{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 8px 0 3px; border-radius:6px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:700}
+  .ent .ty{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .ent .ty svg{width:11px;height:11px}
+  .htail{padding:9px 12px}
+  .h4{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt); margin-bottom:6px}
+  .hc{font-family:var(--stamp); font-size:9px; font-weight:700; text-transform:uppercase; color:var(--txt3); border:1px solid var(--line); border-radius:11px; padding:2px 7px; margin-right:5px; display:inline-block}
+
+  .tip{position:relative; display:inline-block}
+  .tip>.ctl{cursor:help}
+  .tip .bub{position:absolute; bottom:calc(100% + 8px); right:0; width:max-content; max-width:min(70vw,240px); background:#05070a; color:#eef2f7; border:1px solid #3a444e; border-radius:7px; padding:8px 10px; font-family:var(--font); font-size:11.5px; line-height:1.42; text-transform:none; letter-spacing:0; box-shadow:0 12px 30px rgba(0,0,0,.6); opacity:0; transform:translateY(4px); pointer-events:none; transition:opacity .12s, transform .12s; z-index:30}
+  .tip:hover .bub, .tip:focus-within .bub{opacity:1; transform:translateY(0)}
+  .tip .bub .t{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--accent); display:block; margin-bottom:3px}
+  .tip .bub .go{color:var(--commit); font-weight:700}
+
+  .foot{margin-top:24px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:86ch} .foot b{color:var(--txt)}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Three detail views · built to the style skill · matte, aligned, contrast-checked</p>
+  <h1>Detail views — <span class="hl">finished pass</span></h1>
+  <p class="lede">Same structure as before (nothing moved), now to the locked standard: <b>one control height, one baseline</b>; the mono-stamped labels + read-weight names you liked; <b>Signal · Gate · Stamp · Ref · Door</b>; muted blue &amp; deepened red for AA, the CVD-picked yellow (<code>#ffe14d</code>, well clear of orange), an orange calendar; dark ink on every fill; orange under 10%. No glow. The fonts &amp; hexes are <b>our</b> calls; the skill only enforced the numbers. Hover a Signal to see it name its source.</p>
+  <div class="key"><span><b>Signal</b> state chip</span><span><b>Gate</b> turnable</span><span><b>Stamp</b> fact</span><span><b>Ref</b> linked</span><span><b>Door</b> action</span><span>· fill = today · colour = state</span></div>
+
+  <div class="board">
+
+    <!-- ============ UNITS ============ -->
+    <div class="panel">
+      <div class="pcap">Unit detail</div>
+      <div class="ptitle"><div class="pt-name">Highrise <span class="ctl sig f red">field call</span></div><div class="pt-sub">Excavator · Skid Steer 75hp · S/N 4471-K</div></div>
+      <div class="rail">
+        <span class="rnode done"><span class="dot"></span>Reserved</span><span class="rline"></span>
+        <span class="rnode"><span class="dot"></span>On Rent</span>
+        <a class="ent" style="height:20px"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon</a>
+        <span class="rline"></span><span class="rnext">+ Log recovery</span>
+      </div>
+
+      <div class="plate bad"><div class="phead"><span class="plabel">Inspection</span><span class="psum">Failed · 2h ago</span>
+        <span class="tip"><span class="ctl sig f red" tabindex="0">failed</span><span class="bub"><span class="t">Blocks going out</span>Failed condition — can't leave the yard today. <span class="go">→ open the inspection</span></span></span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <div class="plate now"><div class="phead"><span class="plabel">Services</span><span class="psum">Wash due · +4 tasks</span>
+        <span class="ctl sig f yellow">wash now</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <div class="plate wait"><div class="phead"><span class="plabel">Work Orders</span><span class="psum">1 open · hyd seal</span>
+        <span class="tip"><span class="ctl sig f blue" tabindex="0">part on order</span><span class="bub"><span class="t">Waiting on vendor</span>Hydraulic seal on order, ETA Fri. Not your move. <span class="go">→ open WO #113</span></span></span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <div class="plate none"><div class="phead"><span class="plabel">Specs</span><span class="psum">2019 · 1,240 hrs</span>
+        <span class="ctl sig o grey">ok</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <div class="plate done"><div class="phead"><span class="plabel">GPS</span><span class="psum">Reporting · 4m ago</span>
+        <span class="ctl sig o green">reporting</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <!-- EXPANDED: Investment -->
+      <div class="plate done"><div class="phead"><span class="plabel">Investment</span><span class="psum">Owned 14 mo</span>
+        <span class="ctl sig o green">insured</span>
+        <span class="chev open"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span></div>
+        <div class="pbody">
+          <div class="prow"><span class="seg"><b class="on">Insured</b><b>Uninsured</b></span></div>
+          <div class="num"><div class="big">$4,210 <span class="roi">ROI 31%</span></div><div class="prov"><b>Profit</b> — revenue $18,400 − true cost $14,190 · derived</div></div>
+          <div class="kv"><span class="k">Purchase</span><span class="v ed">$13,900 · Mar '25</span></div>
+          <div class="kv"><span class="k">True cost</span><span class="v ed">$14,190</span></div>
+          <div class="kv"><span class="k">Premium</span><span class="v lock">•••• · office tier</span></div>
+          <div class="prow"><span class="tip"><span class="ctl door gated" tabindex="0">Sell <span class="lk">🔒</span></span><span class="bub"><span class="t">Money action · gated</span>Selling books a transaction — Office tier only. The door's here, the guard's on it.</span></span></div>
+        </div>
+      </div>
+
+      <div class="htail"><div class="h4">History</div><span class="hc">12 Inspections</span><span class="hc">3 WOs</span><span class="hc">5 Rentals</span><span class="hc">8 Washes</span></div>
+    </div>
+
+    <!-- ============ RENTALS ============ -->
+    <div class="panel">
+      <div class="pcap">Rental detail</div>
+      <div class="ptitle"><div class="pt-name">Duhon — Skid Steer 75hp</div><div class="pt-sub">6-Day · Jul 8 → Jul 14</div></div>
+
+      <div class="plate none"><div class="phead"><span class="plabel">Notes</span><span class="psum">Add a note…</span>
+        <span class="ctl sig o grey">none</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <!-- EXPANDED: Rental section -->
+      <div class="plate now"><div class="phead"><span class="plabel">Rental</span><span class="psum">Due back today</span>
+        <span class="ctl sig f yellow">end rent</span>
+        <span class="chev open"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span></div>
+        <div class="pbody">
+          <div class="prow" style="justify-content:space-between">
+            <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Duhon Contracting</a>
+            <span class="ctl gate yellow"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>end rent</span>
+          </div>
+          <div class="prow"><span class="ctl door add">+ PO</span><span class="stamp">protection off</span></div>
+          <div class="num owe"><div class="big">$560</div><div class="prov"><b>Balance owed</b> — paid $0 of $560 · invoice #4471</div></div>
+          <div class="cal"><div class="calh"><span>Rental window</span><span>Jul '25</span></div>
+            <div class="calg"><i>6</i><i>7</i><i class="s">8</i><i class="in">9</i><i class="in">10</i><i class="in">11</i><i class="in">12</i><i class="in">13</i><i class="e">14</i><i>15</i><i>16</i><i>17</i><i>18</i><i>19</i></div></div>
+          <div class="subrow"><span class="sn">Skid Steer 75hp <small>SS-12</small></span><span class="ctl sig f yellow">end rent</span><span class="amt">$85/day</span></div>
+          <div class="subrow"><span class="sn" style="color:var(--txt3)">+ Unit · or drag one on</span></div>
+        </div>
+      </div>
+
+      <div class="htail"><div class="h4">History</div><span class="hc">4 Payments</span><span class="hc">2 Edits</span></div>
+    </div>
+
+    <!-- ============ CUSTOMERS ============ -->
+    <div class="panel">
+      <div class="pcap">Customer detail</div>
+      <div class="ptitle">
+        <div class="pt-name">Boudreaux Marine LLC <span class="ctl sig f red">owed 16d</span></div>
+        <div class="stamps"><span class="stamp">Non-member</span><span class="dot">·</span><span class="stamp">Marine</span><span class="dot">·</span><span class="stamp">Net 15</span><span class="stamp more">+1</span></div>
+        <div class="contact">
+          <a class="clink"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z" transform="translate(-1 -1)"/></svg><span class="v">(337) 555-0142</span></a>
+          <a class="clink"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m2 7 10 6 10-6"/></svg><span class="v">marc@boudreaux…</span></a>
+        </div>
+      </div>
+
+      <div class="plate none"><div class="phead"><span class="plabel">Account</span><span class="psum">Boudreaux Marine · Cameron, LA</span>
+        <span class="ctl sig o grey">non-member</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <div class="plate now"><div class="phead"><span class="plabel">Funnel</span><span class="psum">Rental lead · call back due today</span>
+        <span class="ctl sig f yellow">follow up</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <!-- EXPANDED: Invoices -->
+      <div class="plate bad"><div class="phead"><span class="plabel">Invoices</span><span class="psum">1 overdue · 1 in flight</span>
+        <span class="ctl sig f red">owed 16d</span>
+        <span class="chev open"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span></div>
+        <div class="pbody">
+          <div class="prow"><span class="seg"><b class="on">Open</b><b>All</b><b>Transactions</b></span></div>
+          <div class="kpis"><div class="kpi"><div class="kl">Open</div><div class="kn owe">$1,400</div></div><div class="kpi"><div class="kl">Invoices</div><div class="kn">14</div></div><div class="kpi"><div class="kl">1yr avg</div><div class="kn">$1,240</div></div><div class="kpi"><div class="kl">Avg pay</div><div class="kn">12d</div></div></div>
+          <div class="subrow"><span class="sn">#4460 <small>Jun 28</small></span>
+            <span class="tip"><span class="ctl sig f red" tabindex="0">owed 16d</span><span class="bub"><span class="t">Overdue 16 days</span>Still today's problem until it clears. <span class="go">→ send reminder / charge on file</span></span></span>
+            <span class="amt">$840</span></div>
+          <div class="subrow"><span class="sn">#4471 <small>Jul 8</small></span>
+            <span class="tip"><span class="ctl sig f blue" tabindex="0">ACH</span><span class="bub"><span class="t">Payment in flight</span>Clears in 2–4 days — settles itself. <span class="go">→ open payment</span></span></span>
+            <span class="amt">$560</span></div>
+          <div class="subrow"><span class="sn" style="color:var(--txt3)">#4402 <small>paid · May 2</small></span><span class="ctl sig o green">paid</span><span class="amt" style="color:var(--txt3)">$320</span></div>
+          <div class="prow"><span class="ctl door add">+ Invoice</span></div>
+        </div>
+      </div>
+
+      <div class="plate done"><div class="phead"><span class="plabel">Activity</span><span class="psum">★★★★☆ · $1.2k/mo</span>
+        <span class="ctl sig o green">active</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <div class="plate now"><div class="phead"><span class="plabel">Payment</span><span class="psum">2 cards · 1 ACH</span>
+        <span class="ctl sig f yellow">re-sign</span>
+        <span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div></div>
+
+      <div class="htail"><div class="h4">History</div><span class="hc" style="border:0;padding-left:0;color:var(--txt2)">rentals + status log</span></div>
+    </div>
+
+  </div>
+
+  <div class="foot">
+    Everything from the interim work is now on the plate: the crew all sits at one height on one baseline, labels are stamped and names are read-weight, <b>owed / field-call</b> use the deepened red, <b>ACH / part-on-order</b> use the muted blue (dark ink, so they clear AA), facts dropped their pills to become <b>Stamps</b>, refs carry the <b>parent icon</b>, contact shows the <b>real number</b>, the gate chevron leads and hugs, and commit/create wear the deep action-blue while orange stays under 10% (icons, active toggle, gate mark). Matte — no glow. This is the three detail views, done to the <b>style</b> skill.
+  </div>
+
+</div></div>

--- a/docs/design/reference/funnel.html
+++ b/docs/design/reference/funnel.html
@@ -1,0 +1,1160 @@
+<title>Funnel — Section Redesign</title>
+<meta charset="utf-8">
+<style>
+/* ══════════════════════════════════════════════════════════════════════
+   TOKENS — locked steel palette (wrangler-style §1). Dark is default;
+   light overrides via prefers-color-scheme; :root[data-theme] wins both
+   directions because the attribute selector out-specifies a bare :root
+   inside a media query — no !important needed.
+   REV 3: --yellow dimmed to #eed44b in BOTH dark + light (locked in wrangler-style).
+   ══════════════════════════════════════════════════════════════════════ */
+:root{
+  --bg:#0a0d11; --panel:#171d25; --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#717b89;
+  --accent:#ff7e1f; --ink:#1a1205;
+  --green:#34d399; --yellow:#eed44b; --red:#ff4242; --red-fill:#d63636;
+  --blue:#6394cc; --gray:#8b94a3; --commit:#2f6fd0; --tan:#c2925a;
+
+  /* style skill numbers: one control height, two radii, the size ladder.
+     H=26px matches the app's own real precedent for this exact section
+     (addBtn/actionPill calls in the funnel code pass h:26). */
+  --h:26px;
+  --r-pill:999px;           /* actions (Door, segmented toggle) */
+  --r-chip:7px;             /* state (Signal / Gate / Ref square) — ONE chip value */
+  --fs-title:15px; --fs-body:13px; --fs-field:12px; --fs-chip:11px; --fs-small:10px; --fs-fine:9.5px;
+  --w-stamp:800; --w-bold:700; --w-reg:400;
+  --mono: ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+  --sans: -apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+}
+@media (prefers-color-scheme: light){
+  :root{
+    --bg:#e6e8ea; --panel:#fff; --card:#fff; --card-head:#eef0f2;
+    --line:#cfd6e1; --line-soft:#e1e6ec;
+    --txt:#141821; --txt-2:#414b5a; --txt-3:#69727f;
+    --accent:#cf6000; --ink:#1a1205;
+    --green:#0c8f5f; --yellow:#eed44b; --red:#d52a2a; --red-fill:#b5241f;
+    --blue:#2f5fb0; --gray:#566072; --commit:#1f56c0; --tan:#8a5a2b;
+  }
+}
+:root[data-theme="dark"]{
+  --bg:#0a0d11; --panel:#171d25; --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#717b89;
+  --accent:#ff7e1f; --ink:#1a1205;
+  --green:#34d399; --yellow:#eed44b; --red:#ff4242; --red-fill:#d63636;
+  --blue:#6394cc; --gray:#8b94a3; --commit:#2f6fd0; --tan:#c2925a;
+}
+:root[data-theme="light"]{
+  --bg:#e6e8ea; --panel:#fff; --card:#fff; --card-head:#eef0f2;
+  --line:#cfd6e1; --line-soft:#e1e6ec;
+  --txt:#141821; --txt-2:#414b5a; --txt-3:#69727f;
+  --accent:#cf6000; --ink:#1a1205;
+  --green:#0c8f5f; --yellow:#eed44b; --red:#d52a2a; --red-fill:#b5241f;
+  --blue:#2f5fb0; --gray:#566072; --commit:#1f56c0; --tan:#8a5a2b;
+}
+
+*,*::before,*::after{ box-sizing:border-box; }
+body{ margin:0; background:var(--bg); color:var(--txt); font-family:var(--sans);
+  -webkit-font-smoothing:antialiased; }
+.num{ font-variant-numeric:tabular-nums; font-family:var(--mono); }
+button{ font-family:inherit; }
+
+.page{ max-width:1180px; margin:0 auto; padding:28px 20px 60px; }
+.page h1{ font-family:var(--sans); font-size:20px; font-weight:var(--w-bold); margin:0 0 6px; }
+.page > p{ font-size:var(--fs-body); color:var(--txt-2); max-width:76ch; line-height:1.5; margin:0 0 22px; }
+
+.legend{ display:flex; flex-wrap:wrap; gap:6px 18px; align-items:center; margin-bottom:26px;
+  font-family:var(--mono); font-size:var(--fs-small); color:var(--txt-3); letter-spacing:.03em; }
+.legend b{ color:var(--txt-2); font-weight:var(--w-reg); }
+.legend .lg-dot{ display:inline-block; width:9px; height:9px; border-radius:50%; margin-right:5px; vertical-align:-1px; }
+.legend .lg-dmd{ display:inline-block; width:7px; height:7px; background:var(--txt-3); transform:rotate(45deg); margin-right:5px; vertical-align:-1px; }
+
+.compare{ display:flex; flex-wrap:wrap; gap:26px; align-items:flex-start; }
+.customer-shell{ flex:1 1 480px; max-width:600px; min-width:0; }
+
+/* ── faux customer-item chrome (context only — NOT part of the redesign) ── */
+.cust-strip{ display:flex; align-items:baseline; gap:10px; padding:0 2px 8px; border-bottom:1px dashed var(--line); margin-bottom:10px; }
+.cust-name{ font-family:var(--sans); font-weight:var(--w-bold); font-size:var(--fs-title); color:var(--txt); }
+.cust-meta{ font-size:var(--fs-field); color:var(--txt-3); font-family:var(--mono); }
+.cust-chev{ margin-left:auto; font-size:var(--fs-fine); color:var(--txt-3); font-family:var(--mono); }
+.cust-collapsed-note{ font-size:var(--fs-fine); color:var(--txt-3); opacity:.7; margin:-2px 2px 14px; }
+.panel-tag{ display:block; font-family:var(--mono); font-size:var(--fs-fine); font-weight:var(--w-stamp);
+  letter-spacing:.06em; text-transform:uppercase; color:var(--tan); margin-bottom:8px; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   THE FUNNEL SECTION — plate grammar.
+   ══════════════════════════════════════════════════════════════════════ */
+.funnel-mock{ background:var(--card); border:1px solid var(--line); border-radius:10px; overflow:visible; }
+
+.fx-plate{ display:flex; align-items:center; gap:10px; min-height:calc(var(--h) + 14px); padding:0 14px 0 0;
+  background:var(--card-head); border-bottom:1px solid var(--line); border-radius:10px 10px 0 0; position:relative; }
+.fx-bar{ position:absolute; left:0; top:0; bottom:0; width:4px; background:var(--bar,var(--gray)); border-radius:10px 0 0 0; }
+.fx-label{ font-family:var(--mono); font-weight:var(--w-stamp); font-size:var(--fs-chip); letter-spacing:.06em;
+  text-transform:uppercase; color:var(--txt); padding-left:16px; white-space:nowrap; }
+.fx-sum{ font-size:var(--fs-field); color:var(--txt-2); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.fx-sum b{ color:var(--txt); font-weight:var(--w-bold); }
+
+/* ── segmented toggle — REV 2 rule: active segment = filled Signal of that
+   option's OWN status (colour=state); today-urgency → yellow; no status → orange
+   fallback. Inactive tabs keep a small dot carrying their own urgency instead. ── */
+.fx-seg{ display:flex; gap:6px; padding:12px 14px 4px; }
+.fx-tab{ display:inline-flex; align-items:center; gap:7px; height:var(--h); padding:0 13px;
+  border-radius:var(--r-pill); border:1px solid var(--line); background:transparent; color:var(--txt-2);
+  font-family:var(--mono); font-weight:var(--w-stamp); font-size:var(--fs-chip); letter-spacing:.04em;
+  text-transform:uppercase; cursor:pointer; line-height:1; transition:background .12s ease,color .12s ease,border-color .12s ease; }
+.fx-tab:hover{ border-color:var(--txt-3); }
+.fx-tab .tone-suffix{ display:none; }
+.fx-tab.is-active{ background:var(--accent); border-color:var(--accent); color:var(--ink); }
+.fx-tab.is-active[data-tone="today"]{ background:var(--yellow); border-color:var(--yellow); }
+.fx-tab.is-active[data-tone="today"] .tone-suffix{ display:inline; opacity:.7; font-weight:var(--w-reg); margin-left:1px; }
+.fx-dot{ width:7px; height:7px; border-radius:50%; flex:0 0 auto; border:1.5px solid var(--line); background:transparent; }
+.fx-tab:not(.is-active)[data-tone="today"] .fx-dot{ background:var(--yellow); border-color:var(--yellow); }
+.fx-tab.is-active .fx-dot{ display:none; }   /* the whole chip's fill already carries the state — no redundant dot */
+
+.fx-body{ padding:6px 14px 14px; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   STEPPER — vertical dated progression, REAL FUNNELS stage sets
+   (config.js FUNNELS): rental ['Lead','Reserved','Rented'], member
+   ['Lead','Contacted','Not A No!','Payment Discussed','Signed'],
+   equipment ['Lead','Contacted','Not A No!','Payment Discussed','Paid'].
+   ══════════════════════════════════════════════════════════════════════ */
+.fx-block-h{ font-family:var(--mono); font-weight:var(--w-stamp); font-size:var(--fs-fine); letter-spacing:.08em;
+  text-transform:uppercase; color:var(--txt-3); margin:16px 0 8px; display:flex; align-items:center; gap:8px; }
+.fx-block:first-of-type .fx-block-h{ margin-top:10px; }
+.fx-block-h .sub{ font-weight:var(--w-reg); text-transform:none; letter-spacing:0; color:var(--txt-3); opacity:.8; }
+
+.fx-stepper{ list-style:none; margin:0; padding:0; }
+.stage{ display:flex; gap:12px; }
+.stage-rail{ display:flex; flex-direction:column; align-items:center; width:26px; flex:0 0 auto; }
+.stage-dot{ position:relative; width:24px; height:24px; border-radius:50%; display:flex; align-items:center; justify-content:center;
+  flex:0 0 auto; background:transparent; border:2px solid var(--line); color:var(--txt-3); }
+.stage-dot svg{ width:13px; height:13px; }
+.stage-badge{ position:absolute; right:-2px; bottom:-2px; width:10px; height:10px; border:1.5px solid var(--card); }
+.stage-badge.badge-check{ border-radius:50%; background:var(--card); color:var(--green); display:flex; align-items:center; justify-content:center; }
+.stage-badge.badge-check svg{ width:6px; height:6px; }
+.stage-badge.badge-now{ border-radius:0; background:var(--txt); transform:rotate(45deg); }
+.stage-line{ width:2px; flex:1 1 auto; min-height:22px; background:var(--line); margin:2px 0; }
+.stage:last-child .stage-line{ display:none; }
+.stage-body{ display:flex; align-items:center; gap:10px; flex:1 1 auto; min-width:0; padding-bottom:22px; flex-wrap:wrap; }
+.stage:last-child .stage-body{ padding-bottom:2px; }
+.stage-info{ display:flex; align-items:center; gap:8px; flex:0 0 auto; }
+
+/* done — colour=state green, dark ink, steady (no motion), own meaningful icon + circular ✓ badge */
+.stage.is-done .stage-dot{ background:var(--green); border-color:var(--green); color:var(--ink); }
+.stage.is-done .stage-line{ background:var(--green); }
+
+/* current — "you are here": MORE than colour — own icon on a blue fill, a
+   solid 0-blur ring OFFSET from the fill (matte, no glow), a DIAMOND badge
+   (shape, not colour), AND the literal word "· now" in the chip text. */
+.stage.is-current .stage-dot{ background:var(--blue); border-color:var(--blue); color:var(--ink);
+  outline:2px solid var(--txt); outline-offset:2px; }
+
+.stage.is-upcoming .stage-dot{ border-color:var(--line); color:var(--txt-3); }
+
+.stage-name{ display:inline-flex; align-items:center; gap:3px; height:var(--h); padding:0 10px;
+  border-radius:var(--r-chip); font-family:var(--mono); font-weight:var(--w-stamp); font-size:var(--fs-chip);
+  letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; }
+.stage.is-done .stage-name{ background:var(--green); color:var(--ink); }
+.stage.is-current .stage-name{ background:var(--blue); color:var(--ink); cursor:pointer; border:none; }
+.stage.is-current .stage-name svg{ width:9px; height:9px; margin-right:1px; } /* leading chevron hugs text, ≤2px gap */
+.stage.is-current .stage-name .now{ opacity:.75; font-weight:var(--w-reg); margin-left:2px; }
+.stage.is-upcoming .stage-name{ color:var(--txt-3); background:none; padding:0 10px 0 0; }
+
+.stage-date{ font-family:var(--mono); font-size:var(--fs-small); color:var(--txt-3); white-space:nowrap;
+  font-variant-numeric:tabular-nums; flex:0 0 auto; }
+.stage.is-upcoming .stage-date{ opacity:.6; }
+
+/* ── per-checkpoint action zone — sits to the RIGHT of every stage row ── */
+.stage-action{ display:flex; align-items:center; gap:7px; margin-left:auto; min-width:0; flex:1 1 160px; justify-content:flex-end; }
+.stage-atxt{ font-size:var(--fs-field); color:var(--txt-2); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; }
+.stage-action .inline-add{ flex:1 1 auto; justify-content:flex-end; }
+
+/* the Gate status-picker popover — opens on the current stage chip */
+.gate-pop{ display:none; margin:8px 0 4px 34px; border:1px solid var(--line); border-radius:8px; background:var(--panel);
+  padding:9px 10px; max-width:260px; }
+.gate-pop.open{ display:block; }
+.gate-pop-h{ font-family:var(--mono); font-size:var(--fs-fine); font-weight:var(--w-stamp); letter-spacing:.06em;
+  text-transform:uppercase; color:var(--txt-3); margin-bottom:6px; }
+.gate-pop-row{ display:flex; align-items:center; gap:8px; width:100%; height:var(--h); padding:0 8px; border:none;
+  background:none; border-radius:6px; color:var(--txt-2); font-family:var(--sans); font-size:var(--fs-field);
+  cursor:pointer; text-align:left; }
+.gate-pop-row:hover{ background:var(--line-soft); color:var(--txt); }
+.gate-pop-row svg{ width:12px; height:12px; flex:0 0 auto; color:var(--txt-3); }
+.gate-pop-note{ display:flex; align-items:flex-start; gap:7px; font-size:var(--fs-field); color:var(--txt-3); line-height:1.4; padding:2px 2px; }
+.gate-pop-note svg{ width:13px; height:13px; flex:0 0 auto; margin-top:1px; color:var(--txt-3); }
+
+/* ══════════════════════════════════════════════════════════════════════
+   Doors, Signal, Stamp, Ref — shared inline vocabulary
+   ══════════════════════════════════════════════════════════════════════ */
+.signal{ display:inline-flex; align-items:center; height:var(--h); padding:0 9px; border-radius:var(--r-chip);
+  font-family:var(--mono); font-weight:var(--w-stamp); font-size:var(--fs-chip); letter-spacing:.04em;
+  text-transform:uppercase; white-space:nowrap; background:var(--sc,var(--gray)); color:var(--ink); flex:0 0 auto; }
+.stamp{ font-family:var(--mono); font-size:var(--fs-chip); letter-spacing:.02em; color:var(--txt-3);
+  white-space:nowrap; height:var(--h); display:inline-flex; align-items:center; flex:0 0 auto; }
+
+.door{ display:inline-flex; align-items:center; justify-content:center; height:var(--h); padding:0 14px;
+  border-radius:var(--r-pill); font-family:var(--sans); font-weight:var(--w-bold); font-size:var(--fs-field);
+  cursor:pointer; white-space:nowrap; border:1px solid transparent; flex:0 0 auto; }
+.door.sm{ padding:0 10px; font-size:var(--fs-chip); }
+.door-commit{ background:var(--commit); color:#eef2f7; }
+.door-commit:hover{ filter:brightness(1.08); }
+.door-ghost{ background:transparent; border-color:var(--line); color:var(--txt-2); }
+.door-ghost:hover{ border-color:var(--txt-3); color:var(--txt); }
+
+.fx-stamps{ display:flex; flex-wrap:wrap; gap:6px 16px; align-items:center; }
+.fx-stamps .stamp{ height:auto; }
+
+.ref{ display:inline-flex; align-items:center; gap:6px; height:var(--h); padding:0 10px 0 0; border-radius:var(--r-chip);
+  cursor:pointer; }
+.ref-ic{ width:var(--h); height:var(--h); border-radius:var(--r-chip); background:color-mix(in srgb, var(--accent) 16%, transparent);
+  display:flex; align-items:center; justify-content:center; flex:0 0 auto; }
+.ref-ic svg{ width:13px; height:13px; color:var(--accent); }
+.ref-name{ font-family:var(--sans); font-weight:var(--w-bold); font-size:var(--fs-field); color:var(--txt); }
+
+/* ── More Actions (renamed from Next Actions — per-checkpoint actions now
+   live inline on the stepper; this list is the account-level OVERFLOW,
+   i.e. items not tied to any single funnel stage) ── */
+.fx-todo{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
+.todo-row{ display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+.todo-text{ flex:1 1 auto; font-size:var(--fs-body); color:var(--txt); min-width:0; }
+.todo-row.is-quiet .todo-text{ color:var(--txt-2); }
+.todo-add-row{ display:flex; }
+
+/* ── inline add — NO modal. Clicking "+ Action" expands a row in place;
+   the ONE tolerable popup is the calendar+time picker, anchored above the click. ── */
+.inline-add{ display:flex; align-items:center; gap:6px; flex-wrap:wrap; width:100%; }
+.inline-add[hidden]{ display:none; }   /* author display:flex above otherwise beats the UA [hidden] rule */
+.inline-in{ height:var(--h); flex:1 1 150px; min-width:100px; border:1px solid var(--line); border-radius:7px;
+  background:var(--panel); color:var(--txt); padding:0 10px; font:inherit; font-size:var(--fs-field); }
+.inline-in::placeholder{ color:var(--txt-3); }
+.inline-in:focus{ outline:none; border-color:var(--accent); }
+.dt-trigger{ height:var(--h); padding:0 10px; border-radius:var(--r-pill); border:1px dashed var(--line);
+  background:transparent; color:var(--txt-3); font-size:var(--fs-small); font-family:var(--mono); cursor:pointer;
+  white-space:nowrap; flex:0 0 auto; }
+.dt-trigger:hover{ border-color:var(--txt-3); color:var(--txt-2); }
+.dt-trigger.is-set{ border-style:solid; color:var(--txt-2); border-color:var(--txt-3); }
+
+/* ── the ONE tolerable popup — calendar + time, anchored ABOVE the click ── */
+.cal-pop{ position:fixed; z-index:9999; width:220px; background:var(--panel); border:1px solid var(--line);
+  border-radius:10px; padding:10px; display:none; }
+.cal-pop.open{ display:block; }
+.cal-hd{ display:flex; align-items:center; justify-content:space-between; margin-bottom:8px; }
+.cal-month{ font-family:var(--mono); font-weight:var(--w-stamp); font-size:var(--fs-chip); letter-spacing:.04em;
+  text-transform:uppercase; color:var(--txt); }
+.cal-nav{ width:22px; height:22px; border-radius:6px; border:1px solid var(--line); background:transparent;
+  color:var(--txt-2); cursor:pointer; display:inline-flex; align-items:center; justify-content:center; font-size:12px; line-height:1; }
+.cal-nav:hover{ border-color:var(--txt-3); color:var(--txt); }
+.cal-dow{ display:grid; grid-template-columns:repeat(7,1fr); gap:2px; margin-bottom:3px; }
+.cal-dow span{ font-family:var(--mono); font-size:8.5px; color:var(--txt-3); text-align:center; letter-spacing:.02em; }
+.cal-grid{ display:grid; grid-template-columns:repeat(7,1fr); gap:2px; }
+.cal-day{ height:26px; border-radius:6px; border:1px solid transparent; background:transparent; color:var(--txt-2);
+  font-size:var(--fs-small); font-family:var(--mono); cursor:pointer; display:flex; align-items:center; justify-content:center; }
+.cal-day:hover{ border-color:var(--line); }
+.cal-day.is-today{ border-color:var(--txt-3); color:var(--txt); }
+.cal-day.is-sel{ background:var(--blue); color:var(--ink); font-weight:var(--w-bold); }
+.cal-day.is-blank{ visibility:hidden; }
+.cal-time-row{ display:flex; align-items:center; gap:6px; margin-top:9px; }
+.cal-time{ flex:1 1 auto; height:26px; border:1px solid var(--line); border-radius:7px; background:var(--bg);
+  color:var(--txt); padding:0 8px; font:inherit; font-size:var(--fs-field); }
+
+/* ── Action log — compact, dated, scrollable ── */
+.fx-log{ list-style:none; margin:0; padding:0; max-height:172px; overflow-y:auto; display:flex; flex-direction:column;
+  border-top:1px solid var(--line-soft); }
+.fx-log li{ display:flex; gap:10px; padding:7px 2px; border-bottom:1px solid var(--line-soft); align-items:baseline; }
+.fx-log li:last-child{ border-bottom:none; }
+.log-ts{ font-family:var(--mono); font-size:var(--fs-small); color:var(--txt-3); flex:0 0 auto;
+  font-variant-numeric:tabular-nums; }
+.log-txt{ font-size:var(--fs-field); color:var(--txt-2); }
+
+/* reviewer-notes box — annotation only, not part of the shipped component */
+.notes{ margin-top:30px; border:1px dashed var(--line); border-radius:10px; padding:16px 18px; max-width:920px; }
+.notes h2{ font-family:var(--mono); font-size:var(--fs-chip); font-weight:var(--w-stamp); letter-spacing:.06em;
+  text-transform:uppercase; color:var(--txt-3); margin:0 0 10px; }
+.notes ul{ margin:0; padding-left:18px; }
+.notes li{ font-size:var(--fs-field); color:var(--txt-2); line-height:1.65; margin-bottom:4px; }
+.notes b{ color:var(--txt); }
+.notes code{ font-family:var(--mono); font-size:0.92em; background:var(--line-soft); padding:1px 4px; border-radius:4px; }
+
+@media (max-width:520px){
+  .fx-plate{ flex-wrap:wrap; min-height:auto; padding:8px 12px; gap:4px; }
+  .fx-sum{ white-space:normal; }
+  .stage-action{ flex-basis:100%; justify-content:flex-start; margin-left:36px; }
+}
+</style>
+
+<div class="page">
+  <h1>Funnel — section redesign (rev 2)</h1>
+  <p>Rebuilt on the app's <b>real</b> funnel stages (<code>config.js</code> <code>FUNNELS</code> —
+  Rental <code>Lead → Reserved → Rented</code>, its Member-Lead continuation
+  <code>Lead → Contacted → Not A No! → Payment Discussed → Signed</code>, and Equipment
+  <code>Lead → Contacted → Not A No! → Payment Discussed → Paid</code>). Each checkpoint carries
+  its own meaningful icon, and the space to the right of every checkpoint is that checkpoint's
+  own action. <b>More Actions</b> below is the overflow — items not tied to a single stage.
+  Adding an action is fully inline; the only popup is a small calendar + time picker anchored
+  above wherever you clicked.</p>
+
+  <div class="legend">
+    <span><i class="lg-dot" style="background:var(--green)"></i><b>done</b> — filled icon + circular ✓ badge</span>
+    <span><i class="lg-dot" style="background:var(--blue)"></i><b>current</b> — filled icon + ring + <i class="lg-dmd"></i> badge + "· now" (never colour alone)</span>
+    <span><i class="lg-dot" style="border:1.5px solid var(--line)"></i><b>upcoming</b> — outline icon only, muted</span>
+    <span><i class="lg-dot" style="background:var(--yellow)"></i><b>today</b> — filled Signal / active-tab tone</span>
+  </div>
+
+  <div class="compare">
+
+    <!-- ═══════════════ PANEL A — Rental tab active by default ═══════════════ -->
+    <div class="customer-shell">
+      <div class="cust-strip">
+        <span class="cust-name">Bayou Marine Fabrication LLC</span>
+        <span class="cust-meta">Acct #10482 · Commercial</span>
+        <span class="cust-chev">⌄ expanded</span>
+      </div>
+      <div class="cust-collapsed-note">Contact · Billing · Units — collapsed above/below</div>
+
+      <section class="funnel-mock" data-mock>
+        <header class="fx-plate" style="--bar:var(--yellow)">
+          <span class="fx-bar"></span>
+          <span class="fx-label">Funnel</span>
+          <span class="fx-sum">Rental · Rented — Member: Payment Discussed — next: mid-rental check-in <b>today</b></span>
+        </header>
+
+        <div class="fx-seg" role="tablist">
+          <button class="fx-tab is-active" data-tab="rental" data-tone="today" aria-selected="true" role="tab">Rental<span class="tone-suffix">· today</span><i class="fx-dot"></i></button>
+          <button class="fx-tab" data-tab="equipment" data-tone="neutral" aria-selected="false" role="tab">Equipment Sales<i class="fx-dot"></i></button>
+        </div>
+
+        <!-- ── RENTAL TAB BODY ── -->
+        <div class="fx-body" data-panel="rental" role="tabpanel">
+          <div class="fx-block-h">Rental</div>
+          <ol class="fx-stepper">
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v8M8.5 11.5 12 15l3.5-3.5"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Lead</span><span class="stage-date num">Jun 24</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18M8 2v4M16 2v4"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Reserved</span><span class="stage-date num">Jul 02</span></span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Confirm delivery time window</span>
+                  <span class="stamp">in 2d</span>
+                  <button class="door door-commit sm">Edit</button>
+                </span>
+              </span></li>
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="7" r="4"/><path d="M5 21v-1a7 7 0 0 1 14 0v1"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Rented</span><span class="stage-date num">Jul 15</span></span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Mid-rental check-in call</span>
+                  <span class="signal" style="--sc:var(--yellow)">Today</span>
+                  <button class="door door-commit sm">Log</button>
+                </span>
+              </span></li>
+          </ol>
+
+          <div class="fx-block-h">Member <span class="sub">— extends Rental (ticked)</span></div>
+          <ol class="fx-stepper">
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v8M8.5 11.5 12 15l3.5-3.5"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Lead</span><span class="stage-date num">Jul 05</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3-8.6A2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1.9.4 1.8.7 2.7a2 2 0 0 1-.4 2.1L8.1 9.9a16 16 0 0 0 6 6l1.4-1.4a2 2 0 0 1 2.1-.4c.9.3 1.8.6 2.7.7a2 2 0 0 1 1.7 2z"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Contacted</span><span class="stage-date num">Jul 08</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h3zM7 11l4-7a2 2 0 0 1 3 1.5V9h5a2 2 0 0 1 2 2.3l-1.2 7A2 2 0 0 1 20.6 20H7"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Not A No!</span><span class="stage-date num">Jul 12</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+
+            <li class="stage is-current"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><circle cx="12" cy="12" r="2.5"/><path d="M6 12h.01M18 12h.01"/></svg><span class="stage-badge badge-now"></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info">
+                  <span class="stage-name js-gate" data-gate="a"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M9 6l6 6-6 6"/></svg>Payment Discussed<span class="now">· now</span></span>
+                  <span class="stage-date num">Jul 18</span>
+                </span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Send membership agreement link</span>
+                  <span class="stamp">in 1d</span>
+                  <button class="door door-commit sm">Send</button>
+                </span>
+              </span></li>
+            <div class="gate-pop" data-gate-pop="a">
+              <div class="gate-pop-h">Advance funnel</div>
+              <div class="gate-pop-note"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>"Signed" auto-locks when the membership agreement is signed — not a manual pick.</div>
+            </div>
+
+            <li class="stage is-upcoming"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8.5 12.5l2.5 2.5 4.5-5"/></svg></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Signed</span><span class="stage-date num">—</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+          </ol>
+
+          <div class="fx-block">
+            <div class="fx-block-h">More actions</div>
+            <ul class="fx-todo">
+              <li class="todo-row"><span class="todo-text">Update contact — new job-site address</span>
+                <span class="stamp">in 5d</span>
+                <button class="door door-commit sm">Update</button></li>
+              <li class="todo-row is-quiet"><span class="todo-text">Add to spring promo mailing list</span>
+                <span class="stamp">—</span>
+                <button class="door door-ghost sm">Dismiss</button></li>
+              <li class="todo-row todo-add-row">
+                <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                <div class="inline-add" hidden data-list="1">
+                  <input class="inline-in" placeholder="What's the next step?">
+                  <button class="dt-trigger js-dt-trigger">Set date</button>
+                  <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                  <button class="door door-commit sm js-inline-save">Save</button>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Membership / meta</div>
+            <div class="fx-stamps">
+              <span class="stamp">Lead age · <span class="num">26d</span></span>
+              <span class="stamp">Source · Referral</span>
+              <span class="stamp">Rep · J. Broussard</span>
+              <span class="ref"><span class="ref-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 8 12 3 3 8l9 5 9-5Z"/><path d="M3 8v8l9 5 9-5V8"/><path d="M12 13v8"/></svg></span><span class="ref-name">Skid Steer S650</span></span>
+            </div>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Action log</div>
+            <ol class="fx-log">
+              <li><span class="log-ts num">07/18 9:10a</span><span class="log-txt">Membership stage → Payment Discussed</span></li>
+              <li><span class="log-ts num">07/15 8:47a</span><span class="log-txt">Rented — delivery completed</span></li>
+              <li><span class="log-ts num">07/12 3:20p</span><span class="log-txt">Membership stage → Not A No!</span></li>
+              <li><span class="log-ts num">07/12 2:15p</span><span class="log-txt">Deposit received ($350)</span></li>
+              <li><span class="log-ts num">07/08 11:00a</span><span class="log-txt">Membership stage → Contacted</span></li>
+              <li><span class="log-ts num">07/05 10:00a</span><span class="log-txt">Member Lead ticked on</span></li>
+              <li><span class="log-ts num">07/02 11:30a</span><span class="log-txt">Reserved — 42&quot; skid steer, 2wk</span></li>
+              <li><span class="log-ts num">06/24 9:00a</span><span class="log-txt">Lead created — inbound call</span></li>
+            </ol>
+          </div>
+        </div>
+
+        <!-- ── EQUIPMENT TAB BODY ── -->
+        <div class="fx-body" data-panel="equipment" role="tabpanel" hidden>
+          <div class="fx-block-h">Equipment</div>
+          <ol class="fx-stepper">
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v8M8.5 11.5 12 15l3.5-3.5"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Lead</span><span class="stage-date num">Jun 10</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3-8.6A2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1.9.4 1.8.7 2.7a2 2 0 0 1-.4 2.1L8.1 9.9a16 16 0 0 0 6 6l1.4-1.4a2 2 0 0 1 2.1-.4c.9.3 1.8.6 2.7.7a2 2 0 0 1 1.7 2z"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Contacted</span><span class="stage-date num">Jun 14</span></span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Follow up after demo — gauge interest</span>
+                  <span class="stamp">in 1d</span>
+                  <button class="door door-commit sm">Log call</button>
+                </span>
+              </span></li>
+
+            <li class="stage is-current"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h3zM7 11l4-7a2 2 0 0 1 3 1.5V9h5a2 2 0 0 1 2 2.3l-1.2 7A2 2 0 0 1 20.6 20H7"/></svg><span class="stage-badge badge-now"></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info">
+                  <span class="stage-name js-gate" data-gate="b"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M9 6l6 6-6 6"/></svg>Not A No!<span class="now">· now</span></span>
+                  <span class="stage-date num">Jul 17</span>
+                </span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Confirm decision-maker sign-off</span>
+                  <span class="stamp">in 3d</span>
+                  <button class="door door-commit sm">Log call</button>
+                </span>
+              </span></li>
+            <div class="gate-pop" data-gate-pop="b">
+              <div class="gate-pop-h">Advance funnel</div>
+              <button class="gate-pop-row js-gate-close"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M9 6l6 6-6 6"/></svg>Mark as Payment Discussed</button>
+            </div>
+
+            <li class="stage is-upcoming"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><circle cx="12" cy="12" r="2.5"/><path d="M6 12h.01M18 12h.01"/></svg></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Payment Discussed</span><span class="stage-date num">—</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+
+            <li class="stage is-upcoming"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 21h8M12 17v4M7 4h10v4a5 5 0 0 1-10 0zM7 5H4v2a3 3 0 0 0 3 3M17 5h3v2a3 3 0 0 1-3 3"/></svg></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Paid</span><span class="stage-date num">—</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+          </ol>
+
+          <div class="fx-block">
+            <div class="fx-block-h">More actions</div>
+            <ul class="fx-todo">
+              <li class="todo-row"><span class="todo-text">Verify tax-exempt certificate on file</span>
+                <span class="stamp">in 3d</span>
+                <button class="door door-commit sm">Verify</button></li>
+              <li class="todo-row todo-add-row">
+                <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                <div class="inline-add" hidden data-list="1">
+                  <input class="inline-in" placeholder="What's the next step?">
+                  <button class="dt-trigger js-dt-trigger">Set date</button>
+                  <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                  <button class="door door-commit sm js-inline-save">Save</button>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Membership / meta</div>
+            <div class="fx-stamps">
+              <span class="stamp">Lead age · <span class="num">40d</span></span>
+              <span class="stamp">Deal est. · <span class="num">$42,000</span></span>
+              <span class="stamp">Rep · T. Guidry</span>
+              <span class="ref"><span class="ref-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/></svg></span><span class="ref-name">Quote Q-10432</span></span>
+            </div>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Action log</div>
+            <ol class="fx-log">
+              <li><span class="log-ts num">07/17 1:15p</span><span class="log-txt">Stage → Not A No!</span></li>
+              <li><span class="log-ts num">07/10 9:40a</span><span class="log-txt">Demo completed — positive feedback</span></li>
+              <li><span class="log-ts num">06/22 3:00p</span><span class="log-txt">On-site demo scheduled</span></li>
+              <li><span class="log-ts num">06/14 10:15a</span><span class="log-txt">Stage → Contacted</span></li>
+              <li><span class="log-ts num">06/10 8:30a</span><span class="log-txt">Lead created — trade show (LA Contractors Expo)</span></li>
+            </ol>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- ═══════════════ PANEL B — Equipment Sales tab active by default ═══════════════
+         Same customer/data as Panel A — only the DEFAULT active tab differs, to show
+         the toggle rule's other branch (orange/neutral, since Equipment has no today-item). -->
+    <div class="customer-shell">
+      <div class="cust-strip">
+        <span class="cust-name">Bayou Marine Fabrication LLC</span>
+        <span class="cust-meta">Acct #10482 · Commercial</span>
+        <span class="cust-chev">⌄ expanded</span>
+      </div>
+      <div class="cust-collapsed-note">Contact · Billing · Units — collapsed above/below</div>
+
+      <section class="funnel-mock" data-mock>
+        <header class="fx-plate" style="--bar:var(--gray)">
+          <span class="fx-bar"></span>
+          <span class="fx-label">Funnel</span>
+          <span class="fx-sum">Equipment Sales · Not A No! — next: confirm sign-off <b>in 3d</b></span>
+        </header>
+
+        <div class="fx-seg" role="tablist">
+          <button class="fx-tab" data-tab="rental" data-tone="today" aria-selected="false" role="tab">Rental<span class="tone-suffix">· today</span><i class="fx-dot"></i></button>
+          <button class="fx-tab is-active" data-tab="equipment" data-tone="neutral" aria-selected="true" role="tab">Equipment Sales<i class="fx-dot"></i></button>
+        </div>
+
+        <div class="fx-body" data-panel="rental" role="tabpanel" hidden>
+          <div class="fx-block-h">Rental</div>
+          <ol class="fx-stepper">
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v8M8.5 11.5 12 15l3.5-3.5"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Lead</span><span class="stage-date num">Jun 24</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18M8 2v4M16 2v4"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Reserved</span><span class="stage-date num">Jul 02</span></span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Confirm delivery time window</span>
+                  <span class="stamp">in 2d</span>
+                  <button class="door door-commit sm">Edit</button>
+                </span>
+              </span></li>
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="7" r="4"/><path d="M5 21v-1a7 7 0 0 1 14 0v1"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Rented</span><span class="stage-date num">Jul 15</span></span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Mid-rental check-in call</span>
+                  <span class="signal" style="--sc:var(--yellow)">Today</span>
+                  <button class="door door-commit sm">Log</button>
+                </span>
+              </span></li>
+          </ol>
+
+          <div class="fx-block-h">Member <span class="sub">— extends Rental (ticked)</span></div>
+          <ol class="fx-stepper">
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v8M8.5 11.5 12 15l3.5-3.5"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Lead</span><span class="stage-date num">Jul 05</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3-8.6A2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1.9.4 1.8.7 2.7a2 2 0 0 1-.4 2.1L8.1 9.9a16 16 0 0 0 6 6l1.4-1.4a2 2 0 0 1 2.1-.4c.9.3 1.8.6 2.7.7a2 2 0 0 1 1.7 2z"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Contacted</span><span class="stage-date num">Jul 08</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h3zM7 11l4-7a2 2 0 0 1 3 1.5V9h5a2 2 0 0 1 2 2.3l-1.2 7A2 2 0 0 1 20.6 20H7"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Not A No!</span><span class="stage-date num">Jul 12</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+            <li class="stage is-current"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><circle cx="12" cy="12" r="2.5"/><path d="M6 12h.01M18 12h.01"/></svg><span class="stage-badge badge-now"></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info">
+                  <span class="stage-name js-gate" data-gate="c"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M9 6l6 6-6 6"/></svg>Payment Discussed<span class="now">· now</span></span>
+                  <span class="stage-date num">Jul 18</span>
+                </span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Send membership agreement link</span>
+                  <span class="stamp">in 1d</span>
+                  <button class="door door-commit sm">Send</button>
+                </span>
+              </span></li>
+            <div class="gate-pop" data-gate-pop="c">
+              <div class="gate-pop-h">Advance funnel</div>
+              <div class="gate-pop-note"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>"Signed" auto-locks when the membership agreement is signed — not a manual pick.</div>
+            </div>
+            <li class="stage is-upcoming"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8.5 12.5l2.5 2.5 4.5-5"/></svg></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Signed</span><span class="stage-date num">—</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+          </ol>
+
+          <div class="fx-block">
+            <div class="fx-block-h">More actions</div>
+            <ul class="fx-todo">
+              <li class="todo-row"><span class="todo-text">Update contact — new job-site address</span>
+                <span class="stamp">in 5d</span>
+                <button class="door door-commit sm">Update</button></li>
+              <li class="todo-row is-quiet"><span class="todo-text">Add to spring promo mailing list</span>
+                <span class="stamp">—</span>
+                <button class="door door-ghost sm">Dismiss</button></li>
+              <li class="todo-row todo-add-row">
+                <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                <div class="inline-add" hidden data-list="1">
+                  <input class="inline-in" placeholder="What's the next step?">
+                  <button class="dt-trigger js-dt-trigger">Set date</button>
+                  <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                  <button class="door door-commit sm js-inline-save">Save</button>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Membership / meta</div>
+            <div class="fx-stamps">
+              <span class="stamp">Lead age · <span class="num">26d</span></span>
+              <span class="stamp">Source · Referral</span>
+              <span class="stamp">Rep · J. Broussard</span>
+              <span class="ref"><span class="ref-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 8 12 3 3 8l9 5 9-5Z"/><path d="M3 8v8l9 5 9-5V8"/><path d="M12 13v8"/></svg></span><span class="ref-name">Skid Steer S650</span></span>
+            </div>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Action log</div>
+            <ol class="fx-log">
+              <li><span class="log-ts num">07/18 9:10a</span><span class="log-txt">Membership stage → Payment Discussed</span></li>
+              <li><span class="log-ts num">07/15 8:47a</span><span class="log-txt">Rented — delivery completed</span></li>
+              <li><span class="log-ts num">07/12 3:20p</span><span class="log-txt">Membership stage → Not A No!</span></li>
+              <li><span class="log-ts num">07/12 2:15p</span><span class="log-txt">Deposit received ($350)</span></li>
+              <li><span class="log-ts num">07/08 11:00a</span><span class="log-txt">Membership stage → Contacted</span></li>
+              <li><span class="log-ts num">07/05 10:00a</span><span class="log-txt">Member Lead ticked on</span></li>
+              <li><span class="log-ts num">07/02 11:30a</span><span class="log-txt">Reserved — 42&quot; skid steer, 2wk</span></li>
+              <li><span class="log-ts num">06/24 9:00a</span><span class="log-txt">Lead created — inbound call</span></li>
+            </ol>
+          </div>
+        </div>
+
+        <div class="fx-body" data-panel="equipment" role="tabpanel">
+          <div class="fx-block-h">Equipment</div>
+          <ol class="fx-stepper">
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v8M8.5 11.5 12 15l3.5-3.5"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Lead</span><span class="stage-date num">Jun 10</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+            <li class="stage is-done"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.9v3a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3-8.6A2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7c.1.9.4 1.8.7 2.7a2 2 0 0 1-.4 2.1L8.1 9.9a16 16 0 0 0 6 6l1.4-1.4a2 2 0 0 1 2.1-.4c.9.3 1.8.6 2.7.7a2 2 0 0 1 1.7 2z"/></svg><span class="stage-badge badge-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Contacted</span><span class="stage-date num">Jun 14</span></span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Follow up after demo — gauge interest</span>
+                  <span class="stamp">in 1d</span>
+                  <button class="door door-commit sm">Log call</button>
+                </span>
+              </span></li>
+            <li class="stage is-current"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1h3zM7 11l4-7a2 2 0 0 1 3 1.5V9h5a2 2 0 0 1 2 2.3l-1.2 7A2 2 0 0 1 20.6 20H7"/></svg><span class="stage-badge badge-now"></span></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info">
+                  <span class="stage-name js-gate" data-gate="d"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M9 6l6 6-6 6"/></svg>Not A No!<span class="now">· now</span></span>
+                  <span class="stage-date num">Jul 17</span>
+                </span>
+                <span class="stage-action">
+                  <span class="stage-atxt">Confirm decision-maker sign-off</span>
+                  <span class="stamp">in 3d</span>
+                  <button class="door door-commit sm">Log call</button>
+                </span>
+              </span></li>
+            <div class="gate-pop" data-gate-pop="d">
+              <div class="gate-pop-h">Advance funnel</div>
+              <button class="gate-pop-row js-gate-close"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M9 6l6 6-6 6"/></svg>Mark as Payment Discussed</button>
+            </div>
+            <li class="stage is-upcoming"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><circle cx="12" cy="12" r="2.5"/><path d="M6 12h.01M18 12h.01"/></svg></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Payment Discussed</span><span class="stage-date num">—</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+            <li class="stage is-upcoming"><span class="stage-rail">
+                <span class="stage-dot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 21h8M12 17v4M7 4h10v4a5 5 0 0 1-10 0zM7 5H4v2a3 3 0 0 0 3 3M17 5h3v2a3 3 0 0 1-3 3"/></svg></span>
+                <span class="stage-line"></span></span>
+              <span class="stage-body">
+                <span class="stage-info"><span class="stage-name">Paid</span><span class="stage-date num">—</span></span>
+                <span class="stage-action">
+                  <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                  <div class="inline-add" hidden>
+                    <input class="inline-in" placeholder="What's the next step?">
+                    <button class="dt-trigger js-dt-trigger">Set date</button>
+                    <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                    <button class="door door-commit sm js-inline-save">Save</button>
+                  </div>
+                </span>
+              </span></li>
+          </ol>
+
+          <div class="fx-block">
+            <div class="fx-block-h">More actions</div>
+            <ul class="fx-todo">
+              <li class="todo-row"><span class="todo-text">Verify tax-exempt certificate on file</span>
+                <span class="stamp">in 3d</span>
+                <button class="door door-commit sm">Verify</button></li>
+              <li class="todo-row todo-add-row">
+                <button class="door door-ghost sm js-add-trigger">+ Action</button>
+                <div class="inline-add" hidden data-list="1">
+                  <input class="inline-in" placeholder="What's the next step?">
+                  <button class="dt-trigger js-dt-trigger">Set date</button>
+                  <button class="door door-ghost sm js-inline-cancel">Cancel</button>
+                  <button class="door door-commit sm js-inline-save">Save</button>
+                </div>
+              </li>
+            </ul>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Membership / meta</div>
+            <div class="fx-stamps">
+              <span class="stamp">Lead age · <span class="num">40d</span></span>
+              <span class="stamp">Deal est. · <span class="num">$42,000</span></span>
+              <span class="stamp">Rep · T. Guidry</span>
+              <span class="ref"><span class="ref-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/></svg></span><span class="ref-name">Quote Q-10432</span></span>
+            </div>
+          </div>
+
+          <div class="fx-block">
+            <div class="fx-block-h">Action log</div>
+            <ol class="fx-log">
+              <li><span class="log-ts num">07/17 1:15p</span><span class="log-txt">Stage → Not A No!</span></li>
+              <li><span class="log-ts num">07/10 9:40a</span><span class="log-txt">Demo completed — positive feedback</span></li>
+              <li><span class="log-ts num">06/22 3:00p</span><span class="log-txt">On-site demo scheduled</span></li>
+              <li><span class="log-ts num">06/14 10:15a</span><span class="log-txt">Stage → Contacted</span></li>
+              <li><span class="log-ts num">06/10 8:30a</span><span class="log-txt">Lead created — trade show (LA Contractors Expo)</span></li>
+            </ol>
+          </div>
+        </div>
+      </section>
+    </div>
+
+  </div>
+
+  <div class="notes">
+    <h2>Judgment calls</h2>
+    <ul>
+      <li><b>Real stages, sourced verbatim from <code>config.js</code> <code>FUNNELS</code>:</b>
+        rental <code>['Lead','Reserved','Rented']</code>, member <code>['Lead','Contacted','Not A No!','Payment Discussed','Signed']</code>
+        (auto: Signed), equipment <code>['Lead','Contacted','Not A No!','Payment Discussed','Paid']</code> (no auto yet — flagged
+        in the code itself for a future auto-trigger). The Rental tab renders Rental's own 3 stages
+        <i>plus</i> Member's 5 as a second stacked ladder when Member Lead is ticked — matching
+        <code>funnelSectionHtml</code>'s <code>rentalBody()</code> exactly (two independent Lead
+        entries, not one shared one — the earlier 2026-07-17 design doc proposed a single shared
+        Lead rung, but the shipped code keeps them separate, so I followed the code).</li>
+      <li><b>Icons are reused verbatim from the app's own <code>GATE_ICON</code></b> (app.js ~16845) —
+        Reserved (calendar), Contacted (phone), Not A No! (thumbs-up), Payment Discussed (card), Paid
+        (wallet) map 1:1 by stage name. Three stages have no exact <code>GATE_ICON</code> key today, so
+        I reused the closest real semantic match rather than inventing one: <b>Lead</b> → the
+        <code>'Inbound Lead'</code> glyph, <b>Rented</b> → the <code>'On Rent'</code> glyph (same
+        real-world state, different label), <b>Signed</b> → the <code>'Complete'</code> glyph
+        (agreement completed). Flagging these three for Jac to confirm or swap.</li>
+      <li><b>Done/current/upcoming no longer differ by icon</b> (the icon is now the stage's fixed
+        identity) — the state reads instead through fill vs. outline (a shape cue, not just colour),
+        plus a small corner badge: a <b>circle ✓</b> for done, a <b>diamond</b> (◆, pure geometry, no
+        colour dependency) for current, no badge for upcoming — on top of the ring and "· now" text
+        already carrying "current." Four independent non-colour cues on the one state that matters most.</li>
+      <li><b>Per-checkpoint actions model the app's real 3-state layer logic</b>
+        (<code>funnelLayerHtml</code>): a stage with an open, dated action shows that action's text +
+        urgency (a filled-yellow Signal only when due <i>today</i>, else a quiet Stamp) + a commit Door;
+        an unarmed stage (done or upcoming) shows a ghost <b>+ Action</b>. The one auto-locked next
+        stage in this sample (Rental's Payment Discussed → Signed) renders its Gate popover as an
+        informational note instead of a clickable row, since <code>reachFunnelStage</code> genuinely
+        refuses to manually set an auto stage — the mockup doesn't offer a control the real app would reject.</li>
+      <li><b>"More Actions" is the overflow</b> — account-level items with no <code>fkey</code>/<code>stage</code>
+        tag, distinct from the per-checkpoint actions now inline on the stepper (the real
+        <code>nextActionsHtml</code> currently lists both redundantly; this mockup splits them for clarity).</li>
+      <li><b>Inline add, no modal:</b> "+ Action" expands a row in place (text field + Save/Cancel) rather
+        than opening a window. The <b>one</b> tolerable popup is the small calendar + time picker, which
+        opens anchored <i>above</i> the clicked trigger (falls back to below only if there's truly no
+        room above — an edge-case safeguard, not the default). Saving swaps the ghost button for the
+        armed display live, so the whole loop is demonstrable without a page reload.</li>
+      <li><b>Toggle rule applied:</b> the active tab is a filled Signal of that funnel's own state —
+        yellow "· today" when a today-action exists anywhere in it, else the standard orange (no real
+        status = neutral). Panel A's Rental tab demonstrates the yellow branch; Panel B's Equipment tab
+        (same customer, same data) demonstrates the orange fallback, since Equipment carries no
+        due-today item. Inactive tabs keep a small dot instead of the full fill.</li>
+      <li><b>Yellow dimmed to <code>#eed44b</code> in BOTH themes</b> to match the locked
+        <code>wrangler-style</code> token — light theme no longer keeps the brighter
+        <code>#ffe14d</code>. The dark-palette deuter/protan separation (≥90 vs orange &amp; green)
+        was verified when the hex was locked; light-theme separation holds by lightness (the yellow
+        is far lighter than light-orange <code>#cf6000</code> / green <code>#0c8f5f</code>).</li>
+      <li>Control height moved 27px → <b>26px</b> to match the app's own real precedent in this exact
+        section (<code>h:26</code> on <code>addBtn</code>/<code>actionPill</code> calls in
+        <code>funnelSectionHtml</code>'s neighborhood); chip radius stays unified at 7px (style's
+        two-radii rule still overrides wrangler-style's separate 6/8 listing).</li>
+    </ul>
+  </div>
+</div>
+
+<script>
+(function(){
+  var MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  var DOWS = ['Su','Mo','Tu','We','Th','Fr','Sa'];
+
+  // ── shared calendar+time popover — the ONE tolerable popup, anchored ABOVE the click ──
+  var calPop = document.createElement('div');
+  calPop.className = 'cal-pop';
+  calPop.innerHTML =
+    '<div class="cal-hd"><button class="cal-nav cal-prev" type="button">‹</button>' +
+    '<span class="cal-month"></span><button class="cal-nav cal-next" type="button">›</button></div>' +
+    '<div class="cal-dow">' + DOWS.map(function(d){ return '<span>' + d + '</span>'; }).join('') + '</div>' +
+    '<div class="cal-grid"></div>' +
+    '<div class="cal-time-row"><input type="time" class="cal-time" value="09:00">' +
+    '<button class="door door-commit sm cal-set" type="button">Set</button></div>';
+  document.body.appendChild(calPop);
+
+  var calState = { target:null, viewYear:0, viewMonth:0, selDay:null };
+
+  function renderCal(){
+    var today = new Date();
+    calPop.querySelector('.cal-month').textContent = MONTHS[calState.viewMonth] + ' ' + calState.viewYear;
+    var first = new Date(calState.viewYear, calState.viewMonth, 1);
+    var startDow = first.getDay();
+    var daysInMonth = new Date(calState.viewYear, calState.viewMonth + 1, 0).getDate();
+    var grid = calPop.querySelector('.cal-grid');
+    var html = '';
+    for (var b = 0; b < startDow; b++) html += '<span class="cal-day is-blank"></span>';
+    for (var d = 1; d <= daysInMonth; d++) {
+      var isToday = today.getFullYear() === calState.viewYear && today.getMonth() === calState.viewMonth && today.getDate() === d;
+      var isSel = calState.selDay === d;
+      html += '<button type="button" class="cal-day' + (isToday ? ' is-today' : '') + (isSel ? ' is-sel' : '') + '" data-day="' + d + '">' + d + '</button>';
+    }
+    grid.innerHTML = html;
+  }
+
+  function openCal(trigger){
+    calState.target = trigger;
+    var now = new Date();
+    calState.viewYear = now.getFullYear(); calState.viewMonth = now.getMonth(); calState.selDay = null;
+    renderCal();
+    calPop.classList.add('open');
+    var r = trigger.getBoundingClientRect();
+    var w = calPop.offsetWidth || 220, h = calPop.offsetHeight || 260;
+    var left = Math.max(8, Math.min(r.left, window.innerWidth - w - 8));
+    var top = r.top - h - 8;                          // anchored ABOVE the click
+    if (top < 8) top = Math.min(r.bottom + 8, window.innerHeight - h - 8);  // edge-case fallback only
+    calPop.style.left = left + 'px'; calPop.style.top = top + 'px';
+  }
+  function closeCal(){ calPop.classList.remove('open'); calState.target = null; }
+
+  calPop.querySelector('.cal-prev').addEventListener('click', function(){
+    calState.viewMonth--; if (calState.viewMonth < 0) { calState.viewMonth = 11; calState.viewYear--; }
+    calState.selDay = null; renderCal();
+  });
+  calPop.querySelector('.cal-next').addEventListener('click', function(){
+    calState.viewMonth++; if (calState.viewMonth > 11) { calState.viewMonth = 0; calState.viewYear++; }
+    calState.selDay = null; renderCal();
+  });
+  calPop.querySelector('.cal-grid').addEventListener('click', function(e){
+    var b = e.target.closest('.cal-day:not(.is-blank)'); if (!b) return;
+    calState.selDay = parseInt(b.getAttribute('data-day'), 10); renderCal();
+  });
+  calPop.querySelector('.cal-set').addEventListener('click', function(){
+    if (!calState.target) return;
+    var day = calState.selDay || new Date().getDate();
+    var timeVal = calPop.querySelector('.cal-time').value || '09:00';
+    var parts = timeVal.split(':'); var hh = parseInt(parts[0], 10); var mm = parts[1] || '00';
+    var ampm = hh >= 12 ? 'p' : 'a'; var h12 = hh % 12; if (h12 === 0) h12 = 12;
+    var label = MONTHS[calState.viewMonth] + ' ' + day + ' · ' + h12 + ':' + mm + ampm;
+    calState.target.textContent = label;
+    calState.target.classList.add('is-set');
+    closeCal();
+  });
+  document.addEventListener('mousedown', function(e){
+    if (calPop.classList.contains('open') && !calPop.contains(e.target) && !e.target.closest('.js-dt-trigger')) closeCal();
+  });
+
+  // ── per-mock delegated behavior: tabs, gate popovers, inline add ──
+  document.querySelectorAll('[data-mock]').forEach(function(mock){
+    mock.addEventListener('click', function(e){
+      var tab = e.target.closest('.fx-tab');
+      if (tab) {
+        mock.querySelectorAll('.fx-tab').forEach(function(b){ b.classList.remove('is-active'); b.setAttribute('aria-selected','false'); });
+        tab.classList.add('is-active'); tab.setAttribute('aria-selected','true');
+        var name = tab.getAttribute('data-tab');
+        mock.querySelectorAll('.fx-body').forEach(function(p){ p.hidden = p.getAttribute('data-panel') !== name; });
+        mock.querySelectorAll('.gate-pop.open').forEach(function(g){ g.classList.remove('open'); });
+        return;
+      }
+      var gate = e.target.closest('.js-gate');
+      if (gate) {
+        var id = gate.getAttribute('data-gate');
+        var pop = mock.querySelector('.gate-pop[data-gate-pop="' + id + '"]');
+        if (!pop) return;
+        var wasOpen = pop.classList.contains('open');
+        mock.querySelectorAll('.gate-pop.open').forEach(function(g){ g.classList.remove('open'); });
+        if (!wasOpen) pop.classList.add('open');
+        return;
+      }
+      var gateClose = e.target.closest('.js-gate-close');
+      if (gateClose) { gateClose.closest('.gate-pop').classList.remove('open'); return; }
+
+      var addTrig = e.target.closest('.js-add-trigger');
+      if (addTrig) {
+        var zone = addTrig.parentElement;
+        var form = zone.querySelector('.inline-add');
+        addTrig.hidden = true;
+        if (form) { form.hidden = false; var inp = form.querySelector('.inline-in'); if (inp) inp.focus(); }
+        return;
+      }
+      var cancelBtn = e.target.closest('.js-inline-cancel');
+      if (cancelBtn) {
+        var form2 = cancelBtn.closest('.inline-add');
+        var zone2 = form2.parentElement;
+        form2.hidden = true;
+        form2.querySelector('.inline-in').value = '';
+        var dt = form2.querySelector('.dt-trigger'); dt.textContent = 'Set date'; dt.classList.remove('is-set');
+        var trig2 = zone2.querySelector('.js-add-trigger'); if (trig2) trig2.hidden = false;
+        return;
+      }
+      var dtTrig = e.target.closest('.js-dt-trigger');
+      if (dtTrig) { openCal(dtTrig); return; }
+
+      var saveBtn = e.target.closest('.js-inline-save');
+      if (saveBtn) {
+        var form3 = saveBtn.closest('.inline-add');
+        var text = form3.querySelector('.inline-in').value.trim() || 'Follow up';
+        var dtLabel = form3.querySelector('.dt-trigger').textContent;
+        var hasDate = form3.querySelector('.dt-trigger').classList.contains('is-set');
+        if (form3.getAttribute('data-list')) {
+          // "More Actions" overflow row — insert a real new <li> above the add-row
+          var li = document.createElement('li');
+          li.className = 'todo-row';
+          li.innerHTML = '<span class="todo-text"></span><span class="stamp"></span><button class="door door-commit sm" type="button">Do</button>';
+          li.querySelector('.todo-text').textContent = text;
+          li.querySelector('.stamp').textContent = hasDate ? dtLabel : '—';
+          var addLi = form3.closest('.todo-add-row');
+          addLi.parentElement.insertBefore(li, addLi);
+        } else {
+          // per-checkpoint row — swap the zone into an ARMED display, live
+          var zone3 = form3.parentElement;
+          var armed = document.createElement('span'); armed.className = 'stage-atxt'; armed.textContent = text;
+          var chip = document.createElement('span');
+          chip.className = hasDate ? 'stamp' : 'signal'; if (!hasDate) chip.style.setProperty('--sc', 'var(--yellow)');
+          chip.textContent = hasDate ? dtLabel : 'Today';
+          var editBtn = document.createElement('button'); editBtn.className = 'door door-commit sm'; editBtn.type = 'button'; editBtn.textContent = 'Edit';
+          zone3.innerHTML = ''; zone3.appendChild(armed); zone3.appendChild(chip); zone3.appendChild(editBtn);
+        }
+        return;
+      }
+    });
+  });
+})();
+</script>

--- a/docs/design/reference/get-told.html
+++ b/docs/design/reference/get-told.html
@@ -1,0 +1,442 @@
+<title>Get-told — the durable inbox</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --gray:#8b94a3;
+    --tan:#c2925a;
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  @media (prefers-color-scheme:light){ :root{
+    --bg:#e6e8ea; --bg2:#dfe3ea; --panel:#fff; --panel2:#eef1f6; --card:#fff; --cardh:#eef1f6;
+    --line:#cfd6e1; --lineSoft:#e1e6ee; --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#fff;
+    --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  } }
+  :root[data-theme="light"]{
+    --bg:#e6e8ea; --panel:#fff; --card:#fff; --cardh:#eef1f6; --line:#cfd6e1; --lineSoft:#e1e6ee;
+    --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#fff; --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  }
+  :root[data-theme="dark"]{
+    --bg:#0a0d11; --panel:#171d25; --card:#12171e; --cardh:#1a212b; --line:#2c343f; --lineSoft:#212834;
+    --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89; --onAcc:#1a1205; --accent:#ff7e1f; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --green:#34d399; --gray:#8b94a3; --tan:#c2925a;
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1180px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:92ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600}
+  .key{display:flex; flex-wrap:wrap; gap:6px 12px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+  h2.sec{font-family:var(--stamp); font-weight:800; font-size:13px; letter-spacing:.06em; text-transform:uppercase; color:var(--txt); margin:34px 0 4px; display:flex; align-items:center; gap:8px}
+  h2.sec .n{color:var(--accent)}
+  .secnote{font-size:12px; color:var(--txt3); margin:0 0 12px; max-width:88ch}
+
+  .panel{background:var(--panel); border:1px solid var(--line); border-radius:14px; overflow:hidden}
+  .pcap{font-family:var(--stamp); font-size:9.5px; letter-spacing:.13em; text-transform:uppercase; color:var(--txt3); padding:9px 13px 0}
+
+  /* ---------- the five parts (kept identical to the approved reference mockups) ---------- */
+  .ctl{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .sig{padding:0 8px; border-radius:7px}
+  .sig.f.red{background:var(--redStrong);color:#fff} .sig.o.red{color:var(--red);box-shadow:inset 0 0 0 1.3px var(--red)}
+  .sig.f.yellow{background:var(--yellow);color:#211a05} .sig.o.yellow{color:var(--yellow);box-shadow:inset 0 0 0 1.3px var(--yellow)}
+  .sig.f.blue{background:var(--blue);color:#0a1220} .sig.o.blue{color:var(--blue);box-shadow:inset 0 0 0 1.3px var(--blue)}
+  .sig.f.green{background:var(--green);color:#04140d} .sig.o.green{color:var(--green);box-shadow:inset 0 0 0 1.3px var(--green)}
+  .sig.o.grey{color:var(--gray);box-shadow:inset 0 0 0 1.3px var(--gray)}
+  .stamp{font-family:var(--stamp); font-size:10.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap}
+  .dot{color:var(--line); font-family:var(--stamp); font-size:10px} .stamp.more{color:var(--accent)}
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:700; cursor:pointer; text-decoration:none; white-space:nowrap}
+  .ref .ty{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .ref .ty svg{width:11px;height:11px}
+  .ref small{color:var(--gray); font-family:var(--stamp); font-size:9px; font-weight:600; margin-left:1px}
+  .door{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; cursor:pointer; border-radius:999px; padding:0 13px; border:0}
+  .door.save{background:var(--commit); color:#fff}
+  .door.money{background:var(--green); color:#04140d}
+  .door.ghost{background:transparent; color:var(--txt2); border:1px solid var(--line)}
+  .door.add{background:transparent; color:var(--commit); border:1.4px dashed var(--commit); padding:0 11px}
+  .chev{display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; color:var(--txt3); cursor:pointer; flex:none} .chev svg{width:14px;height:14px}
+
+  /* ---------- segmented toggle (Mine/All) — orange fallback per wrangler-style ---------- */
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:7px; overflow:hidden; flex:none}
+  .seg b{display:inline-flex;align-items:center;padding:0 11px;font-family:var(--stamp);font-size:10px;font-weight:800;letter-spacing:.03em;text-transform:uppercase;color:var(--txt3);border-right:1px solid var(--line);cursor:pointer}
+  .seg b:last-child{border-right:0} .seg b.on{background:var(--accent);color:var(--onAcc)}
+
+  /* ================= SECTION A — bell + badge ================= */
+  .bellrow{display:flex; gap:14px; flex-wrap:wrap; margin-top:14px}
+  .bellcard{background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:14px 16px; display:flex; flex-direction:column; align-items:center; gap:9px; min-width:132px}
+  .bellbtn{position:relative; width:44px; height:44px; border-radius:10px; background:var(--card); border:1px solid var(--line); display:flex; align-items:center; justify-content:center; color:var(--txt2)}
+  .bellbtn svg{width:20px;height:20px}
+  .bdg{position:absolute; top:-6px; right:-6px; min-width:18px; height:18px; padding:0 4px; border-radius:999px; display:flex; align-items:center; justify-content:center; font-family:var(--stamp); font-size:11px; font-weight:800; line-height:1}
+  .bdg.red{background:var(--redStrong); color:#fff}
+  .bdg.yellow{background:var(--yellow); color:#211a05}
+  .blabel{font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; color:var(--txt)}
+  .bsub{font-size:10.5px; color:var(--txt3); text-align:center; max-width:16ch}
+  .cmp{display:flex; align-items:stretch; gap:0; border:1px solid var(--line); border-radius:12px; overflow:hidden; flex:1; min-width:280px}
+  .cmphalf{flex:1; padding:12px 16px; display:flex; flex-direction:column; gap:5px; justify-content:center}
+  .cmphalf.old{background:var(--card)}
+  .cmphalf.new{background:var(--cardh); border-left:1px solid var(--line)}
+  .cmptag{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.1em; text-transform:uppercase; color:var(--txt3)}
+  .cmpnum{font-family:var(--font); font-weight:800; font-size:22px; color:var(--txt3); font-variant-numeric:tabular-nums}
+  .cmphalf.new .cmpnum{color:var(--accent)}
+  .cmpwhat{font-size:11.5px; color:var(--txt3)}
+  .cmphalf.old .cmpwhat{text-decoration:line-through; text-decoration-color:var(--line)}
+  .cmphalf.new .cmpwhat{color:var(--txt2)}
+
+  /* ================= SECTION B — the inbox ================= */
+  .inbox-head{display:flex; align-items:center; gap:10px; padding:12px 14px; border-bottom:1px solid var(--line); flex-wrap:wrap; background:var(--bg2)}
+  .addr{display:flex; flex-direction:column; gap:1px; margin-right:6px}
+  .addr .who{font-family:var(--font); font-weight:700; font-size:14px; color:var(--txt); display:flex; align-items:center; gap:6px}
+  .addr .who svg{width:13px;height:13px;color:var(--txt3)}
+  .addr .durable{font-family:var(--stamp); font-size:9px; letter-spacing:.05em; text-transform:uppercase; color:var(--txt3)}
+  .toolbar{display:flex; align-items:center; gap:8px; padding:10px 14px; border-bottom:1px solid var(--line); flex-wrap:wrap}
+  .fchip{height:var(--h); display:inline-flex; align-items:center; padding:0 10px; border-radius:7px; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; color:var(--txt2); border:1px solid var(--line); cursor:pointer; background:transparent; user-select:none}
+  .fchip.active{background:var(--accent); color:var(--onAcc); border-color:var(--accent)}
+  .spacer{flex:1}
+
+  .grouphead{display:flex; align-items:center; gap:9px; padding:8px 14px; background:var(--bg2); border-top:1px solid var(--line); border-bottom:1px solid var(--line); border-left:3px solid transparent}
+  .grouphead.bad{border-left-color:var(--red)} .grouphead.wait{border-left-color:var(--blue)} .grouphead.done{border-left-color:var(--green)}
+  .glabel{font-family:var(--stamp); font-weight:800; font-size:11px; letter-spacing:.07em; text-transform:uppercase; color:var(--txt)}
+  .gcount{font-family:var(--stamp); font-size:11px; font-weight:800; color:var(--txt3)}
+  .ghint{font-size:11px; color:var(--txt3); margin-left:auto}
+
+  .nitem{border-bottom:1px solid var(--lineSoft); border-left:3px solid transparent; padding:11px 14px 12px; background:var(--card)}
+  .nitem:last-child{border-bottom:0}
+  .nitem.unread{background:var(--cardh)}
+  .nitem.red{border-left-color:var(--red)} .nitem.yellow{border-left-color:var(--yellow)} .nitem.blue{border-left-color:var(--blue)} .nitem.green{border-left-color:var(--green)}
+  .nrow1{display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .ndot{width:7px; height:7px; border-radius:50%; flex:none}
+  .ndot.red{background:var(--red)} .ndot.yellow{background:var(--yellow)} .ndot.blue{background:var(--blue)}
+  .nline{font-size:13px; color:var(--txt2); margin:6px 0 0}
+  .nitem.unread .nline{color:var(--txt); font-weight:600}
+  .nmeta{font-family:var(--stamp); font-size:10.5px; color:var(--txt3); margin-top:6px; display:flex; align-items:center; gap:6px; flex-wrap:wrap; font-variant-numeric:tabular-nums; letter-spacing:.01em}
+  .nmeta b{color:var(--txt2); font-weight:800; text-transform:none; font-family:var(--font)}
+  .ndoor{margin-left:auto}
+  .nread-note{font-size:10.5px; color:var(--txt3); font-style:normal}
+
+  /* ---------- bridge callout ---------- */
+  .callout{margin:0 14px 12px; padding:10px 12px; background:var(--bg2); border:1.4px dashed var(--accLine); border-radius:9px; font-size:11.5px; color:var(--txt2); line-height:1.5; position:relative}
+  .callout::before{content:""; position:absolute; top:-7px; left:22px; width:12px; height:12px; background:var(--bg2); border-left:1.4px dashed var(--accLine); border-top:1.4px dashed var(--accLine); transform:rotate(45deg)}
+  .callout .lab{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; color:var(--accent); display:block; margin-bottom:4px}
+  .callout b{color:var(--txt)}
+
+  /* ---------- message thread ---------- */
+  .thread{margin:9px 14px 2px; padding:10px 11px; background:var(--bg2); border:1px solid var(--line); border-radius:9px}
+  .tclose{display:flex; justify-content:space-between; align-items:center; margin-bottom:8px}
+  .tclose .tt{font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.06em; text-transform:uppercase; color:var(--txt3)}
+  .bubbles{display:flex; flex-direction:column; gap:7px; margin-bottom:9px}
+  .brow{display:flex}
+  .brow.out{justify-content:flex-end}
+  .bubble{max-width:72%; padding:7px 10px; border-radius:10px; font-size:12.5px; line-height:1.42}
+  .bubble .who{display:block; font-family:var(--stamp); font-size:9px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; margin-bottom:2px; opacity:.75}
+  .brow.in .bubble{background:var(--panel2); color:var(--txt); border:1px solid var(--line); border-bottom-left-radius:3px}
+  .brow.out .bubble{background:var(--commit); color:#fff; border-bottom-right-radius:3px}
+  .brow.out .bubble .who{color:#dbe6fb}
+  .replyrow{display:flex; align-items:center; gap:8px}
+  .replyin{flex:1; height:var(--h); display:flex; align-items:center; padding:0 10px; background:var(--card); border:1px solid var(--line); border-radius:999px; color:var(--txt3); font-size:12px}
+
+  /* ================= SECTION C — flood vs empty ================= */
+  .stategrid{display:grid; grid-template-columns:1.15fr 1fr; gap:16px; margin-top:14px; align-items:start}
+  @media (max-width:880px){ .stategrid{grid-template-columns:1fr} }
+
+  .fgrouphead{display:flex; align-items:center; gap:8px; padding:7px 13px; background:var(--bg2); border-top:1px solid var(--line); border-bottom:1px solid var(--line); border-left:3px solid transparent; cursor:pointer}
+  .fgrouphead.bad{border-left-color:var(--red)} .fgrouphead.wait{border-left-color:var(--blue)} .fgrouphead.done{border-left-color:var(--green)}
+  .frow{display:flex; align-items:center; gap:8px; padding:7px 13px; border-bottom:1px solid var(--lineSoft); font-size:12px; border-left:3px solid transparent}
+  .frow.red{border-left-color:var(--red)} .frow.yellow{border-left-color:var(--yellow)} .frow.blue{border-left-color:var(--blue)}
+  .frow .fn{flex:1; min-width:0; color:var(--txt2); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .frow.unread .fn{color:var(--txt); font-weight:600}
+  .fmore{padding:6px 13px 9px; font-family:var(--stamp); font-size:10px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--accent); cursor:pointer}
+  .fcollapse-body{display:none}
+  .fcollapse-body.open{display:block}
+  .fgrouphead .chev{margin-left:auto}
+
+  .emptystate{display:flex; flex-direction:column; align-items:center; text-align:center; gap:6px; padding:38px 20px 26px}
+  .esicon{width:56px;height:56px;border-radius:50%; display:flex; align-items:center; justify-content:center; background:var(--card); box-shadow:inset 0 0 0 1.6px var(--green); color:var(--green); margin-bottom:6px}
+  .esicon svg{width:26px;height:26px}
+  .eshead{font-family:var(--font); font-weight:700; font-size:16px; color:var(--txt)}
+  .essub{font-size:12px; color:var(--txt3); max-width:34ch}
+  .escleared{width:100%; margin-top:18px; border-top:1px solid var(--line); padding-top:12px}
+  .esclabel{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; color:var(--txt3); padding:0 16px 6px}
+  .escrow{display:flex; align-items:center; gap:8px; padding:5px 16px; font-size:11.5px; color:var(--txt3)}
+  .escrow svg{width:12px;height:12px;color:var(--green);flex:none}
+
+  .foot{margin-top:30px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:92ch} .foot b{color:var(--txt)}
+  .foot ul{margin:8px 0 0; padding-left:20px} .foot li{margin:5px 0}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Get-told · notifications · first draft — for Jac to react to, not final</p>
+  <h1>Get-told — <span class="hl">a durable, addressed inbox</span></h1>
+  <p class="lede">Today there's <b>no delivery channel</b> — no push, no badge that means anything, no durable inbox. Settings
+  sells three notification engines wired to nothing, and the header bell (confirmed in <code>app.js</code>) surfaces
+  <b>Mr. Wrangler fix-ticket resolutions</b>, not what a worker needs to do next. This mockup builds the seat our own
+  system reserves for this job — <b>WORD: a durable, addressed inbox.</b> The bridge rule: a notification fires when a
+  <b>today-trigger</b> fires on a record — the same <code>fill = triggeredToday</code> discipline that lights a Signal
+  anywhere else. It inherits that Signal's <b>colour = state</b>, names its source as a <b>Ref</b>, and a tap
+  <b>teleports</b> you to that source — never a Gate here, it's read-only until you land. The built per-record
+  <b>message thread</b> (reach-the-person's dead code) lives on this surface too, since it renders nowhere today.</p>
+  <div class="key"><span><b>Signal</b> state chip</span><span><b>Ref</b> linked source</span><span><b>Stamp</b> fact</span><span><b>Door</b> the one move</span><span>· fill = today · colour = state · click = teleport</span></div>
+
+  <!-- ================= A: BELL + BADGE ================= -->
+  <h2 class="sec"><span class="n">1</span> The badge + bell — counts what needs YOU</h2>
+  <p class="secnote">Three states of the same bell. The badge is <b>colour = state</b> too (worst bucket present), and follows
+  the app's own overflow rule found in <code>app.js</code> — <code>n &gt; 9 ? '9+' : n</code>.</p>
+  <div class="bellrow">
+    <div class="bellcard">
+      <div class="bellbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/></svg></div>
+      <div class="blabel">All caught up</div>
+      <div class="bsub">No badge — nothing addressed to Denny right now</div>
+    </div>
+    <div class="bellcard">
+      <div class="bellbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/></svg><span class="bdg red">5</span></div>
+      <div class="blabel">Ordinary Tuesday</div>
+      <div class="bsub">5 unread · worst = red, badge fills red</div>
+    </div>
+    <div class="bellcard">
+      <div class="bellbtn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/></svg><span class="bdg red">9+</span></div>
+      <div class="blabel">Flooded (§5)</div>
+      <div class="bsub">23 unread — caps at 9+, never a huge number</div>
+    </div>
+    <div class="cmp">
+      <div class="cmphalf old">
+        <span class="cmptag">Bell today</span>
+        <span class="cmpnum">14</span>
+        <span class="cmpwhat">Mr. Wrangler fix-ticket resolutions — engineering, not your move</span>
+      </div>
+      <div class="cmphalf new">
+        <span class="cmptag">Bell, redesigned</span>
+        <span class="cmpnum">5</span>
+        <span class="cmpwhat">Addressed to Denny R. · Dispatch — every one has a Door</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ================= B: THE INBOX ================= -->
+  <h2 class="sec"><span class="n">2</span> The durable inbox</h2>
+  <p class="secnote">Grouped <b>worst-first</b>, not one flat list. Unread = solid dot + bold line + brighter card;
+  read = no dot, dimmed, Door drops to a quiet <b>Dismiss</b>. Filters are real toggles below — click a type chip.</p>
+
+  <div class="panel">
+    <div class="inbox-head">
+      <div class="addr">
+        <span class="who"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>Denny R. · Dispatch</span>
+        <span class="durable">Durable — survives reload · not RAM</span>
+      </div>
+    </div>
+    <div class="toolbar">
+      <span class="seg"><b class="on">Mine</b><b>All</b></span>
+      <span class="fchip active js-f" data-type="all">All types</span>
+      <span class="fchip js-f" data-type="returns">Returns</span>
+      <span class="fchip js-f" data-type="repairs">Repairs</span>
+      <span class="fchip js-f" data-type="payments">Payments</span>
+      <span class="fchip js-f" data-type="messages">Messages</span>
+      <span class="spacer"></span>
+      <span class="door ghost">Clear read</span>
+    </div>
+
+    <!-- GROUP 1 — NEEDS YOU NOW -->
+    <div class="grouphead bad"><span class="glabel">Needs you now</span><span class="gcount">3</span><span class="ghint">worst first</span></div>
+
+    <div class="nitem unread yellow" data-type="returns">
+      <div class="nrow1">
+        <span class="ndot yellow"></span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg></span>Gator<small>RC-4700</small></a>
+        <span class="ctl sig f yellow">recovery</span>
+        <span class="ndoor door save">Saddle up for pickup</span>
+      </div>
+      <p class="nline">Rental ended — Gator's back at Broussard Dirt Works, still nobody dispatched for pickup.</p>
+      <div class="nmeta">JUL 20 · 8:20 AM · auto — end-rent trigger, unattended 40 min</div>
+    </div>
+    <div class="callout"><span class="lab">↑ the bridge</span>Lands here because a <b>today-trigger</b> fired on RC-4700
+      (end-rent, 40 min with no dispatch logged) → same <b>filled yellow</b> as Gator's own Signal on its
+      Yard Journey timeline → tap this item and you land on that exact Recovery row, ready to
+      <b>Saddle up for pickup</b> — a notification is a Signal that came to find you.</div>
+
+    <div class="nitem unread red" data-type="repairs">
+      <div class="nrow1">
+        <span class="ndot red"></span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg></span>Highrise<small>4471-K</small></a>
+        <span class="ctl sig f red">failed</span>
+        <span class="stamp">for Duhon · 7 AM pickup</span>
+        <span class="ndoor door ghost">Reassign unit</span>
+      </div>
+      <p class="nline">Failed inspection — Highrise can't leave the yard for Duhon Contracting's 7 AM pickup.</p>
+      <div class="nmeta">JUL 20 · 5:15 AM · <b>Wanda R.</b> — inspection</div>
+    </div>
+
+    <div class="nitem unread red" data-type="payments">
+      <div class="nrow1">
+        <span class="ndot red"></span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Boudreaux Marine LLC</a>
+        <span class="ctl sig f red">owed 18d</span>
+        <span class="stamp">INV #4460 · $840</span>
+        <span class="ndoor door ghost">Call back</span>
+      </div>
+      <p class="nline">Overdue invoice crossed 18 days — escalated from yesterday's 16d, still unpaid.</p>
+      <div class="nmeta">JUL 20 · 12:01 AM · auto — AR aging sweep · <a href="tel:3375550142" style="color:var(--txt2);text-decoration:none;border-bottom:1.4px solid var(--line)">(337) 555-0142</a></div>
+    </div>
+
+    <!-- GROUP 2 — WAITING ON YOU -->
+    <div class="grouphead wait"><span class="glabel">Waiting on you</span><span class="gcount">2</span></div>
+
+    <div class="nitem unread blue" data-type="payments">
+      <div class="nrow1">
+        <span class="ndot blue"></span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Theriot Pipe &amp; Supply</a>
+        <span class="ctl sig f blue">awaiting approval</span>
+        <span class="stamp">INV #4498 · $1,240</span>
+        <span class="ndoor door money">Approve</span>
+      </div>
+      <p class="nline">Requesting a 2-payment split on $1,240 — submitted through the customer portal.</p>
+      <div class="nmeta">JUL 20 · 8:40 AM · <b>submitted</b> — customer portal</div>
+    </div>
+
+    <div class="nitem unread blue" data-type="messages">
+      <div class="nrow1">
+        <span class="ndot blue"></span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg></span>Gator<small>RC-4700</small></a>
+        <span class="ctl sig f blue">message</span>
+        <span class="stamp">from Trey Guidry</span>
+        <span class="ndoor door ghost js-thread-toggle">Reply ▾</span>
+      </div>
+      <p class="nline">Trey has a question before he rolls for the Gator pickup — reach-the-person's message thread, live here.</p>
+      <div class="nmeta">JUL 20 · 9:06 AM · <b>Trey Guidry</b> — driver</div>
+      <div class="thread">
+        <div class="tclose"><span class="tt">Thread · Rental #4501 · Gator recovery</span></div>
+        <div class="bubbles">
+          <div class="brow in"><div class="bubble"><span class="who">Trey Guidry · 9:02 AM</span>Gate code for Broussard Dirt Works still 4471? Heading out for the Gator pickup.</div></div>
+          <div class="brow out"><div class="bubble"><span class="who">Denny R. · 9:04 AM</span>Yep, 4471 still good. Ask for Mike at the shop if it doesn't work.</div></div>
+          <div class="brow in"><div class="bubble"><span class="who">Trey Guidry · 9:06 AM</span>Copy that, rolling now.</div></div>
+        </div>
+        <div class="replyrow"><span class="replyin">Type a reply…</span><span class="door save">Send</span></div>
+      </div>
+    </div>
+
+    <!-- GROUP 3 — HANDLED TODAY (read) -->
+    <div class="grouphead done"><span class="glabel">Handled today</span><span class="gcount">2</span><span class="ghint">read · quiet</span></div>
+
+    <div class="nitem green" data-type="repairs">
+      <div class="nrow1">
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg></span>Ranger<small>BC-7702</small></a>
+        <span class="ctl sig o green">done</span>
+        <span class="stamp">WO #1194 · hyd hose</span>
+        <span class="ndoor door ghost">Dismiss</span>
+      </div>
+      <p class="nline">Work order closed — hydraulic hose replaced, unit back in service.</p>
+      <div class="nmeta">JUL 20 · 7:10 AM · <b>Mikey Fontenot</b> — tech</div>
+    </div>
+
+    <div class="nitem green" data-type="returns">
+      <div class="nrow1">
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg></span>Scout<small>SS-14</small></a>
+        <span class="ctl sig o green">delivered</span>
+        <span class="stamp">→ LeBlanc Construction</span>
+        <span class="ndoor door ghost">Dismiss</span>
+      </div>
+      <p class="nline">Delivered and signed for — dispatch loop closed.</p>
+      <div class="nmeta">JUL 20 · 10:15 AM · <b>Trey Guidry</b> — driver</div>
+    </div>
+  </div>
+
+  <!-- ================= C: STATES ================= -->
+  <h2 class="sec"><span class="n">3</span> States that matter — flooded vs. all caught up</h2>
+  <p class="secnote">Same worst-first grouping under load — the read group starts <b>collapsed</b> so it never buries what's
+  live. And "empty" still shows its work, quietly.</p>
+
+  <div class="stategrid">
+    <div class="panel">
+      <div class="pcap">Flooded — 23 unread</div>
+      <div class="grouphead bad" style="margin-top:8px"><span class="glabel">Needs you now</span><span class="gcount">7</span></div>
+      <div class="frow red unread"><span class="fn"><b style="color:var(--txt);font-weight:600">Gator</b> · recovery — pickup unattended 40 min</span></div>
+      <div class="frow red unread"><span class="fn"><b style="color:var(--txt);font-weight:600">Highrise</b> · failed inspection blocks 7 AM pickup</span></div>
+      <div class="frow red unread"><span class="fn"><b style="color:var(--txt);font-weight:600">Boudreaux Marine</b> · owed 18d, escalated</span></div>
+      <div class="fmore">+ 4 more — same group, worst first</div>
+
+      <div class="grouphead wait"><span class="glabel">Waiting on you</span><span class="gcount">9</span></div>
+      <div class="frow blue unread"><span class="fn"><b style="color:var(--txt);font-weight:600">Theriot Pipe &amp; Supply</b> · split-pay awaiting approval</span></div>
+      <div class="frow blue unread"><span class="fn"><b style="color:var(--txt);font-weight:600">Gator</b> · Trey Guidry — question before rollout</span></div>
+      <div class="fmore">+ 7 more — same group, worst first</div>
+
+      <div class="fgrouphead done js-flood-toggle"><span class="glabel">Handled today</span><span class="gcount">7</span><span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div>
+      <div class="fcollapse-body js-flood-body">
+        <div class="frow"><span class="fn">Ranger · WO #1194 closed — Mikey Fontenot</span></div>
+        <div class="frow"><span class="fn">Scout · delivered to LeBlanc Construction</span></div>
+        <div class="frow"><span class="fn">5 more — read, quiet, out of the way</span></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="pcap">All caught up</div>
+      <div class="emptystate">
+        <div class="esicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.801 10A10 10 0 1 1 17 3.335"/><path d="m9 11 3 3L22 4"/></svg></div>
+        <div class="eshead">All caught up, Denny</div>
+        <div class="essub">Nothing needs you right now. New Signals land here the moment a trigger fires — no refresh needed.</div>
+        <div class="escleared">
+          <div class="esclabel">Last cleared</div>
+          <div class="escrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M21.801 10A10 10 0 1 1 17 3.335"/><path d="m9 11 3 3L22 4"/></svg>WO #1194 · 12m ago</div>
+          <div class="escrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M21.801 10A10 10 0 1 1 17 3.335"/><path d="m9 11 3 3L22 4"/></svg>Scout delivered · 40m ago</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="foot">
+    Judgment calls made for this first draft, flagged so Jac can push back:
+    <ul>
+      <li><b>Chips here are Signals, not Gates</b> — read-only, click teleports to the source. You don't change status
+      from the inbox, only at the record itself; that's a deliberate restriction, not an oversight.</li>
+      <li><b>Filled vs outline follows attention, not group</b> — Needs-you-now and Waiting both fill (they're asking for
+      something); Handled uses the calm outline-green already used for "reporting/insured" elsewhere.</li>
+      <li><b>Unread is three redundant cues</b> (dot + bold + brighter card), never colour alone, per the contrast rule.</li>
+      <li><b>Type filter chips fall back to orange</b> (not a status colour) since "type" isn't a state — matches the
+      toggle rule's stated fallback exactly.</li>
+      <li><b>The flood state collapses "Handled" by default</b> — a made-up call, not yet in the spec: read items are the
+      one group allowed to stay hidden so volume doesn't bury what's still live.</li>
+      <li><b>"Durable" is asserted, not built</b> — this mockup has no backend; the real version needs a persisted table
+      (not <code>state</code> memory) so a reload or a different device doesn't lose the inbox.</li>
+      <li><b>Message thread is shown already expanded</b> for one item so the reach-the-person tie-in is visible without
+      a click; in the shipped version it would start collapsed like the others.</li>
+    </ul>
+  </div>
+
+</div></div>
+
+<script>
+  document.querySelectorAll('.js-f').forEach(function(chip){
+    chip.addEventListener('click', function(){
+      var type = chip.getAttribute('data-type');
+      if (type === 'all') {
+        document.querySelectorAll('.js-f').forEach(function(c){ c.classList.toggle('active', c === chip); });
+      } else {
+        chip.classList.toggle('active');
+        var allChip = document.querySelector('.js-f[data-type="all"]');
+        var anyOn = Array.prototype.some.call(document.querySelectorAll('.js-f:not([data-type="all"])'), function(c){ return c.classList.contains('active'); });
+        allChip.classList.toggle('active', !anyOn);
+      }
+      var actives = Array.prototype.filter.call(document.querySelectorAll('.js-f'), function(c){ return c.classList.contains('active') && c.getAttribute('data-type') !== 'all'; }).map(function(c){ return c.getAttribute('data-type'); });
+      document.querySelectorAll('.nitem[data-type]').forEach(function(item){
+        var show = actives.length === 0 || actives.indexOf(item.getAttribute('data-type')) !== -1;
+        item.style.display = show ? '' : 'none';
+      });
+    });
+  });
+  document.querySelectorAll('.js-thread-toggle').forEach(function(btn){
+    btn.addEventListener('click', function(e){
+      e.stopPropagation();
+      var thread = btn.closest('.nitem').querySelector('.thread');
+      if (thread) thread.style.display = (thread.style.display === 'none') ? '' : 'none';
+    });
+  });
+  document.querySelectorAll('.js-flood-toggle').forEach(function(h){
+    h.addEventListener('click', function(){
+      var body = h.nextElementSibling;
+      body.classList.toggle('open');
+      var chev = h.querySelector('.chev svg');
+      chev.style.transform = body.classList.contains('open') ? 'rotate(90deg)' : '';
+    });
+  });
+</script>

--- a/docs/design/reference/inbox-card.html
+++ b/docs/design/reference/inbox-card.html
@@ -1,0 +1,1818 @@
+<title>Inbox v3 — channels up top, talk native, room to grow</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --gray:#8b94a3;
+    --tan:#c2925a; --tanSoft:rgba(194,146,90,.20);
+    --onFill:#fdfdfd;
+    --shadowPop:0 10px 24px rgba(5,7,10,.45);
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  @media (prefers-color-scheme:light){ :root{
+    --bg:#e6e8ea; --bg2:#dfe3ea; --panel:#fbfbfa; --panel2:#eef1f6; --card:#fbfbfa; --cardh:#eef1f6;
+    --line:#cfd6e1; --lineSoft:#e1e6ee; --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#1a1205;
+    --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+    --accSoft:rgba(207,96,0,.10); --accLine:rgba(207,96,0,.45); --tanSoft:rgba(138,90,43,.14);
+    --shadowPop:0 10px 24px rgba(20,24,33,.16);
+  } }
+  :root[data-theme="light"]{
+    --bg:#e6e8ea; --panel:#fbfbfa; --card:#fbfbfa; --cardh:#eef1f6; --line:#cfd6e1; --lineSoft:#e1e6ee;
+    --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#1a1205; --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+    --accSoft:rgba(207,96,0,.10); --accLine:rgba(207,96,0,.45); --tanSoft:rgba(138,90,43,.14);
+    --shadowPop:0 10px 24px rgba(20,24,33,.16);
+  }
+  :root[data-theme="dark"]{
+    --bg:#0a0d11; --panel:#171d25; --card:#12171e; --cardh:#1a212b; --line:#2c343f; --lineSoft:#212834;
+    --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89; --onAcc:#1a1205; --accent:#ff7e1f; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --green:#34d399; --gray:#8b94a3; --tan:#c2925a;
+    --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5); --tanSoft:rgba(194,146,90,.20);
+    --shadowPop:0 10px 24px rgba(5,7,10,.45);
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1180px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:96ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600} .lede code{font-family:var(--stamp); font-size:11.5px; background:var(--panel2); padding:1px 5px; border-radius:4px; color:var(--txt2)}
+  .key{display:flex; flex-wrap:wrap; gap:6px 12px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+  h2.sec{font-family:var(--stamp); font-weight:800; font-size:13px; letter-spacing:.06em; text-transform:uppercase; color:var(--txt); margin:34px 0 4px; display:flex; align-items:center; gap:8px}
+  h2.sec .n{color:var(--accent)}
+  h3.subsec{font-family:var(--stamp); font-weight:800; font-size:10.5px; letter-spacing:.08em; text-transform:uppercase; color:var(--txt2); margin:20px 0 6px; padding-left:1px}
+  .secnote{font-size:12px; color:var(--txt3); margin:0 0 12px; max-width:94ch}
+
+  .panel{background:var(--panel); border:1px solid var(--line); border-radius:14px; overflow:hidden; transition:border-color .3s}
+  .panel.flash{border-color:var(--accent)}
+  .pcap{font-family:var(--stamp); font-size:9.5px; letter-spacing:.13em; text-transform:uppercase; color:var(--txt3); padding:9px 13px 0}
+
+  /* ================= ICON SPRITE — all glyphs sourced from Lucide, inline, no external requests ================= */
+  .ic{width:16px; height:16px; fill:none; stroke:currentColor; stroke-width:2.2; stroke-linecap:round; stroke-linejoin:round; display:inline-block; flex:none}
+
+  /* ================= shared five-part vocabulary (Signal · Gate · Stamp · Ref · Door) ================= */
+  .ctl{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .sig{padding:0 8px; border-radius:7px}
+  .sig.f.red{background:var(--redStrong);color:var(--onFill)} .sig.o.red{color:var(--red);box-shadow:inset 0 0 0 1.3px var(--red)}
+  .sig.f.yellow{background:var(--yellow);color:#211a05} .sig.o.yellow{color:var(--yellow);box-shadow:inset 0 0 0 1.3px var(--yellow)}
+  .sig.f.blue{background:var(--blue);color:#0a1220} .sig.o.blue{color:var(--blue);box-shadow:inset 0 0 0 1.3px var(--blue)}
+  .sig.f.green{background:var(--green);color:#04140d} .sig.o.green{color:var(--green);box-shadow:inset 0 0 0 1.3px var(--green)}
+  .sig.o.grey{color:var(--gray);box-shadow:inset 0 0 0 1.3px var(--gray)}
+  .stamp{font-family:var(--stamp); font-size:10.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap}
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:700; cursor:pointer; text-decoration:none; white-space:nowrap}
+  .ref .ty{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px;flex:none} .ref .ty .ic{width:11px;height:11px}
+  .ref small{color:var(--gray); font-family:var(--stamp); font-size:9px; font-weight:600; margin-left:1px}
+  .door{height:var(--h); display:inline-flex; align-items:center; gap:5px; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; cursor:pointer; border-radius:999px; padding:0 13px; border:0}
+  .door.save{background:var(--commit); color:var(--onFill)}
+  .door.money{background:var(--green); color:#04140d}
+  .door.ghost{background:transparent; color:var(--txt2); border:1px solid var(--line)}
+  .door.add{background:transparent; color:var(--commit); border:1.4px dashed var(--commit); padding:0 11px}
+  .chev{display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; color:var(--txt3); cursor:pointer; flex:none} .chev .ic{width:14px;height:14px}
+  .seg{height:var(--h); display:inline-flex; border:1px solid var(--line); border-radius:7px; overflow:hidden; flex:none}
+  .seg b{display:inline-flex;align-items:center;padding:0 11px;font-family:var(--stamp);font-size:10px;font-weight:800;letter-spacing:.03em;text-transform:uppercase;color:var(--txt2);border-right:1px solid var(--line);cursor:pointer}
+  .seg b:last-child{border-right:0} .seg b.on{background:var(--accent);color:var(--onAcc)}
+  /* channel toggle — a .seg variant. Active = orange fill/dark ink (channels aren't a status → accent fallback, not a filled Signal) */
+  .seg.chan b{gap:5px; padding:0 12px}
+  .seg.chan b .ic{width:11px;height:11px;color:var(--txt3)}
+  .seg.chan b.on .ic{color:var(--onAcc)}
+  .seg.chan b .cnt{font-size:9px; color:var(--txt3); margin-left:1px}
+  .seg.chan b.on .cnt{color:var(--onAcc); opacity:.78}
+  .seg.chan b.soon{color:var(--txt3); opacity:.5; cursor:not-allowed; pointer-events:none}
+  .seg.chan b.soon .soonmark{font-family:var(--stamp); font-size:8px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:0 4px; border-radius:999px; border:1px solid var(--line); color:var(--txt3); margin-left:4px}
+  .clink{display:inline-flex; align-items:center; gap:5px; color:var(--txt2); font-size:11.5px; text-decoration:none; font-family:var(--font); font-variant-numeric:tabular-nums}
+  .clink .ic{color:var(--accent); width:12px; height:12px} .clink .v{border-bottom:1.4px solid transparent} .clink:hover .v{border-bottom-color:var(--accent)}
+  .attchip,.labelchip{height:var(--h); display:inline-flex; align-items:center; gap:4px; padding:0 8px; border-radius:7px; border:1px solid var(--line); font-family:var(--stamp); font-size:9.5px; font-weight:700; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .attchip{color:var(--txt3); background:var(--card)} .attchip .ic{width:10px;height:10px}
+  .labelchip{color:var(--txt2); background:transparent}
+  .changlyph{width:20px; height:20px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; background:var(--card); border:1px solid var(--line); color:var(--txt3); flex:none}
+  .changlyph .ic{width:11px;height:11px}
+  .fspacer{flex:1}
+
+  /* ================= top chrome — OUR mini-search (pills-in-bar) + globe scope + Views&sort + recent-searches-above ================= */
+  .chromegrid{display:grid; grid-template-columns:1fr 1fr; gap:14px; margin-top:14px; align-items:start}
+  @media (max-width:820px){ .chromegrid{grid-template-columns:1fr} }
+
+  .topbar{display:flex; align-items:center; gap:10px; padding:10px 14px; border-bottom:1px solid var(--line); background:var(--bg2); flex-wrap:wrap}
+  .iconbtn{width:36px; height:36px; border-radius:9px; display:inline-flex; align-items:center; justify-content:center; background:var(--card); border:1px solid var(--line); color:var(--txt2); flex:none; cursor:pointer}
+  .iconbtn .ic{width:17px;height:17px}
+  .searchwrap{flex:1; min-width:140px; position:relative}
+  .searchbar,.mini-search{height:36px; display:flex; align-items:center; gap:7px; padding:0 8px 0 14px; border-radius:999px; background:var(--card); border:1px solid var(--line); color:var(--txt3); font-size:13px; cursor:text}
+  .searchbar .ic,.mini-search .ic{color:var(--txt3); flex:none}
+  .searchbar.focused,.mini-search.focused{border-color:var(--accent); color:var(--txt)}
+  .searchbar .ph,.mini-search .ph{flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+  .avatar{width:32px; height:32px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--stamp); font-weight:800; font-size:11px; flex:none; background:var(--card); border:1px solid var(--line); color:var(--txt2)}
+  .bdgbell{position:relative}
+  .bdgbell .bdg{position:absolute; top:-4px; right:-4px; min-width:15px; height:15px; padding:0 3px; border-radius:999px; background:var(--redStrong); color:var(--onFill); font-family:var(--stamp); font-size:9px; font-weight:800; display:flex; align-items:center; justify-content:center; line-height:1}
+
+  /* removable filter pills — LIVE inside the mini-search bar (one filtering pathway); pill radius = 999, distinct from the row's 7px Signal/Ref/Stamp chips */
+  .spill{height:22px; display:inline-flex; align-items:center; gap:5px; padding:0 5px 0 10px; border-radius:999px; background:var(--accSoft); color:var(--accent); font-family:var(--stamp); font-size:9.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .spx{width:14px;height:14px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);cursor:pointer}
+  .spx .ic{width:9px;height:9px}
+  .gscope{width:26px;height:26px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;color:var(--txt3);cursor:pointer;flex:none}
+  .gscope .ic{width:14px;height:14px}
+  .gscope.on{color:var(--accent); background:var(--accSoft)}
+
+  /* recent-searches — opens ABOVE the bar, never below (so it never covers live results). Demonstrated here with column-reverse flex: real DOM order is bar-then-drop, reverse renders drop on top. */
+  .stackrev{display:flex; flex-direction:column-reverse}
+  .recentdrop{padding:6px 0 10px}
+  .recentdrop.pop{background:var(--panel); border:1px solid var(--line); border-radius:12px; margin:0 10px 8px; box-shadow:var(--shadowPop); overflow:hidden}
+  .recentrow{display:flex; align-items:center; gap:10px; padding:8px 16px; font-size:13px; color:var(--txt2); cursor:pointer}
+  .recentrow:hover{background:var(--cardh)}
+  .recentrow .ic{color:var(--txt3)}
+  .recentrow b{color:var(--txt); font-weight:600}
+
+  /* chrome row — replaces Gmail's filter chips: OUR "Views & sort" (left) + channel toggle (right) */
+  .chromerow{display:flex; align-items:center; gap:8px; padding:9px 14px; border-bottom:1px solid var(--line); flex-wrap:wrap; background:var(--panel); position:relative}
+  .viewsort-menu{position:absolute; top:calc(100% + 8px); left:14px; z-index:15; min-width:210px; background:var(--panel); border:1px solid var(--line); border-radius:12px; box-shadow:var(--shadowPop); padding:6px; overflow:hidden}
+  .vs-label{font-family:var(--stamp); font-size:9px; letter-spacing:.1em; text-transform:uppercase; color:var(--txt3); padding:7px 10px 4px}
+  .vs-opt{display:flex; align-items:center; gap:7px; padding:7px 10px; border-radius:8px; font-size:12.5px; color:var(--txt2); cursor:pointer}
+  .vs-opt:hover{background:var(--cardh)}
+  .vs-opt.on{color:var(--txt); font-weight:700}
+  .vs-opt.on::before{content:''; width:5px; height:5px; border-radius:50%; background:var(--accent); flex:none}
+  .vs-opt .ic{width:12px;height:12px; color:var(--yellow)}
+  .vs-opt.add{color:var(--commit); font-weight:700}
+  .vs-div{height:1px; background:var(--line); margin:4px 4px}
+
+  /* ================= three-pane app frame ================= */
+  .threepane{display:grid; grid-template-columns:200px 360px 1fr; min-height:600px}
+  @media (max-width:900px){ .threepane{grid-template-columns:1fr} .rail,.rpane{display:none} }
+
+  .rail{border-right:1px solid var(--line); padding:12px 10px; display:flex; flex-direction:column; gap:2px; background:var(--panel); overflow-y:auto}
+  .compose-btn{width:100%; justify-content:center; margin-bottom:10px}
+  .navrow{display:flex; align-items:center; gap:10px; padding:7px 10px; border-radius:8px; border-left:3px solid transparent; font-size:13px; color:var(--txt2); cursor:pointer; white-space:nowrap}
+  .navrow .ic{width:16px; height:16px; flex:none; color:var(--txt3)}
+  .navrow .cnt{margin-left:auto; font-family:var(--stamp); font-size:10.5px; font-weight:700; color:var(--txt3)}
+  .navrow.active{background:var(--accSoft); color:var(--txt); border-left-color:var(--accent); font-weight:700}
+  .navrow.active .ic{color:var(--accent)}
+  .navrow.active .cnt{color:var(--accent)}
+
+  /* ================= thread list ================= */
+  .tlist{border-right:1px solid var(--line); overflow-y:auto; background:var(--card)}
+  .trow{display:flex; flex-direction:column; gap:5px; padding:10px 12px; border-bottom:1px solid var(--lineSoft); cursor:pointer; border-left:3px solid transparent}
+  .trow.unread{background:var(--cardh)}
+  .trow.selected{background:var(--accSoft)}
+  .trow.sred{border-left-color:var(--red)} .trow.sblue{border-left-color:var(--blue)} .trow.syellow{border-left-color:var(--yellow)} .trow.sgray{border-left-color:var(--gray)} .trow.sgreen{border-left-color:var(--green)}
+  .trow1{display:flex; align-items:center; gap:8px}
+  .star{width:var(--h); height:var(--h); display:inline-flex; align-items:center; justify-content:center; flex:none; color:var(--txt3); cursor:pointer}
+  .star .ic{width:15px;height:15px; fill:none}
+  .star.on{color:var(--yellow)} .star.on .ic{fill:currentColor}
+  .tavatar{width:28px; height:28px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-family:var(--stamp); font-weight:800; font-size:10px; flex:none; background:var(--card); border:1px solid var(--line); color:var(--txt2)}
+  .tavatar.cust{box-shadow:inset 0 0 0 1.5px var(--accLine)}
+  .tavatar.team{box-shadow:inset 0 0 0 1.5px var(--tan)}
+  .tavatar.bot{box-shadow:inset 0 0 0 1.5px var(--accent); background:var(--accSoft); color:var(--accent)}
+  .tsub{flex:1; min-width:0; display:flex; align-items:baseline; gap:6px; overflow:hidden}
+  .tsender{font-family:var(--font); font-weight:600; font-size:13px; color:var(--txt2); white-space:nowrap; flex:none; max-width:34%; overflow:hidden; text-overflow:ellipsis}
+  .trow.unread .tsender{font-weight:700; color:var(--txt)}
+  .tsubject{font-family:var(--font); font-weight:400; font-size:13px; color:var(--txt2); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; min-width:0}
+  .trow.unread .tsubject{font-weight:700; color:var(--txt)}
+  .tsubject .snip{font-weight:400 !important; color:var(--txt3) !important}
+  .tdot{width:6px; height:6px; border-radius:50%; background:var(--accent); flex:none}
+  .trow:not(.unread) .tdot{visibility:hidden}
+  .ttime{margin-left:auto; font-family:var(--stamp); font-size:11px; color:var(--txt3); font-variant-numeric:tabular-nums; flex:none; padding-left:8px}
+  .trow.unread .ttime{color:var(--txt2); font-weight:700}
+  .trow2{display:flex; align-items:center; gap:6px; flex-wrap:wrap; padding-left:36px}
+  .mention{font-weight:700; color:var(--accent); background:var(--accSoft); padding:1px 5px; border-radius:4px}
+
+  .handoff{background:var(--cardh)}
+  .handoff .trow1{gap:12px}
+  .handoff-icon{width:32px; height:32px; border-radius:8px; background:var(--accSoft); color:var(--accent); display:inline-flex; align-items:center; justify-content:center; flex:none}
+  .handoff-icon .ic{width:16px;height:16px}
+  .handoff-txt{flex:1; min-width:0; font-size:13px; color:var(--txt)}
+  .handoff-txt b{font-weight:700}
+
+  /* ================= reading pane (email — native Gmail form) ================= */
+  .rpane{overflow-y:auto; background:var(--card); display:flex; flex-direction:column}
+  .rp-header{padding:14px 16px; border-bottom:1px solid var(--line)}
+  .rp-context{display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-bottom:9px}
+  .rp-subject{font-family:var(--font); font-weight:700; font-size:15px; color:var(--txt); margin:0 0 6px}
+  .rp-caption{font-size:11.5px; color:var(--txt3); margin:0; max-width:64ch}
+  .rp-caption b{color:var(--txt2)}
+  .rp-msgs{padding:12px 16px; display:flex; flex-direction:column; gap:12px}
+  .msg{border:1px solid var(--line); border-radius:10px; background:var(--panel2); overflow:hidden}
+  .msg-head{display:flex; align-items:center; gap:8px; padding:8px 11px; border-bottom:1px solid var(--line); flex-wrap:wrap}
+  .msg-av{width:24px; height:24px; border-radius:50%; background:var(--card); border:1px solid var(--line); display:inline-flex; align-items:center; justify-content:center; font-family:var(--stamp); font-size:9px; font-weight:800; color:var(--txt2); flex:none}
+  .msg-id{display:flex; flex-direction:column; gap:1px; min-width:0}
+  .msg-who{font-family:var(--font); font-weight:700; font-size:13px; color:var(--txt); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .msg-chan{display:inline-flex; align-items:center; gap:4px; font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.06em; text-transform:uppercase; color:var(--txt3); flex:none}
+  .msg-chan .ic{width:10px;height:10px}
+  .msg-time{margin-left:auto; font-family:var(--stamp); font-size:10.5px; color:var(--txt3); font-variant-numeric:tabular-nums; flex:none}
+  .msg-body{padding:10px 12px; font-size:13px; color:var(--txt2); line-height:1.55}
+  .rp-reply{border-top:1px solid var(--line); padding:12px 16px; margin-top:auto}
+  .replybox{border:1px solid var(--line); border-radius:12px; background:var(--bg2); padding:10px 12px}
+  .replytext{font-size:13px; color:var(--txt3); min-height:20px}
+  .replyfoot{display:flex; align-items:center; gap:8px; margin-top:10px; flex-wrap:wrap}
+
+  /* ================= native conversation — TEXTS (Apple Messages bubbles) ================= */
+  .applemsg{padding:14px 16px 18px; display:flex; flex-direction:column; gap:9px; background:var(--card)}
+  .bubblerow{display:flex; flex-direction:column; max-width:74%}
+  .bubblerow.sent{align-self:flex-end; align-items:flex-end}
+  .bubblerow.recv{align-self:flex-start; align-items:flex-start}
+  .bubble{padding:9px 13px; border-radius:17px; font-size:13px; line-height:1.45}
+  .bubblerow.sent .bubble{background:var(--commit); color:var(--onFill); border-bottom-right-radius:5px}
+  .bubblerow.recv .bubble{background:var(--panel2); color:var(--txt); border:1px solid var(--line); border-bottom-left-radius:5px}
+  .bubble-receipt{font-family:var(--stamp); font-size:9.5px; color:var(--txt3); margin-top:3px; letter-spacing:.04em; text-transform:uppercase; padding-right:2px}
+  .bubble-img{display:inline-flex; align-items:center; gap:6px; padding:5px 10px 5px 5px; border-radius:14px; background:var(--panel2); border:1px solid var(--line); font-size:11.5px; color:var(--txt2); margin-top:1px}
+  .bubble-img .ph{width:22px;height:22px;border-radius:6px;background:var(--card);border:1px solid var(--line);display:inline-flex;align-items:center;justify-content:center;color:var(--txt3); flex:none}
+
+  /* ================= native conversation — TEAM (Messenger-style channels) ================= */
+  .msgr-frame{display:grid; grid-template-columns:158px 1fr; min-height:300px}
+  @media (max-width:640px){ .msgr-frame{grid-template-columns:1fr} .msgr-chanlist{display:none} }
+  .msgr-chanlist{border-right:1px solid var(--line); background:var(--panel); padding:10px 7px; display:flex; flex-direction:column; gap:2px}
+  .msgr-chan{display:flex; align-items:center; gap:6px; padding:8px 8px; border-radius:8px; font-family:var(--font); font-size:12px; color:var(--txt2); cursor:pointer; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .msgr-chan .ic{width:12px;height:12px; color:var(--txt3); flex:none}
+  .msgr-chan.active{background:var(--accSoft); color:var(--txt); font-weight:700}
+  .msgr-chan.active .ic{color:var(--accent)}
+  .msgr-chan .dot{width:6px;height:6px;border-radius:50%;background:var(--accent); margin-left:auto; flex:none}
+  .msgr-body{padding:14px 16px 18px; display:flex; flex-direction:column; gap:16px; background:var(--card)}
+  .msgr-msg{display:flex; gap:9px; align-items:flex-start}
+  .msgr-av-wrap{position:relative; flex:none}
+  .msgr-av{width:30px;height:30px;border-radius:50%;background:var(--card);border:1px solid var(--line);display:inline-flex;align-items:center;justify-content:center;font-family:var(--stamp);font-size:10px;font-weight:800;color:var(--txt2)}
+  .presence{position:absolute; right:-1px; bottom:-1px; width:9px; height:9px; border-radius:50%; background:var(--green); border:2px solid var(--card)}
+  .presence.off{background:var(--gray)}
+  .msgr-col{display:flex; flex-direction:column; gap:3px; max-width:78%; min-width:0}
+  .msgr-name{font-family:var(--font); font-weight:700; font-size:11.5px; color:var(--txt2)}
+  .msgr-bubble{position:relative; padding:9px 13px; border-radius:15px; border-top-left-radius:4px; background:var(--panel2); border:1px solid var(--line); color:var(--txt); font-size:13px; line-height:1.45; width:fit-content}
+  .msgr-reactions{display:inline-flex; align-items:center; gap:3px; position:absolute; bottom:-10px; right:8px; background:var(--card); border:1px solid var(--line); border-radius:999px; padding:2px 6px}
+  .msgr-reactions .ic{width:11px;height:11px}
+  .msgr-reactions .heart{color:var(--red)}
+  .msgr-reactions .laugh{color:var(--yellow)}
+  .msgr-refrow{margin-top:9px}
+
+  /* ================= native conversation — WRANGLER (bot thread, styled distinct) ================= */
+  .wthread{padding:14px 16px 18px; display:flex; flex-direction:column; gap:12px; background:var(--card)}
+  .wmsg{display:flex; gap:9px; align-items:flex-start}
+  .wmsg.user{flex-direction:row-reverse}
+  .wmsg.user .wcol{align-items:flex-end}
+  .wav{width:28px;height:28px;border-radius:7px;background:var(--accSoft);color:var(--accent);display:inline-flex;align-items:center;justify-content:center;flex:none}
+  .wav.person{background:var(--card); border:1px solid var(--line); border-radius:50%; color:var(--txt2)}
+  .wav .ic{width:14px;height:14px}
+  .wcol{display:flex; flex-direction:column; gap:5px; max-width:76%}
+  .wbubble{padding:9px 13px; border-radius:14px; font-size:13px; line-height:1.45}
+  .wmsg.user .wbubble{background:var(--commit); color:var(--onFill); border-bottom-right-radius:4px; font-family:var(--font)}
+  .wmsg.bot .wbubble{background:var(--tanSoft); border:1px solid var(--line); color:var(--txt); border-bottom-left-radius:4px; font-family:var(--stamp); font-size:12px; letter-spacing:.01em}
+  .wfoot{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+
+  /* loud, distinct bell alert — Mr. Wrangler resolving something, vs. today's barely-there ping */
+  .wbell{position:relative; display:flex; align-items:center; gap:11px; padding:12px 14px 12px 20px; background:var(--accSoft); border:1px solid var(--accLine); border-radius:11px; overflow:hidden}
+  .wbell-bar{position:absolute; left:0; top:0; bottom:0; width:5px; background:var(--accent)}
+  .wbell-ic{width:32px;height:32px;border-radius:9px;background:var(--accent);color:var(--onAcc);display:inline-flex;align-items:center;justify-content:center;flex:none}
+  .wbell-ic .ic{width:16px;height:16px}
+  .wbell-txt{flex:1; min-width:0; font-size:13px; color:var(--txt); font-weight:600}
+  .wbell-txt b{font-weight:800}
+
+  /* ================= mobile phone frame ================= */
+  .phonewrap{display:flex; justify-content:center; margin-top:16px}
+  .phone{width:380px; max-width:100%; border:1px solid var(--line); border-radius:22px; overflow:hidden; background:var(--card); position:relative}
+  .phone .topbar{padding:10px 12px}
+  .phone .tlist{max-height:390px; overflow-y:auto; border-right:0}
+  .phone .trow{padding:9px 10px}
+  .phone .trow2{padding-left:34px}
+  .fab{position:absolute; right:14px; bottom:14px; width:52px; height:52px; border-radius:999px; background:var(--commit); color:var(--onFill); display:inline-flex; align-items:center; justify-content:center; cursor:pointer; z-index:6; border:0}
+  .fab .ic{width:22px;height:22px}
+  .scrim{position:absolute; inset:0; background:rgba(5,7,10,.55); opacity:0; pointer-events:none; transition:opacity .18s; z-index:8}
+  .scrim.open{opacity:1; pointer-events:auto}
+  .drawer{position:absolute; top:0; left:0; bottom:0; width:78%; max-width:280px; background:var(--panel); border-right:1px solid var(--line); transform:translateX(-100%); transition:transform .2s ease; z-index:9; display:flex; flex-direction:column; padding:14px 10px; overflow-y:auto}
+  .drawer.open{transform:translateX(0)}
+
+  /* swipeable channel header — mobile's answer to the desktop toggle */
+  .swipehead{display:flex; align-items:center; gap:4px; padding:6px 8px; border-bottom:1px solid var(--line); background:var(--bg2); touch-action:pan-y}
+  .swarrow{width:36px; height:36px; border-radius:9px; display:inline-flex; align-items:center; justify-content:center; color:var(--txt3); cursor:pointer; flex:none; background:var(--card); border:1px solid var(--line)}
+  .swipetrack{flex:1; min-width:0; display:flex; align-items:center; justify-content:center; gap:6px; height:36px; border-radius:999px; background:var(--accent); color:var(--onAcc); font-family:var(--stamp); font-weight:800; font-size:11px; letter-spacing:.03em; text-transform:uppercase; user-select:none}
+  .swipetrack.soon{background:transparent; border:1px dashed var(--line); color:var(--txt3)}
+  .swipetrack .ic{width:13px;height:13px}
+  .swipetrack .cnt{opacity:.8}
+  .swipetrack .soonmark{font-size:8px; padding:0 5px; border-radius:999px; border:1px solid currentColor; margin-left:2px}
+  .swdots{display:flex; align-items:center; justify-content:center; gap:5px; padding:7px 0 2px}
+  .swdots .d{width:6px; height:6px; border-radius:50%; background:var(--line); cursor:pointer}
+  .swdots .d.on{background:var(--accent); width:14px; border-radius:999px}
+  .swplaceholder{padding:36px 20px; text-align:center; font-size:12.5px; color:var(--txt3)}
+
+  /* ================= footer comms dock (altitude two) ================= */
+  .dockdemo{padding:0}
+  .dockbar{position:relative; min-height:230px; background:var(--bg2); padding:16px; display:flex; align-items:flex-end; gap:10px; flex-wrap:wrap}
+  .dockchip{height:34px; display:inline-flex; align-items:center; gap:8px; padding:0 12px; border-radius:9px 9px 0 0; background:var(--panel2); border:1px solid var(--line); border-bottom:0; color:var(--txt2); font-size:12px; font-weight:600; cursor:pointer; white-space:nowrap; position:relative}
+  .dockchip.flash{border-color:var(--accent); background:var(--accSoft)}
+  .dockchip .dot{width:6px; height:6px; border-radius:50%; background:var(--yellow); flex:none}
+  .composedock{width:300px; max-width:100%; background:var(--panel); border:1px solid var(--line); border-bottom:0; border-radius:10px 10px 0 0; overflow:hidden; margin-left:auto}
+  .cd-head{display:flex; align-items:center; gap:8px; padding:8px 10px; background:var(--panel2); border-bottom:1px solid var(--line)}
+  .cd-head .t{font-size:12px; font-weight:700; color:var(--txt); flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .cd-icon{width:20px; height:20px; display:inline-flex; align-items:center; justify-content:center; color:var(--txt3); cursor:pointer; flex:none}
+  .cd-icon .ic{width:12px;height:12px}
+  .cd-body{padding:9px 10px; display:flex; flex-direction:column; gap:7px}
+  .cd-body.min{display:none}
+  .cd-field{font-size:12px; color:var(--txt3); border-bottom:1px solid var(--lineSoft); padding-bottom:6px}
+  .cd-field b{color:var(--txt2); font-weight:600; margin-right:4px}
+  .cd-textarea{font-size:12px; color:var(--txt2); min-height:46px}
+  .cd-foot{display:flex; justify-content:flex-end; padding:8px 10px; border-top:1px solid var(--line)}
+  .cd-foot.min{display:none}
+
+  .annot{font-size:12px; color:var(--txt3); margin:10px 0 0; display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .flow{display:flex; align-items:center; gap:6px; flex-wrap:wrap}
+  .flowstep{display:inline-flex; align-items:center; gap:5px; font-family:var(--stamp); font-size:10px; font-weight:800; text-transform:uppercase; color:var(--txt2)}
+  .flowstep .ic{width:13px;height:13px; color:var(--txt3)}
+  .flowarrow{width:12px;height:12px; color:var(--txt3)}
+
+  .foot{margin-top:30px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:96ch} .foot b{color:var(--txt)}
+  .foot ul{margin:8px 0 0; padding-left:20px} .foot li{margin:7px 0}
+
+  /* ---------- callout (borrowed from get-told — same annotation device) ---------- */
+  .callout{padding:10px 12px; background:var(--bg2); border:1.4px dashed var(--accLine); border-radius:9px; font-size:11.5px; color:var(--txt2); line-height:1.5; position:relative}
+  .callout .lab{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; color:var(--accent); display:block; margin-bottom:4px}
+  .callout b{color:var(--txt)}
+
+  /* ================= v3 — §7.4 draggable divider (roomy stage only) ================= */
+  .paneDivider{width:6px; cursor:col-resize; position:relative; z-index:4; flex:none; background:transparent}
+  .paneDivider::after{content:''; position:absolute; top:0; bottom:0; left:2.5px; width:1px; background:var(--line)}
+  .paneDivider:hover::after,.paneDivider.dragging::after{background:var(--accent); width:2px; left:2px}
+  .threepane.withdivider{grid-template-columns:200px 360px 6px 1fr}
+  @media (max-width:900px){ .threepane.withdivider{grid-template-columns:1fr} .paneDivider{display:none} }
+
+  /* ================= v3 — §7.4 one-card width: hamburger/list/email choreography ================= */
+  .ocdemo{max-width:460px; margin:0 auto; background:var(--card)}
+  .ocbody{position:relative; display:flex; min-height:380px; overflow:hidden}
+  .ocslot1{flex:0 0 130px; border-right:1px solid var(--line); background:var(--panel); position:relative; overflow-y:auto}
+  .ocslot2{flex:1; min-width:0; display:flex; flex-direction:column; overflow-y:auto}
+  .ocmenu{display:none; flex-direction:column; gap:2px; padding:10px 6px}
+  .ocwrap[data-state="browsing"] .ocmenu{display:flex}
+  .ocslot1 .navrow{font-size:11.5px; padding:6px 7px}
+  .ocmenu-peek{position:absolute; top:0; left:0; bottom:0; width:130px; background:var(--panel); border-right:1px solid var(--accLine); box-shadow:var(--shadowPop); z-index:6; padding:10px 6px; display:flex; flex-direction:column; gap:2px; opacity:0; pointer-events:none; transition:opacity .12s}
+  .ocwrap[data-state="reading"] .js-oc-ham:hover ~ .ocbody .ocmenu-peek{opacity:1; pointer-events:auto}
+  .oclistnarrow .trow2{display:none}
+  .ocemail{padding:12px 14px; display:none; flex-direction:column; gap:10px}
+  .oclistwide{display:none}
+  .ocwrap[data-state="reading"] .oclistnarrow{display:block}
+  .ocwrap[data-state="reading"] .ocemail{display:flex}
+  .ocwrap[data-state="browsing"] .oclistnarrow{display:none}
+  .ocwrap[data-state="browsing"] .oclistwide{display:block}
+  .ocwrap[data-state="browsing"] .ocemail{display:none}
+  .ocstate{font-family:var(--stamp); font-size:9px; letter-spacing:.1em; text-transform:uppercase; color:var(--accent); font-weight:800}
+
+  /* ================= v3 — §7 inbox-expand: Focus toggle + sibling spines ================= */
+  .cardpool{display:flex; gap:10px; align-items:stretch; min-height:250px}
+  .poolcard{background:var(--card); border:1px solid var(--line); border-radius:12px; overflow:hidden; display:flex; flex-direction:column; position:relative; transition:flex-basis .22s ease, flex-grow .22s ease, border-color .3s}
+  .poolcard.flash{border-color:var(--accent)}
+  .poolcard.inboxcard{flex:1 1 33.33%}
+  .poolcard.spine{flex:1 1 33.33%}
+  .cardpool[data-focus="half"] .inboxcard{flex:1 1 50%}
+  .cardpool[data-focus="full"] .inboxcard{flex:1 1 100%}
+  .cardpool:not([data-focus="balanced"]) .poolcard.spine{flex:0 0 42px; cursor:pointer}
+  .poolhead{display:flex; align-items:center; gap:8px; padding:10px 12px; border-bottom:1px solid var(--line); background:var(--panel)}
+  .poolttl{font-family:var(--font); font-weight:700; font-size:13px; color:var(--txt); flex:1}
+  .poolbody{padding:10px 12px; display:flex; flex-direction:column; gap:8px; overflow:hidden; flex:1}
+  .cardpool:not([data-focus="balanced"]) .poolcard.spine .poolbody,
+  .cardpool:not([data-focus="balanced"]) .poolcard.spine .poolhead .poolttl{display:none}
+  .spine-tab{display:none; align-items:center; justify-content:center; gap:8px; padding:10px 0; height:100%}
+  .cardpool:not([data-focus="balanced"]) .poolcard.spine .spine-tab{display:flex}
+  .spine-tab .spttl{writing-mode:vertical-rl; text-orientation:mixed; font-family:var(--font); font-weight:700; font-size:12.5px; color:var(--txt2); letter-spacing:.02em}
+  .spine-dot{width:7px; height:7px; border-radius:50%; flex:none}
+  .spine-peek{position:absolute; left:100%; top:0; margin-left:8px; width:190px; background:var(--panel); border:1px solid var(--line); border-radius:10px; box-shadow:var(--shadowPop); padding:10px 12px; z-index:9; opacity:0; pointer-events:none; transition:opacity .12s}
+  .poolcard.spine:hover .spine-peek{opacity:1}
+  .spine-peek .pptitle{font-family:var(--stamp); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase; color:var(--txt3); margin-bottom:6px}
+
+  /* ================= v3 — §7.4 quick actions: hover row actions + right-click menu + drag hint ================= */
+  .trow{position:relative}
+  .rowdrag{width:0; overflow:hidden; opacity:0; display:inline-flex; align-items:center; justify-content:center; color:var(--txt3); cursor:grab; transition:width .15s,opacity .15s; flex:none}
+  .trow:hover .rowdrag{width:14px; opacity:.55}
+  .rowdrag .ic{width:12px;height:12px}
+  .rowacts{display:none; align-items:center; gap:2px; margin-left:auto; padding-left:8px; flex:none}
+  #tlist .trow:hover .ttime{display:none}
+  #tlist .trow:hover .rowacts{display:inline-flex}
+  .rowact-btn{width:24px; height:24px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; color:var(--txt3); cursor:pointer; flex:none}
+  .rowact-btn:hover{background:var(--card); color:var(--txt)}
+  .rowact-btn.danger:hover{color:var(--red)}
+  .rowact-btn .ic{width:14px;height:14px}
+  .ctxmenu{position:absolute; z-index:20; min-width:172px; background:var(--panel); border:1px solid var(--line); border-radius:12px; box-shadow:var(--shadowPop); padding:6px; overflow:hidden}
+  .ctx-opt{display:flex; align-items:center; gap:8px; padding:7px 10px; border-radius:8px; font-size:12.5px; color:var(--txt2); cursor:pointer; white-space:nowrap}
+  .ctx-opt:hover{background:var(--cardh); color:var(--txt)}
+  .ctx-opt .ic{width:13px;height:13px; color:var(--txt3)}
+  .ctx-opt.danger:hover{color:var(--red)} .ctx-opt.danger:hover .ic{color:var(--red)}
+  .ctx-div{height:1px; background:var(--line); margin:4px 4px}
+  .swiperow{position:relative; overflow:hidden; border-radius:10px; border:1px solid var(--line)}
+  .swipe-actions{position:absolute; top:0; right:0; bottom:0; display:flex}
+  .swipe-actions b{width:64px; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:3px; font-family:var(--stamp); font-size:8.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; cursor:pointer; border:0}
+  .swipe-actions b.a-snooze{background:var(--yellow); color:#211a05}
+  .swipe-actions b.a-archive{background:var(--green); color:#04140d}
+  .swiperow .trow{position:relative; z-index:2; background:var(--card); transition:transform .22s ease}
+  .swiperow.peeked .trow{transform:translateX(-128px)}
+
+  /* ================= v3 — §7.5 inbound routing demo ================= */
+  .dcsnip{margin-left:4px; color:var(--txt3); font-weight:400; max-width:150px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-block; vertical-align:bottom}
+  .dockchip.js-newchip{animation:chipin .22s ease}
+  @keyframes chipin{from{opacity:0; transform:translateY(6px)} to{opacity:1; transform:translateY(0)}}
+  .bdgbell.flashbell .ic{color:var(--accent)}
+  .dockpreview{position:absolute; bottom:100%; left:0; margin-bottom:8px; width:220px; background:var(--panel); border:1px solid var(--accLine); border-radius:10px; box-shadow:var(--shadowPop); padding:10px 12px; font-size:12px; color:var(--txt2); z-index:12}
+  .dockpreview b{color:var(--txt)}
+
+  /* ================= v3 — mobile tap-to-read swap (§7.4c) ================= */
+  .phone-reading{position:absolute; inset:0; background:var(--card); transform:translateX(100%); transition:transform .2s ease; z-index:7; display:flex; flex-direction:column}
+  .phone-reading.open{transform:translateX(0)}
+  .pr-head{display:flex; align-items:center; gap:8px; padding:10px 12px; border-bottom:1px solid var(--line); background:var(--bg2)}
+  .pr-back{width:32px; height:32px; border-radius:9px; display:inline-flex; align-items:center; justify-content:center; background:var(--card); border:1px solid var(--line); color:var(--txt2); cursor:pointer; flex:none}
+  .pr-back .ic{width:15px;height:15px}
+  .pr-subject{font-family:var(--font); font-weight:700; font-size:13px; color:var(--txt); margin:0; flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+  .pr-from{padding:10px 14px 0; font-size:11.5px; color:var(--txt3)}
+  .pr-from b{color:var(--txt2)}
+  .pr-body{padding:10px 14px 16px; font-size:13px; color:var(--txt2); line-height:1.55}
+</style>
+
+<svg style="display:none">
+  <symbol id="i-search" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></symbol>
+  <symbol id="i-menu" viewBox="0 0 24 24"><path d="M4 12h16"/><path d="M4 6h16"/><path d="M4 18h16"/></symbol>
+  <symbol id="i-bell" viewBox="0 0 24 24"><path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/></symbol>
+  <symbol id="i-inbox" viewBox="0 0 24 24"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></symbol>
+  <symbol id="i-star" viewBox="0 0 24 24"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></symbol>
+  <symbol id="i-chev-r" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></symbol>
+  <symbol id="i-chev-l" viewBox="0 0 24 24"><path d="m15 18-6-6 6-6"/></symbol>
+  <symbol id="i-chev-d" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></symbol>
+  <symbol id="i-user" viewBox="0 0 24 24"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></symbol>
+  <symbol id="i-circle-user" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="10" r="3"/><path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662"/></symbol>
+  <symbol id="i-truck" viewBox="0 0 24 24"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></symbol>
+  <symbol id="i-wrench" viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94z"/></symbol>
+  <symbol id="i-paperclip" viewBox="0 0 24 24"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></symbol>
+  <symbol id="i-image" viewBox="0 0 24 24"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></symbol>
+  <symbol id="i-file-text" viewBox="0 0 24 24"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></symbol>
+  <symbol id="i-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></symbol>
+  <symbol id="i-send" viewBox="0 0 24 24"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></symbol>
+  <symbol id="i-calendar" viewBox="0 0 24 24"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></symbol>
+  <symbol id="i-archive" viewBox="0 0 24 24"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></symbol>
+  <symbol id="i-octagon-alert" viewBox="0 0 24 24"><path d="M12 16h.01"/><path d="M12 8v4"/><path d="M15.312 2a2 2 0 0 1 1.414.586l4.688 4.688A2 2 0 0 1 22 8.688v6.624a2 2 0 0 1-.586 1.414l-4.688 4.688a2 2 0 0 1-1.414.586H8.688a2 2 0 0 1-1.414-.586l-4.688-4.688A2 2 0 0 1 2 15.312V8.688a2 2 0 0 1 .586-1.414l4.688-4.688A2 2 0 0 1 8.688 2z"/></symbol>
+  <symbol id="i-trash" viewBox="0 0 24 24"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></symbol>
+  <symbol id="i-phone" viewBox="0 0 24 24"><path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.804 1.6l-.469.351a1 1 0 0 0-.311 1.226 12.035 12.035 0 0 0 6.116 6.591Z"/></symbol>
+  <symbol id="i-mail" viewBox="0 0 24 24"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></symbol>
+  <symbol id="i-app-window" viewBox="0 0 24 24"><rect width="18" height="14" x="3" y="5" rx="2"/><path d="M3 9h18"/><path d="M7 7h.01"/><path d="M10 7h.01"/></symbol>
+  <symbol id="i-plus" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="M12 5v14"/></symbol>
+  <symbol id="i-minus" viewBox="0 0 24 24"><path d="M5 12h14"/></symbol>
+  <symbol id="i-x" viewBox="0 0 24 24"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></symbol>
+  <symbol id="i-check" viewBox="0 0 24 24"><path d="M21.801 10A10 10 0 1 1 17 3.335"/><path d="m9 11 3 3L22 4"/></symbol>
+  <symbol id="i-globe" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></symbol>
+  <symbol id="i-hash" viewBox="0 0 24 24"><line x1="4" x2="20" y1="9" y2="9"/><line x1="4" x2="20" y1="15" y2="15"/><line x1="10" x2="8" y1="3" y2="21"/><line x1="16" x2="14" y1="3" y2="21"/></symbol>
+  <symbol id="i-message-circle" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></symbol>
+  <symbol id="i-heart" viewBox="0 0 24 24"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"/></symbol>
+  <symbol id="i-laugh" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M18 13a6 6 0 0 1-6 5 6 6 0 0 1-6-5h12Z"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></symbol>
+  <symbol id="i-eye-off" viewBox="0 0 24 24"><path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"/><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"/><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"/><path d="m2 2 20 20"/></symbol>
+  <symbol id="i-grip" viewBox="0 0 24 24"><circle cx="9" cy="5" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="19" r="1"/></symbol>
+</svg>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Inbox card v3 · comms spec §7.1–7.5 · channels-as-toggle + native-per-medium + responsive space model + inbox-expand — for Jac to react to, not final</p>
+  <h1>Inbox v3 — <span class="hl">channels up top, talk native</span></h1>
+  <p class="lede">Two structural changes from v1. <b>One</b> — <b>channel moves out of the buried left-rail "Streams" list
+  and up to a top toggle</b>: <code>ALL · TEAM · TEXTS · EMAIL · WRANGLER · CALLS</code>, each carrying its own unread
+  count, CALLS dimmed as a "soon" placeholder. The left rail goes back to being <b>just Gmail's folders.</b> <b>Two</b> —
+  <b>a thread now renders in its medium's own native form</b> instead of Gmail's reading pane wearing every hat: email
+  stays a Gmail thread, a text becomes Apple-Messages bubbles, a Team post becomes a Messenger channel with presence +
+  reactions, and Mr. Wrangler gets his own bot-thread with a loud, distinct bell when he actually fixes something. The
+  chrome around all of it — search, filters, sort — is <b>ours</b>, not Gmail's: the <code>mini-search</code> bar with
+  pills live in it, the globe scope toggle, and a <b>Views &amp; sort</b> menu. Same cross-record continuity as v1 —
+  every thread still knows which customer/rental/unit it's about.</p>
+  <p class="lede"><b>v3 adds four things</b> from spec §7.4–§7.5, all new sections below (7–10): the card's own
+  <b>responsive space model</b> — three width stages plus the left-menu hover/click choreography that swaps the
+  hamburger menu for the thread list without ever moving it; an <b>Inbox-only Focus toggle</b> (⅓ → ½ → full) that
+  shrinks its two siblings to slim clickable spines and rebalances the instant you touch one; a <b>shared quick-action
+  set</b> — Hide · Mark unread · Star · Snooze · Archive — live as row actions and a right-click menu on the same
+  five; and the <b>inbound-routing</b> rule for where a new text or email actually lands. Interactive throughout —
+  hover, click, and right-click the demos, don't just read them.</p>
+  <div class="key"><span><b>Signal</b> state chip</span><span><b>Ref</b> linked record</span><span><b>Stamp/Label</b> fact</span><span><b>Door</b> the one move</span><span><b>Contact</b> tel:/mailto:</span><span>· fill = today · colour = state · unread = dot+bold+bright, never colour alone</span></div>
+
+  <!-- ================= 1: TOP CHROME — OURS, NOT GMAIL'S ================= -->
+  <h2 class="sec"><span class="n">1</span> Top chrome — our search + sort, not Gmail's</h2>
+  <p class="secnote">Gmail's From/To/Attachment/Starred/Unread filter chips are gone. In their place: our own
+  <b>mini-search</b> — active filters render as <b>removable pills live in the bar</b> (one filtering pathway, pill
+  radius 999 so they read as "remove me," distinct from the row's chip-radius Signals) — a trailing <b>globe</b> scope
+  toggle (this channel ↔ all comms), and a separate <b>Views &amp; sort</b> button. Focusing search still drops a
+  <b>recent-searches</b> list first — but it now opens <b>above</b> the bar, never below, so it can't cover live results.</p>
+  <div class="chromegrid">
+    <div class="panel">
+      <div class="pcap">Default</div>
+      <div class="topbar" style="border-bottom:0">
+        <span class="iconbtn"><svg class="ic"><use href="#i-menu"></use></svg></span>
+        <div class="searchwrap">
+          <div class="mini-search">
+            <svg class="ic"><use href="#i-search"></use></svg>
+            <span class="ph">Search this channel…</span>
+            <span class="gscope" title="Scope: this channel"><svg class="ic"><use href="#i-globe"></use></svg></span>
+          </div>
+        </div>
+        <span class="door ghost">Views &amp; sort<svg class="ic" style="width:11px;height:11px"><use href="#i-chev-d"></use></svg></span>
+        <span class="iconbtn bdgbell"><svg class="ic"><use href="#i-bell"></use></svg><span class="bdg">3</span></span>
+        <span class="avatar">DR</span>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="pcap">Focused — pills in the bar, recent searches open ABOVE</div>
+      <div class="stackrev">
+        <div class="topbar" style="border-bottom:0">
+          <span class="iconbtn"><svg class="ic"><use href="#i-menu"></use></svg></span>
+          <div class="searchwrap">
+            <div class="mini-search focused">
+              <svg class="ic"><use href="#i-search"></use></svg>
+              <span class="spill">Unread<span class="spx"><svg class="ic"><use href="#i-x"></use></svg></span></span>
+              <span class="ph">sandra@boudreauxmarine.com</span>
+              <span class="gscope on" title="Scope: all comms"><svg class="ic"><use href="#i-globe"></use></svg></span>
+            </div>
+          </div>
+          <span class="door ghost">Views &amp; sort<svg class="ic" style="width:11px;height:11px"><use href="#i-chev-d"></use></svg></span>
+          <span class="iconbtn bdgbell"><svg class="ic"><use href="#i-bell"></use></svg><span class="bdg">3</span></span>
+          <span class="avatar">DR</span>
+        </div>
+        <div class="recentdrop pop">
+          <div class="recentrow"><svg class="ic"><use href="#i-clock"></use></svg><b>sandra@boudreauxmarine.com</b></div>
+          <div class="recentrow"><svg class="ic"><use href="#i-clock"></use></svg><b>bill of sale</b></div>
+          <div class="recentrow"><svg class="ic"><use href="#i-clock"></use></svg><b>Duhon Contracting</b></div>
+          <div class="recentrow"><svg class="ic"><use href="#i-clock"></use></svg>has:attachment from:acadianahydraulic.com</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ================= 2: CHANNELS — TOP SEGMENTED TOGGLE ================= -->
+  <h2 class="sec"><span class="n">2</span> Channels — a top segmented toggle, not a buried streams list</h2>
+  <p class="secnote">Left→right: <b>All · Team · Texts · Email · Wrangler · Calls.</b> Active segment fills
+  <b>orange, dark ink</b> — channels aren't a status, so this is the accent fallback, not a filled Signal (same rule
+  that governs every toggle in the app). Each live segment carries its own unread count. <b>Calls</b> is a future
+  in-app-calling placeholder — dimmed and genuinely non-interactive (<code>pointer-events:none</code>), marked
+  <b>Soon</b>, not just visually quiet.</p>
+  <div class="panel">
+    <div class="pcap">Desktop — sits at the top bar / chrome row, right side</div>
+    <div style="padding:16px 14px">
+      <span class="seg chan">
+        <b class="on" data-chan="all"><svg class="ic"><use href="#i-inbox"></use></svg>All<span class="cnt">5</span></b>
+        <b data-chan="team"><svg class="ic"><use href="#i-hash"></use></svg>Team<span class="cnt">2</span></b>
+        <b data-chan="texts"><svg class="ic"><use href="#i-message-circle"></use></svg>Texts<span class="cnt">1</span></b>
+        <b data-chan="email"><svg class="ic"><use href="#i-mail"></use></svg>Email<span class="cnt">1</span></b>
+        <b data-chan="wrangler"><svg class="ic"><use href="#i-wrench"></use></svg>Wrangler<span class="cnt">1</span></b>
+        <b class="soon" data-chan="calls"><svg class="ic"><use href="#i-phone"></use></svg>Calls<span class="soonmark">Soon</span></b>
+      </span>
+    </div>
+  </div>
+
+  <!-- ================= 3: THE FULL WORKSPACE ================= -->
+  <h2 class="sec"><span class="n">3</span> The full workspace — desktop, three panes</h2>
+  <p class="secnote">The left rail is now <b>only Gmail's folders</b> — Inbox / Starred / Snoozed / Sent / Scheduled /
+  Drafts / All mail / Spam / Trash. The channel toggle lives in the chrome row (right side), <b>Views &amp; sort</b> on
+  the left where the old filter chips were. Click a channel to re-filter the thread list live; click a row to select +
+  mark read. <b>Boudreaux Marine LLC</b> is open at right — the <b>email</b> side of that relationship, native Gmail
+  form; its <b>text</b> side is its own thread over in Texts (see §4) — same customer, same Ref, two native threads
+  instead of one Gmail thread wearing two hats.</p>
+  <p class="secnote"><b>v3 — this is the <b>Roomy</b> width stage (§7.4 §7):</b> all three panes at once, so it now
+  carries a <b>draggable divider</b> (drag the thin bar between list and reading pane) and every row below is wired
+  with <b>hover row-actions + right-click quick actions</b> — hover a row or right-click it (see §9). The narrower
+  stages live in §7.</p>
+
+  <div class="panel">
+    <div class="stackrev">
+      <div class="topbar">
+        <span class="iconbtn js-drawer-toggle"><svg class="ic"><use href="#i-menu"></use></svg></span>
+        <div class="searchwrap">
+          <div class="mini-search js-worksearch">
+            <svg class="ic"><use href="#i-search"></use></svg>
+            <span class="ph">Search this channel…</span>
+            <span class="gscope js-gscope" title="Scope: this channel"><svg class="ic"><use href="#i-globe"></use></svg></span>
+          </div>
+        </div>
+        <span class="door save js-compose"><svg class="ic" style="width:13px;height:13px"><use href="#i-plus"></use></svg>Compose</span>
+        <span class="iconbtn bdgbell"><svg class="ic"><use href="#i-bell"></use></svg><span class="bdg">3</span></span>
+        <span class="avatar">DR</span>
+      </div>
+      <div class="recentdrop pop js-recentpop" hidden>
+        <div class="recentrow"><svg class="ic"><use href="#i-clock"></use></svg><b>sandra@boudreauxmarine.com</b></div>
+        <div class="recentrow"><svg class="ic"><use href="#i-clock"></use></svg><b>Duhon Contracting</b></div>
+        <div class="recentrow"><svg class="ic"><use href="#i-clock"></use></svg>has:attachment from:acadianahydraulic.com</div>
+      </div>
+    </div>
+    <div class="chromerow">
+      <span class="door ghost js-viewsort">Views &amp; sort<svg class="ic" style="width:11px;height:11px"><use href="#i-chev-d"></use></svg></span>
+      <div class="viewsort-menu js-vsmenu" hidden>
+        <div class="vs-label">Sort</div>
+        <div class="vs-opt js-vsopt on">Newest first</div>
+        <div class="vs-opt js-vsopt">Unread first</div>
+        <div class="vs-opt js-vsopt">Needs reply</div>
+        <div class="vs-div"></div>
+        <div class="vs-label">Saved views</div>
+        <div class="vs-opt"><svg class="ic"><use href="#i-star"></use></svg>My open threads</div>
+        <div class="vs-opt"><svg class="ic"><use href="#i-star"></use></svg>Overdue only</div>
+        <div class="vs-opt add">+ Save current as a View</div>
+      </div>
+      <span class="fspacer"></span>
+      <span class="seg chan js-chantoggle">
+        <b class="on" data-chan="all"><svg class="ic"><use href="#i-inbox"></use></svg>All<span class="cnt">0</span></b>
+        <b data-chan="team"><svg class="ic"><use href="#i-hash"></use></svg>Team<span class="cnt">0</span></b>
+        <b data-chan="texts"><svg class="ic"><use href="#i-message-circle"></use></svg>Texts<span class="cnt">0</span></b>
+        <b data-chan="email"><svg class="ic"><use href="#i-mail"></use></svg>Email<span class="cnt">0</span></b>
+        <b data-chan="wrangler"><svg class="ic"><use href="#i-wrench"></use></svg>Wrangler<span class="cnt">0</span></b>
+        <b class="soon" data-chan="calls"><svg class="ic"><use href="#i-phone"></use></svg>Calls<span class="soonmark">Soon</span></b>
+      </span>
+    </div>
+
+    <div class="threepane">
+      <!-- RAIL — Gmail folders ONLY, streams removed -->
+      <nav class="rail">
+        <span class="door save compose-btn js-compose"><svg class="ic" style="width:13px;height:13px"><use href="#i-plus"></use></svg>Compose</span>
+        <div class="navrow active js-folder"><svg class="ic"><use href="#i-inbox"></use></svg>Inbox<span class="cnt">9</span></div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-star"></use></svg>Starred</div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-clock"></use></svg>Snoozed</div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-send"></use></svg>Sent</div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-calendar"></use></svg>Scheduled</div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-file-text"></use></svg>Drafts<span class="cnt">3</span></div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-archive"></use></svg>All mail</div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-octagon-alert"></use></svg>Spam</div>
+        <div class="navrow js-folder"><svg class="ic"><use href="#i-trash"></use></svg>Trash</div>
+      </nav>
+
+      <!-- THREAD LIST -->
+      <div class="tlist" id="tlist">
+
+        <div class="trow selected sred" data-chan="email" data-thread="boudreaux">
+          <div class="trow1">
+            <span class="tdot"></span>
+            <span class="star js-star on"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">SB</span>
+            <span class="tsub"><span class="tsender">Sandra Boudreaux</span><span class="tsubject">Re: Invoice #4460 — payment plan? <span class="snip">— apologies for the wait, I saw this over text too...</span></span></span>
+            <span class="ttime">Jul 19</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Email"><svg class="ic"><use href="#i-mail"></use></svg></span>
+            <span class="ctl sig f red">overdue</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Boudreaux Marine LLC</a>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Gator<small>RC-4700</small></a>
+            <span class="labelchip">Invoicing</span>
+          </div>
+        </div>
+
+        <div class="trow unread sred" data-chan="texts" data-thread="boudreaux-sms">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--red)"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">SB</span>
+            <span class="tsub"><span class="tsender">Sandra Boudreaux</span><span class="tsubject">(337) 555-0188 <span class="snip">— Just so I confirm before I pay — first $420 today, second on the 3rd?</span></span></span>
+            <span class="ttime">9:14 AM</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Text"><svg class="ic"><use href="#i-message-circle"></use></svg></span>
+            <span class="ctl sig f red">overdue</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Boudreaux Marine LLC</a>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Gator<small>RC-4700</small></a>
+          </div>
+        </div>
+
+        <div class="trow unread syellow" data-chan="email" data-thread="theriot">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--yellow)"></span>
+            <span class="star js-star on"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">MT</span>
+            <span class="tsub"><span class="tsender">Marcus Theriot</span><span class="tsubject">Split-pay request — INV #4498 <span class="snip">— Would like to split the $1,240 balance across two payments...</span></span></span>
+            <span class="ttime">8:40 AM</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Email"><svg class="ic"><use href="#i-mail"></use></svg></span>
+            <span class="ctl sig f yellow">awaiting reply</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Theriot Pipe &amp; Supply</a>
+            <span class="labelchip">Invoicing</span>
+          </div>
+        </div>
+
+        <div class="trow sblue" data-chan="email" data-thread="duhon">
+          <div class="trow1">
+            <span class="tdot"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">RD</span>
+            <span class="tsub"><span class="tsender">Ray Duhon</span><span class="tsubject">Quote — Highrise 2-week extension <span class="snip">— Attached is the updated quote through Aug 3...</span></span></span>
+            <span class="ttime">Yesterday</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Email"><svg class="ic"><use href="#i-mail"></use></svg></span>
+            <span class="ctl sig f blue">quote sent</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Duhon Contracting</a>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Highrise<small>4471-K</small></a>
+            <span class="attchip"><svg class="ic"><use href="#i-file-text"></use></svg>PDF</span>
+            <span class="labelchip">Sales</span>
+          </div>
+        </div>
+
+        <div class="trow sgray" data-chan="email" data-thread="acadiana">
+          <div class="trow1">
+            <span class="tdot"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">AH</span>
+            <span class="tsub"><span class="tsender">Acadiana Hydraulic Supply</span><span class="tsubject">Order confirmation — hyd seal kit shipped <span class="snip">— Your order (WO #1198) has shipped, ETA Fri...</span></span></span>
+            <span class="ttime">Jul 18</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Email"><svg class="ic"><use href="#i-mail"></use></svg></span>
+            <span class="ctl sig o grey">closed</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Highrise<small>4471-K</small></a>
+            <span class="labelchip">Parts</span>
+          </div>
+        </div>
+
+        <div class="trow unread syellow" data-chan="team" data-thread="mention1">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--yellow)"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar team">DR</span>
+            <span class="tsub"><span class="tsender">Denny R.</span><span class="tsubject"><span class="mention">@Trey</span> — hydraulics on RC-4700 need a second look before it goes back out</span></span>
+            <span class="ttime">7:52 AM</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Team"><svg class="ic"><use href="#i-hash"></use></svg></span>
+            <span class="ctl sig f yellow">needs review</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-wrench"></use></svg></span>WO #1198<small>RC-4700</small></a>
+          </div>
+        </div>
+
+        <div class="trow handoff unread syellow" data-chan="team" data-thread="handoff1">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--yellow)"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="handoff-icon"><svg class="ic"><use href="#i-app-window"></use></svg></span>
+            <span class="handoff-txt"><b>Denny R.</b> sent you a tab: Gator / RC-4700 recovery</span>
+            <span class="ttime">7:55 AM</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Team"><svg class="ic"><use href="#i-hash"></use></svg></span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Gator<small>RC-4700</small></a>
+            <span class="door save" style="height:20px; padding:0 10px; font-size:9.5px">Open</span>
+          </div>
+        </div>
+
+        <div class="trow sgreen" data-chan="team" data-thread="wanda1">
+          <div class="trow1">
+            <span class="tdot"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar team">WR</span>
+            <span class="tsub"><span class="tsender">Wanda R.</span><span class="tsubject">Highrise reinspection done <span class="snip">— cleared for Duhon's 7 AM pickup tomorrow.</span></span></span>
+            <span class="ttime">Yesterday · 4:10 PM</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Team"><svg class="ic"><use href="#i-hash"></use></svg></span>
+            <span class="ctl sig o green">cleared</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Highrise<small>4471-K</small></a>
+          </div>
+        </div>
+
+        <div class="trow unread sgreen" data-chan="wrangler" data-thread="wrangler1">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--green)"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar bot"><svg class="ic" style="width:14px;height:14px"><use href="#i-wrench"></use></svg></span>
+            <span class="tsub"><span class="tsender">Mr. Wrangler</span><span class="tsubject">Fixed — WO #1198 completion button <span class="snip">— hydraulics recheck now saves clean, redeployed.</span></span></span>
+            <span class="ttime">Just now</span>
+          </div>
+          <div class="trow2">
+            <span class="changlyph" title="Mr. Wrangler"><svg class="ic"><use href="#i-wrench"></use></svg></span>
+            <span class="ctl sig f green">fixed</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-wrench"></use></svg></span>WO #1198<small>RC-4700</small></a>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- v3 §7.4 — draggable divider, roomy stage only (drag the thin bar) -->
+      <div class="paneDivider" id="paneDivider" title="Drag to resize"></div>
+
+      <!-- READING PANE — email native (Gmail) -->
+      <div class="rpane" id="rpane">
+        <div class="rp-header">
+          <div class="rp-context">
+            <span class="ctl sig f red">overdue</span>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Boudreaux Marine LLC</a>
+            <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Gator<small>RC-4700</small></a>
+          </div>
+          <p class="rp-subject">Re: Invoice #4460 — payment plan?</p>
+          <p class="rp-caption">This conversation is linked to <b>RC-4700 / Boudreaux Marine LLC</b> and also shows on
+          their card. Sandra's <b>text</b> replies live in their own native thread over in <b>Texts</b> — same
+          customer, same Ref, different medium.</p>
+        </div>
+        <div class="rp-msgs">
+          <div class="msg">
+            <div class="msg-head">
+              <span class="msg-av">DR</span>
+              <div class="msg-id"><span class="msg-who">Denny R.</span><a class="clink" href="mailto:denny@jacrentals.com"><svg class="ic"><use href="#i-mail"></use></svg><span class="v">denny@jacrentals.com</span></a></div>
+              <span class="msg-chan"><svg class="ic"><use href="#i-mail"></use></svg>Email</span>
+              <span class="msg-time">JUL 18 · 9:02 AM</span>
+            </div>
+            <div class="msg-body">Hi Sandra, following up on Invoice #4460 for the Gator rental (RC-4700) — balance of $840 is now 18 days past due. Let me know if you'd like to set up a payment plan or if there's an issue on your end.</div>
+          </div>
+          <div class="msg">
+            <div class="msg-head">
+              <span class="msg-av">SB</span>
+              <div class="msg-id"><span class="msg-who">Sandra Boudreaux</span><a class="clink" href="mailto:sandra@boudreauxmarine.com"><svg class="ic"><use href="#i-mail"></use></svg><span class="v">sandra@boudreauxmarine.com</span></a></div>
+              <span class="msg-chan"><svg class="ic"><use href="#i-mail"></use></svg>Email</span>
+              <span class="msg-time">JUL 19 · 10:15 AM</span>
+            </div>
+            <div class="msg-body">Hi Denny, apologies for the wait — I saw this over text too, just following up here for our records. Can we still do the two-payment split we talked about?</div>
+          </div>
+          <div class="msg">
+            <div class="msg-head">
+              <span class="msg-av">DR</span>
+              <div class="msg-id"><span class="msg-who">Denny R.</span><a class="clink" href="mailto:denny@jacrentals.com"><svg class="ic"><use href="#i-mail"></use></svg><span class="v">denny@jacrentals.com</span></a></div>
+              <span class="msg-chan"><svg class="ic"><use href="#i-mail"></use></svg>Email</span>
+              <span class="msg-time">JUL 19 · 3:40 PM</span>
+            </div>
+            <div class="msg-body">Confirmed — the split is set up and the first invoice link went out today. Thanks for looping back on both channels!</div>
+          </div>
+        </div>
+        <div class="rp-reply">
+          <div class="replybox">
+            <div class="replyfoot" style="margin-top:0; margin-bottom:9px"><span class="stamp">to sandra@boudreauxmarine.com</span></div>
+            <div class="replytext">Reply to Sandra Boudreaux…</div>
+            <div class="replyfoot">
+              <span class="door ghost"><svg class="ic" style="width:12px;height:12px"><use href="#i-paperclip"></use></svg>Attach</span>
+              <span class="fspacer"></span>
+              <span class="door save"><svg class="ic" style="width:12px;height:12px"><use href="#i-send"></use></svg>Send</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ================= 4: NATIVE CONVERSATION PER MEDIUM ================= -->
+  <h2 class="sec"><span class="n">4</span> Native conversation per medium — talk stays native</h2>
+  <p class="secnote">Triage is one surface (§3); <b>talking is native to the medium.</b> Email's native form is the
+  Gmail reading pane already shown in §3 above. The other three, faithfully duplicated in our skin:</p>
+
+  <h3 class="subsec">Texts → Apple Messages bubbles</h3>
+  <p class="secnote">Sent = <code>--commit</code> blue, right-aligned; received = <code>--panel2</code>/<code>--card</code>
+  tint, left-aligned — both hold AA. A <b>Delivered</b> receipt sits under the last sent bubble, exactly Apple's
+  placement; the contact's own number is the <code>tel:</code> link, tappable on mobile, readable on desktop.</p>
+  <div class="panel">
+    <div class="pcap">Sandra Boudreaux · Boudreaux Marine LLC</div>
+    <div class="rp-header" style="padding:12px 16px 10px">
+      <div class="rp-context">
+        <span class="ctl sig f red">overdue</span>
+        <a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Gator<small>RC-4700</small></a>
+      </div>
+      <p class="rp-subject" style="margin-bottom:2px">Sandra Boudreaux</p>
+      <a class="clink" href="tel:3375550188"><svg class="ic"><use href="#i-phone"></use></svg><span class="v">(337) 555-0188</span></a>
+    </div>
+    <div class="applemsg">
+      <div class="bubblerow recv"><div class="bubble">Hi Denny, sorry for the delay — can we do 2 payments of $420? Can text or call me at this #.</div></div>
+      <div class="bubblerow sent"><div class="bubble">That works — I'll set up the split and send a link for the first $420 today.</div><div class="bubble-receipt">Delivered</div></div>
+      <div class="bubblerow recv">
+        <div class="bubble-img"><span class="ph"><svg class="ic" style="width:12px;height:12px"><use href="#i-image"></use></svg></span>IMG_4021.jpg</div>
+        <div class="bubble" style="margin-top:6px">Here's the oil level on the Gator before anyone drives out — want to check before you send someone?</div>
+      </div>
+      <div class="bubblerow sent"><div class="bubble">Good catch — looks a little low, I'll have Trey top it off when he's out there.</div><div class="bubble-receipt">Delivered</div></div>
+      <div class="bubblerow recv"><div class="bubble">Just so I confirm before I pay — first $420 today, second on the 3rd? Want to make sure it lines up right.</div></div>
+    </div>
+  </div>
+
+  <h3 class="subsec">Team → Facebook Messenger channels</h3>
+  <p class="secnote">Sender name above each bubble, avatar with a <b>presence dot</b> (green = online), <b>reactions</b>
+  on a bubble, <span class="mention">@mentions</span> highlighted — carrying the crew's real workflow channels. Every
+  message that names a unit/rental hangs a <b>Ref</b> off it.</p>
+  <div class="panel">
+    <div class="pcap">On Rent/Delivery/Recovery · Team</div>
+    <div class="msgr-frame">
+      <div class="msgr-chanlist">
+        <div class="msgr-chan"><svg class="ic"><use href="#i-hash"></use></svg>Reservations</div>
+        <div class="msgr-chan active"><svg class="ic"><use href="#i-hash"></use></svg>On Rent/Delivery/Recovery<span class="dot"></span></div>
+        <div class="msgr-chan"><svg class="ic"><use href="#i-hash"></use></svg>Office</div>
+        <div class="msgr-chan"><svg class="ic"><use href="#i-hash"></use></svg>Transport/Field Calls<span class="dot"></span></div>
+      </div>
+      <div class="msgr-body">
+        <div class="msgr-msg">
+          <div class="msgr-av-wrap"><span class="msgr-av">DR</span><span class="presence"></span></div>
+          <div class="msgr-col">
+            <span class="msgr-name">Denny R.</span>
+            <div class="msgr-bubble"><span class="mention">@Trey</span> — hydraulics on RC-4700 need a second look before it goes back out<span class="msgr-reactions"><svg class="ic heart"><use href="#i-heart"></use></svg></span></div>
+            <div class="msgr-refrow"><a class="ref"><span class="ty"><svg class="ic"><use href="#i-wrench"></use></svg></span>WO #1198<small>RC-4700</small></a></div>
+          </div>
+        </div>
+        <div class="msgr-msg">
+          <div class="msgr-av-wrap"><span class="msgr-av">TG</span><span class="presence"></span></div>
+          <div class="msgr-col">
+            <span class="msgr-name">Trey Guidry</span>
+            <div class="msgr-bubble">On it — manifold's the usual suspect, pulling it now. (Also just dropped a bolt in my boot again.)<span class="msgr-reactions"><svg class="ic laugh"><use href="#i-laugh"></use></svg></span></div>
+          </div>
+        </div>
+        <div class="msgr-msg">
+          <div class="msgr-av-wrap"><span class="msgr-av">WR</span><span class="presence off"></span></div>
+          <div class="msgr-col">
+            <span class="msgr-name">Wanda R.</span>
+            <div class="msgr-bubble">Highrise reinspection's done either way — cleared for Duhon's 7 AM pickup tomorrow.</div>
+            <div class="msgr-refrow"><a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Highrise<small>4471-K</small></a></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="callout" style="margin-top:9px">
+    <span class="lab">↑ session hand-off (unchanged from v1)</span>A <b>tab is a whole working context</b> (record +
+    cascade + scroll position), not just a record id. This still surfaces as a row in the unified Team list (§3) —
+    the Messenger view above is the channel it drops into, not a replacement for it.
+  </div>
+
+  <h3 class="subsec">Wrangler → the bot thread</h3>
+  <p class="secnote">Styled deliberately distinct from person-comms: bot lines carry the app's own <b>stamped</b> voice
+  (the same mono face used for labels/data everywhere else) instead of body-voice sentences, on a quiet
+  <code>--tanSoft</code> wash. Today Mr. Wrangler barely signals a fix; below is the <b>loud, distinct bell</b> this
+  spec calls for instead.</p>
+  <div class="panel">
+    <div class="pcap">Mr. Wrangler · bug report thread</div>
+    <div class="wthread">
+      <div class="wmsg user">
+        <span class="wav person">DR</span>
+        <div class="wcol">
+          <div class="wbubble">WO #1198 — the Complete button isn't saving the hydraulics recheck, keeps kicking back to draft.</div>
+        </div>
+      </div>
+      <div class="wmsg bot">
+        <span class="wav"><svg class="ic"><use href="#i-wrench"></use></svg></span>
+        <div class="wcol">
+          <div class="wbubble">got it — investigating wo #1198's completion flow.</div>
+          <div class="wfoot"><span class="ctl sig o yellow">investigating</span></div>
+        </div>
+      </div>
+      <div class="wmsg bot">
+        <span class="wav"><svg class="ic"><use href="#i-wrench"></use></svg></span>
+        <div class="wcol">
+          <div class="wbubble">fixed — recheck now saves clean. redeployed.</div>
+          <div class="wfoot"><span class="ctl sig f green">fixed</span><a class="ref"><span class="ty"><svg class="ic"><use href="#i-wrench"></use></svg></span>WO #1198<small>RC-4700</small></a></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p class="secnote" style="margin-top:12px"><b>The loud alert that fires on resolution</b> — a distinct bell, not folded into the raw engineering feed:</p>
+  <div class="wbell">
+    <span class="wbell-bar"></span>
+    <span class="wbell-ic"><svg class="ic"><use href="#i-bell"></use></svg></span>
+    <div class="wbell-txt"><b>Mr. Wrangler</b> fixed <b>WO #1198</b> — hydraulics recheck now saves clean.</div>
+    <span class="ctl sig f green">fixed</span>
+    <span class="ttime">Just now</span>
+  </div>
+
+  <!-- ================= 5: MOBILE ================= -->
+  <h2 class="sec"><span class="n">5</span> Narrow / mobile — swipeable channel header</h2>
+  <p class="secnote">The desktop segmented toggle becomes a <b>swipeable header</b>: swipe left/right (or tap the
+  chevrons) to change channel; dots below mark position among the six. The rail becomes a slide-over drawer —
+  <b>Gmail folders only</b>, same as desktop. Landing on <b>Calls</b> shows a placeholder, not a broken list.</p>
+  <p class="secnote"><b>v3 — this is the <b>Mobile</b> width stage (§7.4):</b> list only; <b>tap a thread and it
+  swaps to a full-width reading view</b> (no divider, no split — the robust answer at this width), ‹ Back returns to
+  the list.</p>
+  <div class="phonewrap">
+    <div class="phone" id="phoneApp">
+      <div class="topbar">
+        <span class="iconbtn js-phone-drawer"><svg class="ic"><use href="#i-menu"></use></svg></span>
+        <div class="searchwrap"><div class="mini-search"><svg class="ic"><use href="#i-search"></use></svg><span class="ph">Search this channel…</span></div></div>
+        <span class="avatar">DR</span>
+      </div>
+      <div class="swipehead">
+        <span class="swarrow js-sw-prev"><svg class="ic"><use href="#i-chev-l"></use></svg></span>
+        <div class="swipetrack js-swtrack"></div>
+        <span class="swarrow js-sw-next"><svg class="ic"><use href="#i-chev-r"></use></svg></span>
+      </div>
+      <div class="swdots js-swdots"></div>
+      <div class="tlist" id="phoneTlist">
+        <div class="trow selected sred" data-chan="email">
+          <div class="trow1">
+            <span class="tdot"></span>
+            <span class="star js-star on"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">SB</span>
+            <span class="tsub"><span class="tsender">Sandra Boudreaux</span><span class="tsubject">Re: Invoice #4460 <span class="snip">— saw this over text too...</span></span></span>
+            <span class="ttime">Jul 19</span>
+          </div>
+          <div class="trow2"><span class="changlyph"><svg class="ic"><use href="#i-mail"></use></svg></span><span class="ctl sig f red">overdue</span><a class="ref"><span class="ty"><svg class="ic"><use href="#i-truck"></use></svg></span>Gator<small>RC-4700</small></a></div>
+        </div>
+        <div class="trow unread sred" data-chan="texts">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--red)"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">SB</span>
+            <span class="tsub"><span class="tsender">Sandra Boudreaux</span><span class="tsubject">(337) 555-0188 <span class="snip">— first $420 today, second on the 3rd?</span></span></span>
+            <span class="ttime">9:14A</span>
+          </div>
+          <div class="trow2"><span class="changlyph"><svg class="ic"><use href="#i-message-circle"></use></svg></span><span class="ctl sig f red">overdue</span></div>
+        </div>
+        <div class="trow unread syellow" data-chan="team">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--yellow)"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar team">DR</span>
+            <span class="tsub"><span class="tsender">Denny R.</span><span class="tsubject"><span class="mention">@Trey</span> — RC-4700 hydraulics recheck</span></span>
+            <span class="ttime">7:52A</span>
+          </div>
+          <div class="trow2"><span class="changlyph"><svg class="ic"><use href="#i-hash"></use></svg></span><span class="ctl sig f yellow">needs review</span></div>
+        </div>
+        <div class="trow unread syellow" data-chan="email">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--yellow)"></span>
+            <span class="star js-star on"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar cust">MT</span>
+            <span class="tsub"><span class="tsender">Marcus Theriot</span><span class="tsubject">Split-pay — INV #4498 <span class="snip">— split the $1,240 balance...</span></span></span>
+            <span class="ttime">8:40A</span>
+          </div>
+          <div class="trow2"><span class="changlyph"><svg class="ic"><use href="#i-mail"></use></svg></span><span class="ctl sig f yellow">awaiting reply</span></div>
+        </div>
+        <div class="trow unread sgreen" data-chan="wrangler">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--green)"></span>
+            <span class="star js-star"><svg class="ic"><use href="#i-star"></use></svg></span>
+            <span class="tavatar bot"><svg class="ic" style="width:14px;height:14px"><use href="#i-wrench"></use></svg></span>
+            <span class="tsub"><span class="tsender">Mr. Wrangler</span><span class="tsubject">Fixed — WO #1198 <span class="snip">— completion button, redeployed.</span></span></span>
+            <span class="ttime">Now</span>
+          </div>
+          <div class="trow2"><span class="changlyph"><svg class="ic"><use href="#i-wrench"></use></svg></span><span class="ctl sig f green">fixed</span></div>
+        </div>
+      </div>
+      <div class="swplaceholder js-swplaceholder" hidden>In-app calling — coming soon.</div>
+      <span class="fab js-phone-compose"><svg class="ic"><use href="#i-plus"></use></svg></span>
+      <div class="scrim js-phone-scrim"></div>
+      <div class="drawer js-phone-drawer-panel">
+        <span class="door save compose-btn" style="margin-bottom:12px">Compose</span>
+        <div class="navrow active"><svg class="ic"><use href="#i-inbox"></use></svg>Inbox<span class="cnt">9</span></div>
+        <div class="navrow"><svg class="ic"><use href="#i-star"></use></svg>Starred</div>
+        <div class="navrow"><svg class="ic"><use href="#i-clock"></use></svg>Snoozed</div>
+        <div class="navrow"><svg class="ic"><use href="#i-send"></use></svg>Sent</div>
+        <div class="navrow"><svg class="ic"><use href="#i-calendar"></use></svg>Scheduled</div>
+        <div class="navrow"><svg class="ic"><use href="#i-file-text"></use></svg>Drafts<span class="cnt">3</span></div>
+        <div class="navrow"><svg class="ic"><use href="#i-archive"></use></svg>All mail</div>
+        <div class="navrow"><svg class="ic"><use href="#i-octagon-alert"></use></svg>Spam</div>
+        <div class="navrow"><svg class="ic"><use href="#i-trash"></use></svg>Trash</div>
+      </div>
+
+      <!-- v3 §7.4c — tap a thread, it swaps to a full-width reading view -->
+      <div class="phone-reading" id="phoneReading">
+        <div class="pr-head">
+          <span class="pr-back js-pr-back"><svg class="ic"><use href="#i-chev-l"></use></svg></span>
+          <p class="pr-subject" id="prSubject">Re: Invoice #4460 — payment plan?</p>
+        </div>
+        <p class="pr-from" id="prFrom"><b>Sandra Boudreaux</b></p>
+        <div class="pr-body" id="prBody">— apologies for the wait, I saw this over text too...</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ================= 6: FOOTER COMMS RAIL ================= -->
+  <h2 class="sec"><span class="n">6</span> Footer comms rail — the quick dock (altitude two)</h2>
+  <p class="secnote">Minimized thread chips + a docked compose window, bottom-right — Gmail desktop's own pattern,
+  unchanged from v1. A resolved Wrangler thread can dock here too, same as a person thread.</p>
+  <div class="panel dockdemo" id="dockdemo">
+    <div class="dockbar">
+      <span class="dockchip js-dockchip"><span class="dot"></span>Boudreaux Marine LLC</span>
+      <span class="dockchip js-dockchip"><span class="dot" style="background:var(--blue)"></span>Trey Guidry · RC-4700</span>
+      <span class="dockchip js-dockchip"><span class="dot" style="background:var(--green)"></span>Mr. Wrangler · WO #1198</span>
+      <div class="composedock">
+        <div class="cd-head js-cd-toggle">
+          <svg class="ic" style="width:13px;height:13px;color:var(--txt3)"><use href="#i-mail"></use></svg>
+          <span class="t">New message — Theriot Pipe &amp; Supply</span>
+          <span class="cd-icon"><svg class="ic"><use href="#i-minus"></use></svg></span>
+          <span class="cd-icon"><svg class="ic"><use href="#i-x"></use></svg></span>
+        </div>
+        <div class="cd-body">
+          <div class="cd-field"><b>To</b>marcus@theriotpipe.com</div>
+          <div class="cd-field"><b>Subject</b>Re: Split-pay request — INV #4498</div>
+          <div class="cd-textarea">Hi Marcus, that split works on our end — I'll send the first invoice link…</div>
+        </div>
+        <div class="cd-foot"><span class="door save" style="height:22px;font-size:9.5px;padding:0 10px">Send</span></div>
+      </div>
+    </div>
+  </div>
+  <p class="annot">A bell alert opens the thread here — nothing skips a level:</p>
+  <p class="annot">
+    <span class="flow">
+      <span class="flowstep"><svg class="ic"><use href="#i-bell"></use></svg>Bell</span>
+      <svg class="flowarrow"><use href="#i-chev-r"></use></svg>
+      <span class="flowstep"><svg class="ic"><use href="#i-mail"></use></svg>Dock chip</span>
+      <svg class="flowarrow"><use href="#i-chev-r"></use></svg>
+      <span class="flowstep"><svg class="ic"><use href="#i-inbox"></use></svg>Inbox card</span>
+    </span>
+    — alert (get-told) → quick-dock (footer rail) → full workspace (here), exactly like Gmail's badge → docked window → full inbox.
+  </p>
+
+  <!-- ================= 7: RESPONSIVE SPACE MODEL ================= -->
+  <h2 class="sec"><span class="n">7</span> Responsive space model — one lever, three width stages <span style="font-size:9px;color:var(--txt3);font-weight:700;text-transform:none;letter-spacing:0">(spec §7.4)</span></h2>
+  <p class="secnote">ONE interaction model that adds panes when there's room — desktop is "the mobile model with more
+  space." <b>Roomy</b> (§3, above) shows all three panes plus the new draggable divider. <b>Mobile</b> (§5, above)
+  shows list-only with a full-width tap-to-read swap. The squeeze in the middle — <b>one-card width</b>, where the
+  card only ever shows <b>two of the three panes</b> — is the one that needs demonstrating live:</p>
+  <div class="panel">
+    <div class="pcap">One-card width — hover the hamburger to peek, click it to browse, click a thread to read</div>
+    <div class="ocdemo ocwrap" id="ocDemo1" data-state="reading">
+      <div class="topbar" style="border-bottom:1px solid var(--line)">
+        <span class="iconbtn js-oc-ham" id="ocHam1"><svg class="ic"><use href="#i-menu"></use></svg></span>
+        <div class="searchwrap"><div class="mini-search"><svg class="ic"><use href="#i-search"></use></svg><span class="ph">Search this channel…</span></div></div>
+        <span class="ocstate js-ocstate" id="ocState1">Reading</span>
+      </div>
+      <div class="ocbody">
+        <div class="ocslot1">
+          <nav class="ocmenu">
+            <div class="navrow active"><svg class="ic"><use href="#i-inbox"></use></svg>Inbox<span class="cnt">9</span></div>
+            <div class="navrow"><svg class="ic"><use href="#i-star"></use></svg>Starred</div>
+            <div class="navrow"><svg class="ic"><use href="#i-clock"></use></svg>Snoozed</div>
+            <div class="navrow"><svg class="ic"><use href="#i-send"></use></svg>Sent</div>
+            <div class="navrow"><svg class="ic"><use href="#i-file-text"></use></svg>Drafts<span class="cnt">3</span></div>
+          </nav>
+          <div class="oclistnarrow js-oclist">
+            <div class="trow selected sred oc-row" data-oc="boudreaux">
+              <div class="trow1"><span class="tdot"></span><span class="tavatar cust">SB</span><span class="tsub"><span class="tsender">Sandra Boudreaux</span><span class="tsubject">Re: Invoice #4460</span></span><span class="ttime">Jul 19</span></div>
+              <div class="trow2"><span class="ctl sig f red">overdue</span></div>
+            </div>
+            <div class="trow unread syellow oc-row" data-oc="theriot">
+              <div class="trow1"><span class="tdot" style="background:var(--yellow)"></span><span class="tavatar cust">MT</span><span class="tsub"><span class="tsender">Marcus Theriot</span><span class="tsubject">Split-pay — INV #4498</span></span><span class="ttime">8:40A</span></div>
+              <div class="trow2"><span class="ctl sig f yellow">awaiting reply</span></div>
+            </div>
+            <div class="trow sblue oc-row" data-oc="duhon">
+              <div class="trow1"><span class="tdot"></span><span class="tavatar cust">RD</span><span class="tsub"><span class="tsender">Ray Duhon</span><span class="tsubject">Highrise extension quote</span></span><span class="ttime">Jul 18</span></div>
+              <div class="trow2"><span class="ctl sig f blue">quote sent</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="ocslot2">
+          <div class="oclistwide">
+            <div class="trow selected sred oc-row" data-oc="boudreaux">
+              <div class="trow1"><span class="tdot"></span><span class="tavatar cust">SB</span><span class="tsub"><span class="tsender">Sandra Boudreaux</span><span class="tsubject">Re: Invoice #4460 — payment plan? <span class="snip">— apologies for the wait…</span></span></span><span class="ttime">Jul 19</span></div>
+              <div class="trow2"><span class="ctl sig f red">overdue</span><a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Boudreaux Marine LLC</a></div>
+            </div>
+            <div class="trow unread syellow oc-row" data-oc="theriot">
+              <div class="trow1"><span class="tdot" style="background:var(--yellow)"></span><span class="tavatar cust">MT</span><span class="tsub"><span class="tsender">Marcus Theriot</span><span class="tsubject">Split-pay request — INV #4498 <span class="snip">— would like to split the balance…</span></span></span><span class="ttime">8:40A</span></div>
+              <div class="trow2"><span class="ctl sig f yellow">awaiting reply</span><a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Theriot Pipe &amp; Supply</a></div>
+            </div>
+            <div class="trow sblue oc-row" data-oc="duhon">
+              <div class="trow1"><span class="tdot"></span><span class="tavatar cust">RD</span><span class="tsub"><span class="tsender">Ray Duhon</span><span class="tsubject">Quote — Highrise 2-week extension <span class="snip">— attached is the updated quote…</span></span></span><span class="ttime">Jul 18</span></div>
+              <div class="trow2"><span class="ctl sig f blue">quote sent</span><a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Duhon Contracting</a></div>
+            </div>
+          </div>
+          <div class="ocemail">
+            <div class="rp-context" style="margin:0"><span class="ctl sig f red">overdue</span><a class="ref"><span class="ty"><svg class="ic"><use href="#i-user"></use></svg></span>Boudreaux Marine LLC</a></div>
+            <p class="rp-subject" id="ocSubject" style="margin:0">Re: Invoice #4460 — payment plan?</p>
+            <div class="msg">
+              <div class="msg-head"><span class="msg-av">SB</span><div class="msg-id"><span class="msg-who">Sandra Boudreaux</span></div><span class="msg-time">JUL 19</span></div>
+              <div class="msg-body" id="ocBody">Hi Denny, apologies for the wait — I saw this over text too, just following up here. Can we still do the two-payment split?</div>
+            </div>
+          </div>
+        </div>
+        <div class="ocmenu-peek">
+          <div class="navrow active"><svg class="ic"><use href="#i-inbox"></use></svg>Inbox<span class="cnt">9</span></div>
+          <div class="navrow"><svg class="ic"><use href="#i-star"></use></svg>Starred</div>
+          <div class="navrow"><svg class="ic"><use href="#i-clock"></use></svg>Snoozed</div>
+          <div class="navrow"><svg class="ic"><use href="#i-send"></use></svg>Sent</div>
+          <div class="navrow"><svg class="ic"><use href="#i-file-text"></use></svg>Drafts<span class="cnt">3</span></div>
+        </div>
+      </div>
+    </div>
+    <p class="secnote" style="padding:10px 14px 14px">Hover the hamburger above (menu peeks over the list, nothing
+    reflows). Click it to close the email, slide the list into its place, and pin the menu — click a thread to read
+    again. Channels stay up top throughout (not shown at this width — see §2).</p>
+  </div>
+
+  <!-- ================= 8: INBOX EXPAND ================= -->
+  <h2 class="sec"><span class="n">8</span> Inbox expand — Focus toggle + sibling spines <span style="font-size:9px;color:var(--txt3);font-weight:700;text-transform:none;letter-spacing:0">(spec §7, inbox-only)</span></h2>
+  <p class="secnote">The Inbox is the <b>only</b> card that can grow at its siblings' expense. A stepped
+  <b>Focus</b> toggle (⅓ → ½ → full) lives on the Inbox card only; as it grows, the other two cards collapse to
+  <b>slim clickable spines</b> — title + an unread/alert dot, nothing else. <b>Hover</b> a spine for a transient peek
+  (nothing commits); <b>click</b> it and the state machine is exactly <code>{balanced} ↔ {inbox-focused}</code> — the
+  Inbox drops back to ⅓ and that card comes forward, ready to work. There is never a "both expanded" state.</p>
+  <div class="panel">
+    <div class="pcap">Card pool — try the Focus toggle, then hover/click a spine</div>
+    <div class="cardpool" id="cardPool" data-focus="balanced">
+      <div class="poolcard inboxcard" id="poolInbox">
+        <div class="poolhead">
+          <svg class="ic" style="color:var(--accent);width:15px;height:15px"><use href="#i-inbox"></use></svg>
+          <span class="poolttl">Inbox</span>
+          <span class="seg js-focusseg">
+            <b class="on" data-f="third">⅓</b>
+            <b data-f="half">½</b>
+            <b data-f="full">Full</b>
+          </span>
+        </div>
+        <div class="poolbody">
+          <div class="trow sred" style="border-radius:8px; border:1px solid var(--line)">
+            <div class="trow1"><span class="tdot" style="background:var(--red)"></span><span class="tavatar cust">SB</span><span class="tsub"><span class="tsender">Sandra Boudreaux</span><span class="tsubject">Re: Invoice #4460 <span class="snip">— payment plan?</span></span></span><span class="ttime">Jul 19</span></div>
+            <div class="trow2"><span class="ctl sig f red">overdue</span></div>
+          </div>
+          <div class="trow syellow" style="border-radius:8px; border:1px solid var(--line)">
+            <div class="trow1"><span class="tdot" style="background:var(--yellow)"></span><span class="tavatar cust">MT</span><span class="tsub"><span class="tsender">Marcus Theriot</span><span class="tsubject">Split-pay — INV #4498</span></span><span class="ttime">8:40A</span></div>
+            <div class="trow2"><span class="ctl sig f yellow">awaiting reply</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="poolcard spine js-spine" data-card="Units">
+        <div class="poolhead"><svg class="ic" style="color:var(--txt3);width:15px;height:15px"><use href="#i-truck"></use></svg><span class="poolttl">Units</span></div>
+        <div class="poolbody">
+          <p class="secnote" style="margin:0">3 down for maintenance, 1 due back today.</p>
+          <span class="ctl sig f red" style="align-self:flex-start">3 down</span>
+        </div>
+        <div class="spine-tab"><span class="spttl">Units</span><span class="spine-dot" style="background:var(--red)"></span></div>
+        <div class="spine-peek"><div class="pptitle">Units</div><p class="secnote" style="margin:0">3 down for maintenance, 1 due back today.</p></div>
+      </div>
+      <div class="poolcard spine js-spine" data-card="Rentals">
+        <div class="poolhead"><svg class="ic" style="color:var(--txt3);width:15px;height:15px"><use href="#i-calendar"></use></svg><span class="poolttl">Rentals</span></div>
+        <div class="poolbody">
+          <p class="secnote" style="margin:0">1 return overdue, 2 quotes awaiting signature.</p>
+          <span class="ctl sig f yellow" style="align-self:flex-start">1 overdue return</span>
+        </div>
+        <div class="spine-tab"><span class="spttl">Rentals</span><span class="spine-dot" style="background:var(--yellow)"></span></div>
+        <div class="spine-peek"><div class="pptitle">Rentals</div><p class="secnote" style="margin:0">1 return overdue, 2 quotes awaiting signature.</p></div>
+      </div>
+    </div>
+    <p class="secnote" id="focusStatusLine" style="padding:0 14px 14px">Balanced — all three cards at ⅓. Click ½ or Full on the Inbox to grow it.</p>
+  </div>
+  <div class="callout" style="margin-top:9px">
+    <span class="lab">↑ yard → comms never expands the inbox</span>A cross-card action from Units/Rentals opens the
+    <b>dock</b> (§6), never this Focus state — the two worlds don't collide, per the spec's "no heart attack" rule.
+  </div>
+
+  <!-- ================= 9: QUICK ACTIONS ================= -->
+  <h2 class="sec"><span class="n">9</span> Quick actions — one set, two entry points <span style="font-size:9px;color:var(--txt3);font-weight:700;text-transform:none;letter-spacing:0">(spec §7.4)</span></h2>
+  <p class="secnote">A user-customizable set — <b>Hide · Mark unread · Star · Snooze · Archive</b> — surfaced
+  identically everywhere a thread row lives. <b>Try it live on the §3 workspace list above:</b> hover any row
+  (desktop) to swap its timestamp for the action icons, or <b>right-click</b> any row for the same five as a menu.
+  A <b>drag handle</b> (⋮⋮) fades in on the left on hover too — hinted here, not wired to a real reorder in this mock.</p>
+  <div class="panel">
+    <div class="pcap">The five, same order everywhere</div>
+    <div style="padding:14px 16px; display:flex; gap:18px; flex-wrap:wrap; align-items:center">
+      <span class="clink"><svg class="ic"><use href="#i-eye-off"></use></svg>Hide</span>
+      <span class="clink"><svg class="ic"><use href="#i-mail"></use></svg>Mark unread</span>
+      <span class="clink"><svg class="ic"><use href="#i-star"></use></svg>Star</span>
+      <span class="clink"><svg class="ic"><use href="#i-clock"></use></svg>Snooze</span>
+      <span class="clink"><svg class="ic"><use href="#i-archive"></use></svg>Archive</span>
+      <span class="fspacer"></span>
+      <span class="clink" style="color:var(--txt3)"><svg class="ic" style="color:var(--txt3)"><use href="#i-grip"></use></svg>drag to resort (hinted)</span>
+    </div>
+  </div>
+  <div class="panel">
+    <div class="pcap">Mobile — swipe reveals the same two most-used actions</div>
+    <div style="padding:14px; max-width:360px; margin:0 auto">
+      <div class="swiperow" id="swipeDemo">
+        <div class="swipe-actions">
+          <b class="a-snooze" id="swipeSnoozeBtn"><svg class="ic"><use href="#i-clock"></use></svg>Snooze</b>
+          <b class="a-archive" id="swipeArchiveBtn"><svg class="ic"><use href="#i-archive"></use></svg>Archive</b>
+        </div>
+        <div class="trow unread syellow">
+          <div class="trow1">
+            <span class="tdot" style="background:var(--yellow)"></span>
+            <span class="tavatar cust">MT</span>
+            <span class="tsub"><span class="tsender">Marcus Theriot</span><span class="tsubject">Split-pay request <span class="snip">— would like to split the balance…</span></span></span>
+            <span class="ttime">8:40A</span>
+          </div>
+        </div>
+      </div>
+      <p class="secnote" style="text-align:center; margin-top:8px"><span class="door ghost js-swipe-peek" style="height:22px;font-size:9.5px;padding:0 10px">Peek swipe →</span></p>
+    </div>
+  </div>
+
+  <!-- ================= 10: INBOUND ROUTING ================= -->
+  <h2 class="sec"><span class="n">10</span> Inbound routing — where a new message lands <span style="font-size:9px;color:var(--txt3);font-weight:700;text-transform:none;letter-spacing:0">(spec §7.5)</span></h2>
+  <p class="secnote">High-frequency chat (texts, team) reaches the <b>footer rail</b> — a recent/active thread
+  <b>bumps to front, flashes, and pops open</b>; a cold thread just <b>slides in as a quiet tab</b>, truncated
+  preview visible in the tab either way. <b>Email stays calm</b> — bell + inbox only, no rail pop, unless that
+  thread's already docked. Press a button below to see each case land.</p>
+  <div class="panel">
+    <div class="pcap">Simulate an inbound message</div>
+    <div style="padding:12px 14px; display:flex; align-items:center; gap:8px; flex-wrap:wrap; border-bottom:1px solid var(--line)">
+      <span class="door ghost js-sim" data-sim="active">Text — active thread</span>
+      <span class="door ghost js-sim" data-sim="cold">Text — cold thread</span>
+      <span class="door ghost js-sim" data-sim="email">Email</span>
+      <span class="fspacer"></span>
+      <span class="iconbtn bdgbell js-bell10" id="bell10"><svg class="ic"><use href="#i-bell"></use></svg><span class="bdg" id="bellCount10">3</span></span>
+    </div>
+    <div class="dockbar" id="dock10" style="min-height:120px">
+      <span class="dockchip" id="chipActive"><span class="dot" style="background:var(--blue)"></span>Trey Guidry · RC-4700</span>
+    </div>
+    <p class="secnote" id="sim10status" style="padding:0 14px 14px; min-height:16px">Press a button to simulate an inbound message.</p>
+  </div>
+
+  <div class="foot">
+    Judgment calls made for this v2 pass, flagged so Jac can push back:
+    <ul>
+      <li><b>Boudreaux Marine's thread splits into two native, channel-tagged threads</b> (email + texts) instead of
+      staying one interleaved Gmail thread — the direct consequence of "channel is a top-level toggle, native per
+      medium." Both keep the same <b>Boudreaux Marine LLC</b> / <b>Gator RC-4700</b> Ref chips, and the email side now
+      explicitly nods to the parallel text thread, so the "one relationship" story still reads even though it's told
+      across two rows.</li>
+      <li><b>Fixed a pre-existing v1 contrast bug</b> while cleaning up pure <code>#fff</code>: light theme's
+      <code>--onAcc</code> was pure white on the mid-orange accent (3.88:1 — fails AA), which also contradicted
+      <code>wrangler-style</code>'s own "orange fill = dark ink ALWAYS" rule. Now dark ink in both themes (4.70:1).
+      Light <code>--panel</code>/<code>--card</code> moved off pure white to <code>#fbfbfa</code>; the four remaining
+      hardcoded <code>#fff</code> inks (red-fill/commit text, badge, FAB) now route through a new <code>--onFill</code>
+      near-white token instead.</li>
+      <li><b>Filter pills inside the mini-search get pill radius (999)</b>, not the row's chip radius (7) — reads as
+      "removable action," kept visually distinct from the Signal/Ref/Stamp chips sitting in the same view.</li>
+      <li><b>CALLS is genuinely inert</b> (<code>pointer-events:none</code>, dimmed, a "Soon" marker) rather than just
+      styled to look disabled — WCAG's non-text-contrast floor explicitly exempts inactive UI components, so it's
+      dimmed harder than any live control would be.</li>
+      <li><b>Reactions render as Lucide heart/laugh icons</b>, not emoji — keeps the "inline SVG icons only" rule
+      intact; a real build might prefer native emoji for Messenger-authenticity, worth Jac's call.</li>
+      <li><b>Views &amp; sort is visual-only</b> this pass (sort options + two saved Views, no live query behind them)
+      — live sort/filter logic is the parked "Sort redesign" from the spec's Open Problems, not this slice.</li>
+      <li><b>Recent-searches-above is demonstrated via DOM order</b> (a column-reverse flex wrapper), not a true
+      floating overlay — a real build would position:absolute it so it doesn't push layout; the visual direction
+      ("opens above, never below") is faithful either way.</li>
+      <li><b>Mobile channel swipe is a real gesture</b> (touchstart/touchend, ~40px threshold, plus tappable chevrons),
+      wraps at both ends, and re-filters the same thread rows live; landing on Calls shows a "coming soon" placeholder
+      instead of an empty or broken list.</li>
+    </ul>
+    <p style="margin:16px 0 4px"><b>v3 additions — judgment calls:</b></p>
+    <ul>
+      <li><b>Fixed the last 2 pure-black instances</b> — <code>--shadowPop</code>'s dark-theme value was literally
+      <code>rgba(0,0,0,.45)</code> (twice: the <code>:root</code> default and the explicit <code>data-theme="dark"</code>
+      block). Both now use <code>rgba(5,7,10,.45)</code> — the same near-black already established by this file's own
+      <code>.scrim</code> (<code>rgba(5,7,10,.55)</code>), so it's not a new tone, just consistent with one already in use.</li>
+      <li><b>One-card choreography is built as two fixed slots whose CONTENT swaps</b> (slot 1: list ↔ pinned menu;
+      slot 2: email ↔ wide list), not as DOM nodes physically moved between panes — same visual result ("list slides
+      into the email's place, menu pins left") without a manual FLIP animation. The hover-peek overlay is pure CSS
+      (a sibling-combinator hover rule), no JS needed for that half of the choreography.</li>
+      <li><b>Inbox-expand's spines use <code>writing-mode:vertical-rl</code></b> for the collapsed title — reads as a
+      genuine slim, clickable spine (like a collapsed IDE panel) rather than just a narrow box with truncated text.
+      Clicking a spine rebalances via the exact <code>{balanced}↔{inbox-focused}</code> toggle the spec calls for;
+      the "sibling comes forward" cue is a brief accent-border flash (reusing the existing <code>.flash</code> pattern
+      from §1's panel), not a new component.</li>
+      <li><b>Two new Lucide glyphs added to the sprite</b> — <code>eye-off</code> (Hide) and <code>grip-vertical</code>
+      (drag handle) — both standard Lucide icons, traced faithfully, not hand-rolled. Snooze reuses the existing
+      clock glyph (already doing double duty as "recent" elsewhere in this file) rather than adding a third clock-ish icon.</li>
+      <li><b>Quick actions are wired generically onto the real §3 workspace list</b> via a small JS injector
+      (<code>wireRowActions</code>) rather than hand-duplicating the hover/right-click markup onto all nine existing
+      rows — same five actions, same icons, same order, everywhere; §9 also carries a static legend + a standalone
+      swipe-reveal demo for the mobile case, and Star isn't hover-duplicated since every row already has its own
+      always-visible star control (the right-click menu still lists it, for parity).</li>
+      <li><b>Drag-to-resort is a hinted affordance only</b> (a grip icon that fades in on hover), per the brief — no
+      functional drag-and-drop reordering in this mock.</li>
+      <li><b>Inbound routing gets its own compact dock</b> (§10) rather than reusing the §6 dock demo's live DOM
+      nodes — keeps the simulator self-contained so Jac doesn't have to scroll back up mid-demo; same
+      <code>.dockchip</code>/<code>.composedock</code> vocabulary throughout.</li>
+      <li><b>All new v3 elements reuse existing tokens only</b> — no new hex values were introduced, so every new
+      text/fill pairing (spine titles, row-action icons, context menu, dock preview, swipe-action fills) is a
+      already-checked combination borrowed verbatim from elsewhere in this file (e.g. the swipe-action ink colours
+      are the same <code>#211a05</code>/<code>#04140d</code> already used on filled yellow/green Signals).</li>
+    </ul>
+  </div>
+
+</div></div>
+
+<script>
+  // ---- channel toggle + unread-count bookkeeping ----
+  var activeChannel = 'all';
+  function computeChanCounts(scopeSel){
+    var counts = {all:0, team:0, texts:0, email:0, wrangler:0};
+    document.querySelectorAll(scopeSel + ' .trow.unread[data-chan]').forEach(function(row){
+      var c = row.getAttribute('data-chan');
+      if (counts[c] !== undefined){ counts[c]++; counts.all++; }
+    });
+    return counts;
+  }
+  function paintChanCounts(toggleEl, counts){
+    if (!toggleEl) return;
+    toggleEl.querySelectorAll('b[data-chan]').forEach(function(b){
+      var c = b.getAttribute('data-chan');
+      var cntEl = b.querySelector('.cnt');
+      if (cntEl && counts[c] !== undefined) cntEl.textContent = counts[c];
+    });
+  }
+  function applyChanFilter(scopeSel, channel){
+    document.querySelectorAll(scopeSel + ' .trow[data-chan]').forEach(function(row){
+      row.style.display = (channel === 'all' || row.getAttribute('data-chan') === channel) ? '' : 'none';
+    });
+  }
+  function wireChanToggle(toggleEl, tlistSel){
+    if (!toggleEl) return;
+    toggleEl.querySelectorAll('b[data-chan]').forEach(function(b){
+      if (b.classList.contains('soon')) return;
+      b.addEventListener('click', function(){
+        toggleEl.querySelectorAll('b').forEach(function(x){ x.classList.remove('on'); });
+        b.classList.add('on');
+        var chan = b.getAttribute('data-chan');
+        applyChanFilter(tlistSel, chan);
+      });
+    });
+    paintChanCounts(toggleEl, computeChanCounts(tlistSel));
+  }
+  wireChanToggle(document.querySelector('.js-chantoggle'), '#tlist');
+
+  // ---- Gmail-folder rail (visual only — folders aren't the filtering axis anymore, channels are) ----
+  document.querySelectorAll('.js-folder').forEach(function(row){
+    row.addEventListener('click', function(){
+      document.querySelectorAll('.js-folder').forEach(function(r){ r.classList.remove('active'); });
+      row.classList.add('active');
+    });
+  });
+
+  // ---- thread select (select + mark read; recompute channel counts) ----
+  document.querySelectorAll('#tlist .trow[data-thread]').forEach(function(row){
+    row.addEventListener('click', function(e){
+      if (e.target.closest('.star')) return;
+      document.querySelectorAll('#tlist .trow').forEach(function(r){ r.classList.remove('selected'); });
+      row.classList.add('selected');
+      row.classList.remove('unread');
+      paintChanCounts(document.querySelector('.js-chantoggle'), computeChanCounts('#tlist'));
+    });
+  });
+
+  // ---- star toggle ----
+  document.querySelectorAll('.js-star').forEach(function(star){
+    star.addEventListener('click', function(e){
+      e.stopPropagation();
+      star.classList.toggle('on');
+    });
+  });
+
+  // ---- compose -> scroll to + flash the footer dock ----
+  document.querySelectorAll('.js-compose').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      var dock = document.getElementById('dockdemo');
+      if (!dock) return;
+      dock.scrollIntoView({behavior:'smooth', block:'center'});
+      dock.classList.add('flash');
+      setTimeout(function(){ dock.classList.remove('flash'); }, 900);
+    });
+  });
+
+  // ---- docked compose minimize toggle ----
+  document.querySelectorAll('.js-cd-toggle').forEach(function(head){
+    head.addEventListener('click', function(){
+      var dock = head.closest('.composedock');
+      dock.querySelector('.cd-body').classList.toggle('min');
+      dock.querySelector('.cd-foot').classList.toggle('min');
+    });
+  });
+
+  // ---- recent-searches: click the workspace mini-search to reveal it (opens ABOVE, never below) ----
+  var worksearch = document.querySelector('.js-worksearch');
+  var recentpop = document.querySelector('.js-recentpop');
+  if (worksearch && recentpop){
+    worksearch.addEventListener('click', function(e){
+      e.stopPropagation();
+      worksearch.classList.toggle('focused');
+      recentpop.hidden = !recentpop.hidden;
+    });
+    document.addEventListener('click', function(){
+      worksearch.classList.remove('focused');
+      recentpop.hidden = true;
+    });
+    recentpop.addEventListener('click', function(e){ e.stopPropagation(); });
+  }
+
+  // ---- globe scope toggle (this channel <-> all comms) ----
+  document.querySelectorAll('.js-gscope').forEach(function(g){
+    g.addEventListener('click', function(e){
+      e.stopPropagation();
+      g.classList.toggle('on');
+      g.setAttribute('title', g.classList.contains('on') ? 'Scope: all comms' : 'Scope: this channel');
+    });
+  });
+
+  // ---- Views & sort menu ----
+  var vsBtn = document.querySelector('.js-viewsort');
+  var vsMenu = document.querySelector('.js-vsmenu');
+  if (vsBtn && vsMenu){
+    vsBtn.addEventListener('click', function(e){
+      e.stopPropagation();
+      vsMenu.hidden = !vsMenu.hidden;
+    });
+    document.addEventListener('click', function(){ vsMenu.hidden = true; });
+    vsMenu.addEventListener('click', function(e){ e.stopPropagation(); });
+    document.querySelectorAll('.js-vsopt').forEach(function(opt){
+      opt.addEventListener('click', function(){
+        document.querySelectorAll('.js-vsopt').forEach(function(o){ o.classList.remove('on'); });
+        opt.classList.add('on');
+        vsMenu.hidden = true;
+      });
+    });
+  }
+
+  // ---- mobile slide-over drawer ----
+  var phoneDrawer = document.querySelector('.js-phone-drawer-panel');
+  var phoneScrim = document.querySelector('.js-phone-scrim');
+  function togglePhoneDrawer(){
+    phoneDrawer.classList.toggle('open');
+    phoneScrim.classList.toggle('open');
+  }
+  document.querySelector('.js-phone-drawer').addEventListener('click', togglePhoneDrawer);
+  phoneScrim.addEventListener('click', togglePhoneDrawer);
+  document.querySelector('.js-phone-compose').addEventListener('click', function(){
+    var dock = document.getElementById('dockdemo');
+    if (!dock) return;
+    dock.scrollIntoView({behavior:'smooth', block:'center'});
+    dock.classList.add('flash');
+    setTimeout(function(){ dock.classList.remove('flash'); }, 900);
+  });
+
+  // ---- mobile swipeable channel header ----
+  var CHANS = [
+    {key:'all', label:'All', icon:'i-inbox'},
+    {key:'team', label:'Team', icon:'i-hash'},
+    {key:'texts', label:'Texts', icon:'i-message-circle'},
+    {key:'email', label:'Email', icon:'i-mail'},
+    {key:'wrangler', label:'Wrangler', icon:'i-wrench'},
+    {key:'calls', label:'Calls', icon:'i-phone', soon:true}
+  ];
+  var swIndex = 1; // land on Team to start, matching the desktop demo's mixed view
+  var swTrack = document.querySelector('.js-swtrack');
+  var swDots = document.querySelector('.js-swdots');
+  var swPlaceholder = document.querySelector('.js-swplaceholder');
+  var phoneTlist = document.getElementById('phoneTlist');
+
+  function renderSwipe(){
+    var c = CHANS[swIndex];
+    var counts = computeChanCounts('#phoneTlist');
+    if (swDots){
+      swDots.innerHTML = '';
+      CHANS.forEach(function(x, i){
+        var d = document.createElement('span');
+        d.className = 'd' + (i === swIndex ? ' on' : '');
+        d.addEventListener('click', function(){ swIndex = i; renderSwipe(); });
+        swDots.appendChild(d);
+      });
+    }
+    if (swTrack){
+      swTrack.classList.toggle('soon', !!c.soon);
+      var cntHtml = c.soon ? '<span class="soonmark">Soon</span>' : '<span class="cnt">' + (counts[c.key] || 0) + '</span>';
+      swTrack.innerHTML = '<svg class="ic"><use href="#' + c.icon + '"></use></svg>' + c.label + cntHtml;
+    }
+    if (phoneTlist) phoneTlist.hidden = !!c.soon;
+    if (swPlaceholder) swPlaceholder.hidden = !c.soon;
+    if (!c.soon) applyChanFilter('#phoneTlist', c.key);
+  }
+  function swNext(){ swIndex = (swIndex + 1) % CHANS.length; renderSwipe(); }
+  function swPrev(){ swIndex = (swIndex - 1 + CHANS.length) % CHANS.length; renderSwipe(); }
+  var swPrevBtn = document.querySelector('.js-sw-prev');
+  var swNextBtn = document.querySelector('.js-sw-next');
+  if (swPrevBtn) swPrevBtn.addEventListener('click', swPrev);
+  if (swNextBtn) swNextBtn.addEventListener('click', swNext);
+  var swHead = document.querySelector('.swipehead');
+  if (swHead){
+    var touchStartX = null;
+    swHead.addEventListener('touchstart', function(e){ touchStartX = e.touches[0].clientX; }, {passive:true});
+    swHead.addEventListener('touchend', function(e){
+      if (touchStartX === null) return;
+      var dx = e.changedTouches[0].clientX - touchStartX;
+      if (Math.abs(dx) > 40){ dx < 0 ? swNext() : swPrev(); }
+      touchStartX = null;
+    }, {passive:true});
+  }
+  renderSwipe();
+  // re-mark-read on phone tap -> recompute swipe counts too
+  document.querySelectorAll('#phoneTlist .trow').forEach(function(row){
+    row.addEventListener('click', function(e){
+      if (e.target.closest('.star')) return;
+      document.querySelectorAll('#phoneTlist .trow').forEach(function(r){ r.classList.remove('selected'); });
+      row.classList.add('selected');
+      row.classList.remove('unread');
+      renderSwipe();
+    });
+  });
+
+  // ================= v3 additions ================= //
+
+  // ---- §7.4c mobile tap-to-read: swap to full-width reading view, reusing row text already in the DOM ----
+  var phoneReading = document.getElementById('phoneReading');
+  if (phoneReading){
+    document.querySelectorAll('#phoneTlist .trow').forEach(function(row){
+      row.addEventListener('click', function(e){
+        if (e.target.closest('.star')) return;
+        var senderEl = row.querySelector('.tsender');
+        var subjEl = row.querySelector('.tsubject');
+        var snipEl = row.querySelector('.snip');
+        var subjOnly = '';
+        if (subjEl){
+          var clone = subjEl.cloneNode(true);
+          var snipInClone = clone.querySelector('.snip');
+          if (snipInClone) snipInClone.remove();
+          subjOnly = clone.textContent.trim();
+        }
+        document.getElementById('prSubject').textContent = subjOnly || 'Thread';
+        document.getElementById('prFrom').innerHTML = '<b>' + (senderEl ? senderEl.textContent : 'Unknown') + '</b>';
+        document.getElementById('prBody').textContent = snipEl ? snipEl.textContent.replace(/^—\s*/, '') : 'Open to read the full message…';
+        phoneReading.classList.add('open');
+      });
+    });
+    document.querySelectorAll('.js-pr-back').forEach(function(btn){
+      btn.addEventListener('click', function(){ phoneReading.classList.remove('open'); });
+    });
+  }
+
+  // ---- §7.4 draggable divider (roomy stage only) ----
+  (function(){
+    var threepane = document.querySelector('.threepane');
+    var divider = document.getElementById('paneDivider');
+    if (!threepane || !divider) return;
+    threepane.classList.add('withdivider');
+    var railW = 200, dragging = false, startX = 0, startListW = 360;
+    divider.addEventListener('mousedown', function(e){
+      dragging = true; startX = e.clientX;
+      var cols = getComputedStyle(threepane).gridTemplateColumns.split(' ');
+      startListW = parseFloat(cols[1]) || 360;
+      divider.classList.add('dragging');
+      document.body.style.userSelect = 'none';
+      e.preventDefault();
+    });
+    window.addEventListener('mousemove', function(e){
+      if (!dragging) return;
+      var dx = e.clientX - startX;
+      var newW = Math.max(260, Math.min(560, startListW + dx));
+      threepane.style.gridTemplateColumns = railW + 'px ' + newW + 'px 6px 1fr';
+    });
+    window.addEventListener('mouseup', function(){
+      if (!dragging) return;
+      dragging = false;
+      divider.classList.remove('dragging');
+      document.body.style.userSelect = '';
+    });
+  })();
+
+  // ---- §7.4 one-card width choreography: hamburger click toggles reading <-> browsing ----
+  (function(){
+    var wrap = document.getElementById('ocDemo1');
+    if (!wrap) return;
+    var stateEl = document.getElementById('ocState1');
+    var ham = document.getElementById('ocHam1');
+    var OC_CONTENT = {
+      boudreaux: {subject:'Re: Invoice #4460 — payment plan?', body:'Hi Denny, apologies for the wait — I saw this over text too, just following up here. Can we still do the two-payment split?'},
+      theriot: {subject:'Split-pay request — INV #4498', body:'Would like to split the $1,240 balance across two payments, if that still works on your end.'},
+      duhon: {subject:'Quote — Highrise 2-week extension', body:'Attached is the updated quote through Aug 3 — let me know if the numbers work and I\'ll get the paperwork moving.'}
+    };
+    function setState(next){
+      wrap.setAttribute('data-state', next);
+      if (stateEl) stateEl.textContent = next === 'reading' ? 'Reading' : 'Browsing';
+    }
+    if (ham){
+      ham.addEventListener('click', function(){
+        setState(wrap.getAttribute('data-state') === 'reading' ? 'browsing' : 'reading');
+      });
+    }
+    function selectOcRow(key){
+      var content = OC_CONTENT[key];
+      wrap.querySelectorAll('.oc-row').forEach(function(r){ r.classList.remove('selected'); });
+      wrap.querySelectorAll('.oc-row[data-oc="' + key + '"]').forEach(function(r){ r.classList.add('selected'); });
+      if (content){
+        document.getElementById('ocSubject').textContent = content.subject;
+        document.getElementById('ocBody').textContent = content.body;
+      }
+    }
+    wrap.querySelectorAll('.oclistwide .oc-row').forEach(function(row){
+      row.addEventListener('click', function(){
+        selectOcRow(row.getAttribute('data-oc'));
+        setState('reading');
+      });
+    });
+    wrap.querySelectorAll('.oclistnarrow .oc-row').forEach(function(row){
+      row.addEventListener('click', function(){ selectOcRow(row.getAttribute('data-oc')); });
+    });
+  })();
+
+  // ---- §7 inbox-expand: Focus toggle + sibling spines ----
+  (function(){
+    var pool = document.getElementById('cardPool');
+    var focusSeg = document.querySelector('.js-focusseg');
+    var statusLine = document.getElementById('focusStatusLine');
+    if (!pool || !focusSeg) return;
+    focusSeg.querySelectorAll('b[data-f]').forEach(function(b){
+      b.addEventListener('click', function(){
+        focusSeg.querySelectorAll('b').forEach(function(x){ x.classList.remove('on'); });
+        b.classList.add('on');
+        var f = b.getAttribute('data-f');
+        pool.setAttribute('data-focus', f === 'third' ? 'balanced' : f);
+        if (statusLine) statusLine.textContent = f === 'third'
+          ? 'Balanced — all three cards at ⅓. Click ½ or Full on the Inbox to grow it.'
+          : 'Inbox-focused (' + (f === 'half' ? '½' : 'Full') + ') — Units and Rentals collapsed to spines. Hover one to peek, click it to rebalance.';
+      });
+    });
+    document.querySelectorAll('.js-spine').forEach(function(spine){
+      spine.addEventListener('click', function(){
+        if (pool.getAttribute('data-focus') === 'balanced') return;
+        pool.setAttribute('data-focus', 'balanced');
+        focusSeg.querySelectorAll('b').forEach(function(x){ x.classList.remove('on'); });
+        focusSeg.querySelector('b[data-f="third"]').classList.add('on');
+        spine.classList.add('flash');
+        setTimeout(function(){ spine.classList.remove('flash'); }, 900);
+        if (statusLine) statusLine.textContent = 'Back to balanced — ' + spine.getAttribute('data-card') + ' comes forward, ready to work.';
+      });
+    });
+  })();
+
+  // ---- §7.4 quick actions: hover row-actions + right-click menu + drag-hint, wired onto the §3 workspace list ----
+  function runRowAction(row, act){
+    if (act === 'unread'){ row.classList.toggle('unread'); return; }
+    row.style.transition = 'opacity .18s, transform .18s';
+    row.style.opacity = '0';
+    row.style.transform = 'translateX(24px)';
+    setTimeout(function(){ row.style.display = 'none'; }, 190);
+  }
+  var openCtxEl = null;
+  function closeCtxMenu(){ if (openCtxEl){ openCtxEl.remove(); openCtxEl = null; } }
+  function openCtxMenu(row, evt){
+    closeCtxMenu();
+    var rect = row.getBoundingClientRect();
+    var menu = document.createElement('div');
+    menu.className = 'ctxmenu';
+    menu.style.top = Math.max(0, evt.clientY - rect.top) + 'px';
+    menu.style.left = Math.max(0, Math.min(evt.clientX - rect.left, rect.width - 180)) + 'px';
+    menu.innerHTML =
+      '<div class="ctx-opt" data-act="hide"><svg class="ic"><use href="#i-eye-off"></use></svg>Hide</div>' +
+      '<div class="ctx-opt" data-act="unread"><svg class="ic"><use href="#i-mail"></use></svg>Mark unread</div>' +
+      '<div class="ctx-opt" data-act="star"><svg class="ic"><use href="#i-star"></use></svg>Star</div>' +
+      '<div class="ctx-opt" data-act="snooze"><svg class="ic"><use href="#i-clock"></use></svg>Snooze</div>' +
+      '<div class="ctx-div"></div>' +
+      '<div class="ctx-opt danger" data-act="archive"><svg class="ic"><use href="#i-archive"></use></svg>Archive</div>';
+    row.appendChild(menu);
+    openCtxEl = menu;
+    menu.querySelectorAll('.ctx-opt').forEach(function(opt){
+      opt.addEventListener('click', function(e){
+        e.stopPropagation();
+        var act = opt.getAttribute('data-act');
+        if (act === 'star'){ var star = row.querySelector('.star'); if (star) star.classList.toggle('on'); }
+        else { runRowAction(row, act); }
+        closeCtxMenu();
+      });
+    });
+    setTimeout(function(){ document.addEventListener('click', closeCtxMenu, {once:true}); }, 0);
+  }
+  function wireRowActions(scopeSel){
+    var list = document.querySelector(scopeSel);
+    if (!list) return;
+    list.querySelectorAll('.trow').forEach(function(row){
+      var trow1 = row.querySelector('.trow1');
+      if (!trow1 || trow1.querySelector('.rowacts')) return;
+      var drag = document.createElement('span');
+      drag.className = 'rowdrag'; drag.title = 'Drag to resort';
+      drag.innerHTML = '<svg class="ic"><use href="#i-grip"></use></svg>';
+      trow1.insertBefore(drag, trow1.firstChild);
+
+      var acts = document.createElement('span');
+      acts.className = 'rowacts';
+      acts.innerHTML =
+        '<span class="rowact-btn js-ra" data-act="hide" title="Hide"><svg class="ic"><use href="#i-eye-off"></use></svg></span>' +
+        '<span class="rowact-btn js-ra" data-act="unread" title="Mark unread"><svg class="ic"><use href="#i-mail"></use></svg></span>' +
+        '<span class="rowact-btn js-ra" data-act="snooze" title="Snooze"><svg class="ic"><use href="#i-clock"></use></svg></span>' +
+        '<span class="rowact-btn js-ra danger" data-act="archive" title="Archive"><svg class="ic"><use href="#i-archive"></use></svg></span>';
+      trow1.appendChild(acts);
+
+      acts.querySelectorAll('.js-ra').forEach(function(btn){
+        btn.addEventListener('click', function(e){
+          e.stopPropagation();
+          runRowAction(row, btn.getAttribute('data-act'));
+        });
+      });
+      row.addEventListener('contextmenu', function(e){
+        e.preventDefault();
+        openCtxMenu(row, e);
+      });
+    });
+  }
+  wireRowActions('#tlist');
+
+  // ---- §7.4 mobile swipe-reveal demo (standalone, §9) ----
+  (function(){
+    var btn = document.querySelector('.js-swipe-peek');
+    var demoRow = document.getElementById('swipeDemo');
+    if (!btn || !demoRow) return;
+    btn.addEventListener('click', function(){
+      demoRow.classList.toggle('peeked');
+      btn.textContent = demoRow.classList.contains('peeked') ? '← Close' : 'Peek swipe →';
+    });
+    var snoozeBtn = document.getElementById('swipeSnoozeBtn');
+    var archiveBtn = document.getElementById('swipeArchiveBtn');
+    if (snoozeBtn) snoozeBtn.addEventListener('click', function(){ demoRow.classList.remove('peeked'); btn.textContent = 'Peek swipe →'; });
+    if (archiveBtn) archiveBtn.addEventListener('click', function(){ demoRow.remove(); });
+  })();
+
+  // ---- §7.5 inbound routing simulator ----
+  (function(){
+    var statusEl = document.getElementById('sim10status');
+    var dock10 = document.getElementById('dock10');
+    var chipActive = document.getElementById('chipActive');
+    var bell10 = document.getElementById('bell10');
+    var bellCount10 = document.getElementById('bellCount10');
+    if (!dock10) return;
+    var coldSeq = 0;
+    var texts = ['running about 15 late, sorry!', 'can you resend the quote PDF?', 'confirmed — see you at 7'];
+    document.querySelectorAll('.js-sim').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var kind = btn.getAttribute('data-sim');
+        if (kind === 'active'){
+          var msg = texts[Math.floor(Math.random() * texts.length)];
+          var snip = chipActive.querySelector('.dcsnip');
+          if (!snip){ snip = document.createElement('span'); snip.className = 'dcsnip'; chipActive.appendChild(snip); }
+          snip.textContent = '— ' + msg;
+          dock10.insertBefore(chipActive, dock10.firstChild);
+          chipActive.classList.add('flash');
+          setTimeout(function(){ chipActive.classList.remove('flash'); }, 900);
+          var oldPreview = chipActive.querySelector('.dockpreview');
+          if (oldPreview) oldPreview.remove();
+          var preview = document.createElement('div');
+          preview.className = 'dockpreview';
+          preview.innerHTML = '<b>Trey Guidry</b> · ' + msg;
+          chipActive.appendChild(preview);
+          if (statusEl) statusEl.textContent = '→ recent/active thread: bumped to front, flashed, and popped open with a preview.';
+        } else if (kind === 'cold'){
+          coldSeq++;
+          var chip = document.createElement('span');
+          chip.className = 'dockchip js-newchip';
+          chip.innerHTML = '<span class="dot" style="background:var(--gray)"></span>Acadiana Hydraulic<span class="dcsnip">— WO #120' + coldSeq + ' parts ETA update</span>';
+          dock10.appendChild(chip);
+          if (statusEl) statusEl.textContent = '→ cold thread: a new tab slid onto the rail, quiet — no pop, no flash.';
+        } else if (kind === 'email'){
+          bellCount10.textContent = (parseInt(bellCount10.textContent, 10) || 0) + 1;
+          if (bell10) bell10.classList.add('flashbell');
+          setTimeout(function(){ if (bell10) bell10.classList.remove('flashbell'); }, 900);
+          if (statusEl) statusEl.textContent = '→ email: bell +1 only. No dock activity — email stays calm.';
+        }
+      });
+    });
+  })();
+</script>

--- a/docs/design/reference/inspection.html
+++ b/docs/design/reference/inspection.html
@@ -1,0 +1,427 @@
+<title>Inspection — a live capture surface</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#7f8896; --txt3-lo:#717b89;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --gray:#8b94a3;
+    --tan:#c2925a;
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  @media (prefers-color-scheme:light){ :root{
+    --bg:#e6e8ea; --bg2:#dfe3ea; --panel:#fff; --panel2:#eef1f6; --card:#fff; --cardh:#eef1f6;
+    --line:#cfd6e1; --lineSoft:#e1e6ee; --txt:#141821; --txt2:#414b5a; --txt3:#69727f;
+    --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  } }
+  :root[data-theme="light"]{
+    --bg:#e6e8ea; --panel:#fff; --card:#fff; --cardh:#eef1f6; --line:#cfd6e1; --lineSoft:#e1e6ee;
+    --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  }
+  :root[data-theme="dark"]{
+    --bg:#0a0d11; --panel:#171d25; --card:#12171e; --cardh:#1a212b; --line:#2c343f; --lineSoft:#212834;
+    --txt:#eef2f7; --txt2:#aab4c1; --txt3:#7f8896; --accent:#ff7e1f; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --green:#34d399; --gray:#8b94a3; --tan:#c2925a;
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1180px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:90ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600}
+  .key{display:flex; flex-wrap:wrap; gap:6px 12px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+
+  .insp-grid{display:grid; grid-template-columns:1fr 1fr; gap:16px; margin-top:20px; align-items:start}
+  @media (max-width:880px){ .insp-grid{grid-template-columns:1fr} }
+
+  .panel{background:var(--panel); border:1px solid var(--line); border-radius:14px; overflow:hidden}
+  .pcap{font-family:var(--stamp); font-size:9.5px; letter-spacing:.13em; text-transform:uppercase; color:var(--txt3); padding:9px 13px 0; display:flex; align-items:center; gap:7px}
+  .dnote{font-family:var(--stamp); font-size:9px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); border:1px solid var(--line); border-radius:7px; padding:2px 7px}
+  .ptitle{padding:1px 13px 11px}
+  .pt-name{font-family:var(--font); font-weight:700; font-size:15px; color:var(--txt); letter-spacing:-.005em; display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .pt-sub{font-size:11px; color:var(--txt3); margin-top:2px; font-family:var(--stamp); letter-spacing:.02em}
+
+  /* ---------- the five parts (identical to yard-journey.html / detail-views.html) ---------- */
+  .ctl{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .sig{padding:0 8px; border-radius:7px}
+  .sig.f.red{background:var(--redStrong);color:#fff} .sig.o.red{color:var(--red);box-shadow:inset 0 0 0 1.3px var(--red)}
+  .sig.f.yellow{background:var(--yellow);color:#211a05} .sig.o.yellow{color:var(--yellow);box-shadow:inset 0 0 0 1.3px var(--yellow)}
+  .sig.f.blue{background:var(--blue);color:#0a1220} .sig.o.blue{color:var(--blue);box-shadow:inset 0 0 0 1.3px var(--blue)}
+  .sig.f.green{background:var(--green);color:#04140d} .sig.o.green{color:var(--green);box-shadow:inset 0 0 0 1.3px var(--green)}
+  .sig.o.grey{color:var(--gray);box-shadow:inset 0 0 0 1.3px var(--gray)}
+  .stamp{font-family:var(--stamp); font-size:10.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap}
+  .dot{color:var(--line); font-family:var(--stamp); font-size:10px}
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 8px 0 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:600; cursor:pointer; text-decoration:none; white-space:nowrap}
+  .ref .ty{width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .ref .ty svg{width:11px;height:11px}
+  .door{height:var(--h); display:inline-flex; align-items:center; gap:5px; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; cursor:pointer; border-radius:999px; padding:0 13px; border:0; background:none}
+  .door.save{background:var(--commit); color:#fff; border:0}
+  .door.add{background:transparent; color:var(--commit); border:1.4px dashed var(--commit); padding:0 11px}
+  .door.ghost{background:transparent; color:var(--txt2); border:1px solid var(--line)}
+  .door.gated{background:transparent; color:var(--txt3); border:1px solid var(--line); cursor:help}
+  .door .lk{width:11px;height:11px;opacity:.85;flex:none}
+
+  /* ---------- section-chip rail (top row = item's own tabs; Inspection active) ---------- */
+  .secrail{display:flex; align-items:center; gap:6px; padding:9px 10px; border-bottom:1px solid var(--line); border-top:1px solid var(--line); background:var(--bg2)}
+  .scnav{flex:none; width:20px; height:20px; display:inline-flex; align-items:center; justify-content:center; background:transparent; border:1px solid var(--line); border-radius:6px; color:var(--txt3); cursor:pointer}
+  .scnav svg{width:11px;height:11px}
+  .scchips{display:flex; gap:6px; overflow-x:auto; flex:1; scrollbar-width:none}
+  .scchips::-webkit-scrollbar{display:none}
+  .schip{height:var(--h); display:inline-flex; align-items:center; padding:0 10px; border-radius:7px; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; flex:none; color:var(--txt3); border:1px solid transparent; cursor:pointer}
+  .schip.dim{opacity:.6}
+  .schip.active{background:var(--accent); color:var(--onAcc)}
+  .scdots{display:flex; gap:4px; padding:0 12px 8px; justify-content:flex-end; background:var(--bg2)}
+  .scdots i{width:5px;height:5px;border-radius:50%;background:var(--line);display:inline-block;font-style:normal}
+  .scdots i.on{background:var(--accent)}
+
+  /* ---------- progress head: N of M captured + rollup Signal + the ONE Door ---------- */
+  .inschead{padding:12px 14px; background:var(--cardh); border-bottom:1px solid var(--line)}
+  .ih-row{display:flex; align-items:center; gap:10px; flex-wrap:wrap}
+  .ih-count{font-family:var(--font); font-weight:700; font-size:13px; color:var(--txt); font-variant-numeric:tabular-nums}
+  .ih-spacer{flex:1}
+  .ih-sub{font-size:12px; color:var(--txt2); width:100%; margin-top:2px}
+  .tip{position:relative; display:inline-block}
+  .tip .bub{position:absolute; top:calc(100% + 8px); right:0; width:max-content; max-width:min(70vw,230px); background:#05070a; color:#eef2f7; border:1px solid #3a444e; border-radius:7px; padding:8px 10px; font-family:var(--font); font-size:11.5px; line-height:1.42; text-transform:none; letter-spacing:0; box-shadow:0 12px 30px rgba(0,0,0,.6); opacity:0; transform:translateY(-4px); pointer-events:none; transition:opacity .12s, transform .12s; z-index:30}
+  @media (prefers-color-scheme:light){ .tip .bub{background:#fff; color:#141821; border-color:#c7ccd2} } :root[data-theme="light"] .tip .bub{background:#fff; color:#141821; border-color:#c7ccd2}
+  .tip:hover .bub, .tip:focus-within .bub{opacity:1; transform:translateY(0)}
+  .tip .bub .t{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--accent); display:block; margin-bottom:3px}
+
+  /* ---------- checklist: plate grammar reused as capture rows ---------- */
+  .clist{}
+  .plate{border-bottom:1px solid var(--line); border-left:3px solid transparent}
+  .clist .plate:last-child{border-bottom:0}
+  .plate.bad{border-left-color:var(--red)} .plate.now{border-left-color:var(--yellow)} .plate.done{border-left-color:var(--green)} .plate.none{border-left-color:var(--gray)}
+  .phead{display:flex; align-items:center; gap:9px; min-height:42px; padding:8px 12px}
+  .phead.toggle{cursor:pointer}
+  .crow-ic{flex:none; width:18px; height:18px; display:inline-flex; align-items:center; justify-content:center; color:var(--txt3)}
+  .crow-ic svg{width:14px;height:14px}
+  .plabel{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt); flex:none}
+  .psum{flex:1; min-width:120px; font-size:11px; color:var(--txt2)}
+  .chev{font-size:12px; color:var(--txt3); flex:none; display:inline-flex; align-items:center; width:12px; height:12px}
+  .chev svg{width:12px;height:12px} .chev.open{color:var(--accent)}
+  .capzone{padding:0 12px 12px 39px; display:flex; gap:8px; flex-wrap:wrap}
+  .pbody{padding:2px 12px 12px 39px; background:var(--bg2); border-top:1px solid var(--lineSoft)}
+  .kv{display:flex; gap:10px; padding:8px 0 2px; font-size:12px; align-items:flex-start}
+  .kv .k{font-family:var(--stamp); font-size:9.5px; letter-spacing:.05em; text-transform:uppercase; color:var(--txt3); flex:none; padding-top:1px}
+  .kv .v{color:var(--txt2)}
+  .prow{display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-top:8px}
+
+  .htail{padding:9px 12px; border-top:1px solid var(--line)}
+  .h4{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt); margin-bottom:6px}
+  .hc{font-family:var(--stamp); font-size:9px; font-weight:700; text-transform:uppercase; color:var(--txt3); border:1px solid var(--line); border-radius:11px; padding:2px 7px; margin-right:5px; display:inline-block}
+
+  .foot{margin-top:24px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:92ch} .foot b{color:var(--txt)}
+  .foot ul{margin:8px 0 0; padding-left:20px} .foot li{margin:4px 0}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Units · Inspection · new live-capture redesign · built to style + wrangler-style</p>
+  <h1>Inspection — <span class="hl">a live capture surface</span></h1>
+  <p class="lede">Replaces the outdated "tap a button, fill a separate form" Inspection (spec §6, 2026-07-20). Framed as
+  one section of a Unit's inline-expanded card — same <b>section-chip rail</b> as Yard Journey across the top, Inspection
+  active. The checklist stays <b>open live in the section</b>: each item is captured in place, a <b>progress head</b> tracks
+  "N of M captured" plus a rollup Signal (worst item wins), and the single <b>Door</b> stays a disabled/ghost lock until
+  every required item is captured — it can only be pressed when the inspection is actually done. <b>Gator (left) is
+  interactive</b> — capture the last two items and press the Door yourself. <b>Scout (right)</b> shows the calm
+  afterimage once it's finished.</p>
+  <div class="key"><span><b>Signal</b> state chip</span><span><b>Gate</b> turnable</span><span><b>Stamp</b> fact</span><span><b>Ref</b> linked</span><span><b>Door</b> action</span><span>· fill = today · colour = state</span></div>
+
+  <div class="insp-grid">
+
+    <!-- ============ IN PROGRESS — GATOR ============ -->
+    <div class="panel">
+      <div class="pcap">Unit · inline-expanded</div>
+      <div class="ptitle">
+        <div class="pt-name">Gator <span class="ctl sig f red">flagged</span></div>
+        <div class="pt-sub">CAT 320 Excavator · S/N RC-4700</div>
+      </div>
+
+      <div class="secrail">
+        <button class="scnav" aria-label="previous sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button>
+        <div class="scchips">
+          <span class="schip dim">To Do</span>
+          <span class="schip dim">Yard Journey</span>
+          <span class="schip active">Inspection</span>
+          <span class="schip dim">Services</span>
+          <span class="schip dim">Work Orders</span>
+          <span class="schip dim">Specs</span>
+          <span class="schip dim">Investment</span>
+          <span class="schip dim">GPS</span>
+        </div>
+        <button class="scnav" aria-label="next sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></button>
+      </div>
+      <div class="scdots"><i class="on"></i><i></i></div>
+
+      <!-- progress head -->
+      <div class="inschead">
+        <div class="ih-row">
+          <span class="ih-count" id="p1-count">4 of 6 captured</span>
+          <span class="ctl sig f red" id="p1-rollup">flagged</span>
+          <span class="ih-spacer"></span>
+          <span class="tip" id="p1-doorwrap">
+            <span class="ctl door gated" id="p1-door" tabindex="0">Mark inspection done <svg class="lk" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span>
+            <span class="bub" id="p1-doorbub"><span class="t">Not yet unlocked</span><span class="rmsg">2 items left — capture damage photos + cleanliness to unlock.</span></span>
+          </span>
+        </div>
+        <div class="ih-sub">One item already failed (Hydraulics) — that's why the rollup reads <b style="color:var(--red)">flagged</b>. It stays that way even after the Door unlocks; done ≠ clean.</div>
+      </div>
+
+      <!-- live checklist -->
+      <div class="clist">
+
+        <div class="plate done" data-row="tires">
+          <div class="phead">
+            <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg></span>
+            <span class="plabel">Tires / PSI</span>
+            <span class="psum">36 · 35 · 37 · 34 psi · within range</span>
+            <span class="ctl sig o green rowsig">pass</span>
+          </div>
+        </div>
+
+        <div class="plate now" data-row="hours">
+          <div class="phead">
+            <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
+            <span class="plabel">Hours / meter</span>
+            <span class="psum">1,180 hrs logged · PM service interval due now</span>
+            <span class="ctl sig f yellow rowsig">due now</span>
+          </div>
+        </div>
+
+        <div class="plate none" data-row="fluids">
+          <div class="phead">
+            <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.4-4 6C6 11.1 5 13 5 15a7 7 0 0 0 7 7z"/></svg></span>
+            <span class="plabel">Fluids</span>
+            <span class="psum">Full · clean · no contamination</span>
+            <span class="ctl sig o green rowsig">pass</span>
+          </div>
+        </div>
+
+        <div class="plate bad" data-row="hydraulics">
+          <div class="phead toggle">
+            <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
+            <span class="plabel">Hydraulics</span>
+            <span class="psum">Leak at main cylinder seal</span>
+            <span class="ctl sig f red rowsig">failed</span>
+            <span class="chev open"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>
+          </div>
+          <div class="pbody" style="display:block">
+            <div class="kv"><span class="k">Noted</span><span class="v">Seeping fluid at the boom cylinder, left side — caught on the visual pass.</span></div>
+            <div class="prow">
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>WO #1201 · hyd cylinder seal</a>
+              <span class="stamp">auto-linked on flag · 10:02 AM</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="plate none" data-row="photos">
+          <div class="phead">
+            <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3z"/><circle cx="12" cy="13" r="3"/></svg></span>
+            <span class="plabel">Damage photos</span>
+            <span class="psum">Required before done</span>
+            <span class="ctl sig o grey rowsig">not captured</span>
+          </div>
+          <div class="capzone">
+            <button class="ctl door add" onclick="rwCapture('photos','pass','4 photos captured')">+ Add photos</button>
+          </div>
+        </div>
+
+        <div class="plate none" data-row="clean">
+          <div class="phead">
+            <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg></span>
+            <span class="plabel">Cleanliness</span>
+            <span class="psum">Required before done</span>
+            <span class="ctl sig o grey rowsig">not captured</span>
+          </div>
+          <div class="capzone">
+            <button class="ctl door ghost" onclick="rwCapture('clean','pass','Washed · no debris')">Pass</button>
+            <button class="ctl door ghost" onclick="rwCapture('clean','fail','Debris buildup — needs recleaning before dispatch')">Flag</button>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="htail"><div class="h4">History</div><span class="hc">12 Inspections</span><span class="hc">3 WOs</span></div>
+    </div>
+
+    <!-- ============ JUST COMPLETED — SCOUT ============ -->
+    <div class="panel">
+      <div class="pcap">Unit · inline-expanded <span class="dnote">just-completed example</span></div>
+      <div class="ptitle">
+        <div class="pt-name">Scout <span class="ctl sig o green">available</span></div>
+        <div class="pt-sub">Skid Steer 70hp · S/N SS-14</div>
+      </div>
+
+      <div class="secrail">
+        <button class="scnav" aria-label="previous sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button>
+        <div class="scchips">
+          <span class="schip dim">To Do</span>
+          <span class="schip dim">Yard Journey</span>
+          <span class="schip active">Inspection</span>
+          <span class="schip dim">Services</span>
+          <span class="schip dim">Specs</span>
+        </div>
+        <button class="scnav" aria-label="next sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></button>
+      </div>
+      <div class="scdots"><i class="on"></i><i></i></div>
+
+      <div class="inschead">
+        <div class="ih-row">
+          <span class="ih-count">6 of 6 captured</span>
+          <span class="ctl sig o green">clear</span>
+          <span class="ih-spacer"></span>
+          <span class="ctl sig o green">done</span>
+          <span class="stamp">Completed 9:14 AM · Trey G.</span>
+        </div>
+        <div class="ih-sub">Every required item captured clean — the Door is gone, not just disabled: nothing left to act on, so it's a plain fact now, not a button.</div>
+      </div>
+
+      <div class="clist">
+        <div class="plate done"><div class="phead">
+          <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg></span>
+          <span class="plabel">Tires / PSI</span><span class="psum">37 · 36 · 38 · 35 psi · within range</span>
+          <span class="ctl sig o green">pass</span></div></div>
+
+        <div class="plate done"><div class="phead">
+          <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>
+          <span class="plabel">Hours / meter</span><span class="psum">842 hrs logged</span>
+          <span class="ctl sig o green">pass</span></div></div>
+
+        <div class="plate done"><div class="phead">
+          <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.4-4 6C6 11.1 5 13 5 15a7 7 0 0 0 7 7z"/></svg></span>
+          <span class="plabel">Fluids</span><span class="psum">Full · clean · no contamination</span>
+          <span class="ctl sig o green">pass</span></div></div>
+
+        <div class="plate done"><div class="phead">
+          <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
+          <span class="plabel">Hydraulics</span><span class="psum">No leaks · pressure nominal</span>
+          <span class="ctl sig o green">pass</span></div></div>
+
+        <div class="plate done"><div class="phead">
+          <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3z"/><circle cx="12" cy="13" r="3"/></svg></span>
+          <span class="plabel">Damage photos</span><span class="psum">4 photos captured · none flagged</span>
+          <span class="ctl sig o green">pass</span></div></div>
+
+        <div class="plate done"><div class="phead">
+          <span class="crow-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg></span>
+          <span class="plabel">Cleanliness</span><span class="psum">Washed · no debris</span>
+          <span class="ctl sig o green">pass</span></div></div>
+      </div>
+
+      <div class="htail"><div class="h4">History</div><span class="hc">9 Inspections</span><span class="hc">1 WO</span></div>
+    </div>
+
+  </div>
+
+  <div class="foot">
+    <b>Inspection</b> is now a section, not a button that launches a form — the checklist lives open in place, and answers
+    fill in as you go. Notes for review:
+    <ul>
+      <li>The <b>progress head</b> carries "N of M captured" (a value you read → bold, body-voice, on the size ladder)
+      + the <b>rollup Signal</b> (worst item wins) + the <b>one</b> Door. Nothing else on the section competes for a
+      second action.</li>
+      <li>Four item states, same vocabulary used everywhere else — <b>grey</b> = not captured, <b>green</b> = pass,
+      <b>dimmed yellow (<code>#eed44b</code>)</b> = due now, <b>filled red</b> = failed. No new colour language.</li>
+      <li><b>Hydraulics failing raises the whole section to red</b> and auto-spawns a linked <b>WO Ref</b> — expand that
+      row (it opens by default here) to see it; the fact stays visible even once the inspection is marked done.</li>
+      <li><b>The Door is gated, not just greyed</b> — it carries a lock icon + tooltip naming exactly what's left, matching
+      the same honest-lock pattern as the money-gated Door in the Units detail mock. Capture the last two items on Gator
+      and it unlocks to solid commit-blue; press it and the whole head flips to a plain <b>Completed</b> Stamp — proving
+      "done" is a real state change, not a lie.</li>
+      <li><b>Done ≠ clean.</b> Marking the inspection done does not soften or hide the still-open Hydraulics flag — that's
+      the whole point of "the inspection only flips to Done when it's actually done," not when someone taps past it.</li>
+      <li>Scout (right) is the calm afterimage: once truly finished, the <b>Door disappears</b> rather than staying an
+      inert button — honest-affordance: not tappable ⇒ it doesn't look tappable.</li>
+      <li>Matte, no glow; dark-theme <code>--txt3</code> nudged <code>#717b89→#7f8896</code> (measured 4.2:1 → 5.0:1 on
+      <code>--card</code>) to clear the AA text floor — everything else is the exact palette from Yard Journey / Detail
+      views, reused for continuity.</li>
+    </ul>
+  </div>
+
+</div></div>
+
+<script>
+(function(){
+  var STATE = { photos:'unset', clean:'unset' };
+  var FIXED = { tires:'pass', hours:'due', fluids:'pass', hydraulics:'fail' };
+  var TOTAL = 6;
+  var SEV = { fail:3, due:2, pass:1, unset:0 };
+  var CLS = { fail:'bad', due:'now', pass:'done', unset:'none' };
+  var SIG = { fail:['sig f red','failed'], due:['sig f yellow','due now'], pass:['sig o green','pass'], unset:['sig o grey','not captured'] };
+  var ROLL = { fail:['sig f red','flagged'], due:['sig f yellow','due now'], pass:['sig o green','clear'], unset:['sig o grey','pending'] };
+
+  function paint(id, state, text){
+    var row = document.querySelector('[data-row="'+id+'"]');
+    if(!row) return;
+    row.classList.remove('bad','now','done','none');
+    row.classList.add(CLS[state]);
+    var sig = row.querySelector('.rowsig');
+    if(sig){ sig.className = 'ctl rowsig ' + SIG[state][0]; sig.textContent = SIG[state][1]; }
+    var sum = row.querySelector('.psum');
+    if(sum && text) sum.textContent = text;
+    var cap = row.querySelector('.capzone');
+    if(cap) cap.style.display = state === 'unset' ? '' : 'none';
+  }
+
+  function recompute(){
+    var all = {}; for(var k in FIXED) all[k]=FIXED[k]; for(var k2 in STATE) all[k2]=STATE[k2];
+    var captured = 0, worst = 'unset', worstSev = -1;
+    Object.keys(all).forEach(function(k){
+      if(all[k] !== 'unset') captured++;
+      if(SEV[all[k]] > worstSev){ worstSev = SEV[all[k]]; worst = all[k]; }
+    });
+    document.getElementById('p1-count').textContent = captured + ' of ' + TOTAL + ' captured';
+    var roll = document.getElementById('p1-rollup');
+    roll.className = 'ctl ' + ROLL[worst][0];
+    roll.textContent = ROLL[worst][1];
+
+    var door = document.getElementById('p1-door');
+    var bub = document.getElementById('p1-doorbub');
+    if(!door) return;
+    if(captured === TOTAL){
+      door.className = 'ctl door save';
+      door.innerHTML = 'Mark inspection done';
+      door.style.cursor = 'pointer';
+      door.onclick = markDone;
+      if(bub) bub.style.display = 'none';
+    } else {
+      var remain = TOTAL - captured;
+      door.className = 'ctl door gated';
+      door.innerHTML = 'Mark inspection done <svg class="lk" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>';
+      door.onclick = null;
+      door.style.cursor = 'help';
+      if(bub){
+        bub.style.display='';
+        var rmsg = bub.querySelector('.rmsg');
+        if(rmsg) rmsg.textContent = remain + ' item' + (remain>1?'s':'') + ' left — capture damage photos + cleanliness to unlock.';
+      }
+    }
+  }
+
+  function markDone(){
+    var wrap = document.getElementById('p1-doorwrap');
+    if(wrap){ wrap.outerHTML = '<span class="ctl sig o green">done</span><span class="stamp">Completed just now · Trey G.</span>'; }
+  }
+
+  window.rwCapture = function(id, state, text){
+    STATE[id] = state;
+    paint(id, state, text);
+    recompute();
+  };
+
+  document.querySelectorAll('.phead.toggle').forEach(function(h){
+    h.addEventListener('click', function(){
+      var body = h.parentElement.querySelector('.pbody');
+      var chev = h.querySelector('.chev');
+      if(!body) return;
+      var isOpen = body.style.display !== 'none';
+      body.style.display = isOpen ? 'none' : 'block';
+      if(chev) chev.classList.toggle('open', !isOpen);
+    });
+  });
+
+  recompute();
+})();
+</script>

--- a/docs/design/reference/intake.html
+++ b/docs/design/reference/intake.html
@@ -1,0 +1,647 @@
+<title>Intake — first draft, for Jac to react to</title>
+<style>
+/* ══════════════════════════════════════════════════════════════════════
+   TOKENS — locked steel palette (wrangler-style §1), identical to the
+   detail-views / funnel reference files. Dark is default; light overrides
+   via prefers-color-scheme; :root[data-theme] wins both directions.
+   ══════════════════════════════════════════════════════════════════════ */
+:root{
+  --bg:#0a0d11; --panel:#171d25; --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#717b89;
+  --accent:#ff7e1f; --ink:#1a1205;
+  --green:#34d399; --yellow:#eed44b; --red:#ff4242; --red-fill:#d63636;
+  --blue:#6394cc; --gray:#8b94a3; --commit:#2f6fd0; --tan:#c2925a;
+  --on-blue:#1a1205;   /* dark ink reads fine on the dark theme's lighter blue; light theme's darker blue needs white — see below */
+
+  --h:26px;                 /* ONE control height — every inline control */
+  --r-pill:999px;            /* actions: Door, segmented toggle, quick-pick */
+  --r-chip:7px;               /* state: Signal / Gate / Ref backing — ONE chip value */
+  /* size ladder — 28 · 15 · 13 · 12 · 11 · 10 · 9.5 (value·title·content·field·label/chip·small·finest) */
+  --fs-value:28px; --fs-title:15px; --fs-content:13px; --fs-field:12px;
+  --fs-chip:11px; --fs-small:10px; --fs-finest:9.5px;
+  --w-stamp:800; --w-bold:700; --w-reg:400;   /* three weights, capped */
+  --mono: ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+  --sans: -apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+}
+@media (prefers-color-scheme: light){
+  :root{
+    --bg:#e6e8ea; --panel:#fff; --card:#fff; --card-head:#eef0f2;
+    --line:#cfd6e1; --line-soft:#e1e6ec;
+    --txt:#141821; --txt-2:#414b5a; --txt-3:#69727f;
+    --accent:#cf6000; --ink:#1a1205;
+    --green:#0c8f5f; --yellow:#eed44b; --red:#d52a2a; --red-fill:#b5241f;
+    --blue:#2f5fb0; --gray:#566072; --commit:#1f56c0; --tan:#8a5a2b;
+    --on-blue:#fff;   /* light theme's --blue is darker — ink fails (2.99), white clears (6.20) */
+  }
+}
+:root[data-theme="dark"]{
+  --bg:#0a0d11; --panel:#171d25; --card:#12171e; --card-head:#1a212b;
+  --line:#2c343f; --line-soft:#212834;
+  --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#717b89;
+  --accent:#ff7e1f; --ink:#1a1205;
+  --green:#34d399; --yellow:#eed44b; --red:#ff4242; --red-fill:#d63636;
+  --blue:#6394cc; --gray:#8b94a3; --commit:#2f6fd0; --tan:#c2925a; --on-blue:#1a1205;
+}
+:root[data-theme="light"]{
+  --bg:#e6e8ea; --panel:#fff; --card:#fff; --card-head:#eef0f2;
+  --line:#cfd6e1; --line-soft:#e1e6ec;
+  --txt:#141821; --txt-2:#414b5a; --txt-3:#69727f;
+  --accent:#cf6000; --ink:#1a1205;
+  --green:#0c8f5f; --yellow:#eed44b; --red:#d52a2a; --red-fill:#b5241f;
+  --blue:#2f5fb0; --gray:#566072; --commit:#1f56c0; --tan:#8a5a2b; --on-blue:#fff;
+}
+
+*,*::before,*::after{ box-sizing:border-box; }
+body{ margin:0; background:var(--bg); color:var(--txt); font-family:var(--sans);
+  line-height:1.5; -webkit-font-smoothing:antialiased; }
+.num{ font-variant-numeric:tabular-nums; font-family:var(--mono); }
+button,input{ font-family:inherit; color:inherit; }
+
+.page{ max-width:1180px; margin:0 auto; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px; }
+.eyebrow{ font-family:var(--mono); font-size:var(--fs-field); letter-spacing:.16em; text-transform:uppercase;
+  color:var(--txt-2); margin:0; font-weight:var(--w-bold); }
+h1{ font-family:var(--mono); font-weight:var(--w-stamp); font-size:clamp(20px,3.3vw,var(--fs-value));
+  line-height:1; margin:.28em 0 .34em; letter-spacing:.01em; text-transform:uppercase; }
+h1 .hl{ color:var(--accent); }
+.lede{ max-width:82ch; font-size:var(--fs-content); color:var(--txt-2); margin:0 0 4px; }
+.lede b{ color:var(--txt); font-weight:var(--w-bold); }
+
+.legend{ display:flex; flex-wrap:wrap; gap:6px 16px; margin:14px 0 22px; font-family:var(--mono);
+  font-size:var(--fs-small); letter-spacing:.03em; text-transform:uppercase; color:var(--txt-2); }
+.legend b{ color:var(--tan); font-weight:var(--w-bold); }
+
+/* ══════════════════════════════════════════════════════════════════════
+   LAYOUT — two intake shells side by side (first-touch vs mid-call),
+   wrapping to a stack on narrow viewports.
+   ══════════════════════════════════════════════════════════════════════ */
+.compare{ display:flex; flex-wrap:wrap; gap:22px; align-items:flex-start; }
+.intake-shell{ flex:1 1 380px; max-width:460px; min-width:0; }
+.ix-head{ display:flex; align-items:baseline; gap:9px; padding:0 2px 9px; border-bottom:1px dashed var(--line); margin-bottom:12px; }
+.ix-tag{ font-family:var(--mono); font-size:var(--fs-finest); font-weight:var(--w-stamp); letter-spacing:.1em;
+  text-transform:uppercase; color:var(--tan); }
+.ix-title{ font-family:var(--sans); font-weight:var(--w-bold); font-size:var(--fs-title); color:var(--txt); margin-left:auto; }
+
+.ix-panel{ background:var(--card); border:1px solid var(--line); border-radius:12px; overflow:visible; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   PLATE GRAMMAR — reused verbatim: left status-bar + stamped label +
+   summary + chip + chevron → body. Header colour = worst item inside.
+   ══════════════════════════════════════════════════════════════════════ */
+.plate{ border-bottom:1px solid var(--line); border-left:3px solid transparent; }
+.plate:last-child{ border-bottom:0; }
+.plate.bad{ border-left-color:var(--red); } .plate.now{ border-left-color:var(--yellow); }
+.plate.wait{ border-left-color:var(--blue); } .plate.done{ border-left-color:var(--green); }
+.plate.none{ border-left-color:var(--gray); } .plate.locked{ border-left-color:transparent; }
+.phead{ display:flex; align-items:center; gap:9px; min-height:calc(var(--h) + 10px); padding:6px 12px; cursor:pointer; }
+.plate.locked .phead{ cursor:not-allowed; }
+.plabel{ font-family:var(--mono); font-size:var(--fs-chip); font-weight:var(--w-stamp); letter-spacing:.05em;
+  text-transform:uppercase; color:var(--txt); flex:none; }
+.plate.locked .plabel{ color:var(--txt-2); }
+.psum{ flex:1; min-width:0; font-size:var(--fs-chip); color:var(--txt-2); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.plate.locked .psum{ color:var(--txt-2); font-style:italic; }
+.chev{ font-size:var(--fs-chip); color:var(--txt-3); flex:none; display:inline-flex; align-items:center; width:12px; height:12px; }
+.chev svg{ width:12px; height:12px; } .chev.open{ color:var(--accent); transform:rotate(90deg); }
+.lockic{ flex:none; width:13px; height:13px; display:inline-flex; color:var(--txt-3); }
+.lockic svg{ width:13px; height:13px; }
+.pbody{ padding:2px 12px 14px; background:var(--card-head); border-top:1px solid var(--line); }
+
+/* ══════════════════════════════════════════════════════════════════════
+   THE FIVE PARTS — shared inline vocabulary (identical look to the
+   detail-view / funnel reference components).
+   ══════════════════════════════════════════════════════════════════════ */
+.ctl{ height:var(--h); display:inline-flex; align-items:center; font-family:var(--mono); font-size:var(--fs-chip);
+  font-weight:var(--w-stamp); letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none; }
+/* Signal */
+.sig{ padding:0 9px; border-radius:var(--r-chip); }
+.sig.f.red{ background:var(--red-fill); color:#fff; } .sig.o.red{ color:var(--red); box-shadow:inset 0 0 0 1.3px var(--red); }
+.sig.f.yellow{ background:var(--yellow); color:var(--ink); } .sig.o.yellow{ color:var(--yellow); box-shadow:inset 0 0 0 1.3px var(--yellow); }
+.sig.f.blue{ background:var(--blue); color:var(--on-blue); } .sig.o.blue{ color:var(--blue); box-shadow:inset 0 0 0 1.3px var(--blue); }
+.sig.f.green{ background:var(--green); color:var(--ink); } .sig.o.green{ color:var(--green); box-shadow:inset 0 0 0 1.3px var(--green); }
+.sig.o.gray{ color:var(--gray); box-shadow:inset 0 0 0 1.3px var(--gray); }
+/* Stamp — plain fact, no box, no colour */
+.stamp{ font-family:var(--mono); font-size:var(--fs-chip); font-weight:var(--w-bold); letter-spacing:.03em;
+  text-transform:uppercase; color:var(--txt-2); white-space:nowrap; height:var(--h); display:inline-flex; align-items:center; }
+.dotsep{ color:var(--line); font-family:var(--mono); font-size:var(--fs-small); }
+/* Ref — linked record: square icon backing + body-voice name */
+.ref{ height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 9px 0 3px; border-radius:var(--r-chip);
+  background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:var(--fs-field); font-weight:var(--w-bold);
+  cursor:pointer; text-decoration:none; white-space:nowrap; }
+.ref .ty{ width:19px; height:19px; display:inline-flex; align-items:center; justify-content:center; color:var(--accent);
+  background:color-mix(in srgb, var(--accent) 16%, transparent); border-radius:var(--r-chip); }
+.ref .ty svg{ width:11px; height:11px; }
+/* Doors — verbs, radius = pill always */
+.door{ height:var(--h); display:inline-flex; align-items:center; justify-content:center; font-family:var(--sans);
+  font-size:var(--fs-field); font-weight:var(--w-bold); cursor:pointer; border-radius:var(--r-pill); padding:0 13px;
+  border:1px solid transparent; white-space:nowrap; }
+.door.commit{ background:var(--commit); color:#fff; } .door.commit:hover{ filter:brightness(1.08); }
+.door.money{ background:var(--green); color:var(--ink); } .door.money:hover{ filter:brightness(1.06); }
+.door.add{ background:transparent; color:var(--txt); border:1.4px dashed var(--commit); }
+.door.ghost{ background:transparent; color:var(--txt-2); border-color:var(--line); }
+.door.ghost:hover{ border-color:var(--txt-3); color:var(--txt); }
+.door.sm{ padding:0 10px; font-size:var(--fs-chip); }
+.door:disabled{ opacity:.45; cursor:not-allowed; }
+/* segmented toggle — active segment = filled Signal of ITS OWN status */
+.seg{ display:inline-flex; height:var(--h); border:1px solid var(--line); border-radius:var(--r-pill); overflow:hidden; }
+.seg b{ display:inline-flex; align-items:center; padding:0 11px; font-family:var(--mono); font-size:var(--fs-chip);
+  font-weight:var(--w-stamp); letter-spacing:.03em; text-transform:uppercase; color:var(--txt-2); cursor:pointer;
+  border-right:1px solid var(--line); user-select:none; }
+.seg b:last-child{ border-right:0; }
+.seg b.on{ background:var(--accent); color:var(--ink); }
+.seg.tone-yellow b.on{ background:var(--yellow); color:var(--ink); }
+/* contact — the number IS the link */
+.clink{ display:inline-flex; align-items:center; gap:6px; color:var(--txt); font-size:var(--fs-field); text-decoration:none; }
+.clink svg{ color:var(--accent); width:13px; height:13px; }
+.clink .v{ border-bottom:1.4px solid transparent; } .clink:hover .v{ border-bottom-color:var(--accent); }
+/* tooltip */
+.tip{ position:relative; display:inline-block; }
+.tip>*{ cursor:help; }
+.tip .bub{ position:absolute; bottom:calc(100% + 8px); left:0; width:max-content; max-width:min(70vw,250px);
+  background:#05070a; color:#eef2f7; border:1px solid #3a444e; border-radius:8px; padding:9px 11px; font-family:var(--sans);
+  font-size:var(--fs-field); line-height:1.45; text-transform:none; letter-spacing:0; font-weight:var(--w-reg);
+  box-shadow:0 12px 30px rgba(0,0,0,.6); opacity:0; transform:translateY(4px); pointer-events:none;
+  transition:opacity .12s,transform .12s; z-index:40; }
+@media (prefers-color-scheme:light){ .tip .bub{ background:#fff; color:#141821; border-color:#c7ccd2; } }
+:root[data-theme="light"] .tip .bub{ background:#fff; color:#141821; border-color:#c7ccd2; }
+.tip:hover .bub,.tip:focus-within .bub{ opacity:1; transform:translateY(0); pointer-events:auto; }
+.tip .bub .t{ font-family:var(--mono); font-size:var(--fs-finest); font-weight:var(--w-stamp); letter-spacing:.05em;
+  text-transform:uppercase; color:var(--tan); display:block; margin-bottom:4px; }
+.tip .bub .go{ color:var(--blue); font-weight:var(--w-bold); }
+
+/* ══════════════════════════════════════════════════════════════════════
+   STEP 1 · WHO — lookup-or-create
+   ══════════════════════════════════════════════════════════════════════ */
+.ix-searchwrap{ position:relative; margin-bottom:9px; }
+.ix-searchic{ position:absolute; left:9px; top:50%; transform:translateY(-50%); width:13px; height:13px; color:var(--txt-3); pointer-events:none; }
+.ix-search{ width:100%; height:var(--h); border:1px solid var(--line); border-radius:7px; background:var(--panel);
+  color:var(--txt); padding:0 10px 0 30px; font-size:var(--fs-field); }
+.ix-search::placeholder{ color:var(--txt-3); }
+.ix-search:focus{ outline:none; border-color:var(--accent); }
+.ix-results{ display:flex; flex-direction:column; gap:5px; margin-bottom:4px; }
+.ix-result{ display:flex; align-items:center; gap:9px; padding:7px 9px; border:1px solid var(--line); border-radius:8px;
+  background:var(--card); cursor:pointer; }
+.ix-result:hover{ border-color:var(--txt-3); }
+.ix-result.is-picked{ border-color:var(--commit); background:color-mix(in srgb, var(--commit) 10%, var(--card)); }
+.ix-r-ic{ width:26px; height:26px; border-radius:var(--r-chip); background:color-mix(in srgb, var(--accent) 16%, transparent);
+  display:flex; align-items:center; justify-content:center; flex:none; color:var(--accent); }
+.ix-r-ic svg{ width:14px; height:14px; }
+.ix-r-body{ min-width:0; flex:1; }
+.ix-r-name{ font-family:var(--sans); font-weight:var(--w-bold); font-size:var(--fs-field); color:var(--txt); }
+.ix-r-meta{ display:flex; flex-wrap:wrap; align-items:center; gap:5px 8px; margin-top:3px; }
+.ix-newrow{ display:flex; align-items:center; gap:8px; padding:7px 2px 2px; }
+.ix-newrow .stamp{ color:var(--txt-2); font-weight:var(--w-reg); text-transform:none; letter-spacing:0; font-family:var(--sans); }
+.ix-recent{ display:flex; flex-wrap:wrap; gap:6px; margin:8px 0 2px; }
+.ix-recentchip{ height:var(--h); display:inline-flex; align-items:center; gap:5px; padding:0 10px; border-radius:var(--r-pill);
+  border:1px dashed var(--line); background:transparent; color:var(--txt-2); font-size:var(--fs-chip); font-family:var(--mono);
+  letter-spacing:.02em; cursor:pointer; }
+.ix-recentchip:hover{ border-color:var(--txt-3); color:var(--txt); }
+.ix-recentlbl{ font-family:var(--mono); font-size:var(--fs-finest); letter-spacing:.08em; text-transform:uppercase;
+  color:var(--txt-2); margin:10px 0 5px; }
+.ix-sizeup{ margin-top:10px; padding-top:10px; border-top:1px dashed var(--line-soft); }
+.ix-sizeup-row{ display:flex; flex-wrap:wrap; align-items:center; gap:7px; margin-bottom:8px; }
+.ix-contactrow{ display:flex; flex-wrap:wrap; gap:12px; margin-bottom:4px; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   STEP 2 · WHEN — quick-pick + calendar (idiom reused from detail views)
+   ══════════════════════════════════════════════════════════════════════ */
+.ix-qprow{ display:flex; flex-wrap:wrap; gap:6px; margin-bottom:10px; }
+.ix-qp{ height:var(--h); display:inline-flex; align-items:center; padding:0 11px; border-radius:var(--r-pill);
+  border:1px solid var(--line); background:transparent; color:var(--txt-2); font-family:var(--mono); font-size:var(--fs-chip);
+  font-weight:var(--w-stamp); letter-spacing:.03em; text-transform:uppercase; cursor:pointer; }
+.ix-qp:hover{ border-color:var(--txt-3); }
+.ix-qp.on{ background:var(--commit); border-color:var(--commit); color:#fff; }
+.cal{ margin:0 0 9px; padding:9px; background:var(--card); border:1px solid var(--line); border-radius:9px; }
+.calh{ font-family:var(--mono); font-size:var(--fs-small); letter-spacing:.06em; text-transform:uppercase; color:var(--txt-2);
+  margin-bottom:6px; display:flex; justify-content:space-between; }
+.calg{ display:grid; grid-template-columns:repeat(7,1fr); gap:3px; }
+.calg i{ font-style:normal; font-family:var(--sans); font-size:var(--fs-small); text-align:center; padding:5px 0;
+  border-radius:4px; color:var(--txt-2); position:relative; }
+.calg i.tdy{ box-shadow:inset 0 0 0 1.3px var(--txt-3); color:var(--txt); }
+.calg i.in{ background:color-mix(in srgb, var(--accent) 14%, transparent); color:var(--txt); }
+.calg i.s,.calg i.e{ background:var(--accent); color:var(--ink); font-weight:var(--w-bold); }
+.ix-availnote{ display:flex; align-items:center; gap:7px; font-size:var(--fs-field); color:var(--txt-2); margin-top:2px; }
+.ix-availnote svg{ width:13px; height:13px; color:var(--green); flex:none; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   STEP 3 · WHAT — category + fitness-gated unit list
+   ══════════════════════════════════════════════════════════════════════ */
+.ix-catrow{ display:flex; align-items:center; gap:8px; margin-bottom:9px; }
+.ix-gatenote{ display:flex; align-items:flex-start; gap:7px; font-size:var(--fs-field); color:var(--txt-2); line-height:1.4;
+  margin-bottom:9px; }
+.ix-gatenote svg{ width:13px; height:13px; flex:none; margin-top:1px; color:var(--txt-3); }
+.ix-units{ display:flex; flex-direction:column; gap:6px; }
+.ix-unit{ display:flex; align-items:center; gap:9px; padding:7px 9px; border:1px solid var(--line); border-radius:8px;
+  background:var(--card); cursor:pointer; }
+.ix-unit:hover{ border-color:var(--txt-3); }
+.ix-unit.is-sel{ border-color:var(--commit); background:color-mix(in srgb, var(--commit) 10%, var(--card)); }
+.ix-unit.is-out{ cursor:help; opacity:1; }
+.ix-u-ic{ width:26px; height:26px; border-radius:var(--r-chip); background:color-mix(in srgb, var(--accent) 16%, transparent);
+  display:flex; align-items:center; justify-content:center; flex:none; color:var(--accent); }
+.ix-unit.is-out .ix-u-ic{ background:var(--line-soft); color:var(--txt-3); }
+.ix-u-ic svg{ width:14px; height:14px; }
+.ix-u-body{ flex:1; min-width:0; }
+.ix-u-name{ font-family:var(--sans); font-weight:var(--w-bold); font-size:var(--fs-field); color:var(--txt); }
+.ix-unit.is-out .ix-u-name{ color:var(--txt-2); text-decoration:line-through; text-decoration-color:var(--txt-3); }
+.ix-u-sub{ font-family:var(--mono); font-size:var(--fs-small); color:var(--txt-2); margin-top:1px; }
+.ix-u-rate{ font-family:var(--mono); font-size:var(--fs-field); font-weight:var(--w-bold); color:var(--txt); flex:none;
+  font-variant-numeric:tabular-nums; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   STEP 4 · HOW MUCH — the owned number
+   ══════════════════════════════════════════════════════════════════════ */
+.num{ margin:0 0 9px; padding:11px 12px; background:var(--card); border:1px solid var(--line); border-radius:9px; }
+.num .big{ font-family:var(--sans); font-size:var(--fs-value); font-weight:var(--w-bold); letter-spacing:-.02em;
+  color:var(--txt); line-height:1; font-variant-numeric:tabular-nums; display:flex; align-items:baseline; gap:9px; flex-wrap:wrap; }
+.num .prov{ font-size:var(--fs-small); color:var(--txt-2); margin-top:6px; }
+.num .prov b{ color:var(--txt); }
+.ix-linerow{ display:flex; align-items:center; gap:8px; padding:5px 0; border-bottom:1px solid var(--line-soft); font-size:var(--fs-field); }
+.ix-linerow:last-of-type{ border-bottom:0; }
+.ix-linerow .lname{ flex:1; color:var(--txt-2); }
+.ix-linerow .lamt{ font-family:var(--mono); color:var(--txt); font-variant-numeric:tabular-nums; font-weight:var(--w-bold); }
+.ix-linerow.is-est .lamt{ color:var(--txt-2); }
+.ix-protrow{ display:flex; align-items:center; gap:9px; margin:9px 0; }
+.ix-savenote{ display:flex; align-items:center; gap:6px; margin-top:8px; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   STEP 5 · COMMIT — Door + Refs + the Yard Journey it flows into
+   ══════════════════════════════════════════════════════════════════════ */
+.ix-refrow{ display:flex; flex-wrap:wrap; gap:7px; margin-bottom:10px; }
+.ix-committext{ font-size:var(--fs-field); color:var(--txt-2); margin-bottom:10px; line-height:1.5; }
+.ix-committext b{ color:var(--txt); }
+.ix-donebox{ display:none; }
+.ix-donebox.show{ display:block; }
+.ix-donehead{ display:flex; align-items:center; gap:8px; margin-bottom:10px; }
+.ix-donehead svg{ width:17px; height:17px; color:var(--green); flex:none; }
+.ix-donehead .t{ font-family:var(--sans); font-weight:var(--w-bold); font-size:var(--fs-field); color:var(--txt); }
+.ix-mini{ display:flex; align-items:center; gap:0; padding:9px; background:var(--card); border:1px solid var(--line); border-radius:9px; margin-bottom:9px; }
+.ix-mstage{ display:flex; align-items:center; gap:6px; flex:none; }
+.ix-mdot{ width:20px; height:20px; border-radius:50%; display:flex; align-items:center; justify-content:center;
+  border:2px solid var(--line); color:var(--txt-3); flex:none; }
+.ix-mdot svg{ width:10px; height:10px; }
+.ix-mstage.done .ix-mdot{ background:var(--green); border-color:var(--green); color:var(--ink); }
+.ix-mstage.cur .ix-mdot{ background:var(--blue); border-color:var(--blue); color:var(--on-blue); outline:2px solid var(--txt); outline-offset:2px; }
+.ix-mname{ font-family:var(--mono); font-size:var(--fs-small); font-weight:var(--w-stamp); letter-spacing:.03em; text-transform:uppercase; color:var(--txt-2); }
+.ix-mstage.done .ix-mname,.ix-mstage.cur .ix-mname{ color:var(--txt); }
+.ix-mline{ flex:1 1 16px; height:1.5px; background:var(--line); margin:0 8px; min-width:14px; }
+.ix-mstage.done + .ix-mline{ background:var(--green); }
+
+/* ── first-touch (empty) recent panel spacing ── */
+.ix-emptynote{ font-size:var(--fs-field); color:var(--txt-2); margin:2px 0 0; line-height:1.5; }
+
+/* reviewer notes box — annotation, not shipped chrome */
+.notes{ margin-top:30px; border:1px dashed var(--line); border-radius:10px; padding:16px 18px; max-width:960px; }
+.notes h2{ font-family:var(--mono); font-size:var(--fs-chip); font-weight:var(--w-stamp); letter-spacing:.06em;
+  text-transform:uppercase; color:var(--txt-2); margin:0 0 10px; }
+.notes ul{ margin:0; padding-left:18px; }
+.notes li{ font-size:var(--fs-field); color:var(--txt-2); line-height:1.65; margin-bottom:5px; }
+.notes b{ color:var(--txt); }
+.notes code{ font-family:var(--mono); font-size:.92em; background:var(--line-soft); padding:1px 4px; border-radius:4px; }
+
+@media (max-width:460px){
+  .ix-linerow{ flex-wrap:wrap; }
+}
+</style>
+
+<div class="page">
+  <p class="eyebrow">Intake · first draft · counter-rep, live call → reservation</p>
+  <h1>Intake — <span class="hl">who / when / what / how much / commit</span></h1>
+  <p class="lede">The front of the workflow, un-designed until now. A rep is on the phone with a caller who wants to
+    rent — this turns the call into a reservation in five calm steps, one plate each, no modal wall. <b>Left:</b> the very
+    first paint, nothing dialed in yet. <b>Right:</b> mid-call, quoting a real return caller — click a chevron to
+    open/close a step, click a unit or the Protection toggle to watch the quote move, click <b>Reserve</b> to see it land.</p>
+
+  <div class="legend">
+    <span><b>Signal</b> state chip</span><span><b>Gate</b> turnable</span><span><b>Stamp</b> fact</span>
+    <span><b>Ref</b> linked record</span><span><b>Door</b> action</span><span>· fill = today · colour = state</span>
+  </div>
+
+  <div class="compare">
+
+    <!-- ═══════════════════════════ PANEL A — FIRST TOUCH ═══════════════════════════ -->
+    <div class="intake-shell">
+      <div class="ix-head"><span class="ix-tag">First touch</span><span class="ix-title">Nothing dialed in yet</span></div>
+
+      <div class="ix-panel">
+        <!-- STEP 1 open + empty -->
+        <div class="plate none">
+          <div class="phead"><span class="plabel">1 · Who</span><span class="psum">Type a name or number…</span>
+            <span class="ctl sig o gray">no caller</span>
+            <span class="chev open"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span></div>
+          <div class="pbody">
+            <div class="ix-searchwrap">
+              <svg class="ix-searchic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+              <input class="ix-search" placeholder="Name or phone number…">
+            </div>
+            <div class="ix-recentlbl">Recent</div>
+            <div class="ix-recent">
+              <span class="ix-recentchip">Duhon Contracting</span>
+              <span class="ix-recentchip">Boudreaux Marine LLC</span>
+              <span class="ix-recentchip">Gator · RC-4700</span>
+            </div>
+            <div class="ix-newrow"><button class="door add sm"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" style="margin-right:5px"><path d="M12 5v14M5 12h14"/></svg>New customer</button>
+              <span class="stamp">no match? start fresh</span></div>
+          </div>
+        </div>
+
+        <!-- STEPS 2-5 locked -->
+        <div class="plate locked"><div class="phead"><span class="plabel">2 · When</span><span class="psum">Resolve Who first</span><span class="lockic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span></div></div>
+        <div class="plate locked"><div class="phead"><span class="plabel">3 · What</span><span class="psum">Resolve Who first</span><span class="lockic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span></div></div>
+        <div class="plate locked"><div class="phead"><span class="plabel">4 · How Much</span><span class="psum">Resolve Who first</span><span class="lockic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span></div></div>
+        <div class="plate locked"><div class="phead"><span class="plabel">5 · Commit</span><span class="psum">Resolve Who first</span><span class="lockic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span></div></div>
+      </div>
+      <p class="ix-emptynote">Everything downstream is locked (icon, not just colour) until a caller resolves — the
+        guided order can't be skipped by accident.</p>
+    </div>
+
+    <!-- ═══════════════════════════ PANEL B — MID-CALL ═══════════════════════════ -->
+    <div class="intake-shell">
+      <div class="ix-head"><span class="ix-tag">Mid-call</span><span class="ix-title">Quoting a return caller</span></div>
+
+      <div class="ix-panel" id="wizard">
+
+        <!-- STEP 1 · WHO — resolved, collapsed -->
+        <div class="plate done" data-step="who" id="plateWho">
+          <div class="phead" data-toggle="who"><span class="plabel">1 · Who</span><span class="psum" id="whoSum">Boudreaux Marine LLC · matched</span>
+            <span class="ctl sig f green">matched</span>
+            <span class="chev" id="chevWho"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div>
+          <div class="pbody" id="bodyWho" style="display:none">
+            <div class="ix-searchwrap">
+              <svg class="ix-searchic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+              <input class="ix-search" id="whoInput" value="Boudreaux" placeholder="Name or phone number…">
+            </div>
+            <div class="ix-results">
+              <div class="ix-result is-picked" data-pick="boudreaux">
+                <span class="ix-r-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
+                <div class="ix-r-body"><div class="ix-r-name">Boudreaux Marine LLC</div>
+                  <div class="ix-r-meta">
+                    <span class="tip"><span class="ctl sig f red" tabindex="0">owed 16d</span><span class="bub"><span class="t">Overdue balance</span>Invoice #4460 still open 16 days. Worth a mention before quoting more work. <span class="go">→ open invoices</span></span></span>
+                    <span class="stamp">Non-member</span><span class="dotsep">·</span><span class="stamp">Marine</span><span class="dotsep">·</span><span class="stamp">Net 15</span>
+                  </div></div>
+              </div>
+              <div class="ix-result" data-pick="duhon">
+                <span class="ix-r-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
+                <div class="ix-r-body"><div class="ix-r-name">Duhon Contracting</div>
+                  <div class="ix-r-meta"><span class="ctl sig o gray">active</span><span class="stamp">Non-member</span><span class="dotsep">·</span><span class="stamp">2 past rentals</span></div></div>
+              </div>
+            </div>
+            <div class="ix-newrow"><button class="door add sm"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" style="margin-right:5px"><path d="M12 5v14M5 12h14"/></svg>New customer</button></div>
+            <div class="ix-sizeup">
+              <div class="ix-sizeup-row">
+                <span class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Boudreaux Marine LLC</span>
+                <span class="tip"><span class="ctl sig f red" tabindex="0">owed 16d</span><span class="bub"><span class="t">Sized up on pickup</span>Every match surfaces this immediately — no digging for it mid-call. <span class="go">→ open account</span></span></span>
+                <span class="stamp">Non-member</span><span class="dotsep">·</span><span class="stamp">Net 15</span>
+              </div>
+              <div class="ix-contactrow">
+                <a class="clink"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z" transform="translate(-1 -1)"/></svg><span class="v">(337) 555-0142</span></a>
+                <a class="clink"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m2 7 10 6 10-6"/></svg><span class="v">marc@boudreaux…</span></a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- STEP 2 · WHEN — resolved, collapsed -->
+        <div class="plate done" data-step="when" id="plateWhen">
+          <div class="phead" data-toggle="when"><span class="plabel">2 · When</span><span class="psum" id="whenSum">Jul 22 → Jul 25 · 3 days</span>
+            <span class="ctl sig f green" id="whenChip">3 days</span>
+            <span class="chev" id="chevWhen"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div>
+          <div class="pbody" id="bodyWhen" style="display:none">
+            <div class="ix-qprow">
+              <span class="ix-qp" data-qp="1">1 Day</span>
+              <span class="ix-qp on" data-qp="3">3 Day</span>
+              <span class="ix-qp" data-qp="7">1 Week</span>
+              <span class="ix-qp" data-qp="custom">Custom</span>
+            </div>
+            <div class="cal">
+              <div class="calh"><span>Rental window</span><span>Jul '26</span></div>
+              <div class="calg">
+                <i>29</i><i>30</i><i class="tdy">1</i><i>2</i><i>3</i><i>4</i><i>5</i>
+                <i>6</i><i>7</i><i>8</i><i>9</i><i>10</i><i>11</i><i>12</i>
+                <i>13</i><i>14</i><i>15</i><i>16</i><i>17</i><i>18</i><i>19</i>
+                <i class="tdy">20</i><i>21</i><i class="s" id="calS">22</i><i class="in">23</i><i class="in">24</i><i class="e" id="calE">25</i><i>26</i>
+                <i>27</i><i>28</i><i>29</i><i>30</i><i>31</i><i></i><i></i>
+              </div>
+            </div>
+            <div class="ix-availnote"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.5l4 4 10-11"/></svg><span id="availTxt">Skid Steer 75hp — 2 of 3 units free those dates</span></div>
+          </div>
+        </div>
+
+        <!-- STEP 3 · WHAT — resolved, collapsed -->
+        <div class="plate done" data-step="what" id="plateWhat">
+          <div class="phead" data-toggle="what"><span class="plabel">3 · What</span><span class="psum" id="whatSum">Skid Steer 75hp · SS-12</span>
+            <span class="ctl sig f green">selected</span>
+            <span class="chev" id="chevWhat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div>
+          <div class="pbody" id="bodyWhat" style="display:none">
+            <div class="ix-catrow">
+              <span class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8 12 3 3 8l9 5 9-5Z"/><path d="M3 8v8l9 5 9-5V8"/><path d="M12 13v8"/></svg></span>Skid Steer 75hp</span>
+              <span class="stamp">$360/day retail</span>
+            </div>
+            <div class="ix-gatenote"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>Fitness gate — only units that passed today's inspection are offered. Failed/out-of-service units show but can't be picked.</div>
+            <div class="ix-units">
+              <div class="ix-unit is-sel" data-unit="ss12">
+                <span class="ix-u-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18M8 2v4M16 2v4"/></svg></span>
+                <div class="ix-u-body"><div class="ix-u-name">Skid Steer 75hp <span style="color:var(--txt-2);font-weight:var(--w-reg)">SS-12</span></div>
+                  <div class="ix-u-sub"><span class="ctl sig o gray" style="height:auto">ready</span></div></div>
+                <span class="ix-u-rate">$360/day</span>
+              </div>
+              <div class="ix-unit" data-unit="ss07">
+                <span class="ix-u-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18M8 2v4M16 2v4"/></svg></span>
+                <div class="ix-u-body"><div class="ix-u-name">Skid Steer 75hp <span style="color:var(--txt-2);font-weight:var(--w-reg)">SS-07</span></div>
+                  <div class="ix-u-sub"><span class="ctl sig o gray" style="height:auto">ready</span></div></div>
+                <span class="ix-u-rate">$360/day</span>
+              </div>
+              <div class="tip ix-unit is-out" tabindex="0">
+                <span class="ix-u-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18M8 2v4M16 2v4"/></svg></span>
+                <div class="ix-u-body"><div class="ix-u-name">Highrise <span style="color:var(--txt-2);font-weight:var(--w-reg)">4471-K</span></div>
+                  <div class="ix-u-sub"><span class="ctl sig f red" style="height:auto">failed</span></div></div>
+                <span class="bub" style="left:auto;right:0"><span class="t">Not offered</span>Failed inspection 2h ago — can't leave the yard today. <span class="go">→ open unit</span></span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- STEP 4 · HOW MUCH — the current step, expanded -->
+        <div class="plate now" data-step="howmuch" id="plateHowMuch">
+          <div class="phead" data-toggle="howmuch"><span class="plabel">4 · How Much</span><span class="psum">Live quote</span>
+            <span class="ctl sig f yellow">quoting</span>
+            <span class="chev open" id="chevHowMuch"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span></div>
+          <div class="pbody" id="bodyHowMuch">
+            <div class="num">
+              <div class="big">$<span id="totalAmt">1,080</span></div>
+              <div class="prov"><b>Retail — non-member</b> · 3 days × $360/day <span class="dotsep">·</span> rate 1-Day×3</div>
+            </div>
+            <div class="ix-linerow"><span class="lname">Equipment — SS-12, 3 days</span><span class="lamt">$1,080</span></div>
+            <div class="ix-linerow" id="protLine" style="display:none"><span class="lname">Protection (8%)</span><span class="lamt">$86</span></div>
+            <div class="ix-linerow is-est"><span class="lname">Tax — estimated at checkout</span><span class="lamt">est.</span></div>
+            <div class="ix-protrow">
+              <span class="seg"><b class="on" data-prot="off">Protection Off</b><b data-prot="on">Protection On</b></span>
+            </div>
+            <div class="ix-savenote">
+              <span class="tip"><span class="ctl sig o blue" tabindex="0">non-member rate</span><span class="bub"><span class="t">Membership upsell</span>Member rate on this booking would be <b>$267</b> — saves <b>$813</b>. Worth mentioning while she's on the line. <span class="go">→ start membership</span></span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- STEP 5 · COMMIT -->
+        <div class="plate wait" data-step="commit" id="plateCommit">
+          <div class="phead" data-toggle="commit"><span class="plabel">5 · Commit</span><span class="psum" id="commitSum">Reserve → creates a real rental</span>
+            <span class="ctl sig o blue">next</span>
+            <span class="chev" id="chevCommit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span></div>
+          <div class="pbody" id="bodyCommit" style="display:none">
+
+            <div id="commitPre">
+              <p class="ix-committext">Every field above maps to a record — nothing about closing this out is new,
+                it's the same <b>Yard Journey</b> any rental walks.</p>
+              <div class="ix-refrow">
+                <span class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Boudreaux Marine LLC</span>
+                <span class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8 12 3 3 8l9 5 9-5Z"/><path d="M3 8v8l9 5 9-5V8"/><path d="M12 13v8"/></svg></span>SS-12</span>
+              </div>
+              <button class="door commit" id="reserveBtn" style="width:100%">Reserve — $1,080</button>
+            </div>
+
+            <div id="commitDone" class="ix-donebox">
+              <div class="ix-donehead"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M5 12.5l4 4 10-11"/></svg><span class="t">Rental #4483 created</span></div>
+              <div class="ix-mini">
+                <div class="ix-mstage done"><span class="ix-mdot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v8M8.5 11.5 12 15l3.5-3.5"/><circle cx="12" cy="12" r="9"/></svg></span><span class="ix-mname">Lead</span></div>
+                <span class="ix-mline"></span>
+                <div class="ix-mstage cur"><span class="ix-mdot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18M8 2v4M16 2v4"/></svg></span><span class="ix-mname">Reserved · now</span></div>
+                <span class="ix-mline"></span>
+                <div class="ix-mstage"><span class="ix-mdot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><span class="ix-mname">Rented</span></div>
+              </div>
+              <p class="ix-committext">Closure is nothing new — it lives on the Rental card from here, same as any other. <button class="door ghost sm">View rental</button></p>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+  <div class="notes">
+    <h2>Judgment calls — for Jac to react to</h2>
+    <ul>
+      <li><b>The five plates ARE the wizard.</b> Reused the exact plate grammar from the detail views instead of a
+        separate "wizard" widget — one component vocabulary, no new pattern to learn. Steps collapse to a one-line
+        summary once resolved (a real rep won't want Who's search box sitting open through the whole call).</li>
+      <li><b>"How Much" defaults open, not "Who."</b> In the mid-call panel the interesting state is live-quoting —
+        earlier steps default collapsed-done so the number is what's on screen. All five stay independently
+        expandable by chevron.</li>
+      <li><b>Fitness gate rendered as a note + a struck-through, hover-explained row</b> (reusing the failed
+        <code>Highrise · 4471-K</code> unit from the detail views), not the literal <b>Gate</b> component — Gate turns
+        a status via a picker; this is a read-only availability filter, a different job even though the brief calls
+        it a "gate."</li>
+      <li><b>Boudreaux Marine's "owed 16d" surfaces the instant she's matched</b> — same red Signal as her detail
+        view, same invoice #4460 — so sizing-up costs the rep zero extra clicks. The member-rate savings ($267 vs
+        $1,080) is offered as an upsell tip, not a Door — no money action fires itself.</li>
+      <li><b>Protection defaults OFF</b> to match her real account state (the "protection off" stamp already on her
+        Rental plate) — toggling it live-updates the quote, demonstrating "live" honestly, while tax stays labelled
+        <code>estimated</code> since jurisdiction/final tax isn't known until invoice time.</li>
+      <li><b>Quote math is real</b>, not invented: Skid Steer 75hp non-member, 3 days, is <code>rate1Day×3 = $1,080</code>
+        under the app's actual cheapest-blend pricing (checked against <code>rentalPrice()</code> in <code>app.js</code>);
+        member rate would be <code>memberDaily×3 = $267</code>.</li>
+      <li><b>Not built:</b> real typeahead search (the input/results here are a fixed demo set), true click-to-pick
+        calendar range selection (quick-picks are wired; individual day clicks are decorative), and what happens if
+        NO unit is fit to go out (an all-excluded empty state) — flagged rather than guessed.</li>
+    </ul>
+  </div>
+
+</div>
+
+<script>
+(function(){
+  function toggle(step, forceOpen){
+    var body = document.getElementById('body' + cap(step));
+    var chev = document.getElementById('chev' + cap(step));
+    var open = forceOpen != null ? forceOpen : body.style.display === 'none';
+    body.style.display = open ? 'block' : 'none';
+    if (chev) chev.classList.toggle('open', open);
+  }
+  function cap(s){ return s.charAt(0).toUpperCase() + s.slice(1); }
+
+  document.querySelectorAll('[data-toggle]').forEach(function(h){
+    h.addEventListener('click', function(){ toggle(h.getAttribute('data-toggle')); });
+  });
+
+  // ── Who: pick a result ──
+  document.querySelectorAll('.ix-result[data-pick]').forEach(function(r){
+    r.addEventListener('click', function(e){
+      e.stopPropagation();
+      document.querySelectorAll('.ix-result').forEach(function(x){ x.classList.remove('is-picked'); });
+      r.classList.add('is-picked');
+      var name = r.querySelector('.ix-r-name').textContent;
+      document.getElementById('whoSum').textContent = name + ' · matched';
+    });
+  });
+
+  // ── When: quick-pick ──
+  var qpDays = { '1':1, '3':3, '7':7 };
+  document.querySelectorAll('.ix-qp[data-qp]').forEach(function(p){
+    p.addEventListener('click', function(e){
+      e.stopPropagation();
+      document.querySelectorAll('.ix-qp').forEach(function(x){ x.classList.remove('on'); });
+      p.classList.add('on');
+      var qp = p.getAttribute('data-qp');
+      if (qp === 'custom') return;
+      var days = qpDays[qp];
+      var rate1 = 360;
+      var amt = days === 7 ? 1190 : days * rate1;
+      var label = days === 7 ? '7-Day×1' : ('1-Day×' + days);
+      document.getElementById('whenSum').textContent = 'Jul 22 → ' + (22+days) + ' · ' + days + ' day' + (days===1?'':'s');
+      document.getElementById('whenChip').textContent = days + (days===1?' day':' days');
+      window.__ixDays = days; window.__ixAmt = amt; window.__ixRateLabel = label;
+      updateQuote();
+    });
+  });
+
+  // ── What: select a unit (excluded ones are inert) ──
+  document.querySelectorAll('.ix-unit[data-unit]').forEach(function(u){
+    u.addEventListener('click', function(e){
+      e.stopPropagation();
+      document.querySelectorAll('.ix-unit[data-unit]').forEach(function(x){ x.classList.remove('is-sel'); });
+      u.classList.add('is-sel');
+      var id = u.getAttribute('data-unit');
+      var label = u.querySelector('.ix-u-name').textContent.trim().replace(/\s+/g,' ');
+      document.getElementById('whatSum').textContent = 'Skid Steer 75hp · ' + id.toUpperCase();
+    });
+  });
+
+  // ── How Much: protection toggle ──
+  var protOn = false;
+  document.querySelectorAll('[data-prot]').forEach(function(b){
+    b.addEventListener('click', function(e){
+      e.stopPropagation();
+      document.querySelectorAll('[data-prot]').forEach(function(x){ x.classList.remove('on'); });
+      b.classList.add('on');
+      protOn = b.getAttribute('data-prot') === 'on';
+      updateQuote();
+    });
+  });
+
+  function updateQuote(){
+    var amt = window.__ixAmt || 1080;
+    var days = window.__ixDays || 3;
+    var rateLabel = window.__ixRateLabel || '1-Day×3';
+    var prot = protOn ? Math.round(amt * 0.08) : 0;
+    var total = amt + prot;
+    document.getElementById('totalAmt').textContent = total.toLocaleString();
+    document.getElementById('protLine').style.display = protOn ? 'flex' : 'none';
+    document.getElementById('protLine').querySelector('.lamt').textContent = '$' + prot;
+    document.querySelector('#plateHowMuch .prov').innerHTML = '<b>Retail — non-member</b> · ' + days + ' day' + (days===1?'':'s') + ' × $360/day <span class="dotsep">·</span> rate ' + rateLabel;
+    document.querySelector('#bodyHowMuch .ix-linerow:first-of-type .lname').textContent = 'Equipment — SS-12, ' + days + ' day' + (days===1?'':'s');
+    document.querySelector('#bodyHowMuch .ix-linerow:first-of-type .lamt').textContent = '$' + amt.toLocaleString();
+    document.getElementById('reserveBtn').textContent = 'Reserve — $' + total.toLocaleString();
+  }
+
+  // ── Commit ──
+  document.getElementById('reserveBtn').addEventListener('click', function(e){
+    e.stopPropagation();
+    document.getElementById('commitPre').style.display = 'none';
+    document.getElementById('commitDone').classList.add('show');
+    var plate = document.getElementById('plateCommit');
+    plate.classList.remove('wait'); plate.classList.add('done');
+    plate.querySelector('.sig').className = 'ctl sig f green';
+    plate.querySelector('.sig').textContent = 'reserved';
+    document.getElementById('commitSum').textContent = 'Rental #4483 · Reserved';
+  });
+})();
+</script>

--- a/docs/design/reference/list-views.html
+++ b/docs/design/reference/list-views.html
@@ -1,0 +1,1709 @@
+<title>Rental Wrangler — 3-Column List Views (Inline-Expand Mockup)</title>
+<style>
+  /* ============================================================
+     TOKENS — wrangler-style decisions + style rulebook numbers
+     ============================================================ */
+  :root{
+    color-scheme: dark;
+    /* dark (default) surfaces */
+    --bg:#0a0d11; --panel:#171d25; --card:#12171e; --card-head:#1a212b;
+    --line:#2c343f; --line-soft:#212834;
+    --txt:#eef2f7; --txt-2:#aab4c1; --txt-3:#717b89;
+    /* accent — safety orange, dark ink always */
+    --accent:#ff7e1f;
+    /* status */
+    --c-green:#34d399; --c-yellow:#eed44b; --c-red:#ff4242; --c-red-fill:#d63636;
+    --c-blue:#6394cc; --c-gray:#8b94a3;
+    --green-fill:var(--c-green);
+    --blue-fill-ink:var(--ink-dark);
+    --gray-fill-ink:var(--ink-dark);
+    --commit:#2f6fd0;
+    --tan:#c2925a;
+    /* dark-ink / light-ink pair — never pure #000/#fff (contrast-verified, see build notes) */
+    --ink-dark:#14181d; --ink-light:#fafbfc;
+    /* one control height (rule: 24–28 desktop, >=44 touch) */
+    --h:26px;
+    /* two radii */
+    --r-chip:8px; --r-ref:6px; --r-pill:999px;
+    /* size ladder — no value off this list */
+    --fs-value:28px; --fs-title:15px; --fs-content:13px; --fs-field:12px;
+    --fs-label:11px; --fs-small:10px; --fs-finest:9.5px;
+    /* two type voices */
+    --font-mono: ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --font-sans: -apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+  }
+  @media (pointer:coarse){ :root{ --h:44px; } }
+
+  *{ box-sizing:border-box; }
+  html,body{ margin:0; padding:0; }
+  body{
+    background:var(--bg); color:var(--txt); font-family:var(--font-sans);
+    -webkit-font-smoothing:antialiased; overflow-x:hidden;
+  }
+  ::selection{ background:color-mix(in srgb, var(--accent) 30%, transparent); }
+  @media (prefers-reduced-motion: reduce){
+    *{ animation-duration:.001s !important; animation-delay:0s !important; transition-duration:.001s !important; }
+  }
+
+  /* ============================================================
+     PAGE SHELL
+     ============================================================ */
+  .yard-page{ max-width:1440px; margin:0 auto; padding:22px clamp(12px,2.4vw,30px) 70px; }
+  .yard-top{ margin-bottom:16px; }
+  .yard-eyebrow{
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.08em;
+    font-size:var(--fs-label); font-weight:800; color:var(--accent);
+  }
+  .yard-h1{
+    font-family:var(--font-sans); font-weight:700; font-size:var(--fs-value);
+    color:var(--txt); margin:3px 0 5px; letter-spacing:-.01em;
+  }
+  .yard-sub{
+    font-size:var(--fs-content); color:var(--txt-2); max-width:76ch; line-height:1.5;
+  }
+  .yard-sub b{ color:var(--txt); font-weight:700; }
+
+  .yard-grid{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:16px; align-items:start; }
+  @media (max-width: 980px){ .yard-grid{ grid-template-columns:1fr; } }
+
+  .yard-col{
+    background:var(--panel); border:1px solid var(--line); border-radius:12px;
+    display:flex; flex-direction:column; min-width:0;
+    /* NOT overflow:hidden — the hover-jump popover's ALT (left-stack) placement
+       is spec'd to bleed past the column edge; corners stay rounded via
+       border-radius on col-head (below) rather than ancestor clipping. */
+  }
+  .col-head{
+    display:flex; align-items:center; gap:10px; padding:11px 12px;
+    border-bottom:1px solid var(--line); background:var(--card-head);
+    border-radius:12px 12px 0 0;
+  }
+  .col-titlewrap{ display:flex; flex-direction:column; gap:1px; min-width:0; }
+  .col-title{ font-family:var(--font-sans); font-weight:700; font-size:var(--fs-title); color:var(--txt); }
+  .col-desc{
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.05em;
+    font-size:var(--fs-small); color:var(--txt-3); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+  }
+  .col-body{ padding:12px; display:flex; flex-direction:column; gap:14px; min-width:0; }
+
+  /* ============================================================
+     DOOR — verb actions (radius = pill). Your-Work toggle = orange active-segment.
+     ============================================================ */
+  .door{
+    height:var(--h); display:inline-flex; align-items:center; gap:5px; padding:0 11px;
+    border-radius:var(--r-pill); font-family:var(--font-mono); font-weight:700;
+    font-size:var(--fs-label); text-transform:uppercase; letter-spacing:.04em;
+    border:1px solid var(--line); background:transparent; color:var(--txt-2);
+    cursor:pointer; white-space:nowrap; flex:0 0 auto; transition:background .12s,border-color .12s,color .12s;
+  }
+  .door:hover{ border-color:color-mix(in srgb, var(--accent) 45%, var(--line)); color:var(--txt); }
+  .door:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+  .yourwork-tog{ margin-left:auto; }
+  .yourwork-tog.on{ background:var(--accent); border-color:var(--accent); color:var(--ink-dark); }
+  .yourwork-tog svg{ width:12px; height:12px; }
+
+  /* ============================================================
+     PLATE GRAMMAR — group headers. colour = worst item inside.
+     ============================================================ */
+  .gwrap{ display:flex; flex-direction:column; gap:8px; }
+  .gwrap.is-hidden{ display:none; }
+  .ghead{ display:flex; align-items:center; gap:8px; height:var(--h); }
+  .ghead-bar{ width:3px; align-self:stretch; border-radius:2px; background:var(--txt-3); flex:0 0 auto; }
+  .ghead-label{
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.06em;
+    font-size:var(--fs-label); font-weight:800; color:var(--txt-2);
+  }
+  .ghead-count{
+    font-family:var(--font-mono); font-size:var(--fs-label); color:var(--txt-3);
+    font-variant-numeric:tabular-nums; margin-left:2px;
+  }
+  .ghead-line{ flex:1 1 auto; height:1px; background:var(--line-soft); }
+  .ghead[data-c="red"] .ghead-bar{ background:var(--c-red); }
+  .ghead[data-c="red"] .ghead-label{ color:var(--c-red); }
+  .ghead[data-c="yellow"] .ghead-bar{ background:var(--c-yellow); }
+  .ghead[data-c="yellow"] .ghead-label{ color:var(--c-yellow); }
+  .ghead[data-c="blue"] .ghead-bar{ background:var(--c-blue); }
+  .ghead[data-c="blue"] .ghead-label{ color:var(--c-blue); }
+  .ghead[data-c="green"] .ghead-bar{ background:var(--c-green); }
+  .ghead[data-c="green"] .ghead-label{ color:var(--c-green); }
+  .ghead[data-c="gray"] .ghead-bar{ background:var(--c-gray); }
+  .ghead[data-c="gray"] .ghead-label{ color:var(--txt-3); }
+
+  /* ============================================================
+     Signal / Gate — chip family, colour=state, fill=today. radius=chip.
+     ============================================================ */
+  .chipx{
+    height:var(--h); display:inline-flex; align-items:center; gap:4px; padding:0 8px;
+    border-radius:var(--r-chip); border:1px solid transparent; min-width:0;
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.04em;
+    font-weight:700; font-size:var(--fs-label); white-space:nowrap; flex:0 1 auto;
+  }
+  .chipx svg{ width:11px; height:11px; flex:0 0 auto; }
+  .chipx .t{ flex:1 1 auto; min-width:0; overflow:hidden; text-overflow:ellipsis; }
+
+  .chipx.st-red{ background:color-mix(in srgb, var(--c-red) 14%, transparent); color:var(--c-red); border-color:color-mix(in srgb, var(--c-red) 38%, transparent); }
+  .chipx.st-yellow{ background:color-mix(in srgb, var(--c-yellow) 14%, transparent); color:var(--c-yellow); border-color:color-mix(in srgb, var(--c-yellow) 38%, transparent); }
+  .chipx.st-blue{ background:color-mix(in srgb, var(--c-blue) 14%, transparent); color:var(--c-blue); border-color:color-mix(in srgb, var(--c-blue) 38%, transparent); }
+  .chipx.st-green{ background:color-mix(in srgb, var(--c-green) 14%, transparent); color:var(--c-green); border-color:color-mix(in srgb, var(--c-green) 38%, transparent); }
+  .chipx.st-gray{ background:color-mix(in srgb, var(--c-gray) 14%, transparent); color:var(--txt-3); border-color:var(--line); }
+
+  .chipx.is-fill.st-red{ background:var(--c-red-fill); border-color:var(--c-red-fill); color:var(--ink-light); }
+  .chipx.is-fill.st-yellow{ background:var(--c-yellow); border-color:var(--c-yellow); color:var(--ink-dark); }
+  .chipx.is-fill.st-blue{ background:var(--c-blue); border-color:var(--c-blue); color:var(--blue-fill-ink); }
+  .chipx.is-fill.st-green{ background:var(--green-fill); border-color:var(--green-fill); color:var(--ink-dark); }
+  .chipx.is-fill.st-gray{ background:var(--c-gray); border-color:var(--c-gray); color:var(--gray-fill-ink); }
+
+  .chipx.k-gate svg{ opacity:.95; }
+
+  /* Ref — linked record: square accent-tinted backing + parent icon + bold name */
+  .ref{ height:var(--h); display:inline-flex; align-items:center; gap:6px; min-width:0; }
+  .ref-ico{
+    width:var(--h); height:var(--h); flex:0 0 auto; border-radius:var(--r-ref);
+    background:color-mix(in srgb, var(--accent) 16%, transparent);
+    border:1px solid color-mix(in srgb, var(--accent) 34%, transparent);
+    display:flex; align-items:center; justify-content:center; color:var(--accent);
+  }
+  .ref-ico svg{ width:13px; height:13px; }
+  .ref-name{
+    font-family:var(--font-sans); font-weight:700; font-size:var(--fs-field);
+    color:var(--txt); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0;
+  }
+
+  /* Stamp — plain fact, no box, no colour */
+  .stamp{
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.04em;
+    font-size:var(--fs-label); font-weight:700; color:var(--txt-3); white-space:nowrap;
+  }
+
+  /* ============================================================
+     UNITS — 3-up compact tiles
+     ============================================================ */
+  .tiles-grid{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; align-items:start; }
+  @media (max-width:460px){ .tiles-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
+
+  .unit-tile{
+    background:var(--card); border:1px solid var(--line); border-radius:10px;
+    padding:9px; cursor:pointer; min-width:0; position:relative;
+    transition:height .15s ease, border-color .12s, box-shadow .12s;
+  }
+  .unit-tile.is-open{ grid-column:1 / -1; }
+  .unit-tile:hover{ border-color:color-mix(in srgb, var(--accent) 32%, var(--line)); }
+  .unit-tile:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+  .unit-tile.is-open{ box-shadow:0 10px 26px rgba(0,0,0,.4); }
+
+  .ut-name{
+    font-family:var(--font-sans); font-weight:700; font-size:var(--fs-content); color:var(--txt);
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap; margin-bottom:1px;
+  }
+  .ut-cat{
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.03em;
+    font-size:var(--fs-finest); color:var(--txt-3); overflow:hidden; text-overflow:ellipsis;
+    white-space:nowrap; margin-bottom:7px;
+  }
+  .ut-chip-row{ display:flex; }
+  .ut-chip-row .chipx{ width:100%; justify-content:flex-start; }
+
+  /* ============================================================
+     RENTALS — 2-up mini-cards
+     ============================================================ */
+  .cards-grid{ display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:9px; align-items:start; }
+  @media (max-width:380px){ .cards-grid{ grid-template-columns:1fr; } }
+
+  .rental-card{
+    background:var(--card); border:1px solid var(--line); border-radius:10px;
+    padding:9px; cursor:pointer; min-width:0; position:relative;
+    transition:height .15s ease, border-color .12s, box-shadow .12s;
+  }
+  /* NOTE: unlike unit-tile, a rental-card does NOT span the full grid row on expand —
+     the calendar anchor must never move, and a right-column card spanning full-width
+     would shift its own x position (and reflow its row). It grows taller in place only. */
+  .rental-card:hover{ border-color:color-mix(in srgb, var(--accent) 32%, var(--line)); }
+  .rental-card:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+  .rental-card.is-open{ box-shadow:0 10px 26px rgba(0,0,0,.4); }
+
+  /* rc-anchor — the CONSTANT calendar anchor. Fixed intrinsic size (cal-cell is fixed-width,
+     not flex:1), so it never resizes or reflows between collapsed and expanded. Always the
+     first child in normal flow, so its top-left position never moves either. */
+  .rc-anchor{ flex:0 0 auto; width:180px; max-width:100%; } /* 180 = 7 cal-cells(24px) + 6 gaps(2px) exactly — must equal .minical's intrinsic width so max-width never clamps it in either state */
+  .rc-title{
+    font-family:var(--font-sans); font-weight:700; font-size:var(--fs-field); color:var(--txt);
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap; margin-bottom:6px;
+  }
+  .minical{ display:flex; gap:2px; margin-bottom:7px; width:180px; max-width:100%; }
+  .cal-cell{
+    flex:0 0 24px; width:24px; min-width:0; display:flex; flex-direction:column; align-items:center; justify-content:center;
+    gap:1px; padding:2.5px 0; border-radius:4px; background:var(--line-soft);
+  }
+  .cal-l{ font-family:var(--font-mono); font-size:var(--fs-finest); color:var(--txt-3); text-transform:uppercase; line-height:1; }
+  .cal-n{ font-family:var(--font-mono); font-size:var(--fs-finest); color:var(--txt-2); font-weight:700; font-variant-numeric:tabular-nums; line-height:1; }
+  .cal-cell.is-hi{ background:var(--accent); }
+  .cal-cell.is-hi .cal-l, .cal-cell.is-hi .cal-n{ color:var(--ink-dark); }
+  .cal-cell.is-today:not(.is-hi){ box-shadow:inset 0 0 0 1.5px var(--accent); }
+  .cal-cell.is-today.is-hi{ box-shadow:inset 0 0 0 1.5px var(--ink-dark); }
+
+  .rc-row{ display:flex; align-items:center; gap:6px; margin-bottom:6px; }
+  .rc-row .ref{ flex:1 1 auto; min-width:0; }
+  .rc-row .ref-name{ font-size:var(--fs-field); }
+  .rc-row .chipx{ padding:0 6px; flex:0 1 auto; }
+  .rc-route{
+    display:flex; align-items:center; gap:4px; font-size:var(--fs-small); color:var(--txt-3);
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  }
+  .rc-route svg{ width:10px; height:10px; flex:0 0 auto; }
+
+  /* rc-reveal — everything revealed around the fixed anchor when a Rental expands. ONE view,
+     no paging: customer Ref + status Gate, balance Signal+number, per-unit rows, PO/protection. */
+  .rc-reveal{ flex:1 1 auto; min-height:0; overflow-y:auto; display:flex; flex-direction:column; gap:10px; }
+  .rc-reveal-row{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+  .rc-reveal-row .ref{ flex:1 1 auto; min-width:0; }
+  .rc-reveal-d{ font-size:var(--fs-field); color:var(--txt-2); line-height:1.45; }
+  .rc-bal{ display:flex; align-items:center; gap:10px; padding:8px 0; border-top:1px solid var(--line-soft); border-bottom:1px solid var(--line-soft); }
+  .rc-bal-num{ font-family:var(--font-mono); font-weight:800; font-size:var(--fs-value); font-variant-numeric:tabular-nums; }
+  .rc-units{ display:flex; flex-direction:column; gap:6px; }
+  .rc-unit-row{ display:flex; align-items:center; gap:8px; }
+  .rc-unit-row .ref{ flex:1 1 auto; min-width:0; }
+  .rc-unit-rate{ font-family:var(--font-mono); font-size:var(--fs-small); color:var(--txt-3); font-variant-numeric:tabular-nums; flex:0 0 auto; }
+  .rc-po-row{ display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+  .rc-po-row .kv-l{ min-width:auto; }
+
+  /* ============================================================
+     CUSTOMERS — strict 1-line rows
+     ============================================================ */
+  .rows-list{ display:flex; flex-direction:column; gap:5px; }
+  .cust-row{
+    background:var(--card); border:1px solid var(--line); border-radius:8px;
+    padding:0 10px; height:calc(var(--h) + 14px); min-height:40px;
+    display:flex; align-items:center; gap:9px; cursor:pointer; min-width:0;
+    transition:height .15s ease, border-color .12s, box-shadow .12s;
+  }
+  .cust-row:hover{ border-color:color-mix(in srgb, var(--accent) 32%, var(--line)); }
+  .cust-row:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+  .cust-row.is-open{ height:auto; flex-direction:column; align-items:stretch; padding:9px; box-shadow:0 10px 26px rgba(0,0,0,.4); }
+
+  .cr-name{
+    font-family:var(--font-sans); font-weight:700; font-size:var(--fs-content); color:var(--txt);
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap; flex:1 1 auto; min-width:0;
+  }
+  .cr-collapsed{ display:flex; align-items:center; gap:9px; width:100%; min-width:0; }
+  .cr-stamps{ display:flex; gap:8px; flex:0 0 auto; }
+
+  /* ============================================================
+     GENERIC EXPAND MECHANISM — shared across all three densities
+     ============================================================ */
+  .jitem{ overflow:visible; min-width:0; position:relative; }
+  .jitem.is-open{ overflow:hidden; } /* clip only while animating/expanded — collapsed rows need visible
+    overflow so the hover-jump popover (below) can float outside the row's own box */
+  .jitem-collapsed{ display:block; opacity:1; transition:opacity .12s ease; min-width:0; }
+  .jitem-expanded{ display:none; opacity:0; height:100%; flex-direction:column; transition:opacity .12s ease .04s; }
+  .jitem.is-open .jitem-collapsed{ display:none; }
+  .jitem.is-open .jitem-expanded{ display:flex; opacity:1; }
+  .cust-row .jitem-expanded{ height:auto; }
+
+  .jexp-head{ display:flex; align-items:center; gap:8px; margin-bottom:8px; flex:0 0 auto; }
+  .jexp-title{ min-width:0; flex:1 1 auto; }
+  .jexp-name{ font-family:var(--font-sans); font-weight:700; font-size:var(--fs-title); color:var(--txt);
+    overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .jexp-meta{ font-family:var(--font-mono); font-size:var(--fs-small); color:var(--txt-3); text-transform:uppercase; letter-spacing:.04em; }
+  .jexp-close{
+    width:var(--h); height:var(--h); flex:0 0 auto; border-radius:var(--r-pill);
+    border:1px solid var(--line); background:transparent; color:var(--txt-2);
+    display:inline-flex; align-items:center; justify-content:center; cursor:pointer;
+  }
+  .jexp-close:hover{ color:var(--txt); border-color:color-mix(in srgb, var(--c-red) 40%, var(--line)); }
+  .jexp-close svg{ width:13px; height:13px; }
+
+  .jexp-tabbar{
+    display:flex; gap:5px; overflow-x:auto; padding-bottom:2px; margin-bottom:8px;
+    flex:0 0 auto; scrollbar-width:none;
+  }
+  .jexp-tabbar::-webkit-scrollbar{ display:none; }
+  .jtab{
+    height:var(--h); flex:0 0 auto; padding:0 10px; border-radius:var(--r-pill);
+    border:1px solid var(--line); background:transparent; color:var(--txt-2);
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.04em;
+    font-weight:700; font-size:var(--fs-label); cursor:pointer; white-space:nowrap;
+  }
+  .jtab.is-active{ background:var(--accent); border-color:var(--accent); color:var(--ink-dark); }
+
+  .jexp-pager{ display:flex; align-items:center; gap:8px; margin-bottom:8px; flex:0 0 auto; }
+  .jchev{
+    width:var(--h); height:var(--h); flex:0 0 auto; border-radius:var(--r-pill);
+    border:1px solid var(--line); background:transparent; color:var(--txt-2);
+    display:inline-flex; align-items:center; justify-content:center; cursor:pointer;
+  }
+  .jchev:hover{ color:var(--accent); border-color:color-mix(in srgb, var(--accent) 45%, var(--line)); }
+  .jchev svg{ width:13px; height:13px; }
+  .jdots{ flex:1 1 auto; display:flex; align-items:center; justify-content:center; gap:6px; }
+  .jdot{
+    width:6px; height:6px; border-radius:999px; background:var(--line); border:none; padding:8px;
+    background-clip:content-box; cursor:pointer; flex:0 0 auto;
+  }
+  .jdot.is-active{ background:var(--accent); }
+
+  .jexp-sections{ flex:1 1 auto; min-height:0; overflow-y:auto; position:relative; }
+  .jsection{ display:none; }
+  .jsection.is-active{ display:block; }
+  .jsection.anim-in{ animation:sectionIn .16s ease; }
+  @keyframes sectionIn{ from{ opacity:0; transform:translateX(var(--slide-from,10px)); } to{ opacity:1; transform:translateX(0); } }
+
+  /* ============================================================
+     PERSISTENT HISTORY-SEARCH FOOTER — every expanded item, every
+     section (never pages away). Focus/click the search = reveal
+     a short log + quick-filter chips, growing the card taller.
+     ============================================================ */
+  .jhist-wrap{ flex:0 0 auto; margin-top:8px; border-top:1px solid var(--line); padding-top:8px; }
+  .jhist-bar{ display:flex; align-items:center; gap:8px; height:var(--h); }
+  .jhist-label{
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.04em;
+    font-size:var(--fs-label); font-weight:800; color:var(--txt-3); flex:0 0 auto;
+  }
+  .jhist-search-wrap{
+    flex:1 1 auto; min-width:0; height:var(--h); display:flex; align-items:center;
+    border:1px solid var(--line); border-radius:var(--r-chip); background:var(--panel);
+    padding:0 9px; transition:border-color .12s;
+  }
+  .jhist-search-wrap:focus-within{ border-color:color-mix(in srgb, var(--accent) 45%, var(--line)); }
+  .jhist-search{
+    flex:1 1 auto; min-width:0; border:none; background:transparent; outline:none;
+    font-family:var(--font-sans); font-size:var(--fs-field); color:var(--txt);
+  }
+  .jhist-search::placeholder{ color:var(--txt-3); }
+  .jhist-toggle{
+    width:var(--h); height:var(--h); flex:0 0 auto; border-radius:var(--r-pill);
+    border:1px solid var(--line); background:transparent; color:var(--txt-2);
+    display:inline-flex; align-items:center; justify-content:center; cursor:pointer;
+    transition:transform .16s ease, color .12s;
+  }
+  .jhist-toggle svg{ width:13px; height:13px; }
+  .jhist-toggle[aria-expanded="true"]{ transform:rotate(180deg); color:var(--accent); }
+  .jhist-log{ max-height:0; overflow:hidden; transition:max-height .18s ease; }
+  .jhist-log.is-open{ max-height:280px; }
+  .jhist-filters{ display:flex; gap:6px; flex-wrap:wrap; padding:8px 0 6px; }
+  .jhist-filter-chip{
+    height:var(--h); padding:0 10px; border-radius:var(--r-pill); border:1px solid var(--line);
+    background:transparent; color:var(--txt-2); font-family:var(--font-mono); text-transform:uppercase;
+    letter-spacing:.04em; font-weight:700; font-size:var(--fs-label); cursor:pointer;
+  }
+  .jhist-filter-chip.is-active{ background:var(--accent); border-color:var(--accent); color:var(--ink-dark); }
+  .jhist-entries{ max-height:190px; overflow-y:auto; display:flex; flex-direction:column; gap:0; }
+  .jhist-entry{ display:flex; gap:8px; padding:6px 0; border-top:1px solid var(--line-soft); font-size:var(--fs-field); }
+  .jhist-entry:first-child{ border-top:none; }
+  .jhist-entry[hidden]{ display:none; }
+  .jhist-when{ font-family:var(--font-mono); font-size:var(--fs-small); color:var(--txt-3); flex:0 0 auto; white-space:nowrap; }
+  .jhist-text{ color:var(--txt-2); min-width:0; }
+
+  /* ============================================================
+     HOVER-JUMP POPOVER — desktop-only preview of the section rail
+     from a COLLAPSED row/tile/mini-card (spec §2). Instant, no
+     dwell. Frees the row surface entirely: the menu floats ABOVE,
+     tail/notch on the item's TOP edge (contiguous hover zone, no
+     dead-gap) — or, near the list top where "above" has no room,
+     flips BELOW. ALT candidate: hovering the record NAME shows the
+     same chips as a vertical stack to the LEFT (may bleed off the
+     card/column — allowed). Click a chip -> open on that section;
+     click the row -> To Do landing. Rentals has no sections, so it
+     never renders this (see renderRentalCard) or the menu at all.
+     ============================================================ */
+  .jhop{
+    position:absolute; left:8px; right:8px; bottom:100%; z-index:20;
+    display:flex; align-items:center; gap:5px; height:var(--h); overflow:hidden;
+    padding:0 5px; background:var(--card-head); border:1px solid var(--line);
+    border-radius:var(--r-chip); box-shadow:0 6px 16px rgba(0,0,0,.35);
+    opacity:0; transform:translateY(4px); pointer-events:none;
+    transition:opacity .1s ease, transform .1s ease;
+  }
+  .jhop-tail{
+    position:absolute; left:16px; bottom:-5px; width:10px; height:10px;
+    background:var(--card-head); transform:rotate(45deg);
+    border-right:1px solid var(--line); border-bottom:1px solid var(--line);
+  }
+  .jitem[data-hop-flip="below"] .jhop{ bottom:auto; top:100%; transform:translateY(-4px); }
+  .jitem[data-hop-flip="below"] .jhop-tail{
+    bottom:auto; top:-5px; border-right:none; border-bottom:none;
+    border-left:1px solid var(--line); border-top:1px solid var(--line);
+  }
+  .jhop-chip{
+    height:calc(var(--h) - 6px); flex:0 0 auto; padding:0 8px; border-radius:var(--r-chip);
+    border:1px solid var(--line); background:var(--panel); color:var(--txt-2);
+    font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.04em;
+    font-weight:700; font-size:var(--fs-small); cursor:pointer; white-space:nowrap;
+  }
+  .jhop-chip:hover{ border-color:var(--accent); color:var(--accent); }
+
+  .jhop-left{
+    position:absolute; right:calc(100% + 8px); top:0; z-index:20;
+    display:flex; flex-direction:column; gap:5px; width:max-content; max-width:170px;
+    opacity:0; transform:translateX(4px); pointer-events:none;
+    transition:opacity .1s ease, transform .1s ease;
+  }
+  .jhop-left .jhop-chip{ width:100%; display:flex; justify-content:flex-start; text-align:left; }
+
+  .jitem.is-open .jhop, .jitem.is-open .jhop-left{ display:none; }
+
+  /* forced demo state (mockup review only) — always on regardless of hover capability */
+  .jitem.is-hover-demo .jhop{ opacity:1; transform:translateY(0); pointer-events:auto; }
+  .jitem.is-hover-demo-alt .jhop-left{ opacity:1; transform:translateX(0); pointer-events:auto; }
+
+  @media (hover:hover) and (pointer:fine){
+    .jitem:not(.is-open):hover .jhop{ opacity:1; transform:translateY(0); pointer-events:auto; }
+    /* hovering the NAME specifically swaps to the alt left-stack instead of the above popover */
+    .jitem:not(.is-open):has(.ut-name:hover) .jhop,
+    .jitem:not(.is-open):has(.cr-name:hover) .jhop{ opacity:0; pointer-events:none; }
+    .jitem:not(.is-open):has(.ut-name:hover) .jhop-left,
+    .jitem:not(.is-open):has(.cr-name:hover) .jhop-left{ opacity:1; transform:translateX(0); pointer-events:auto; }
+  }
+
+  /* ============================================================
+     MOBILE / COARSE-POINTER — focused full-screen overlay instead
+     of inline expand. Units/Customers keep swipe-paging inside it;
+     Rentals stays the same single calendar-anchored view (no paging).
+     ============================================================ */
+  @media (pointer:coarse), (max-width:680px){
+    .jitem.is-fullscreen{
+      position:fixed; inset:0; z-index:1000; border-radius:0; height:auto !important;
+      background:var(--card); display:flex; flex-direction:column;
+      padding:max(12px,env(safe-area-inset-top)) max(12px,env(safe-area-inset-right))
+              max(12px,env(safe-area-inset-bottom)) max(12px,env(safe-area-inset-left));
+    }
+    .jitem.is-fullscreen .jitem-collapsed{ display:none; }
+    .jitem.is-fullscreen .jitem-expanded{ display:flex; opacity:1; height:100%; }
+    .jitem.is-fullscreen .rc-anchor{ width:auto; max-width:220px; }
+    .jitem.is-fullscreen .minical{ width:auto; max-width:220px; }
+  }
+  body.no-scroll{ overflow:hidden; }
+
+  /* Signal-summary section */
+  .sig-hero{ display:flex; align-items:baseline; gap:8px; margin-bottom:8px; min-width:0; }
+  .sig-hero-val{ font-family:var(--font-mono); font-weight:800; font-size:var(--fs-value); color:var(--c-red); font-variant-numeric:tabular-nums; flex:0 0 auto; }
+  .sig-hero-lbl{ font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.05em; font-size:var(--fs-label); color:var(--txt-3);
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis; min-width:0; flex:1 1 auto; }
+  .sig-item{ display:flex; gap:8px; padding:8px 0; border-top:1px solid var(--line-soft); }
+  .sig-item:first-child{ border-top:none; }
+  .sig-bar{ width:3px; align-self:stretch; border-radius:2px; flex:0 0 auto; }
+  .sig-item[data-c="red"] .sig-bar{ background:var(--c-red); }
+  .sig-item[data-c="yellow"] .sig-bar{ background:var(--c-yellow); }
+  .sig-item[data-c="blue"] .sig-bar{ background:var(--c-blue); }
+  .sig-item[data-c="green"] .sig-bar{ background:var(--c-green); }
+  .sig-item[data-c="gray"] .sig-bar{ background:var(--c-gray); }
+  .sig-body{ min-width:0; }
+  .sig-t{ font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.03em; font-size:var(--fs-label); font-weight:800; margin-bottom:2px; }
+  .sig-item[data-c="red"] .sig-t{ color:var(--c-red); }
+  .sig-item[data-c="yellow"] .sig-t{ color:var(--c-yellow); }
+  .sig-item[data-c="blue"] .sig-t{ color:var(--c-blue); }
+  .sig-item[data-c="green"] .sig-t{ color:var(--c-green); }
+  .sig-item[data-c="gray"] .sig-t{ color:var(--txt-3); }
+  .sig-d{ font-size:var(--fs-field); color:var(--txt-2); line-height:1.45; }
+  .sig-clear{ display:flex; align-items:center; gap:8px; padding:10px 0; color:var(--c-green); }
+  .sig-clear svg{ width:18px; height:18px; flex:0 0 auto; }
+  .sig-clear-t{ font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.04em; font-size:var(--fs-label); font-weight:800; }
+  .sig-clear-d{ font-size:var(--fs-field); color:var(--txt-2); margin-top:1px; }
+
+  /* generic kv rows for lightweight sections */
+  .kv-grid{ display:flex; flex-direction:column; gap:0; }
+  .kv{ display:flex; align-items:baseline; gap:8px; padding:6px 0; border-top:1px solid var(--line-soft); }
+  .kv:first-child{ border-top:none; }
+  .kv-l{ font-family:var(--font-mono); text-transform:uppercase; letter-spacing:.04em; font-size:var(--fs-small); color:var(--txt-3); flex:0 0 auto; min-width:88px; }
+  .kv-v{ font-size:var(--fs-field); color:var(--txt); font-weight:600; overflow-wrap:anywhere; }
+  .kv-v.mono{ font-family:var(--font-mono); font-variant-numeric:tabular-nums; }
+
+  .list-rows{ display:flex; flex-direction:column; gap:0; }
+  .list-row{ padding:7px 0; border-top:1px solid var(--line-soft); }
+  .list-row:first-child{ border-top:none; }
+  .list-row-h{ display:flex; align-items:center; gap:6px; margin-bottom:2px; }
+  .list-row-id{ font-family:var(--font-mono); font-size:var(--fs-small); color:var(--txt-3); font-variant-numeric:tabular-nums; }
+  .list-row-when{ font-family:var(--font-mono); font-size:var(--fs-small); color:var(--txt-3); margin-left:auto; white-space:nowrap; }
+  .list-row-d{ font-size:var(--fs-field); color:var(--txt-2); line-height:1.4; }
+  .empty-note{ font-size:var(--fs-field); color:var(--txt-3); font-style:normal; padding:8px 0; }
+
+  /* ============================================================
+     Footer note
+     ============================================================ */
+  .yard-foot{ margin-top:26px; font-size:var(--fs-small); color:var(--txt-3); line-height:1.6; }
+</style>
+
+<div class="yard-page">
+  <header class="yard-top">
+    <div class="yard-eyebrow">JACRENTALS · DESIGN PROTOTYPE</div>
+    <h1 class="yard-h1">List Views — Units · Rentals · Customers</h1>
+    <p class="yard-sub"><b>Wrangle any tile, card, or row</b> — click it to expand in place, landing on
+      <b>To Do</b>. Page Units/Customers' sections with the tabs, the ‹ › chevrons, the dots, a swipe, or the arrow
+      keys — Rentals stays one calendar-anchored view, no sections. Hover a collapsed row for an instant jump menu
+      (above it, or off its name to the left) straight to a section. Every expanded item keeps a <b>History</b>
+      search footer pinned at the bottom. Click the item again (or ✕) to close it.</p>
+  </header>
+
+  <div class="yard-grid">
+    <section class="yard-col" data-col="units">
+      <div class="col-head">
+        <div class="col-titlewrap">
+          <div class="col-title">Units</div>
+          <div class="col-desc">3-up tiles · staff priority order</div>
+        </div>
+        <button class="door yourwork-tog" data-col="units" type="button">Your Work</button>
+      </div>
+      <div class="col-body" id="col-units"></div>
+    </section>
+
+    <section class="yard-col" data-col="rentals">
+      <div class="col-head">
+        <div class="col-titlewrap">
+          <div class="col-title">Rentals</div>
+          <div class="col-desc">2-up mini-cards · this week at a glance</div>
+        </div>
+        <button class="door yourwork-tog" data-col="rentals" type="button">Your Work</button>
+      </div>
+      <div class="col-body" id="col-rentals"></div>
+    </section>
+
+    <section class="yard-col" data-col="customers">
+      <div class="col-head">
+        <div class="col-titlewrap">
+          <div class="col-title">Customers</div>
+          <div class="col-desc">1-line rows · account standing</div>
+        </div>
+        <button class="door yourwork-tog" data-col="customers" type="button">Your Work</button>
+      </div>
+      <div class="col-body" id="col-customers"></div>
+    </section>
+  </div>
+
+  <p class="yard-foot">Mockup only — sample yard/rental/customer data is invented for this prototype. Today is fixed
+    at Mon Jul 20, 2026 for the mini-calendars. Built to the <code>wrangler-style</code> + <code>style</code> skills:
+    locked steel palette, mono-stamped labels, system-sans record names, matte (no glow), colour = state / fill = today.</p>
+</div>
+
+<script>
+(function(){
+  "use strict";
+
+  /* ---------------------------------------------------------
+     ICONS — inline Lucide-style paths (24x24, stroke, no fill)
+     --------------------------------------------------------- */
+  var ICONS = {
+    chevronLeft:  '<path d="m15 18-6-6 6-6"/>',
+    chevronRight: '<path d="m9 18 6-6-6-6"/>',
+    chevronDown:  '<path d="m6 9 6 6 6-6"/>',
+    x:            '<path d="M18 6 6 18"/><path d="m6 6 12 12"/>',
+    wrench:       '<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.4-3.4a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94Z"/>',
+    calendar:     '<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/>',
+    user:         '<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
+    mapPin:       '<path d="M20 10c0 4.99-5.54 10.19-7.4 11.8a1 1 0 0 1-1.2 0C9.54 20.19 4 14.99 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/>',
+    alertTriangle:'<path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/>',
+    checkCircle:  '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>'
+  };
+  function icon(name){ return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'+(ICONS[name]||'')+'</svg>'; }
+
+  var TYPE_ICON = { unit:'wrench', rental:'calendar', customer:'user' };
+
+  /* ---------------------------------------------------------
+     STATE PRIORITY — red > yellow > blue > green > gray
+     --------------------------------------------------------- */
+  var PRI = ['red','yellow','blue','green','gray'];
+  function rollup(colors){
+    for (var i=0;i<PRI.length;i++){ if (colors.indexOf(PRI[i])>-1) return PRI[i]; }
+    return 'gray';
+  }
+
+  /* ---------------------------------------------------------
+     COMPONENT RENDERERS
+     --------------------------------------------------------- */
+  function signalChip(typeName, color, isFill, label, fullTitle){
+    var t = fullTitle ? ' title="'+fullTitle.replace(/"/g,'&quot;')+'"' : '';
+    return '<span class="chipx k-signal st-'+color+(isFill?' is-fill':'')+'"'+t+'>'+icon(TYPE_ICON[typeName])+'<span class="t">'+label+'</span></span>';
+  }
+  function gateChip(color, isFill, label, fullTitle){
+    var t = fullTitle ? ' title="'+fullTitle.replace(/"/g,'&quot;')+'"' : '';
+    return '<span class="chipx k-gate st-'+color+(isFill?' is-fill':'')+'"'+t+'>'+icon('chevronRight')+'<span class="t">'+label+'</span></span>';
+  }
+  function stamp(text){ return '<span class="stamp">'+text+'</span>'; }
+  function ref(name){
+    return '<span class="ref" title="'+name.replace(/"/g,'&quot;')+'"><span class="ref-ico">'+icon('user')+'</span><span class="ref-name">'+name+'</span></span>';
+  }
+
+  function kv(label, value, mono){
+    return '<div class="kv"><span class="kv-l">'+label+'</span><span class="kv-v'+(mono?' mono':'')+'">'+value+'</span></div>';
+  }
+
+  function signalSection(sig, typeName){
+    if (!sig || !sig.length){
+      return '<div class="sig-clear">'+icon('checkCircle')+
+        '<div><div class="sig-clear-t">All clear</div><div class="sig-clear-d">Nothing needs your attention right now.</div></div></div>';
+    }
+    var hero = '';
+    var top = sig[0];
+    var m = /\$[\d,]+(\.\d{2})?/.exec(top.t);
+    if (top.c === 'red' && m){
+      hero = '<div class="sig-hero"><span class="sig-hero-val">'+m[0]+'</span><span class="sig-hero-lbl">'+top.t.replace(m[0],'').replace(/[—-]\s*$/,'').trim()+'</span></div>';
+    }
+    var rows = sig.map(function(s){
+      return '<div class="sig-item" data-c="'+s.c+'"><span class="sig-bar"></span><div class="sig-body">'+
+        '<div class="sig-t">'+s.t+'</div><div class="sig-d">'+s.d+'</div></div></div>';
+    }).join('');
+    return hero + rows;
+  }
+
+  function listRows(items, render){
+    if (!items || !items.length) return '<div class="empty-note">Nothing on file yet.</div>';
+    return '<div class="list-rows">'+items.map(render).join('')+'</div>';
+  }
+
+  /* ---------------------------------------------------------
+     HOVER-JUMP POPOVER — desktop-only preview of a COLLAPSED
+     item's section rail (spec §2). Up to 3 chips, lit sections
+     first; falls back to the first two non-landing sections when
+     nothing's lit. Never built for Rentals (no sections there —
+     see renderRentalCard, which never calls this).
+     --------------------------------------------------------- */
+  function hopChipList(sections, litLabels){
+    var idxs = [];
+    (litLabels||[]).forEach(function(lbl){
+      var i = sections.findIndex(function(s){ return s.label === lbl; });
+      if (i > 0 && idxs.indexOf(i) === -1) idxs.push(i); /* skip idx 0 — the row click already opens on that (To Do) landing */
+    });
+    for (var i=1; i<sections.length && idxs.length<2; i++){ if (idxs.indexOf(i)===-1) idxs.push(i); }
+    return idxs.slice(0,3).map(function(i){
+      return '<button type="button" class="jhop-chip" tabindex="-1" data-sec-idx="'+i+'">'+sections[i].label+'</button>';
+    }).join('');
+  }
+  function hopMarkup(sections, litLabels){
+    var chips = hopChipList(sections, litLabels);
+    return (
+      '<div class="jhop" aria-hidden="true"><span class="jhop-tail"></span>'+chips+'</div>'+
+      '<div class="jhop-left" aria-hidden="true">'+chips+'</div>'
+    );
+  }
+
+  /* ---------------------------------------------------------
+     MINI CALENDAR — 7-day window centred on today (offset 0)
+     --------------------------------------------------------- */
+  var CAL_DAYS = [
+    {o:-3,l:'F',n:17},{o:-2,l:'S',n:18},{o:-1,l:'S',n:19},{o:0,l:'M',n:20},
+    {o:1,l:'T',n:21},{o:2,l:'W',n:22},{o:3,l:'T',n:23}
+  ];
+  function miniCal(startOff, endOff){
+    return '<div class="minical">'+CAL_DAYS.map(function(d){
+      var hi = d.o>=startOff && d.o<=endOff;
+      var today = d.o===0;
+      return '<div class="cal-cell'+(hi?' is-hi':'')+(today?' is-today':'')+'">'+
+        '<span class="cal-l">'+d.l+'</span><span class="cal-n">'+d.n+'</span></div>';
+    }).join('')+'</div>';
+  }
+
+  /* ---------------------------------------------------------
+     DOM helper
+     --------------------------------------------------------- */
+  function el(html){ var t=document.createElement('template'); t.innerHTML=html.trim(); return t.content.firstElementChild; }
+
+  var SECTION_ID = 0;
+
+  /* ---------------------------------------------------------
+     PERSISTENT HISTORY-SEARCH FOOTER — shared by all three card
+     types. Never pages away; lives below whatever else is shown.
+     --------------------------------------------------------- */
+  function hEntry(kind, when, text){ return { kind:kind, when:when, text:text }; }
+
+  function buildUnitHistory(u){
+    var out = [];
+    if (u.insp && u.insp.last && u.insp.last !== '—') out.push(hEntry('inspection', u.insp.last, 'Inspection — '+u.insp.result+' (by '+u.insp.by+')'));
+    (u.wo||[]).forEach(function(w){ out.push(hEntry('wo', '—', w.id+' — '+w.st+': '+w.d)); });
+    out.push(hEntry('wash', (u.svc && u.svc.last !== '—') ? u.svc.last : '—', 'Wash + fuel top-off'));
+    (u.hist||[]).forEach(function(h){ out.push(hEntry('rental', h.when, 'Rented by '+h.who)); });
+    return out;
+  }
+  function buildRentalHistory(r){
+    var out = [];
+    (r.hist||[]).forEach(function(h){ out.push(hEntry('edit', h.when, h.ev)); });
+    (r.notes||[]).forEach(function(n){ out.push(hEntry('edit', n.when, n.by+': '+n.t)); });
+    var owed = parseFloat((r.bal||'').replace(/[^0-9.]/g,'')) || 0;
+    if (owed === 0 && /\$/.test(r.bal||'')) out.push(hEntry('payment', r.win.split(/[–-]/)[0].trim(), 'Balance paid in full'));
+    return out;
+  }
+  function buildCustomerHistory(c){
+    /* two quick-filter buckets to match the customers footer chips: Invoices
+       (billing + payments) and Contacts (the activity/comms log). */
+    var out = [];
+    (c.inv||[]).forEach(function(iv){ out.push(hEntry('invoices', iv.due, iv.num+' — '+iv.amt+' ('+iv.st+')')); });
+    (c.act||[]).forEach(function(a){ out.push(hEntry('contacts', a.when, a.t)); });
+    if (c.pay && c.pay.last) out.push(hEntry('invoices', c.pay.last.split(' on ')[1] || c.pay.last, 'Payment — '+c.pay.last));
+    return out;
+  }
+
+  function historyFooter(kinds, entries){
+    var filterChips = kinds.map(function(k){
+      return '<button type="button" class="jhist-filter-chip" data-kind="'+k.toLowerCase()+'">'+k+'</button>';
+    }).join('');
+    var rows = entries.map(function(e){
+      var searchText = (e.text+' '+e.when).toLowerCase().replace(/"/g,'&quot;');
+      return '<div class="jhist-entry" data-kind="'+e.kind+'" data-text="'+searchText+'">'+
+        '<span class="jhist-when">'+e.when+'</span><span class="jhist-text">'+e.text+'</span></div>';
+    }).join('');
+    return (
+      '<div class="jhist-wrap">'+
+        '<div class="jhist-bar">'+
+          '<span class="jhist-label">History</span>'+
+          '<div class="jhist-search-wrap"><input class="jhist-search" type="text" placeholder="Search history…" aria-label="Search history" /></div>'+
+          '<button type="button" class="jhist-toggle" aria-expanded="false" aria-label="Expand history">'+icon('chevronDown')+'</button>'+
+        '</div>'+
+        '<div class="jhist-log">'+
+          '<div class="jhist-filters">'+filterChips+'</div>'+
+          '<div class="jhist-entries">'+(rows || '<div class="empty-note">No history yet.</div>')+'</div>'+
+        '</div>'+
+      '</div>'
+    );
+  }
+
+  /* build the shared expanded shell: head + tabbar + pager + section panels + history footer.
+     Used by Units and Customers (both still page sections). Rentals does NOT use this — it
+     gets its own single calendar-anchored view (see renderRentalCard). */
+  function expandedShell(titleHtml, metaText, sections, historyKinds, historyEntries){
+    var tabs = sections.map(function(s,i){
+      return '<button class="jtab'+(i===0?' is-active':'')+'" type="button" data-idx="'+i+'" role="tab" aria-selected="'+(i===0?'true':'false')+'">'+s.label+'</button>';
+    }).join('');
+    var dots = sections.map(function(s,i){
+      return '<button class="jdot'+(i===0?' is-active':'')+'" type="button" data-idx="'+i+'" aria-label="Section '+(i+1)+' of '+sections.length+'"></button>';
+    }).join('');
+    var panels = sections.map(function(s,i){
+      return '<div class="jsection'+(i===0?' is-active':'')+'" data-idx="'+i+'" role="tabpanel"'+(i===0?'':' hidden')+'>'+s.body+'</div>';
+    }).join('');
+    return (
+      '<div class="jitem-expanded">'+
+        '<div class="jexp-head">'+
+          '<div class="jexp-title"><div class="jexp-name">'+titleHtml+'</div><div class="jexp-meta">'+metaText+'</div></div>'+
+          '<button class="jexp-close" type="button" aria-label="Close">'+icon('x')+'</button>'+
+        '</div>'+
+        '<div class="jexp-tabbar" role="tablist">'+tabs+'</div>'+
+        '<div class="jexp-pager">'+
+          '<button class="jchev jchev-prev" type="button" aria-label="Previous section">'+icon('chevronLeft')+'</button>'+
+          '<div class="jdots">'+dots+'</div>'+
+          '<button class="jchev jchev-next" type="button" aria-label="Next section">'+icon('chevronRight')+'</button>'+
+        '</div>'+
+        '<div class="jexp-sections">'+panels+'</div>'+
+        historyFooter(historyKinds, historyEntries)+
+      '</div>'
+    );
+  }
+
+  /* ===========================================================
+     UNITS — data + renderers
+     =========================================================== */
+  var UNIT_GROUPS = ['Field Calls','Not Ready/Failed+Reserved','Not Ready','Failed','Transport','Reserved','On Rent','End Rent','Available','Incomplete'];
+  var UNITS = {
+    'Field Calls':[
+      { id:'EX-214', name:'Excavator 214', cat:'Mini Excavator', color:'red', today:true,
+        sig:[{c:'red',t:'FIELD CALL — HYD LEAK',d:'Operator reports rear boom hydraulic leak on active job site. Tech dispatched, ETA 40 min.'}],
+        insp:{last:'Jul 8',result:'Passed',by:'R. Boudreaux',next:'Aug 8'},
+        svc:{last:'Jun 28 — 250-hr service',hours:'814 hrs',next:'900 hrs / ~Aug 15'},
+        wo:[{id:'WO-1088',st:'Open',d:'Hydraulic hose, rear boom — field call in progress'}],
+        specs:{make:'Cat',model:'305.5E2',year:'2019',serial:'CAT03055JAB00214',cap:'11,000 lb op. wt.'},
+        gps:{zone:'Job site — Moss Bluff Rd',ping:'3 min ago',fence:'Off-yard, active job'},
+        inv:{buy:'$142,000',val:'$96,400',rate:'$650/day',util:'74%'},
+        hist:[{who:'Broussard Bros. Excavation',when:'Jul 6 – present'},{who:'Fontenot Industrial',when:'May 2–9'}] },
+      { id:'SS-108', name:'Skid Steer 108', cat:'Skid Steer', color:'red', today:true, hopDemo:true,
+        sig:[{c:'red',t:'FIELD CALL — WON’T START',d:'No-crank reported on site. Battery + starter check requested by customer.'}],
+        insp:{last:'Jul 2',result:'Passed',by:'K. Landry',next:'Aug 2'},
+        svc:{last:'Jul 1 — battery test',hours:'420 hrs',next:'500 hrs / ~Aug 1'},
+        wo:[{id:'WO-1091',st:'Open',d:'No-crank — battery/starter diagnosis'}],
+        specs:{make:'Bobcat',model:'S650',year:'2021',serial:'BCS650KX0108',cap:'2,700 lb rated op.'},
+        gps:{zone:'Job site — Hwy 27 laydown',ping:'11 min ago',fence:'Off-yard, active job'},
+        inv:{buy:'$58,500',val:'$41,200',rate:'$275/day',util:'81%'},
+        hist:[{who:'Guidry Marine Rentals',when:'Jul 5 – present'}] }
+    ],
+    'Not Ready/Failed+Reserved':[
+      { id:'BL-071', name:'Boom Lift 071', cat:'Articulating Boom Lift', color:'red', today:true,
+        sig:[{c:'red',t:'FAILED + RESERVED CONFLICT',d:'Failed annual inspection Jul 17 — a reservation starts tomorrow. Needs re-inspect or swap before pickup.'},
+             {c:'yellow',t:'RESERVED — PICKUP TOMORROW',d:'Comeaux Paving Co. — Jul 21 pickup, Rte 9.'}],
+        insp:{last:'Jul 17',result:'Failed — platform control cable',by:'R. Boudreaux',next:'Re-inspect before release'},
+        svc:{last:'Jul 17 — flagged at inspection',hours:'1,102 hrs',next:'On hold pending repair'},
+        wo:[{id:'WO-1085',st:'Open',d:'Platform control cable replacement'}],
+        specs:{make:'JLG',model:'450AJ',year:'2018',serial:'JLG450AJHT0071',cap:'500 lb platform'},
+        gps:{zone:'Yard A — Row 1',ping:'22 min ago',fence:'In yard'},
+        inv:{buy:'$88,000',val:'$52,900',rate:'$310/day',util:'58%'},
+        hist:[{who:'Comeaux Paving Co.',when:'Jun 1–5'}] }
+    ],
+    'Not Ready':[
+      { id:'RF-302', name:'Reach Forklift 302', cat:'Reach Forklift', color:'yellow', today:false,
+        sig:[{c:'yellow',t:'PREP IN PROGRESS',d:'Wash + fuel + forks swap queued for return-to-ready. Target Jul 22.'}],
+        insp:{last:'Jul 12',result:'Passed',by:'K. Landry',next:'Aug 12'},
+        svc:{last:'In progress — wash/fuel/forks',hours:'661 hrs',next:'700 hrs / ~Aug 5'},
+        wo:[], specs:{make:'JCB',model:'560-80',year:'2020',serial:'JCB56080TN0302',cap:'6,000 lb @ 80in load ctr'},
+        gps:{zone:'Yard B — Wash bay',ping:'2 min ago',fence:'In yard'},
+        inv:{buy:'$96,000',val:'$67,300',rate:'$295/day',util:'69%'},
+        hist:[{who:'Hebert Site Services',when:'Jun 20 – Jul 18'}] },
+      { id:'TL-019', name:'Telehandler 019', cat:'Telehandler', color:'yellow', today:false,
+        sig:[{c:'yellow',t:'AWAITING PARTS',d:'Replacement mirror + light guard on order, ETA Jul 24.'}],
+        insp:{last:'Jul 9',result:'Passed w/ note',by:'R. Boudreaux',next:'Aug 9'},
+        svc:{last:'Jul 9 — minor body repair queued',hours:'930 hrs',next:'1,000 hrs / ~Aug 18'},
+        wo:[{id:'WO-1079',st:'Open',d:'Mirror + light guard replacement — parts on order'}],
+        specs:{make:'Genie',model:'GTH-844',year:'2019',serial:'GNTH844LA0019',cap:'8,000 lb @ 44ft'},
+        gps:{zone:'Yard A — Row 4',ping:'8 min ago',fence:'In yard'},
+        inv:{buy:'$104,000',val:'$71,500',rate:'$340/day',util:'63%'},
+        hist:[{who:'Thibodeaux Oilfield Services',when:'May 26 – Jun 30'}] }
+    ],
+    'Failed':[
+      { id:'SL-455', name:'Scissor Lift 455', cat:'Electric Scissor Lift', color:'red', today:true,
+        sig:[{c:'red',t:'FAILED INSPECTION',d:'Platform gate latch failed Jul 16. Do not release until repaired + re-inspected.'}],
+        insp:{last:'Jul 16',result:'Failed — gate latch',by:'K. Landry',next:'Re-inspect before release'},
+        svc:{last:'Jul 16 — flagged',hours:'505 hrs',next:'On hold'},
+        wo:[{id:'WO-1082',st:'Open',d:'Platform gate latch repair'}],
+        specs:{make:'JLG',model:'2646ES',year:'2020',serial:'JLG2646ES0455',cap:'500 lb platform'},
+        gps:{zone:'Yard B — Row 2',ping:'40 min ago',fence:'In yard'},
+        inv:{buy:'$32,500',val:'$21,800',rate:'$150/day',util:'55%'},
+        hist:[{who:'LeBlanc Concrete',when:'May 30 – Jun 12'}] },
+      { id:'AC-140', name:'Air Compressor 140', cat:'Tow-Behind Air Compressor', color:'red', today:true,
+        sig:[{c:'red',t:'FAILED — OIL LEAK',d:'Fails pre-rent check, active oil leak at compressor housing. Blocked from dispatch.'}],
+        insp:{last:'Jul 15',result:'Failed — oil leak',by:'R. Boudreaux',next:'Re-inspect before release'},
+        svc:{last:'Jul 15 — flagged',hours:'1,340 hrs',next:'On hold'},
+        wo:[{id:'WO-1080',st:'Open',d:'Oil leak, compressor housing seal'}],
+        specs:{make:'Doosan',model:'XP185',year:'2017',serial:'DSNXP185LA0140',cap:'185 CFM'},
+        gps:{zone:'Yard A — Row 2',ping:'1 hr ago',fence:'In yard'},
+        inv:{buy:'$28,000',val:'$14,600',rate:'$95/day',util:'44%'},
+        hist:[{who:'Fontenot Industrial',when:'May 1–8'}] }
+    ],
+    'Transport':[
+      { id:'TR-812', name:'Lowboy Trailer 812', cat:'Lowboy Trailer', color:'blue', today:false,
+        sig:[{c:'blue',t:'IN TRANSPORT',d:'En route to Broussard Bros. jobsite, Moss Bluff. Driver: D. Hebert.'}],
+        insp:{last:'Jul 5',result:'Passed',by:'K. Landry',next:'Aug 5'},
+        svc:{last:'Jun 15 — bearing check',hours:'—',next:'Annual — Oct'}, wo:[],
+        specs:{make:'Trail King',model:'TK80LP',year:'2016',serial:'TKTK80LP0812',cap:'80,000 lb GVW'},
+        gps:{zone:'Hwy 90 westbound',ping:'4 min ago',fence:'In transit'},
+        inv:{buy:'$46,000',val:'$29,000',rate:'$180/day',util:'52%'},
+        hist:[{who:'Broussard Bros. Excavation',when:'Jul 20 – present'}] },
+      { id:'DZ-501', name:'Dozer 501', cat:'Track Dozer', color:'blue', today:false,
+        sig:[{c:'blue',t:'IN TRANSPORT',d:'Loaded for delivery to Guidry Marine Rentals, Iowa LA. ETA 2:30 PM.'}],
+        insp:{last:'Jul 10',result:'Passed',by:'R. Boudreaux',next:'Aug 10'},
+        svc:{last:'Jul 9 — undercarriage grease',hours:'2,240 hrs',next:'2,300 hrs / ~Aug 1'}, wo:[],
+        specs:{make:'Cat',model:'D6',year:'2015',serial:'CATD6LA00501',cap:'Topsoil grade'},
+        gps:{zone:'Hwy 90 westbound',ping:'6 min ago',fence:'In transit'},
+        inv:{buy:'$210,000',val:'$118,000',rate:'$720/day',util:'66%'},
+        hist:[{who:'Guidry Marine Rentals',when:'Jul 20 – present'}] }
+    ],
+    'Reserved':[
+      { id:'LT-233', name:'Light Tower 233', cat:'Towable Light Tower', color:'blue', today:false,
+        sig:[{c:'blue',t:'RESERVED — JUL 24',d:'Reserved for Domingue Site Services, night pour job. Confirm delivery Jul 24 AM.'}],
+        insp:{last:'Jul 3',result:'Passed',by:'K. Landry',next:'Aug 3'},
+        svc:{last:'Jun 25 — fuel + bulb check',hours:'—',next:'Quarterly — Sep'}, wo:[],
+        specs:{make:'Allmand',model:'Night-Lite Pro',year:'2019',serial:'ALLNLP0233',cap:'4x1000W metal halide'},
+        gps:{zone:'Yard A — Row 3',ping:'15 min ago',fence:'In yard'},
+        inv:{buy:'$18,500',val:'$11,900',rate:'$85/day',util:'38%'},
+        hist:[{who:'Domingue Site Services',when:'Jun 3–7'}] },
+      { id:'GN-260', name:'Generator 260', cat:'Towable Diesel Generator', color:'blue', today:false,
+        sig:[{c:'blue',t:'RESERVED — JUL 23',d:'Reserved for Hebert Site Services, weekend standby power.'}],
+        insp:{last:'Jul 1',result:'Passed',by:'R. Boudreaux',next:'Aug 1'},
+        svc:{last:'Jun 29 — load test',hours:'—',next:'Quarterly — Sep'}, wo:[],
+        specs:{make:'Generac',model:'MDG60',year:'2020',serial:'GENMDG600260',cap:'60 kW'},
+        gps:{zone:'Yard B — Row 1',ping:'19 min ago',fence:'In yard'},
+        inv:{buy:'$34,000',val:'$22,400',rate:'$140/day',util:'47%'},
+        hist:[{who:'Hebert Site Services',when:'Jun 10–14'}] }
+    ],
+    'On Rent':[
+      { id:'EX-190', name:'Excavator 190', cat:'Standard Excavator', color:'green', today:false,
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'Out to Thibodeaux Oilfield Services, no open issues.'}],
+        insp:{last:'Jun 20',result:'Passed',by:'K. Landry',next:'Jul 20'},
+        svc:{last:'Jun 18 — 250-hr service',hours:'1,455 hrs',next:'1,500 hrs / ~Jul 28'}, wo:[],
+        specs:{make:'Cat',model:'320',year:'2018',serial:'CAT320LA00190',cap:'20,000 lb op. wt.'},
+        gps:{zone:'Job site — Sulphur',ping:'9 min ago',fence:'Off-yard, active job'},
+        inv:{buy:'$168,000',val:'$104,000',rate:'$610/day',util:'77%'},
+        hist:[{who:'Thibodeaux Oilfield Services',when:'Jul 1 – present'}] },
+      { id:'SS-140', name:'Skid Steer 140', cat:'Skid Steer', color:'green', today:false,
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'Out to LeBlanc Concrete, no open issues.'}],
+        insp:{last:'Jun 25',result:'Passed',by:'R. Boudreaux',next:'Jul 25'},
+        svc:{last:'Jun 20 — filter change',hours:'380 hrs',next:'500 hrs / ~Aug 3'}, wo:[],
+        specs:{make:'Bobcat',model:'S770',year:'2022',serial:'BCS770KX0140',cap:'3,150 lb rated op.'},
+        gps:{zone:'Job site — Westlake',ping:'14 min ago',fence:'Off-yard, active job'},
+        inv:{buy:'$64,000',val:'$52,100',rate:'$285/day',util:'83%'},
+        hist:[{who:'LeBlanc Concrete',when:'Jul 8 – present'}] },
+      { id:'WT-006', name:'Water Truck 006', cat:'4,000-Gal Water Truck', color:'green', today:false,
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'Out to Broussard Bros. Excavation, dust control.'}],
+        insp:{last:'Jun 30',result:'Passed',by:'K. Landry',next:'Jul 30'},
+        svc:{last:'Jun 28 — pump check',hours:'—',next:'Monthly — Aug'}, wo:[],
+        specs:{make:'International',model:'WT4000',year:'2017',serial:'INTWT4K0006',cap:'4,000 gal'},
+        gps:{zone:'Job site — Moss Bluff',ping:'26 min ago',fence:'Off-yard, active job'},
+        inv:{buy:'$92,000',val:'$54,700',rate:'$260/day',util:'70%'},
+        hist:[{who:'Broussard Bros. Excavation',when:'Jul 3 – present'}] }
+    ],
+    'End Rent':[
+      { id:'BL-098', name:'Boom Lift 098', cat:'Telescopic Boom Lift', color:'yellow', today:true,
+        sig:[{c:'yellow',t:'DUE BACK TODAY',d:'Comeaux Paving Co. — end of rental Jul 20. Schedule pickup.'}],
+        insp:{last:'Jul 1',result:'Passed',by:'R. Boudreaux',next:'Aug 1'},
+        svc:{last:'Jun 30 — filter change',hours:'812 hrs',next:'900 hrs / ~Aug 10'}, wo:[],
+        specs:{make:'JLG',model:'660SJ',year:'2019',serial:'JLG660SJ0098',cap:'660 lb platform'},
+        gps:{zone:'Job site — Hwy 27',ping:'12 min ago',fence:'Off-yard, active job'},
+        inv:{buy:'$156,000',val:'$98,200',rate:'$420/day',util:'72%'},
+        hist:[{who:'Comeaux Paving Co.',when:'Jul 6 – present'}] },
+      { id:'RF-275', name:'Reach Forklift 275', cat:'Reach Forklift', color:'yellow', today:true,
+        sig:[{c:'yellow',t:'DUE BACK TODAY',d:'Fontenot Industrial — end of rental Jul 20. Confirm pickup window.'}],
+        insp:{last:'Jun 22',result:'Passed',by:'K. Landry',next:'Jul 22'},
+        svc:{last:'Jun 20 — forks check',hours:'590 hrs',next:'700 hrs / ~Aug 2'}, wo:[],
+        specs:{make:'JCB',model:'540-140',year:'2018',serial:'JCB540140LA275',cap:'4,000 lb @ 140in load ctr'},
+        gps:{zone:'Job site — Sulphur',ping:'20 min ago',fence:'Off-yard, active job'},
+        inv:{buy:'$88,000',val:'$56,300',rate:'$270/day',util:'68%'},
+        hist:[{who:'Fontenot Industrial',when:'Jul 6 – present'}] }
+    ],
+    'Available':[
+      { id:'SS-221', name:'Skid Steer 221', cat:'Skid Steer', color:'green', today:false,
+        sig:[{c:'green',t:'AVAILABLE — READY',d:'Serviced, inspected, staged in Yard A.'}],
+        insp:{last:'Jul 15',result:'Passed',by:'R. Boudreaux',next:'Aug 15'},
+        svc:{last:'Jul 15 — full service',hours:'210 hrs',next:'500 hrs / ~Sep'}, wo:[],
+        specs:{make:'Bobcat',model:'S650',year:'2023',serial:'BCS650KX0221',cap:'2,700 lb rated op.'},
+        gps:{zone:'Yard A — Row 1',ping:'5 min ago',fence:'In yard'},
+        inv:{buy:'$62,000',val:'$54,800',rate:'$275/day',util:'22%'},
+        hist:[{who:'Guidry Marine Rentals',when:'May 12–19'}] },
+      { id:'GN-104', name:'Generator 104', cat:'Towable Diesel Generator', color:'green', today:false,
+        sig:[{c:'green',t:'AVAILABLE — READY',d:'Serviced, inspected, staged in Yard B.'}],
+        insp:{last:'Jul 12',result:'Passed',by:'K. Landry',next:'Aug 12'},
+        svc:{last:'Jul 12 — load test',hours:'—',next:'Quarterly — Oct'}, wo:[],
+        specs:{make:'Generac',model:'MDG40',year:'2021',serial:'GENMDG400104',cap:'40 kW'},
+        gps:{zone:'Yard B — Row 2',ping:'9 min ago',fence:'In yard'},
+        inv:{buy:'$26,000',val:'$19,400',rate:'$110/day',util:'18%'},
+        hist:[{who:'Domingue Site Services',when:'Apr 20–24'}] },
+      { id:'LT-088', name:'Light Tower 088', cat:'Towable Light Tower', color:'yellow', today:true,
+        sig:[{c:'yellow',t:'PM DUE SOON',d:'Ready for dispatch, but 250-hr PM window opens in 3 days — flag if a long rental is requested.'}],
+        insp:{last:'Jul 10',result:'Passed',by:'R. Boudreaux',next:'Aug 10'},
+        svc:{last:'Apr 10 — last PM',hours:'246 hrs',next:'250 hrs / ~Jul 23'}, wo:[],
+        specs:{make:'Allmand',model:'Night-Lite Pro',year:'2018',serial:'ALLNLP0088',cap:'4x1000W metal halide'},
+        gps:{zone:'Yard A — Row 4',ping:'17 min ago',fence:'In yard'},
+        inv:{buy:'$17,000',val:'$9,800',rate:'$80/day',util:'31%'},
+        hist:[{who:'Hebert Site Services',when:'Mar 2–9'}] }
+    ],
+    'Incomplete':[
+      { id:'TL-410', name:'Telehandler 410', cat:'Telehandler', color:'gray', today:false,
+        sig:[{c:'gray',t:'INCOMPLETE SETUP',d:'New unit — specs + photos not yet entered. Not bookable until setup finishes.'}],
+        insp:{last:'—',result:'Not yet inspected',by:'—',next:'Schedule initial inspection'},
+        svc:{last:'—',hours:'0 hrs',next:'—'}, wo:[],
+        specs:{make:'Genie',model:'GTH-1056',year:'2024',serial:'Pending entry',cap:'Pending entry'},
+        gps:{zone:'Yard receiving',ping:'—',fence:'In yard'},
+        inv:{buy:'$118,000',val:'—',rate:'Not set',util:'0%'}, hist:[] }
+    ]
+  };
+
+  function unitStatusLabel(u){ return u.sig && u.sig[0] ? u.sig[0].t : u.cat.toUpperCase(); }
+
+  function renderUnitTile(u){
+    var top = u.sig[0];
+    var collapsed =
+      '<div class="jitem-collapsed">'+
+        '<div class="ut-name">'+u.name+'</div>'+
+        '<div class="ut-cat">'+u.cat+'</div>'+
+        '<div class="ut-chip-row">'+signalChip('unit', u.color, u.today, top ? top.t : u.cat.toUpperCase())+'</div>'+
+      '</div>';
+
+    var sections = [
+      { label:'To Do', body: signalSection(u.sig,'unit') }, /* user-facing rename (2026-07-20) — "Signal" stays the internal component name only */
+      { label:'INSPECTION', body:
+          '<div class="kv-grid">'+kv('LAST','Result: '+u.insp.result+' ('+u.insp.last+')')+kv('INSPECTOR',u.insp.by)+kv('NEXT DUE',u.insp.next)+'</div>' },
+      { label:'SERVICES', body:
+          '<div class="kv-grid">'+kv('LAST SERVICE',u.svc.last)+kv('METER',u.svc.hours,true)+kv('NEXT DUE',u.svc.next)+'</div>' },
+      { label:'WORK ORDERS', body: u.wo.length ? listRows(u.wo, function(w){
+          return '<div class="list-row"><div class="list-row-h"><span class="list-row-id">'+w.id+'</span><span class="list-row-when">'+w.st+'</span></div><div class="list-row-d">'+w.d+'</div></div>';
+        }) : '<div class="empty-note">No open work orders.</div>' },
+      { label:'SPECS', body:
+          '<div class="kv-grid">'+kv('MAKE / MODEL',u.specs.make+' '+u.specs.model)+kv('YEAR',u.specs.year,true)+kv('SERIAL',u.specs.serial,true)+kv('CAPACITY',u.specs.cap)+'</div>' },
+      { label:'GPS', body:
+          '<div class="kv-grid">'+kv('ZONE',u.gps.zone)+kv('LAST PING',u.gps.ping)+kv('GEOFENCE',u.gps.fence)+'</div>' },
+      { label:'INVESTMENT', body:
+          '<div class="sig-hero"><span class="sig-hero-val" style="color:var(--txt)">'+u.inv.val+'</span><span class="sig-hero-lbl">CURRENT VALUE</span></div>'+
+          '<div class="kv-grid">'+kv('PURCHASE',u.inv.buy)+kv('DAY RATE',u.inv.rate)+kv('UTILIZATION',u.inv.util)+'</div>' }
+    ];
+
+    var litUnit = [];
+    if (u.wo && u.wo.length) litUnit.push('WORK ORDERS');
+    if (u.insp && /fail/i.test(u.insp.result||'')) litUnit.push('INSPECTION');
+
+    var item = el('<article class="jitem unit-tile" data-color="'+u.color+'" data-rec-id="'+u.id+'" tabindex="0" role="button" aria-expanded="false"></article>');
+    if (u.hopFlip) item.dataset.hopFlip = 'below';
+    if (u.hopDemo) item.classList.add('is-hover-demo');
+    if (u.hopDemoAlt) item.classList.add('is-hover-demo-alt');
+    item.insertAdjacentHTML('beforeend', collapsed + hopMarkup(sections, litUnit) + expandedShell(u.name, u.cat+' · '+u.id, sections, ['Inspections','WOs','Washes'], buildUnitHistory(u)));
+    wireItem(item);
+    return item;
+  }
+
+  /* ===========================================================
+     RENTALS — data + renderers
+     =========================================================== */
+  var RENTAL_GROUPS = ['Today','Tomorrow','This Week','On Rent','Off Rent','End Rent','Returned','Quote','No Show','Cancelled'];
+  var RENTALS = {
+    'Today':[
+      { id:'RC-4821', unit:'Excavator 214', cust:'Broussard Bros. Excavation', color:'red', today:true, s:-3,e:0,
+        bal:'$2,180.00', rate:'$650/day', po:'PO-88214', protectionOff:false,
+        route:'Rte 12 · Yard → Moss Bluff Rd jobsite', win:'Jul 17 – Jul 20',
+        sig:[{c:'red',t:'DUE BACK TODAY — $2,180.00',d:'End of rental Jul 20 — schedule return pickup before 5 PM.'}],
+        notes:[{by:'Dispatch',when:'Jul 19',t:'Customer confirmed unit stays on site until pickup.'}],
+        hist:[{when:'Jul 17',ev:'Delivered to site'},{when:'Jul 20',ev:'Return due'}] },
+      { id:'RC-4833', unit:'Skid Steer 108', cust:'Guidry Marine Rentals', color:'red', today:true, s:0,e:0,
+        bal:'$0.00', rate:'$275/day', po:null, protectionOff:true,
+        route:'Rte 4 · Yard → Iowa LA yard pickup', win:'Jul 20 (1-day)',
+        sig:[{c:'red',t:'OUT + BACK TODAY',d:'Single-day rental, must return by close of business.'}],
+        notes:[{by:'Counter',when:'Jul 20',t:'Customer picked up 7:40 AM, expects to return ~4 PM.'}],
+        hist:[{when:'Jul 20',ev:'Picked up at counter'}] },
+      { id:'RC-4790', unit:'Boom Lift 098', cust:'Comeaux Paving Co.', color:'red', today:true, s:-1,e:0,
+        bal:'$640.00', rate:'$420/day', po:'PO-77031', protectionOff:false,
+        route:'Rte 9 · Yard → Hwy 27 jobsite', win:'Jul 19 – Jul 20',
+        sig:[{c:'red',t:'DUE BACK TODAY — $640.00',d:'End of rental Jul 20 — balance due at return.'}],
+        notes:[], hist:[{when:'Jul 19',ev:'Delivered to site'},{when:'Jul 20',ev:'Return due'}] }
+    ],
+    'Tomorrow':[
+      { id:'RC-4808', unit:'Reach Forklift 275', cust:'Fontenot Industrial', color:'yellow', today:false, s:-2,e:1,
+        bal:'$1,080.00', rate:'$270/day', po:'PO-56120', protectionOff:false,
+        route:'Rte 3 · Yard → Sulphur plant yard', win:'Jul 18 – Jul 21',
+        sig:[{c:'yellow',t:'DUE BACK TOMORROW',d:'End of rental Jul 21 — confirm pickup window with customer.'}],
+        notes:[{by:'Dispatch',when:'Jul 19',t:'Customer may extend 2 more days — awaiting confirmation.'}],
+        hist:[{when:'Jul 18',ev:'Delivered to site'}] },
+      { id:'RC-4855', unit:'Generator 260', cust:'Hebert Site Services', color:'yellow', today:false, s:1,e:1,
+        bal:'$140.00', rate:'$140/day', po:null, protectionOff:false,
+        route:'Rte 6 · Yard → Weekend standby, Sulphur', win:'Jul 21 (1-day)',
+        sig:[{c:'yellow',t:'DELIVERY TOMORROW',d:'Weekend standby power — confirm delivery Jul 21 AM.'}],
+        notes:[], hist:[{when:'Jul 15',ev:'Contract signed'}] }
+    ],
+    'This Week':[
+      { id:'RC-4860', unit:'Light Tower 233', cust:'Domingue Site Services', color:'blue', today:false, s:2,e:3,
+        bal:'$255.00', rate:'$85/day', po:'PO-90042', protectionOff:false,
+        route:'Rte 9 · Yard → Night pour site, Sulphur', win:'Jul 22 – Jul 23',
+        sig:[{c:'blue',t:'SCHEDULED — JUL 22',d:'Night pour job — confirm delivery Jul 22 AM.'}],
+        notes:[], hist:[{when:'Jul 12',ev:'Contract signed'}] },
+      { id:'RC-4700', unit:'Dozer 501', cust:'Guidry Marine Rentals', color:'blue', today:false, s:-3,e:3,
+        bal:'$4,320.00', rate:'$720/day', po:'PO-90501', protectionOff:false,
+        units:[
+          {name:'Dozer 501', rate:'$720/day', color:'blue', today:false, label:'ON RENT — MULTI-WEEK'},
+          {name:'Light Tower 233', rate:'$85/day', color:'blue', today:false, label:'ON RENT — SAME SITE'}
+        ],
+        route:'Rte 90 · Yard → Iowa LA site', win:'Jul 10 – Jul 27 (multi-week)',
+        sig:[{c:'blue',t:'ON RENT — MULTI-WEEK',d:'Long-term rental, mid-cycle billing Jul 27.'}],
+        notes:[], hist:[{when:'Jul 10',ev:'Delivered to site'}] },
+      { id:'RC-4862', unit:'Telehandler 019', cust:'Thibodeaux Oilfield Services', color:'red', today:true, s:3,e:3,
+        bal:'$340.00', rate:'$340/day', po:'PO-11238', protectionOff:false,
+        route:'Rte 27 · Yard → Delivery pending', win:'Jul 23 (scheduled)',
+        sig:[{c:'red',t:'PAYMENT DECLINED',d:'Card on file declined Jul 19 — delivery Jul 23 is on hold pending payment.'}],
+        notes:[{by:'Billing',when:'Jul 19',t:'Called customer, awaiting updated card info.'}],
+        hist:[{when:'Jul 18',ev:'Contract signed'},{when:'Jul 19',ev:'Payment declined'}] }
+    ],
+    'On Rent':[
+      { id:'RC-4650', unit:'Excavator 190', cust:'Thibodeaux Oilfield Services', color:'green', today:false, s:-3,e:3,
+        bal:'$0.00', rate:'$610/day', po:'PO-11190', protectionOff:false,
+        units:[
+          {name:'Excavator 190', rate:'$610/day', color:'green', today:false, label:'ON RENT — ALL CLEAR'},
+          {name:'Generator 260', rate:'$140/day', color:'yellow', today:true, label:'DUE BACK TODAY'}
+        ],
+        route:'Rte 27 · Yard → Sulphur site', win:'Jul 1 – Aug 1',
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'Current on billing, no open issues.'}],
+        notes:[], hist:[{when:'Jul 1',ev:'Delivered to site'}] },
+      { id:'RC-4712', unit:'Skid Steer 140', cust:'LeBlanc Concrete', color:'green', today:false, s:-2,e:2,
+        bal:'$0.00', rate:'$285/day', po:null, protectionOff:true,
+        route:'Rte 14 · Yard → Westlake site', win:'Jul 8 – Jul 29',
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'Current on billing, no open issues.'}],
+        notes:[], hist:[{when:'Jul 8',ev:'Delivered to site'}] }
+    ],
+    'Off Rent':[
+      { id:'RC-4550', unit:'Excavator 214', cust:'Fontenot Industrial', color:'gray', today:false, s:-3,e:-1,
+        bal:'$0.00', rate:'$650/day', po:'PO-55214', protectionOff:false,
+        route:'Rte 12 · Returned to yard', win:'Jun 28 – Jul 19',
+        sig:[{c:'gray',t:'OFF RENT',d:'Closed out, invoice paid in full.'}],
+        notes:[], hist:[{when:'Jul 19',ev:'Returned to yard'}] },
+      { id:'RC-4561', unit:'Scissor Lift 455', cust:'LeBlanc Concrete', color:'gray', today:false, s:-2,e:-1,
+        bal:'$0.00', rate:'$150/day', po:null, protectionOff:false,
+        route:'Rte 14 · Returned to yard', win:'Jun 30 – Jul 19',
+        sig:[{c:'gray',t:'OFF RENT',d:'Closed out, invoice paid in full.'}],
+        notes:[], hist:[{when:'Jul 19',ev:'Returned to yard'}] }
+    ],
+    'End Rent':[
+      { id:'RC-4780', unit:'Boom Lift 071', cust:'Comeaux Paving Co.', color:'yellow', today:true, s:-3,e:1,
+        bal:'$890.00', rate:'$310/day', po:'PO-77071', protectionOff:false,
+        route:'Rte 9 · Staging for return', win:'Jul 15 – Jul 21',
+        sig:[{c:'yellow',t:'RETURN STAGED',d:'Customer confirmed return Jul 21 — transport scheduled.'}],
+        notes:[], hist:[{when:'Jul 15',ev:'Delivered to site'}] },
+      { id:'RC-4791', unit:'Reach Forklift 302', cust:'Hebert Site Services', color:'yellow', today:true, s:-2,e:0,
+        bal:'$410.00', rate:'$295/day', po:null, protectionOff:false,
+        route:'Rte 6 · Staging for return', win:'Jul 18 – Jul 20',
+        sig:[{c:'yellow',t:'RETURN STAGED',d:'Return today — unit prepped for wash bay on arrival.'}],
+        notes:[], hist:[{when:'Jul 18',ev:'Delivered to site'}] }
+    ],
+    'Returned':[
+      { id:'RC-4400', unit:'Generator 104', cust:'Domingue Site Services', color:'gray', today:false, s:-3,e:-2,
+        bal:'$0.00', rate:'$110/day', po:'PO-90104', protectionOff:false,
+        route:'Rte 6 · Returned to yard', win:'Jul 5 – Jul 18',
+        sig:[{c:'gray',t:'RETURNED — CLOSED',d:'Returned and closed out, no balance.'}],
+        notes:[], hist:[{when:'Jul 18',ev:'Returned to yard'},{when:'Jul 18',ev:'Invoice closed'}] },
+      { id:'RC-4390', unit:'Skid Steer 221', cust:'Guidry Marine Rentals', color:'gray', today:false, s:-3,e:-3,
+        bal:'$0.00', rate:'$275/day', po:null, protectionOff:false,
+        route:'Rte 4 · Returned to yard', win:'Jul 10 – Jul 17',
+        sig:[{c:'gray',t:'RETURNED — CLOSED',d:'Returned and closed out, no balance.'}],
+        notes:[], hist:[{when:'Jul 17',ev:'Returned to yard'}] }
+    ],
+    'Quote':[
+      { id:'QT-2201', unit:'Telehandler 410', cust:'Broussard Bros. Excavation', color:'blue', today:false, s:2,e:3,
+        bal:'$0.00 (quote)', rate:'Quote — TBD', po:null, protectionOff:true,
+        route:'Rte 12 · Proposed delivery', win:'Jul 22 – Jul 23 (proposed)',
+        sig:[{c:'blue',t:'QUOTE — AWAITING APPROVAL',d:'Sent Jul 18, follow up if no response by Jul 22.'}],
+        notes:[], hist:[{when:'Jul 18',ev:'Quote sent'}] },
+      { id:'QT-2196', unit:'Light Tower 088', cust:'Fontenot Industrial', color:'blue', today:false, s:1,e:3,
+        bal:'$0.00 (quote)', rate:'$80/day', po:null, protectionOff:false,
+        route:'Rte 3 · Proposed delivery', win:'Jul 21 – Jul 23 (proposed)',
+        sig:[{c:'blue',t:'QUOTE — AWAITING APPROVAL',d:'Sent Jul 17, customer reviewing budget.'}],
+        notes:[], hist:[{when:'Jul 17',ev:'Quote sent'}] }
+    ],
+    'No Show':[
+      { id:'RC-4770', unit:'Air Compressor 140', cust:'Thibodeaux Oilfield Services', color:'red', today:true, s:-1,e:2,
+        bal:'$0.00', rate:'$95/day', po:'PO-11140', protectionOff:false,
+        route:'Rte 27 · Delivery attempted', win:'Jul 19 – Jul 22 (scheduled)',
+        sig:[{c:'red',t:'NO SHOW — JUL 19',d:'Delivery crew arrived, no one on site to receive. Customer not answering — follow up needed.'}],
+        notes:[{by:'Dispatch',when:'Jul 19',t:'Left voicemail, no callback yet.'}],
+        hist:[{when:'Jul 19',ev:'Delivery attempted — no show'}] }
+    ],
+    'Cancelled':[
+      { id:'RC-4655', unit:'Water Truck 006', cust:'LeBlanc Concrete', color:'gray', today:false, s:-3,e:-1,
+        bal:'$0.00', rate:'$260/day', po:null, protectionOff:true,
+        route:'Rte 14 · Cancelled', win:'Jul 17 – Jul 19 (cancelled)',
+        sig:[{c:'gray',t:'CANCELLED',d:'Customer cancelled Jul 16 — job postponed.'}],
+        notes:[], hist:[{when:'Jul 16',ev:'Cancelled by customer'}] }
+    ]
+  };
+
+  /* Rentals — NOT a paged card. ONE view, built around the calendar. The anchor
+     (title + window-picker calendar) is a sibling of both collapsed/expanded blocks,
+     never touched by the open/close toggle, so it is pixel-identical — same size,
+     same top-left position — whether the card is closed or open. Expanding reveals
+     the rest (customer Ref, status Gate, balance, per-unit rows, PO/protection) in
+     the newly-available space below/around it, all at once — no tabs, no chevrons. */
+  function renderRentalCard(r){
+    var top = r.sig[0];
+    var units = r.units || [{ name:r.unit, rate:r.rate, color:r.color, today:r.today, label: top ? top.t : r.color.toUpperCase() }];
+    var owed = parseFloat((r.bal||'').replace(/[^0-9.]/g,'')) || 0;
+    var balColor = owed > 0 ? r.color : 'green';
+    var balLabel = owed > 0 ? 'BALANCE OWED' : 'NO BALANCE DUE';
+    var balValColor = owed > 0 ? 'var(--c-'+(balColor==='gray'?'gray':balColor)+')' : 'var(--txt)';
+
+    var anchor =
+      '<div class="rc-anchor">'+
+        '<div class="rc-title">'+r.unit+'</div>'+
+        miniCal(r.s, r.e)+
+      '</div>';
+
+    var collapsed =
+      '<div class="jitem-collapsed">'+
+        '<div class="rc-row">'+ref(r.cust)+gateChip(r.color, r.today, top ? top.t.split(' — ')[0] : r.color.toUpperCase(), top ? top.t : null)+'</div>'+
+        '<div class="rc-route">'+icon('mapPin')+'<span>'+r.route+'</span></div>'+
+      '</div>';
+
+    var unitRows = units.map(function(u){
+      return '<div class="rc-unit-row">'+ref(u.name)+'<span class="rc-unit-rate">'+u.rate+'</span>'+gateChip(u.color, u.today, u.label)+'</div>';
+    }).join('');
+
+    var expanded =
+      '<div class="jitem-expanded">'+
+        '<div class="jexp-head">'+
+          '<div class="jexp-title"><div class="jexp-name">'+r.unit+'</div><div class="jexp-meta">'+r.cust+' · '+r.id+'</div></div>'+
+          '<button class="jexp-close" type="button" aria-label="Close">'+icon('x')+'</button>'+
+        '</div>'+
+        '<div class="rc-reveal">'+
+          '<div class="rc-reveal-row">'+ref(r.cust)+gateChip(r.color, r.today, top ? top.t : r.color.toUpperCase())+'</div>'+
+          (top ? '<div class="rc-reveal-d">'+top.d+'</div>' : '')+
+          '<div class="rc-bal">'+signalChip('rental', balColor, owed>0 && r.today, balLabel)+
+            '<div class="rc-bal-num" style="color:'+balValColor+'">'+r.bal+'</div></div>'+
+          '<div class="rc-units">'+unitRows+'</div>'+
+          '<div class="rc-po-row">'+
+            '<span class="kv-l">PO</span><span class="kv-v">'+(r.po || '— none on file')+'</span>'+
+            (r.protectionOff ? '<span class="chipx st-yellow"><span class="t">PROTECTION OFF</span></span>' : stamp('PROTECTED'))+
+          '</div>'+
+        '</div>'+
+        historyFooter(['Payments','Edits'], buildRentalHistory(r))+
+      '</div>';
+
+    var item = el('<article class="jitem rental-card" data-color="'+r.color+'" data-rec-id="'+r.id+'" tabindex="0" role="button" aria-expanded="false"></article>');
+    item.insertAdjacentHTML('beforeend', anchor + collapsed + expanded);
+    wireItem(item);
+    return item;
+  }
+
+  /* ===========================================================
+     CUSTOMERS — data + renderers
+     =========================================================== */
+  var CUST_GROUPS = ['Past Due','Not Due','Reserved','On Rent','Members','Non-Members'];
+  var CUSTOMERS = {
+    'Past Due':[
+      { id:'CU-3381', name:'Boudreaux Construction', color:'red', today:true, hopFlip:true, hopDemo:true, s1:'NET-15', s2:'14 RENTALS',
+        sig:[{c:'red',t:'PAST DUE — $2,140.00',d:'Invoice 3381, due Jul 12 — 8 days overdue.'}],
+        acct:{phone:'(337) 555-0142',email:'billing@boudreauxconst.test',bill:'412 Ruth St, Sulphur, LA',since:'2021'},
+        funnel:{stage:'Won · Active account',src:'Referral — repeat customer'},
+        inv:[{num:'INV-3381',amt:'$2,140.00',due:'Jul 12',st:'Past due'}],
+        act:[{when:'Jul 17',t:'Called re: invoice 3381, no answer'},{when:'Jul 10',t:'Picked up Skid Steer 108'}],
+        pay:{method:'Visa •••• 4417',last:'$1,240 on Jun 30',terms:'Net 15'},
+        histSum:{total:'14 rentals',ltv:'$38,600 lifetime',since:'Member since 2021'} },
+      { id:'CU-3402', name:'Domingue Site Services', color:'red', today:true, hopDemoAlt:true, s1:'NET-30', s2:'6 RENTALS',
+        sig:[{c:'red',t:'PAST DUE — $890.00',d:'Invoice 3402, due Jul 5 — 15 days overdue.'}],
+        acct:{phone:'(337) 555-0187',email:'ap@domingueservices.test',bill:'88 Prater Rd, Sulphur, LA',since:'2023'},
+        funnel:{stage:'Won · Active account',src:'Google — organic'},
+        inv:[{num:'INV-3402',amt:'$890.00',due:'Jul 5',st:'Past due'}],
+        act:[{when:'Jul 14',t:'Sent past-due reminder'}],
+        pay:{method:'Mastercard •••• 2280',last:'$620 on Jun 3',terms:'Net 30'},
+        histSum:{total:'6 rentals',ltv:'$9,400 lifetime',since:'Member since 2023'} },
+      { id:'CU-3415', name:'Chad Domingue', color:'red', today:true, s1:'NET-15', s2:'2 RENTALS',
+        sig:[{c:'red',t:'PAST DUE — $340.00',d:'Invoice 3415, due Jul 13 — 7 days overdue.'}],
+        acct:{phone:'(337) 555-0223',email:'chad.domingue@example.test',bill:'204 Cypress Ave, Sulphur, LA',since:'2025'},
+        funnel:{stage:'Won · New account',src:'Walk-in'},
+        inv:[{num:'INV-3415',amt:'$340.00',due:'Jul 13',st:'Past due'}],
+        act:[{when:'Jul 16',t:'Left voicemail re: balance'}],
+        pay:{method:'Visa •••• 9081',last:'No prior payment',terms:'Net 15'},
+        histSum:{total:'2 rentals',ltv:'$1,120 lifetime',since:'Member since 2025'} }
+    ],
+    'Not Due':[
+      { id:'CU-3200', name:'Thibodeaux Oilfield Services', color:'green', today:false, s1:'NET-30', s2:'22 RENTALS',
+        sig:[{c:'green',t:'ACCOUNT CURRENT',d:'No open balance, all invoices paid on time.'}],
+        acct:{phone:'(337) 555-0110',email:'ap@thibodeauxoilfield.test',bill:'900 Refinery Rd, Sulphur, LA',since:'2019'},
+        funnel:{stage:'Won · Key account',src:'Referral'},
+        inv:[
+          {num:'INV-3388',amt:'$4,320.00',due:'Jul 27',st:'Current'},
+          {num:'INV-3360',amt:'$1,340.00',due:'Jul 6',st:'Paid'},
+          {num:'INV-3341',amt:'$2,180.00',due:'Jun 22',st:'Paid'},
+          {num:'INV-3318',amt:'$610.00',due:'Jun 8',st:'Paid'},
+          {num:'INV-3299',amt:'$3,050.00',due:'May 25',st:'Paid'},
+          {num:'INV-3270',amt:'$720.00',due:'May 11',st:'Paid'},
+          {num:'INV-3241',amt:'$1,900.00',due:'Apr 27',st:'Paid'},
+          {num:'INV-3212',amt:'$2,440.00',due:'Apr 13',st:'Paid'},
+          {num:'INV-3188',amt:'$860.00',due:'Mar 30',st:'Paid'},
+          {num:'INV-3160',amt:'$1,220.00',due:'Mar 16',st:'Paid'}
+        ],
+        act:[{when:'Jul 18',t:'Signed contract RC-4862'}],
+        pay:{method:'ACH on file',last:'$2,900 on Jul 1',terms:'Net 30'},
+        histSum:{total:'22 rentals',ltv:'$142,000 lifetime',since:'Member since 2019'} },
+      { id:'CU-3221', name:'Guidry Marine Rentals', color:'green', today:false, s1:'NET-30', s2:'11 RENTALS',
+        sig:[{c:'green',t:'ACCOUNT CURRENT',d:'No open balance.'}],
+        acct:{phone:'(337) 555-0134',email:'accounts@guidrymarine.test',bill:'1500 Dock St, Iowa, LA',since:'2020'},
+        funnel:{stage:'Won · Active account',src:'Trade show'},
+        inv:[{num:'INV-3350',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 20',t:'Picked up Dozer 501'}],
+        pay:{method:'Visa •••• 6602',last:'$1,900 on Jul 5',terms:'Net 30'},
+        histSum:{total:'11 rentals',ltv:'$54,200 lifetime',since:'Member since 2020'} },
+      { id:'CU-3245', name:'Hebert Site Services', color:'green', today:false, s1:'NET-15', s2:'8 RENTALS',
+        sig:[{c:'green',t:'ACCOUNT CURRENT',d:'No open balance.'}],
+        acct:{phone:'(337) 555-0198',email:'billing@hebertsite.test',bill:'77 Ruth St, Sulphur, LA',since:'2022'},
+        funnel:{stage:'Won · Active account',src:'Referral'},
+        inv:[{num:'INV-3300',amt:'$410.00',due:'Aug 3',st:'Current'}],
+        act:[{when:'Jul 18',t:'Delivered Reach Forklift 302'}],
+        pay:{method:'Mastercard •••• 4471',last:'$780 on Jun 20',terms:'Net 15'},
+        histSum:{total:'8 rentals',ltv:'$22,600 lifetime',since:'Member since 2022'} },
+      { id:'CU-3260', name:'Tammy Broussard', color:'green', today:false, s1:'NET-15', s2:'3 RENTALS',
+        sig:[{c:'green',t:'ACCOUNT CURRENT',d:'No open balance.'}],
+        acct:{phone:'(337) 555-0256',email:'tammy.broussard@example.test',bill:'55 Oak Park Dr, Sulphur, LA',since:'2024'},
+        funnel:{stage:'Won · Active account',src:'Walk-in'},
+        inv:[{num:'INV-3260',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 9',t:'Returned Scissor Lift 455'}],
+        pay:{method:'Visa •••• 7743',last:'$450 on Jul 9',terms:'Net 15'},
+        histSum:{total:'3 rentals',ltv:'$3,800 lifetime',since:'Member since 2024'} }
+    ],
+    'Reserved':[
+      { id:'CU-3299', name:'Comeaux Paving Co.', color:'blue', today:false, s1:'NET-30', s2:'17 RENTALS',
+        sig:[{c:'blue',t:'RESERVATION — JUL 21',d:'Boom Lift 071 pickup scheduled Jul 21.'}],
+        acct:{phone:'(337) 555-0177',email:'ap@comeauxpaving.test',bill:'340 Hwy 9, Sulphur, LA',since:'2018'},
+        funnel:{stage:'Won · Key account',src:'Repeat customer'},
+        inv:[{num:'INV-3299',amt:'$890.00',due:'Jul 28',st:'Current'}],
+        act:[{when:'Jul 15',t:'Reservation confirmed for Jul 21'}],
+        pay:{method:'ACH on file',last:'$1,100 on Jul 2',terms:'Net 30'},
+        histSum:{total:'17 rentals',ltv:'$71,400 lifetime',since:'Member since 2018'} },
+      { id:'CU-3312', name:'Fontenot Industrial', color:'blue', today:false, s1:'NET-30', s2:'9 RENTALS',
+        sig:[{c:'blue',t:'QUOTE PENDING — JUL 21',d:'Awaiting approval for Telehandler + Light Tower delivery.'}],
+        acct:{phone:'(337) 555-0165',email:'purchasing@fontenotind.test',bill:'220 Industrial Blvd, Sulphur, LA',since:'2021'},
+        funnel:{stage:'Quoted · Awaiting approval',src:'Website form'},
+        inv:[{num:'INV-3200',amt:'$1,080.00',due:'Jul 25',st:'Current'}],
+        act:[{when:'Jul 17',t:'Quote sent for Jul 21 delivery'}],
+        pay:{method:'Visa •••• 3390',last:'$980 on Jul 8',terms:'Net 30'},
+        histSum:{total:'9 rentals',ltv:'$29,700 lifetime',since:'Member since 2021'} },
+      { id:'CU-3330', name:'Marcus Guidry', color:'blue', today:false, s1:'NET-15', s2:'1 RENTAL',
+        sig:[{c:'blue',t:'RESERVATION — JUL 22',d:'Light Tower 233 delivery scheduled Jul 22.'}],
+        acct:{phone:'(337) 555-0289',email:'marcus.guidry@example.test',bill:'19 Bayou Rd, Sulphur, LA',since:'2026'},
+        funnel:{stage:'Won · New account',src:'Referral'},
+        inv:[{num:'INV-3410',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 12',t:'First contract signed'}],
+        pay:{method:'Visa •••• 5521',last:'No prior payment',terms:'Net 15'},
+        histSum:{total:'1 rental',ltv:'$255 lifetime',since:'Member since 2026'} }
+    ],
+    'On Rent':[
+      { id:'CU-3140', name:'Broussard Bros. Excavation', color:'green', today:false, s1:'NET-30', s2:'19 RENTALS',
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'2 units out, both current on billing.'}],
+        acct:{phone:'(337) 555-0121',email:'ap@broussardbros.test',bill:'610 Ruth St, Sulphur, LA',since:'2017'},
+        funnel:{stage:'Won · Key account',src:'Referral'},
+        inv:[{num:'INV-3140',amt:'$2,180.00',due:'Jul 30',st:'Current'}],
+        act:[{when:'Jul 17',t:'Delivered Excavator 214'}],
+        pay:{method:'ACH on file',last:'$3,400 on Jul 1',terms:'Net 30'},
+        histSum:{total:'19 rentals',ltv:'$118,900 lifetime',since:'Member since 2017'} },
+      { id:'CU-3155', name:'LeBlanc Concrete', color:'green', today:false, s1:'NET-15', s2:'13 RENTALS',
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'1 unit out, current on billing.'}],
+        acct:{phone:'(337) 555-0143',email:'billing@leblancconcrete.test',bill:'88 Maplewood Dr, Westlake, LA',since:'2020'},
+        funnel:{stage:'Won · Active account',src:'Referral'},
+        inv:[{num:'INV-3155',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 8',t:'Delivered Skid Steer 140'}],
+        pay:{method:'Visa •••• 1187',last:'$640 on Jul 9',terms:'Net 15'},
+        histSum:{total:'13 rentals',ltv:'$46,300 lifetime',since:'Member since 2020'} },
+      { id:'CU-3168', name:'Ray Thibodeaux', color:'green', today:false, s1:'NET-15', s2:'4 RENTALS',
+        sig:[{c:'green',t:'ON RENT — ALL CLEAR',d:'1 unit out, current on billing.'}],
+        acct:{phone:'(337) 555-0299',email:'ray.thibodeaux@example.test',bill:'12 Bayou Rd, Sulphur, LA',since:'2023'},
+        funnel:{stage:'Won · Active account',src:'Walk-in'},
+        inv:[{num:'INV-3168',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 15',t:'Picked up unit at counter'}],
+        pay:{method:'Visa •••• 8843',last:'$310 on Jul 15',terms:'Net 15'},
+        histSum:{total:'4 rentals',ltv:'$5,600 lifetime',since:'Member since 2023'} }
+    ],
+    'Members':[
+      { id:'CU-3050', name:'Kevin Landry', color:'green', today:false, s1:'MEMBER', s2:'27 RENTALS',
+        sig:[{c:'green',t:'MEMBER — GOOD STANDING',d:'Loyalty member since 2016, account current.'}],
+        acct:{phone:'(337) 555-0301',email:'kevin.landry@example.test',bill:'44 Ranch Rd, Sulphur, LA',since:'2016'},
+        funnel:{stage:'Won · Key account',src:'Founding member'},
+        inv:[{num:'INV-3050',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 5',t:'Renewed membership'}],
+        pay:{method:'ACH on file',last:'$1,200 on Jun 28',terms:'Net 15'},
+        histSum:{total:'27 rentals',ltv:'$203,000 lifetime',since:'Member since 2016'} },
+      { id:'CU-3061', name:'Sulphur Rig Services', color:'green', today:false, s1:'MEMBER', s2:'20 RENTALS',
+        sig:[{c:'green',t:'MEMBER — GOOD STANDING',d:'Loyalty member since 2018, account current.'}],
+        acct:{phone:'(337) 555-0312',email:'ap@sulphurrig.test',bill:'700 Refinery Rd, Sulphur, LA',since:'2018'},
+        funnel:{stage:'Won · Key account',src:'Founding member'},
+        inv:[{num:'INV-3061',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jun 30',t:'Renewed membership'}],
+        pay:{method:'ACH on file',last:'$2,600 on Jun 15',terms:'Net 30'},
+        histSum:{total:'20 rentals',ltv:'$156,400 lifetime',since:'Member since 2018'} },
+      { id:'CU-3072', name:'Dwayne Fontenot', color:'red', today:true, s1:'MEMBER', s2:'9 RENTALS',
+        sig:[{c:'red',t:'PAST DUE — $560.00',d:'Invoice 3072, due Jul 8 — 12 days overdue. Member standing on hold until paid.'}],
+        acct:{phone:'(337) 555-0323',email:'dwayne.fontenot@example.test',bill:'901 Cypress Ave, Sulphur, LA',since:'2019'},
+        funnel:{stage:'Won · Member (on hold)',src:'Referral'},
+        inv:[{num:'INV-3072',amt:'$560.00',due:'Jul 8',st:'Past due'}],
+        act:[{when:'Jul 16',t:'Called re: invoice 3072'}],
+        pay:{method:'Visa •••• 2214',last:'$400 on Jun 2',terms:'Net 15'},
+        histSum:{total:'9 rentals',ltv:'$31,200 lifetime',since:'Member since 2019'} }
+    ],
+    'Non-Members':[
+      { id:'CU-3500', name:'Fabian Prejean', color:'gray', today:false, s1:'NON-MEMBER', s2:'1 RENTAL',
+        sig:[{c:'gray',t:'NON-MEMBER',d:'No loyalty program enrollment. Standard rates apply.'}],
+        acct:{phone:'(337) 555-0410',email:'fabian.prejean@example.test',bill:'23 Farm Rd, Sulphur, LA',since:'2026'},
+        funnel:{stage:'Won · New account',src:'Walk-in'},
+        inv:[{num:'INV-3500',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 2',t:'First rental completed'}],
+        pay:{method:'Visa •••• 9902',last:'$150 on Jul 2',terms:'Net 15'},
+        histSum:{total:'1 rental',ltv:'$150 lifetime',since:'Member since 2026'} },
+      { id:'CU-3511', name:'Ashley Comeaux', color:'gray', today:false, s1:'NON-MEMBER', s2:'2 RENTALS',
+        sig:[{c:'gray',t:'NON-MEMBER',d:'No loyalty program enrollment. Standard rates apply.'}],
+        acct:{phone:'(337) 555-0421',email:'ashley.comeaux@example.test',bill:'8 Cypress Ave, Sulphur, LA',since:'2025'},
+        funnel:{stage:'Won · Active account',src:'Google — organic'},
+        inv:[{num:'INV-3511',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jun 20',t:'Rented Air Compressor'}],
+        pay:{method:'Mastercard •••• 6634',last:'$95 on Jun 20',terms:'Net 15'},
+        histSum:{total:'2 rentals',ltv:'$420 lifetime',since:'Member since 2025'} },
+      { id:'CU-3522', name:'Brody Landry', color:'gray', today:false, s1:'NON-MEMBER', s2:'1 RENTAL',
+        sig:[{c:'gray',t:'NON-MEMBER',d:'No loyalty program enrollment. Standard rates apply.'}],
+        acct:{phone:'(337) 555-0432',email:'brody.landry@example.test',bill:'150 Oak Park Dr, Sulphur, LA',since:'2026'},
+        funnel:{stage:'Won · New account',src:'Walk-in'},
+        inv:[{num:'INV-3522',amt:'$0.00',due:'—',st:'Current'}],
+        act:[{when:'Jul 4',t:'First rental completed'}],
+        pay:{method:'Visa •••• 4470',last:'$85 on Jul 4',terms:'Net 15'},
+        histSum:{total:'1 rental',ltv:'$85 lifetime',since:'Member since 2026'} }
+    ]
+  };
+
+  function renderCustRow(c){
+    var top = c.sig[0];
+    var fullLabel = top ? top.t : c.color.toUpperCase();
+    var shortLabel = fullLabel.split(' — ')[0];
+    var collapsed =
+      '<div class="jitem-collapsed"><div class="cr-collapsed">'+
+        '<span class="cr-name">'+c.name+'</span>'+
+        '<div class="cr-stamps">'+stamp(c.s1)+stamp(c.s2)+'</div>'+
+        signalChip('customer', c.color, c.today, shortLabel, fullLabel)+
+      '</div></div>';
+
+    var sections = [
+      { label:'To Do', body: signalSection(c.sig,'customer') }, /* user-facing rename (2026-07-20) — "Signal" stays the internal component name only */
+      { label:'ACCOUNT', body:
+          '<div class="sig-hero"><span class="sig-hero-val" style="color:var(--txt)">'+c.histSum.total+'</span><span class="sig-hero-lbl">'+c.histSum.ltv+'</span></div>'+
+          '<div class="kv-grid">'+
+            kv('PHONE','<a href="tel:'+c.acct.phone.replace(/[^\d+]/g,'')+'" style="color:var(--txt);text-decoration:underline">'+c.acct.phone+'</a>')+
+            kv('EMAIL','<a href="mailto:'+c.acct.email+'" style="color:var(--txt);text-decoration:underline">'+c.acct.email+'</a>')+
+            kv('BILL TO',c.acct.bill)+kv('STANDING',c.histSum.since)+
+          '</div>' },
+      { label:'FUNNEL', body:
+          '<div class="kv-grid">'+kv('STAGE',c.funnel.stage)+kv('SOURCE',c.funnel.src)+'</div>' },
+      { label:'INVOICES', body: listRows(c.inv, function(iv){
+          return '<div class="list-row"><div class="list-row-h"><span class="list-row-id">'+iv.num+'</span><span class="list-row-when">Due '+iv.due+'</span></div><div class="list-row-d">'+iv.amt+' — '+iv.st+'</div></div>';
+        }) },
+      { label:'ACTIVITY', body: listRows(c.act, function(a){
+          return '<div class="list-row"><div class="list-row-h"><span class="list-row-when">'+a.when+'</span></div><div class="list-row-d">'+a.t+'</div></div>';
+        }) },
+      { label:'PAYMENT', body:
+          '<div class="kv-grid">'+kv('METHOD',c.pay.method)+kv('LAST PAID',c.pay.last)+kv('TERMS',c.pay.terms)+'</div>' }
+    ];
+
+    var litCust = [];
+    if (c.inv && c.inv.some(function(iv){ return /past due/i.test(iv.st); })) litCust.push('INVOICES');
+
+    var item = el('<article class="jitem cust-row" data-color="'+c.color+'" data-rec-id="'+c.id+'" tabindex="0" role="button" aria-expanded="false"></article>');
+    if (c.hopFlip) item.dataset.hopFlip = 'below';
+    if (c.hopDemo) item.classList.add('is-hover-demo');
+    if (c.hopDemoAlt) item.classList.add('is-hover-demo-alt');
+    item.insertAdjacentHTML('beforeend', collapsed + hopMarkup(sections, litCust) + expandedShell(c.name, c.s1+' · '+c.id, sections, ['Invoices','Contacts'], buildCustomerHistory(c)));
+    wireItem(item);
+    return item;
+  }
+
+  /* ===========================================================
+     GENERIC EXPAND / PAGER MECHANISM (shared by all three types)
+     =========================================================== */
+  function computeExpandHeight(){
+    return Math.max(260, Math.min(680, Math.round(window.innerHeight*0.7)));
+  }
+
+  /* coarse-pointer or narrow viewport = focused full-screen mode instead of inline expand */
+  function isMobileMode(){
+    return window.matchMedia('(pointer:coarse)').matches || window.innerWidth <= 680;
+  }
+
+  var HIST_GROW_PX = 260; /* fixed grow amount when the history log opens — matches .jhist-log.is-open max-height */
+
+  function setHistoryOpen(item, open){
+    var log = item.querySelector('.jhist-log');
+    var toggle = item.querySelector('.jhist-toggle');
+    if (!log) return;
+    var isOpen = log.classList.contains('is-open');
+    if (open === isOpen) return;
+    var fullscreen = item.classList.contains('is-fullscreen');
+    if (open){
+      log.classList.add('is-open');
+      if (toggle) toggle.setAttribute('aria-expanded','true');
+      if (!fullscreen){
+        var cur = item.getBoundingClientRect().height;
+        item.style.height = cur+'px'; void item.offsetWidth;
+        requestAnimationFrame(function(){ item.style.height = (cur+HIST_GROW_PX)+'px'; });
+      }
+    } else {
+      log.classList.remove('is-open');
+      if (toggle) toggle.setAttribute('aria-expanded','false');
+      if (!fullscreen){
+        var curH = item.getBoundingClientRect().height;
+        item.style.height = curH+'px'; void item.offsetWidth;
+        var floor = parseFloat(item.dataset.collapsedH || '120');
+        requestAnimationFrame(function(){ item.style.height = Math.max(floor, curH-HIST_GROW_PX)+'px'; });
+      }
+    }
+  }
+
+  function applyHistoryFilter(item){
+    var log = item.querySelector('.jhist-log');
+    if (!log) return;
+    var q = (item.querySelector('.jhist-search').value || '').trim().toLowerCase();
+    var activeKinds = Array.prototype.slice.call(log.querySelectorAll('.jhist-filter-chip.is-active')).map(function(c){ return c.dataset.kind; });
+    Array.prototype.slice.call(log.querySelectorAll('.jhist-entry')).forEach(function(row){
+      var kindOk = !activeKinds.length || activeKinds.indexOf(row.dataset.kind) > -1;
+      var textOk = !q || row.dataset.text.indexOf(q) > -1;
+      row.hidden = !(kindOk && textOk);
+    });
+  }
+
+  function toggleHistFilter(item, chip){
+    chip.classList.toggle('is-active');
+    applyHistoryFilter(item);
+  }
+
+  function resetHistory(item){
+    var log = item.querySelector('.jhist-log');
+    if (!log) return;
+    log.classList.remove('is-open');
+    var toggle = item.querySelector('.jhist-toggle');
+    if (toggle) toggle.setAttribute('aria-expanded','false');
+    var search = item.querySelector('.jhist-search');
+    if (search) search.value = '';
+    Array.prototype.slice.call(log.querySelectorAll('.jhist-filter-chip.is-active')).forEach(function(c){ c.classList.remove('is-active'); });
+    Array.prototype.slice.call(log.querySelectorAll('.jhist-entry')).forEach(function(row){ row.hidden = false; });
+  }
+
+  function getPanels(item){ return Array.prototype.slice.call(item.querySelectorAll(':scope > .jitem-expanded .jsection')); }
+  function getTabs(item){ return Array.prototype.slice.call(item.querySelectorAll(':scope > .jitem-expanded .jtab')); }
+  function getDots(item){ return Array.prototype.slice.call(item.querySelectorAll(':scope > .jitem-expanded .jdot')); }
+
+  function setSection(item, newIdx){
+    var panels = getPanels(item), tabs = getTabs(item), dots = getDots(item);
+    var n = panels.length;
+    newIdx = Math.max(0, Math.min(n-1, newIdx));
+    var oldIdx = panels.findIndex(function(p){ return p.classList.contains('is-active'); });
+    if (oldIdx < 0) oldIdx = 0;
+    if (newIdx === oldIdx) return;
+    var dir = newIdx > oldIdx ? 1 : -1;
+
+    panels[oldIdx].classList.remove('is-active');
+    panels[oldIdx].hidden = true;
+    var np = panels[newIdx];
+    np.hidden = false;
+    np.classList.add('is-active');
+    np.style.setProperty('--slide-from', (dir*14)+'px');
+    np.classList.remove('anim-in'); void np.offsetWidth; np.classList.add('anim-in');
+
+    tabs.forEach(function(t,i){ t.classList.toggle('is-active', i===newIdx); t.setAttribute('aria-selected', i===newIdx ? 'true':'false'); });
+    dots.forEach(function(d,i){ d.classList.toggle('is-active', i===newIdx); });
+  }
+
+  function openItem(item){
+    if (item.classList.contains('is-open')) return;
+    if (isMobileMode()){
+      item.classList.add('is-open','is-fullscreen');
+      item.setAttribute('aria-expanded','true');
+      document.body.classList.add('no-scroll');
+      return;
+    }
+    var startH = item.getBoundingClientRect().height;
+    item.dataset.collapsedH = startH;
+    item.style.height = startH+'px';
+    item.classList.add('is-open');
+    item.setAttribute('aria-expanded','true');
+    void item.offsetWidth;
+    var targetH = computeExpandHeight();
+    requestAnimationFrame(function(){ item.style.height = targetH+'px'; });
+  }
+
+  function closeItem(item){
+    if (!item.classList.contains('is-open')) return;
+    resetHistory(item);
+    if (item.classList.contains('is-fullscreen')){
+      item.classList.remove('is-open','is-fullscreen');
+      item.setAttribute('aria-expanded','false');
+      document.body.classList.remove('no-scroll');
+      return;
+    }
+    var currentH = item.getBoundingClientRect().height;
+    item.style.height = currentH+'px';
+    void item.offsetWidth;
+    var targetH = parseFloat(item.dataset.collapsedH || '120');
+    requestAnimationFrame(function(){ item.style.height = targetH+'px'; });
+    item.classList.remove('is-open');
+    item.setAttribute('aria-expanded','false');
+    var cleaned = false;
+    function cleanup(e){
+      if (e && e.target !== item) return;
+      if (cleaned) return; cleaned = true;
+      item.style.height = '';
+      item.removeEventListener('transitionend', cleanup);
+    }
+    item.addEventListener('transitionend', cleanup);
+    setTimeout(cleanup, 260);
+  }
+
+  function toggleItem(item){
+    if (item.classList.contains('is-open')) closeItem(item); else openItem(item);
+  }
+
+  function wireItem(item){
+    item.addEventListener('click', function(e){
+      var hopChip = e.target.closest('.jhop-chip');
+      if (hopChip){ e.stopPropagation(); openItem(item); setSection(item, parseInt(hopChip.dataset.secIdx,10)); return; }
+      var inHist = e.target.closest('.jhist-bar') || e.target.closest('.jhist-log');
+      if (inHist){
+        e.stopPropagation();
+        var histToggle = e.target.closest('.jhist-toggle');
+        var histFilter = e.target.closest('.jhist-filter-chip');
+        if (histToggle){ setHistoryOpen(item, !item.querySelector('.jhist-log').classList.contains('is-open')); }
+        else if (histFilter){ toggleHistFilter(item, histFilter); }
+        else if (e.target.closest('.jhist-search-wrap')){ setHistoryOpen(item, true); }
+        return;
+      }
+      var closeBtn = e.target.closest('.jexp-close');
+      var tab = e.target.closest('.jtab');
+      var dot = e.target.closest('.jdot');
+      var prev = e.target.closest('.jchev-prev');
+      var next = e.target.closest('.jchev-next');
+      var link = e.target.closest('a');
+      if (link) return; /* let tel:/mailto: links work without toggling the card */
+      if (closeBtn){ e.stopPropagation(); closeItem(item); return; }
+      if (tab){ e.stopPropagation(); setSection(item, parseInt(tab.dataset.idx,10)); return; }
+      if (dot){ e.stopPropagation(); setSection(item, parseInt(dot.dataset.idx,10)); return; }
+      if (prev){ e.stopPropagation(); var cp = getPanels(item).findIndex(function(p){return p.classList.contains('is-active');}); setSection(item, cp-1); return; }
+      if (next){ e.stopPropagation(); var cn = getPanels(item).findIndex(function(p){return p.classList.contains('is-active');}); setSection(item, cn+1); return; }
+      toggleItem(item);
+    });
+    item.addEventListener('keydown', function(e){
+      if (e.target !== item) return; /* only when the item itself has focus, not a child control */
+      if (e.key === 'Enter' || e.key === ' '){ e.preventDefault(); toggleItem(item); }
+      else if (item.classList.contains('is-open')){
+        if (e.key === 'ArrowRight'){ e.preventDefault(); var c=getPanels(item).findIndex(function(p){return p.classList.contains('is-active');}); setSection(item,c+1); }
+        else if (e.key === 'ArrowLeft'){ e.preventDefault(); var c2=getPanels(item).findIndex(function(p){return p.classList.contains('is-active');}); setSection(item,c2-1); }
+        else if (e.key === 'Escape'){ e.preventDefault(); closeItem(item); }
+      }
+    });
+    /* history search: focusing opens the log, typing filters live, blurring away closes it */
+    item.addEventListener('focusin', function(e){
+      if (e.target.classList && e.target.classList.contains('jhist-search')) setHistoryOpen(item, true);
+    });
+    item.addEventListener('focusout', function(e){
+      if (!(e.target.classList && e.target.classList.contains('jhist-search'))) return;
+      var rt = e.relatedTarget;
+      var wrap = item.querySelector('.jhist-wrap');
+      if (!rt || !wrap || !wrap.contains(rt)) setHistoryOpen(item, false);
+    });
+    item.addEventListener('input', function(e){
+      if (e.target.classList && e.target.classList.contains('jhist-search')) applyHistoryFilter(item);
+    });
+    /* touch/pointer swipe across the section area while open (Units/Customers only — Rentals has no .jexp-sections) */
+    var startX=0, startY=0, tracking=false;
+    item.addEventListener('pointerdown', function(e){
+      if (!item.classList.contains('is-open')) return;
+      if (!e.target.closest('.jexp-sections')) return;
+      startX = e.clientX; startY = e.clientY; tracking = true;
+    });
+    item.addEventListener('pointerup', function(e){
+      if (!tracking) return; tracking = false;
+      var dx = e.clientX - startX, dy = e.clientY - startY;
+      if (Math.abs(dx) > 40 && Math.abs(dx) > Math.abs(dy)){
+        var cur = getPanels(item).findIndex(function(p){return p.classList.contains('is-active');});
+        setSection(item, dx < 0 ? cur+1 : cur-1);
+      }
+    });
+  }
+
+  /* ===========================================================
+     COLUMN BUILDER + YOUR-WORK FILTER + HEADER ROLLUP
+     =========================================================== */
+  function buildColumn(containerId, groupOrder, dataset, gridClass, renderFn){
+    var body = document.getElementById(containerId);
+    groupOrder.forEach(function(name){
+      var items = dataset[name] || [];
+      if (!items.length) return;
+      var worst = rollup(items.map(function(i){ return i.color; }));
+      var gwrap = document.createElement('div');
+      gwrap.className = 'gwrap';
+      gwrap.dataset.worst = worst;
+      var ghead = document.createElement('div');
+      ghead.className = 'ghead';
+      ghead.dataset.c = worst;
+      ghead.innerHTML = '<span class="ghead-bar"></span><span class="ghead-label">'+name+'</span><span class="ghead-count">'+items.length+'</span><span class="ghead-line"></span>';
+      var grid = document.createElement('div');
+      grid.className = gridClass;
+      items.forEach(function(rec){ grid.appendChild(renderFn(rec)); });
+      gwrap.appendChild(ghead);
+      gwrap.appendChild(grid);
+      body.appendChild(gwrap);
+    });
+  }
+
+  buildColumn('col-units', UNIT_GROUPS, UNITS, 'tiles-grid', renderUnitTile);
+  buildColumn('col-rentals', RENTAL_GROUPS, RENTALS, 'cards-grid', renderRentalCard);
+  buildColumn('col-customers', CUST_GROUPS, CUSTOMERS, 'rows-list', renderCustRow);
+
+  /* ---------------------------------------------------------
+     REVIEW DEMO STATE (mockup-only) — pre-open one item per
+     column so the sections, the To Do landing, the History
+     footer, and (Units/Customers) the section rail are all
+     visible without a click; Customers lands on Invoices to show
+     it scrolling internally within a fixed card height (spec §2).
+     --------------------------------------------------------- */
+  requestAnimationFrame(function(){
+    var u1 = document.querySelector('[data-rec-id="EX-214"]'); if (u1) openItem(u1);
+    var r1 = document.querySelector('[data-rec-id="RC-4700"]'); if (r1) openItem(r1);
+    var c1 = document.querySelector('[data-rec-id="CU-3200"]');
+    if (c1){ openItem(c1); setSection(c1, 3); }
+  });
+
+  document.querySelectorAll('.yourwork-tog').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      var on = btn.classList.toggle('on');
+      var col = document.querySelector('.yard-col[data-col="'+btn.dataset.col+'"]');
+      col.querySelectorAll('.gwrap').forEach(function(g){
+        var hideIt = on && (g.dataset.worst === 'green' || g.dataset.worst === 'gray');
+        g.classList.toggle('is-hidden', hideIt);
+      });
+      btn.innerHTML = (on ? icon('checkCircle') : '') + 'Your Work';
+    });
+  });
+})();
+</script>

--- a/docs/design/reference/text-links-flags.html
+++ b/docs/design/reference/text-links-flags.html
@@ -1,0 +1,281 @@
+<title>Words, links &amp; flags — v2</title>
+
+<style>
+  :root{ --pg:#0a0d11; --pg-ink:#eef2f7; --pg-ink2:#aab4c1; --pg-line:#2c343f; --pg-acc:#ff7e1f;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    --mono:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --na:#8b94a3; --na-bg:#2b343d; --wait:#6394cc; --now:#ffe14d; --bad:#ff4242; --badFill:#d63636; --done:#34d399; --commit:#2f6fd0;
+    --pnl:#171d25; --pnl2:#12171e; --edge:#2c343f; }
+  @media (prefers-color-scheme:light){ :root{ --pg:#e6e8ea; --pg-ink:#141821; --pg-ink2:#414b5a; --pg-line:#cfd6e1; --pg-acc:#cf6000; --pnl:#fff; --pnl2:#eef1f6; --edge:#cfd6e1; --commit:#1f56c0; --na:#566072; --wait:#2f5fb0; --now:#ffe14d; --bad:#d52a2a; --badFill:#b5241f; --done:#0c8f5f; } }
+  :root[data-theme="light"]{ --pg:#e6e8ea; --pg-ink:#141821; --pg-ink2:#414b5a; --pg-line:#cfd6e1; --pg-acc:#cf6000; --pnl:#fff; --pnl2:#eef1f6; --edge:#cfd6e1; --commit:#1f56c0; --na:#566072; --wait:#2f5fb0; --now:#ffe14d; --bad:#d52a2a; --badFill:#b5241f; --done:#0c8f5f; }
+  :root[data-theme="dark"]{ --pg:#0a0d11; --pg-ink:#eef2f7; --pg-ink2:#aab4c1; --pg-line:#2c343f; --pg-acc:#ff7e1f; --pnl:#171d25; --pnl2:#12171e; --edge:#2c343f; --commit:#2f6fd0; --na:#8b94a3; --wait:#6394cc; --now:#ffe14d; --bad:#ff4242; --badFill:#d63636; --done:#34d399; }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--pg); color:var(--pg-ink); font-family:var(--sans); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,22px) 60px}
+  .sheet{max-width:960px; margin:0 auto}
+  .eyebrow{font-family:var(--mono); font-size:11px; letter-spacing:.2em; text-transform:uppercase; color:var(--pg-ink2); margin:0}
+  h1{font-family:var(--mono); font-weight:700; font-size:clamp(19px,3.2vw,26px); line-height:1.1; margin:.3em 0 .35em; letter-spacing:-.01em}
+  h1 .hl{color:var(--pg-acc)}
+  .lede{max-width:82ch; font-size:13.5px; color:var(--pg-ink2); margin:0}
+  .lede b{color:var(--pg-ink); font-weight:600}
+  h2{font-family:var(--mono); font-size:13px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; margin:30px 0 4px; color:var(--pg-ink)}
+  h2 .n{color:var(--pg-acc)}
+  .sub{font-size:12.5px; color:var(--pg-ink2); margin:0 0 12px; max-width:82ch} .sub b{color:var(--pg-ink)}
+  code{font-family:var(--mono); font-size:.85em}
+
+  .card{border:1px solid var(--edge); border-radius:10px; background:var(--pnl); overflow:hidden; margin-top:12px}
+
+  /* law */
+  .axes{display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--edge); border:1px solid var(--edge); border-radius:10px; overflow:hidden; margin-top:16px}
+  @media (max-width:640px){ .axes{grid-template-columns:1fr} }
+  .ax{background:var(--pnl); padding:12px 13px}
+  .ax .t{font-family:var(--mono); font-size:11px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; margin-bottom:4px}
+  .ax.state .t{color:var(--pg-ink)} .ax.touch .t{color:var(--pg-acc)} .ax.commit .t{color:var(--commit)}
+  .ax p{margin:0; font-size:12px; color:var(--pg-ink2)} .ax p b{color:var(--pg-ink)}
+  .ax .demo{display:flex; gap:5px; margin-top:8px; flex-wrap:wrap; align-items:center}
+
+  .twoblue{display:flex; gap:16px; align-items:center; flex-wrap:wrap; margin-top:12px; padding:11px 13px; border:1px dashed var(--edge); border-radius:9px; background:var(--pnl2); font-size:12px; color:var(--pg-ink2)}
+  .twoblue b{color:var(--pg-ink)} .twoblue .col{display:flex; align-items:center; gap:8px}
+
+  /* type specimens */
+  .spec{display:grid; grid-template-columns:150px 1fr; border-bottom:1px solid var(--edge)}
+  .spec:last-child{border-bottom:0}
+  .spec .role{padding:10px 12px; border-right:1px solid var(--edge); background:var(--pnl2)}
+  .spec .role .rn{font-family:var(--mono); font-size:10px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--pg-ink)}
+  .spec .role .rr{font-size:10.5px; color:var(--pg-ink2); margin-top:2px}
+  .spec .ex{padding:10px 12px; display:flex; align-items:center; min-width:0; flex-wrap:wrap; gap:6px}
+  .t-title{font-family:var(--sans); font-weight:700; font-size:17px; color:var(--pg-ink); letter-spacing:-.01em}
+  .t-label{font-family:var(--mono); font-size:11px; font-weight:800; letter-spacing:.06em; text-transform:uppercase; color:var(--pg-ink)}
+  .t-flabel{font-family:var(--mono); font-size:9.5px; font-weight:700; letter-spacing:.06em; text-transform:uppercase; color:var(--pg-ink2)}
+  .t-value{font-family:var(--sans); font-size:13px; color:var(--pg-ink)}
+  .t-num{font-family:var(--mono); font-size:13px; color:var(--pg-ink2); font-weight:600}
+  .t-hint{font-family:var(--sans); font-size:12px; color:var(--pg-ink2); font-style:italic}
+
+  .demorow{display:flex; gap:9px; flex-wrap:wrap; align-items:center; padding:12px 13px}
+  .demorow + .demorow{border-top:1px solid var(--edge)}
+  .rlabel{font-family:var(--mono); font-size:9px; letter-spacing:.08em; text-transform:uppercase; color:var(--pg-ink2); width:100px; flex:none}
+
+  /* contact — show the value, make it the link */
+  .contact{font-family:var(--sans); font-size:13px; color:var(--pg-ink); text-decoration:none; display:inline-flex; align-items:center; gap:6px; cursor:pointer}
+  .contact svg{color:var(--pg-acc)} .contact .v{border-bottom:1.5px solid transparent} .contact:hover .v{border-bottom-color:var(--pg-acc)}
+  .mini{font-family:var(--mono); font-size:8.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; color:var(--pg-ink2); border:1px solid var(--edge); border-radius:4px; padding:2px 6px; cursor:pointer}
+  .mini:hover{border-color:var(--pg-acc); color:var(--pg-ink)}
+  .hlink{font-family:var(--sans); font-size:13px; color:var(--pg-ink); text-decoration:none; border-bottom:1.5px solid var(--pg-acc); padding-bottom:1px; cursor:pointer}
+  .hlink:hover{color:var(--pg-acc)} .hlink .ext{font-family:var(--mono); font-size:10px; color:var(--pg-acc)}
+  .dead{font-family:var(--sans); font-size:13px; color:var(--pg-ink2)}
+
+  /* reference token — icon in the square backing */
+  .ref{font-family:var(--sans); font-size:12px; font-weight:600; color:var(--pg-ink); background:var(--pg); border:1px solid var(--edge); border-radius:6px; padding:2px 8px 2px 3px; display:inline-flex; align-items:center; gap:6px; cursor:pointer; white-space:nowrap; text-decoration:none}
+  .ref .ty{display:inline-flex; align-items:center; justify-content:center; width:19px; height:19px; color:var(--pg-acc); background:rgba(255,126,31,.15); border-radius:4px}
+  .ref .ty svg{width:12px; height:12px}
+  .ref:hover{border-color:var(--pg-acc)} .ref:hover .nm{text-decoration:underline; text-decoration-color:var(--pg-acc)}
+  .ref small{color:var(--na); font-family:var(--mono); font-size:9px; font-weight:500}
+  .trace{display:flex; align-items:center; gap:6px; flex-wrap:wrap}
+  .trace .arr{color:var(--pg-ink2); font-family:var(--mono); font-size:12px}
+
+  /* flags */
+  .buckets{display:grid; grid-template-columns:1fr 1fr; gap:1px; background:var(--edge)}
+  @media (max-width:640px){ .buckets{grid-template-columns:1fr} }
+  .bk{background:var(--pnl); padding:12px 13px}
+  .bk .bh{font-family:var(--mono); font-size:10.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; margin-bottom:3px}
+  .bk.sig .bh{color:var(--pg-ink)} .bk.tag .bh{color:var(--pg-ink2)}
+  .bk .bd{font-size:11.5px; color:var(--pg-ink2); margin-bottom:9px} .bk .bd b{color:var(--pg-ink)}
+  .bk .demo{display:flex; gap:8px; flex-wrap:wrap; align-items:center}
+
+  .chip{font-family:var(--mono); font-size:8.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; padding:3px 6px; border-radius:2px; white-space:nowrap; display:inline-block}
+  .f.red{background:var(--badFill);color:#fff} .o.red{color:var(--bad);box-shadow:inset 0 0 0 1.3px var(--bad)}
+  .f.blue{background:var(--wait);color:#0b1420} .o.blue{color:var(--wait);box-shadow:inset 0 0 0 1.3px var(--wait)}
+  .f.yellow{background:var(--now);color:#171206} .o.yellow{color:var(--now);box-shadow:inset 0 0 0 1.3px var(--now)}
+  .o.grey{color:var(--na);box-shadow:inset 0 0 0 1.3px var(--na)}
+  /* STAMP: fact = chip text, no box, no colour */
+  .stamp{font-family:var(--mono); font-size:8.5px; font-weight:700; letter-spacing:.03em; text-transform:uppercase; color:var(--na); white-space:nowrap}
+  .stamp.more{color:var(--pg-acc)}
+  .dotsep{color:var(--edge); font-family:var(--mono); font-size:9px}
+
+  /* gates + names */
+  .gate{font-family:var(--mono); font-size:8.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; padding:3px 6px 3px 5px; border-radius:2px; white-space:nowrap; display:inline-flex; align-items:center; gap:2px; cursor:pointer}
+  .gate .car{display:inline-flex; align-items:center; justify-content:center; width:11px; height:11px} .gate .car svg{width:11px; height:11px; display:block}
+  .gate.y{background:var(--now); color:#171206} .gate.b{background:var(--wait); color:#0b1420} .gate.r{background:var(--badFill); color:#fff}
+  .menu{border:1px solid var(--edge); border-radius:7px; overflow:hidden; background:var(--pnl); width:170px; box-shadow:0 10px 26px rgba(0,0,0,.4)}
+  .menu .mi{display:flex; align-items:center; gap:8px; padding:7px 10px; font-size:11.5px; color:var(--pg-ink); border-bottom:1px solid var(--edge); cursor:pointer}
+  .menu .mi:last-child{border-bottom:0} .menu .mi:hover{background:var(--pnl2)}
+  .menu .mi .sw{width:8px; height:8px; border-radius:2px; flex:none}
+  .menu .mi.on{font-weight:800} .menu .mi.on:after{content:"✓"; margin-left:auto; color:var(--pg-acc); font-family:var(--mono); font-size:11px}
+  .selfield{font-family:var(--sans); font-size:12px; color:var(--pg-ink); border:1px solid var(--edge); border-radius:6px; padding:5px 8px; display:inline-flex; align-items:center; gap:8px; cursor:pointer}
+  .selfield .car{color:var(--pg-acc); font-family:var(--mono)}
+  .door{font-family:var(--mono); font-size:9.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; color:var(--pg-ink); background:transparent; border:1px solid var(--edge); border-radius:6px; padding:5px 9px; cursor:pointer}
+  .door.commit{background:var(--commit); color:#fff; border-color:var(--commit)}
+
+  .names{border:1px solid var(--edge); border-radius:10px; overflow:hidden; margin-top:12px}
+  .nr{display:grid; grid-template-columns:88px 150px 1fr; align-items:center; border-bottom:1px solid var(--edge)}
+  .nr:last-child{border-bottom:0}
+  .nr.head{background:var(--pnl2); font-family:var(--mono); font-size:9px; letter-spacing:.08em; text-transform:uppercase; color:var(--pg-ink2)}
+  .nr .c{padding:10px 12px; min-width:0}
+  .nr .nmn{font-family:var(--mono); font-size:11px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--pg-acc)}
+  .nr .cc{border-right:1px solid var(--edge)} .nr .dd{font-size:12px; color:var(--pg-ink2)} .nr .dd b{color:var(--pg-ink)}
+
+  /* before/after */
+  .ba{display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:12px}
+  @media (max-width:700px){ .ba{grid-template-columns:1fr} }
+  .bax{border:1px solid var(--edge); border-radius:10px; overflow:hidden}
+  .bah{font-family:var(--mono); font-size:10px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; padding:8px 11px; border-bottom:1px solid var(--edge)}
+  .bax.now .bah{color:var(--bad); background:rgba(255,66,66,.08)}
+  .bax.new .bah{color:var(--done); background:rgba(52,211,153,.08)}
+  .bab{padding:12px 12px; background:var(--pnl)}
+  .messrow{display:flex; gap:8px; flex-wrap:wrap; align-items:center; margin-bottom:8px}
+  .messrow:last-child{margin-bottom:0}
+  .bluelink{color:#5b9bd5; text-decoration:underline; font-size:12.5px; cursor:pointer}
+  .fakeqr{font-family:var(--mono); font-size:8.5px; font-weight:800; text-transform:uppercase; color:#5b9bd5; text-decoration:underline dotted; padding:2px 5px; border:1px solid var(--edge); border-radius:3px}
+  .badge-g{font-family:var(--mono); font-size:8.5px; font-weight:800; text-transform:uppercase; background:#3a7d44; color:#fff; padding:3px 6px; border-radius:3px}
+  .badge-r{font-family:var(--mono); font-size:8.5px; font-weight:800; text-transform:uppercase; background:#b0413c; color:#fff; padding:3px 6px; border-radius:3px}
+  .badge-b{font-family:var(--mono); font-size:8.5px; font-weight:800; text-transform:uppercase; background:#3f6fa0; color:#fff; padding:3px 6px; border-radius:3px}
+  .plainph{font-size:12.5px; color:var(--pg-ink2)}
+  .xnote{font-size:10.5px; color:var(--bad); font-family:var(--mono); margin-top:4px}
+  .gnote{font-size:10.5px; color:var(--done); font-family:var(--mono); margin-top:4px}
+  .name{font-family:var(--sans); font-weight:700; font-size:15px; color:var(--pg-ink)}
+
+  .foot{margin-top:26px; padding-top:16px; border-top:1px solid var(--pg-line); font-size:13.5px; color:var(--pg-ink2); max-width:84ch}
+  .foot b{color:var(--pg-ink)}
+  .map{display:flex; gap:6px 14px; flex-wrap:wrap; margin-top:8px; font-family:var(--mono); font-size:11px; color:var(--pg-ink2)}
+  .map b{color:var(--pg-acc)} .map .cm{color:var(--commit)}
+  .q{border-left:3px solid var(--pg-acc); background:var(--pnl2); padding:10px 13px; border-radius:0 8px 8px 0; margin-top:10px; font-size:12.5px; color:var(--pg-ink2)} .q b{color:var(--pg-ink)}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Connective layer · refreshed to the locked, CVD-checked palette</p>
+  <h1>Words, links &amp; flags — <span class="hl">v3</span></h1>
+  <p class="lede">Now on the same locked standard as the detail views: the <b>CVD-picked yellow</b> (well clear of orange), the <b>muted blue</b> and <b>deepened filled-red</b> that clear AA, the deep <b>commit-blue</b>, mono-stamped labels — and the gate lost its orange dot for a <b>leading chevron</b>. The parts are unchanged: contact shows the real number, refs carry the parent icon, facts are plain Stamps, and Signal · Gate · Stamp · Ref · Door name the pieces.</p>
+
+  <h2><span class="n">0.</span> The colour law — now with your blue</h2>
+  <p class="sub">You didn't love white for save. The honest snag: <b>blue is already a status colour (Waiting)</b>. The clean way to still use blue is to make <b>commit</b> a <i>deep, saturated</i> blue and keep <b>Waiting</b> a <i>pale, desaturated</i> one — and commit is always a big solid button while Waiting is always a tiny chip, so they never read the same. That's the split, locked.</p>
+  <div class="axes">
+    <div class="ax state"><div class="t">Status colours → STATE</div><p>Red / yellow / blue / green / grey say <b>what's going on</b>. Never used to decorate.</p><div class="demo"><span class="chip f red">owed 16d</span><span class="chip f yellow">due back</span><span class="chip f blue">ACH</span></div></div>
+    <div class="ax touch"><div class="t">Orange → TOUCHABLE</div><p>The one accent = <b>"you can act on this"</b> — toggles, links, reference tokens, gate carets.</p><div class="demo"><a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><span class="nm">Duhon</span></a></div></div>
+    <div class="ax commit"><div class="t">Deep blue → COMMIT</div><p>The one button that <b>writes / saves / confirms</b>. Deep, saturated, solid — rare on the page, so it always means "commit."</p><div class="demo"><span class="door commit">Save</span></div></div>
+  </div>
+  <div class="twoblue">
+    <span class="col"><span class="chip f blue">ACH</span> <b>Waiting</b> — pale, tiny chip</span>
+    <span class="col"><span class="door commit">Save</span> <b>Commit</b> — deep, solid button</span>
+    <span>Different saturation, different shape, never adjacent → <b>no collision.</b> If you'd rather, orange can carry commit instead and blue stays purely status.</span>
+  </div>
+
+  <h2><span class="n">1.</span> Text — six roles, nothing more</h2>
+  <p class="sub">Labels <b>stamped</b> (Saira/data-plate), content <b>sans</b>, anything technical (#, $, time, S/N) <b>mono</b> so it aligns as machine-truth. Three families, six roles, never a seventh.</p>
+  <div class="card">
+    <div class="spec"><div class="role"><div class="rn">Record title</div><div class="rr">sans · 700</div></div><div class="ex"><span class="t-title">Boudreaux Marine LLC</span></div></div>
+    <div class="spec"><div class="role"><div class="rn">Stamped label</div><div class="rr">section &amp; field · mono</div></div><div class="ex"><span class="t-label">Work Orders</span><span class="t-flabel">Purchase date</span></div></div>
+    <div class="spec"><div class="role"><div class="rn">Value / body</div><div class="rr">sans</div></div><div class="ex"><span class="t-value">Marine construction · Cameron, LA</span></div></div>
+    <div class="spec"><div class="role"><div class="rn">Number / ID / time</div><div class="rr">mono · muted · tabular</div></div><div class="ex"><span class="t-num">#4471 · $560 · 2h ago · S/N 4471-K</span></div></div>
+    <div class="spec"><div class="role"><div class="rn">Chip / flag</div><div class="rr">mono · tiny · caps</div></div><div class="ex"><span class="chip f yellow">due back</span></div></div>
+    <div class="spec"><div class="role"><div class="rn">Hint / empty</div><div class="rr">sans · italic · muted</div></div><div class="ex"><span class="t-hint">No cards on file yet</span></div></div>
+  </div>
+
+  <h2><span class="n">2.</span> Links — show the value, make the value the link</h2>
+  <p class="sub"><b>The number is visible so you can read it off a desktop and dial from your handheld</b> — the value <i>is</i> the link, not a "Call" verb. Same for email. And the honest rule holds: if it looks tappable it is; if not, it's plain text.</p>
+  <div class="card">
+    <div class="demorow"><span class="rlabel">Phone</span>
+      <a class="contact"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z" transform="translate(-1 -1)"/></svg><span class="v">(337) 555-0142</span></a>
+      <span class="mini">✦ text</span>
+      <span class="dead" style="font-size:11px">— <code>tel:</code> / <code>sms:</code>, always readable</span></div>
+    <div class="demorow"><span class="rlabel">Email</span>
+      <a class="contact"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m2 7 10 6 10-6"/></svg><span class="v">marc@boudreaux-marine.com</span></a>
+      <span class="dead" style="font-size:11px">— shown too (your call; I left it visible)</span></div>
+    <div class="demorow"><span class="rlabel">True hyperlink</span>
+      <a class="hlink">manufacturer service schedule <span class="ext">↗</span></a>
+      <span class="dead" style="font-size:11px">— rare, external. Ink + accent underline + ↗.</span></div>
+    <div class="demorow"><span class="rlabel">Dead text</span>
+      <span class="dead">S/N 4471-K</span><span class="dead" style="font-size:11px">— not interactive → no underline, no cursor. Honest.</span></div>
+  </div>
+
+  <h2><span class="n">3.</span> Linked items — parent icon in the square backing</h2>
+  <p class="sub">Kept the chip shape and the square backing you liked — swapped the two-letter code for the <b>parent record's icon</b> (Lucide, matched to each type). Still quiet, name-forward, one accent mark — unlike a status chip. Tap to open (or expand inline).</p>
+  <div class="card">
+    <div class="demorow"><span class="rlabel">The six types</span>
+      <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><span class="nm">Duhon Contracting</span></a>
+      <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span><span class="nm">Skid Steer</span> <small>SS-12</small></a>
+      <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span><span class="nm">Rental</span> <small>#4471</small></a>
+      <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8M8 15h5"/></svg></span><span class="nm">Invoice</span> <small>#4460</small></a>
+      <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.6 2.6A2 2 0 0 0 11.2 2H4a2 2 0 0 0-2 2v7.2a2 2 0 0 0 .6 1.4l8.7 8.7a2.4 2.4 0 0 0 3.4 0l6.6-6.6a2.4 2.4 0 0 0 0-3.4z"/><circle cx="7.5" cy="7.5" r="1.3"/></svg></span><span class="nm">Excavator</span></a>
+      <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg></span><span class="nm">Cameron, LA</span></a></div>
+    <div class="demorow"><span class="rlabel">A trace</span>
+      <div class="trace">
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><span class="nm">Duhon</span></a><span class="arr">→</span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M8 2v4M16 2v4M3 10h18"/></svg></span><span class="nm">Rental</span> <small>#4471</small></a><span class="arr">→</span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.6a1 1 0 0 0-.2-.6l-3.5-4.4A1 1 0 0 0 17.5 8H14"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span><span class="nm">Skid Steer</span></a><span class="arr">→</span>
+        <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1z"/><path d="M8 7h8M8 11h8"/></svg></span><span class="nm">#4460</span></a> <span class="chip f red" style="margin-left:2px">owed 16d</span>
+      </div></div>
+  </div>
+
+  <h2><span class="n">4.</span> Flags — pill dropped, fact = plain stamp</h2>
+  <p class="sub">You called it: no circle around facts. A fact now uses the <b>same text as a status chip but drops the box and the colour</b> — so it can sit right beside a status chip and read as its quiet sibling. The eye sorts them instantly: <b>in a coloured box = attention; plain = fact.</b></p>
+  <div class="card"><div class="buckets">
+    <div class="bk sig">
+      <div class="bh">Status flag → coloured chip</div>
+      <div class="bd">Carries a move / urgency. One source per fact (kills the UD-002/046 contradictions).</div>
+      <div class="demo"><span class="chip f red">field call</span><span class="chip o yellow">protection off</span><span class="chip f yellow">no rates</span><span class="chip o grey">mixed</span></div>
+    </div>
+    <div class="bk tag">
+      <div class="bh">Fact → plain stamp (no box)</div>
+      <div class="bd">Just a fact. Same type as a chip, no box, no colour. Budgeted — overflow rolls to <span class="stamp more">+2</span>.</div>
+      <div class="demo"><span class="stamp">Non-member</span><span class="dotsep">·</span><span class="stamp">Excavator</span><span class="dotsep">·</span><span class="stamp">PO 4821</span><span class="dotsep">·</span><span class="stamp">Marine</span><span class="stamp more">+2</span></div>
+    </div>
+  </div>
+  <div class="demorow card" style="margin-top:12px"><span class="rlabel">Side by side</span>
+    <span class="chip f red">owed 16d</span><span class="stamp">Non-member</span><span class="dotsep">·</span><span class="stamp">Marine</span><span class="dotsep">·</span><span class="stamp">Net 15</span>
+    <span class="dead" style="font-size:11px; margin-left:6px">— one glance: the red box is the state, the rest are facts.</span></div>
+
+  <h2><span class="n">5.</span> Chips, gates &amp; dropdowns — how they relate, and their names</h2>
+  <p class="sub">Your question: do status gates <b>compete</b> with status chips? No — they <b>merge</b>. A plain chip is <b>read-only</b> SIGNAL. A <b>gate</b> is that same chip <b>made turnable</b>: same colour = state, plus a leading chevron, and tapping opens the picker to advance it. That's the one spot SIGNAL and DOOR become a single control. A plain dropdown that <i>isn't</i> status stays neutral (orange caret = touchable, no colour).</p>
+  <div class="card">
+    <div class="demorow"><span class="rlabel">Read-only</span><span class="chip f yellow">end rent</span><span class="dead" style="font-size:11px">— a <b>SIGNAL</b>. Reports state. Not tappable.</span></div>
+    <div class="demorow" style="align-items:flex-start"><span class="rlabel">Turnable</span>
+      <span class="gate y"><span class="car"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>end rent</span>
+      <div class="menu" style="margin-left:4px">
+        <div class="mi"><span class="sw" style="background:var(--na)"></span>Reserved</div>
+        <div class="mi"><span class="sw" style="background:var(--wait)"></span>On Rent</div>
+        <div class="mi on"><span class="sw" style="background:var(--now)"></span>End Rent</div>
+        <div class="mi"><span class="sw" style="background:var(--done)"></span>Returned</div>
+      </div>
+      <span class="dead" style="font-size:11px; max-width:150px">— a <b>GATE</b>. Same chip, now opens the picker. The leading chevron = you can turn it.</span></div>
+    <div class="demorow"><span class="rlabel">Plain dropdown</span><span class="selfield">Rider: All-risk <span class="car">▾</span></span><span class="dead" style="font-size:11px">— not a status → neutral control, orange caret, no colour.</span></div>
+  </div>
+
+  <p class="sub" style="margin-top:16px"><b>The names</b> — so we can point at things fast:</p>
+  <div class="names">
+    <div class="nr head"><div class="c cc">Name</div><div class="c cc">Looks like</div><div class="c">Means</div></div>
+    <div class="nr"><div class="c cc"><span class="nmn">Signal</span></div><div class="c cc"><span class="chip f red">owed 16d</span></div><div class="c dd">Coloured chip, <b>read-only</b>. State + fill = live today.</div></div>
+    <div class="nr"><div class="c cc"><span class="nmn">Gate</span></div><div class="c cc"><span class="gate b"><span class="car"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>on rent</span></div><div class="c dd">A Signal you can <b>turn</b> — opens a picker to advance status.</div></div>
+    <div class="nr"><div class="c cc"><span class="nmn">Stamp</span></div><div class="c cc"><span class="stamp">Non-member</span></div><div class="c dd">A plain <b>fact</b> — chip text, no box, no colour.</div></div>
+    <div class="nr"><div class="c cc"><span class="nmn">Ref</span></div><div class="c cc"><a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span><span class="nm">Duhon</span></a></div><div class="c dd">A <b>linked item</b> — parent icon + name, walks to that record.</div></div>
+    <div class="nr"><div class="c cc"><span class="nmn">Door</span></div><div class="c cc"><span class="door">+ Invoice</span></div><div class="c dd">A <b>verb action</b>. Ghost normally; <b>deep-blue</b> when it commits.</div></div>
+  </div>
+
+  <h2><span class="n">6.</span> All of it, on one header — mess vs. layer</h2>
+  <div class="ba">
+    <div class="bax now">
+      <div class="bah">Roughly what's there now (per the findings)</div>
+      <div class="bab">
+        <div class="messrow"><span class="name">Boudreaux Marine</span> <a class="bluelink">Boudreaux Marine LLC</a> <span class="fakeqr">QR</span></div>
+        <div class="messrow"><span class="badge-g">Member</span><span class="badge-r">Past Due</span><span class="badge-b">Marine</span><span class="badge-g">Insured</span><span class="badge-r">No Card</span></div>
+        <div class="messrow"><span class="plainph">(337) 555-0142</span></div>
+        <div class="xnote">✕ blue link that isn't status · ✕ fake-clickable QR · ✕ colours competing · ✕ phone is dead text</div>
+      </div>
+    </div>
+    <div class="bax new">
+      <div class="bah">The connective layer</div>
+      <div class="bab">
+        <div class="messrow"><span class="name">Boudreaux Marine LLC</span> <span class="chip f red">owed 16d</span></div>
+        <div class="messrow"><span class="stamp">Non-member</span><span class="dotsep">·</span><span class="stamp">Marine</span><span class="dotsep">·</span><span class="stamp">Net 15</span><span class="stamp more">+1</span></div>
+        <div class="messrow"><a class="contact"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z" transform="translate(-1 -1)"/></svg><span class="v">(337) 555-0142</span></a><span class="mini">✦ text</span><a class="contact"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m2 7 10 6 10-6"/></svg><span class="v">marc@…</span></a></div>
+        <div class="gnote">✓ one Signal = the state · ✓ facts are plain Stamps · ✓ number visible &amp; live · ✓ nothing fake</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="foot">
+    Vocabulary locked-in-waiting: <b>Signal</b> (read-only state) · <b>Gate</b> (state you can turn) · <b>Stamp</b> (plain fact) · <b>Ref</b> (linked item) · <b>Door</b> (action). And the law:
+    <div class="map"><b>status colour</b> = what · <b>orange</b> = touchable · <span class="cm">deep blue</span> = commit · plain text = fact / honest.</div>
+    <div class="q">Open decisions for you: <b>(1)</b> commit = deep blue (shown) — good, or should orange carry commit and blue stay purely status? <b>(2)</b> show the email value in full or truncate to <code>marc@…</code>? <b>(3)</b> the names — keep Signal / Gate / Stamp / Ref / Door, or rename any? Then we harden the sections idea with this layer folded in (and your role-default-landing + drag-to-resort parked for it).</div>
+  </div>
+
+</div></div>

--- a/docs/design/reference/trips-card.html
+++ b/docs/design/reference/trips-card.html
@@ -1,0 +1,710 @@
+<title>Trips — dispatch v2, rebuilt on the new model</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#838e9c;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redFill:#d63636; --onRedFill:#fdfdfd;
+    --blue:#6394cc; --commit:#2f6fd0; --onCommit:#fdfdfd; --gray:#8b94a3; --tan:#c2925a;
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1320px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:96ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600}
+  .key{display:flex; flex-wrap:wrap; gap:6px 12px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+
+  /* ---------- the five parts (kept identical to the approved detail-views look) ---------- */
+  .ctl{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .sig{padding:0 8px; border-radius:7px}
+  .sig.f.red{background:var(--redFill);color:var(--onRedFill)} .sig.o.red{color:var(--red);box-shadow:inset 0 0 0 1.3px var(--red)}
+  .sig.f.yellow{background:var(--yellow);color:var(--onAcc)} .sig.o.yellow{color:var(--yellow);box-shadow:inset 0 0 0 1.3px var(--yellow)}
+  .sig.f.green{background:var(--green);color:var(--onAcc)} .sig.o.green{color:var(--green);box-shadow:inset 0 0 0 1.3px var(--green)}
+  .sig.o.grey{color:var(--gray);box-shadow:inset 0 0 0 1.3px var(--gray)}
+  .gate{padding:0 8px 0 6px; border-radius:7px; gap:2px; cursor:pointer; border:0}
+  .gate .cv{display:inline-flex;align-items:center;justify-content:center;width:11px;height:11px} .gate .cv svg{width:11px;height:11px;display:block}
+  .gate.grey{background:var(--gray);color:var(--onAcc)}
+  .gate.o.grey{background:transparent;color:var(--txt3);box-shadow:inset 0 0 0 1.3px var(--line)}
+  .gate.yellow{background:var(--yellow);color:var(--onAcc)}
+  .gate.green{background:var(--green);color:var(--onAcc)}
+  .gate.red{background:var(--redFill);color:var(--onRedFill)}
+  .stamp{font-family:var(--stamp); font-size:10px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap}
+  .dot{color:var(--line); font-family:var(--stamp); font-size:10px}
+  .ref{height:var(--h); display:inline-flex; align-items:center; gap:6px; padding:0 8px 0 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:600; cursor:pointer; text-decoration:none; white-space:nowrap}
+  .ref.warn{border-color:var(--red)}
+  .ref .ty{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .ref .ty svg{width:10px;height:10px}
+  .door{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; cursor:pointer; border-radius:999px; padding:0 13px; border:0}
+  .door.save{background:var(--commit); color:var(--onCommit)}
+  .door.ghost{background:transparent; color:var(--txt2); border:1px solid var(--line)}
+  .door.dash{background:transparent; color:var(--commit); border:1.4px dashed var(--commit)}
+  .clink{display:inline-flex; align-items:center; gap:6px; color:var(--txt); font-size:12px; text-decoration:none; font-family:var(--font); height:var(--h)}
+  .clink svg{color:var(--accent); width:13px; height:13px; flex:none} .clink .v{border-bottom:1.4px solid transparent} .clink:hover .v{border-bottom-color:var(--accent)}
+
+  /* ---------- page-level Dispatch/Driver toggle + the 4-way +Trip toggle (Door rule: toggle w/ no status = orange fill, dark ink) ---------- */
+  .viewtoggle{display:inline-flex; height:var(--h); border:1px solid var(--line); border-radius:7px; overflow:hidden; flex:none}
+  .viewtoggle button{all:unset; box-sizing:border-box; cursor:pointer; height:100%; display:inline-flex; align-items:center; gap:5px; padding:0 12px; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); border-right:1px solid var(--line)}
+  .viewtoggle button:last-child{border-right:0}
+  .viewtoggle button.on{background:var(--accent); color:var(--onAcc)}
+  .viewtoggle button svg{width:12px;height:12px}
+  .toggle4{display:inline-flex; height:var(--h); border-radius:7px; overflow:hidden; border:1px solid var(--line); flex:none}
+  .toggle4 button{all:unset; box-sizing:border-box; cursor:pointer; height:100%; padding:0 11px; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3); border-right:1px solid var(--line); display:inline-flex; align-items:center}
+  .toggle4 button:last-child{border-right:0}
+  .toggle4 button.on{background:var(--accent); color:var(--onAcc)}
+
+  .tip{position:relative; display:inline-block}
+  .tip>.ctl{cursor:help}
+  .tip .bub{position:absolute; bottom:calc(100% + 8px); left:0; width:max-content; max-width:min(72vw,270px); background:#05070a; color:#eef2f7; border:1px solid #3a444e; border-radius:7px; padding:8px 10px; font-family:var(--font); font-size:12px; line-height:1.42; text-transform:none; letter-spacing:0; opacity:0; transform:translateY(4px); pointer-events:none; transition:opacity .12s, transform .12s; z-index:30}
+  .tip:hover .bub, .tip:focus-within .bub{opacity:1; transform:translateY(0)}
+  .tip .bub .t{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--red); display:block; margin-bottom:3px}
+  .tip .bub .go{color:var(--commit); font-weight:700}
+
+  .reason{font-family:var(--font); font-size:12px; color:var(--txt2); background:rgba(214,54,54,.14); border:1px solid rgba(214,54,54,.4); border-radius:7px; padding:6px 9px; display:flex; align-items:center; gap:7px}
+  .reason svg{width:13px;height:13px; color:var(--red); flex:none}
+
+  /* ================= the +Trip creation snippet (rental-side entry point, §8.1) ================= */
+  .addtrip{background:var(--card); border:1px dashed var(--line); border-radius:12px; padding:12px 14px; margin-top:16px; display:flex; align-items:center; gap:12px; flex-wrap:wrap}
+  .addtrip .at-label{font-family:var(--stamp); font-size:9.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--txt3); flex-basis:100%}
+  .addtrip .at-cap{flex-basis:100%; font-size:12px; color:var(--txt3); font-style:italic; margin-top:2px}
+  .addtrip .at-cap b{color:var(--txt2); font-style:normal}
+
+  /* ================= surface ladder (Priority #1 contrast fix): bg < card(trough) < panel(trip card) < cardh(stop well) ================= */
+  .stage{display:grid; grid-template-columns:minmax(0,1.5fr) minmax(280px,.95fr) 334px; gap:16px; margin-top:16px; align-items:start}
+  @media (max-width:1280px){ .stage{grid-template-columns:minmax(0,1.5fr) minmax(280px,.95fr)} .stage>.phonewrap{grid-column:1/-1; justify-self:center} }
+  @media (max-width:860px){ .stage{grid-template-columns:1fr} .stage>.phonewrap{justify-self:stretch} }
+
+  .dpanel{background:var(--card); border:1px solid var(--line); border-radius:14px; overflow:hidden; display:flex; flex-direction:column}
+  .dhead{padding:11px 14px 10px; display:flex; align-items:flex-start; justify-content:space-between; gap:10px; flex-wrap:wrap; border-bottom:1px solid var(--line)}
+  .dh-name{font-family:var(--font); font-weight:700; font-size:15px; color:var(--txt); letter-spacing:-.005em}
+  .dh-sub{font-size:11px; color:var(--txt3); margin-top:2px; font-family:var(--stamp); letter-spacing:.02em}
+
+  .draglegend{display:flex; flex-wrap:wrap; gap:8px 16px; padding:9px 14px; background:var(--bg2); border-bottom:1px solid var(--line)}
+  .draglegend .li{display:inline-flex; align-items:center; gap:6px; font-size:11px; color:var(--txt3)}
+  .draglegend .li b{color:var(--txt2); font-weight:600}
+  .draglegend svg{width:12px;height:12px; color:var(--txt3); flex:none}
+
+  .railcap{padding:8px 14px; font-size:11px; color:var(--txt3); font-style:italic; border-bottom:1px solid var(--line); background:var(--bg2)}
+
+  .dgroup{border-bottom:1px solid var(--line)}
+  .dgroup:last-child{border-bottom:0}
+  .dghead{display:flex; align-items:center; gap:9px; padding:9px 14px; border-left:3px solid var(--gray)}
+  .dghead.red{border-left-color:var(--redFill)}
+  .dghead.yellow{border-left-color:var(--yellow)}
+  .dghead.green{border-left-color:var(--green)}
+  .dglabel{font-family:var(--stamp); font-weight:800; font-size:12px; letter-spacing:.06em; text-transform:uppercase; color:var(--txt)}
+
+  .dgbody{padding:11px 12px 12px; display:flex; flex-direction:column; gap:11px}
+  .rbody{padding:11px 12px 12px; display:flex; flex-direction:column; gap:10px}
+
+  /* ---- trip card: a real step UP off the trough (--card) onto --panel, with air + a lift so cards don't blur together ---- */
+  .trip{background:var(--panel); border:1px solid var(--line); border-radius:11px; padding:10px 11px 11px; box-shadow:0 1px 0 rgba(255,255,255,.03) inset, 0 5px 12px rgba(4,6,9,.3)}
+  .trip.st-bad{border-color:rgba(214,54,54,.55)}
+  .trip.st-warn{border-color:rgba(238,212,75,.4)}
+  .trip-top{display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .dragh{display:inline-flex; color:var(--txt3); cursor:grab; flex:none; opacity:.75}
+  .dragh svg{width:13px;height:13px}
+  .trip-spacer{flex:1; min-width:6px}
+
+  .driverpick{margin-top:8px; background:var(--cardh); border:1px solid var(--line); border-radius:9px; padding:5px; display:flex; flex-direction:column; gap:1px}
+  .driverpick .dp-cap{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; color:var(--txt3); padding:4px 8px 5px}
+  .drow{display:flex; align-items:center; justify-content:space-between; gap:10px; padding:6px 8px; border-radius:6px; flex-wrap:wrap}
+  .drow.sel{background:rgba(255,126,31,.13); box-shadow:inset 0 0 0 1px rgba(255,126,31,.32)}
+  .drow .dname{font-family:var(--font); font-weight:700; font-size:13px; color:var(--txt)}
+  .drow .dstate{font-size:11px; color:var(--txt3)}
+  .drow .dstate.busy{color:var(--red); font-weight:600}
+  .drow .dstate.near{color:var(--txt2)}
+
+  /* ---- stops nested inside a trip: step UP again to --cardh, the brightest surface — the thing a dispatcher actually reads ---- */
+  .tstops{margin-top:9px; display:flex; flex-direction:column; gap:5px}
+  .tstop{display:flex; align-items:center; gap:8px; flex-wrap:wrap; background:var(--cardh); border:1px solid var(--lineSoft); border-radius:8px; padding:6px 8px}
+  .seq{font-family:var(--stamp); font-size:9.5px; font-weight:800; color:var(--txt3); background:var(--card); width:15px; height:15px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; flex:none}
+  .stoptype{display:inline-flex; align-items:center; gap:4px; font-family:var(--stamp); font-size:10px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt3); flex:none}
+  .stoptype svg{width:11px;height:11px}
+  .tdoor{display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-top:9px}
+  .futurelink{margin-top:8px; padding-top:8px; border-top:1px dashed var(--lineSoft); font-size:11px; color:var(--txt3); display:flex; align-items:center; gap:6px}
+  .futurelink svg{width:12px;height:12px;flex:none} .futurelink b{color:var(--txt2)}
+
+  /* ---- right rail: unplanned stops, sorted by urgency ---- */
+  .railitem{background:var(--panel); border:1px solid var(--line); border-radius:9px; padding:8px 9px; display:flex; flex-direction:column; gap:6px}
+  .railitem.far{opacity:.62; border-style:dashed}
+  .ri-top{display:flex; align-items:center; gap:7px; flex-wrap:wrap}
+  .ri-due{display:flex; align-items:center; gap:4px; font-family:var(--stamp); font-size:10px; color:var(--txt3)}
+  .ri-due svg{width:10px;height:10px}
+
+  .htail{padding:9px 14px; border-top:1px solid var(--line)}
+  .h4{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt); margin-bottom:2px}
+  .hnote{font-size:11px; color:var(--txt3)}
+
+  /* ---------- phone frame (kept — driver view Jac liked) ---------- */
+  .phonewrap{display:flex; flex-direction:column; align-items:center; gap:10px}
+  .phone{width:334px; max-width:100%; padding:11px; background:#151a21; border:1px solid #262e38; border-radius:32px}
+  .phone-status{display:flex; justify-content:space-between; padding:3px 10px 8px; font-family:var(--stamp); font-size:9.5px; letter-spacing:.04em; color:var(--txt3)}
+  .phone-screen{background:var(--bg); border:1px solid #0d1116; border-radius:22px; overflow:hidden; display:flex; flex-direction:column}
+
+  .papp-top{display:flex; align-items:center; justify-content:space-between; gap:8px; padding:11px 12px 9px; border-bottom:1px solid var(--line)}
+  .papp-title{font-family:var(--stamp); font-weight:800; font-size:13px; letter-spacing:.06em; text-transform:uppercase; color:var(--txt)}
+
+  .pdriver{padding:10px 12px 0; display:flex; align-items:center; justify-content:space-between; gap:8px; flex-wrap:wrap}
+  .pd-name{font-family:var(--font); font-weight:700; font-size:15px; color:var(--txt)}
+  .pd-sub{font-size:11px; color:var(--txt3); margin-top:1px; font-family:var(--stamp); letter-spacing:.02em}
+  .rolebadge{display:inline-flex; align-items:center; gap:5px; font-family:var(--stamp); font-size:9px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--tan); border:1px dashed var(--tan); border-radius:7px; padding:3px 7px; flex:none}
+  .rolebadge svg{width:10px;height:10px}
+
+  .nownext{margin:10px 12px 0; padding:10px 11px; background:var(--cardh); border:1px solid var(--line); border-radius:9px; display:flex; flex-direction:column; gap:6px}
+  .nn-row{display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .nn-tag{font-family:var(--stamp); font-size:10px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; flex:none}
+  .nn-tag.now{color:var(--yellow)}
+  .nn-tag.next{color:var(--commit)}
+  .nn-headline{font-family:var(--font); font-weight:700; font-size:13px; color:var(--txt)}
+  .nn-sub{font-size:11.5px; color:var(--txt2)}
+
+  .stops{padding:6px 12px 4px}
+  .stop{display:grid; grid-template-columns:16px 1fr; gap:10px}
+  .stop-col{display:flex; flex-direction:column; align-items:center}
+  .stop-dot{width:10px; height:10px; border-radius:50%; margin-top:5px; flex:none; background:var(--gray)}
+  .stop.done .stop-dot{background:var(--green)}
+  .stop.current .stop-dot{background:var(--yellow); box-shadow:0 0 0 3px rgba(238,212,75,.28)}
+  .stop.trouble .stop-dot{background:var(--redFill); box-shadow:0 0 0 3px rgba(214,54,54,.26)}
+  .stop.upcoming .stop-dot{background:transparent; border:2px solid var(--line)}
+  .stop-conn{width:2px; flex:1; min-height:16px; background:var(--line); margin-top:2px}
+  .stop:last-child .stop-conn{display:none}
+  .stop-content{padding-bottom:14px; border-bottom:1px solid var(--lineSoft); min-width:0}
+  .stop:last-child .stop-content{border-bottom:0; padding-bottom:2px}
+  .stop-head{display:flex; align-items:center; gap:8px; min-height:var(--h); flex-wrap:wrap}
+  .stop-place{font-family:var(--font); font-weight:700; font-size:13.5px; color:var(--txt)}
+  .stop.upcoming .stop-place{color:var(--txt2)}
+  .stop-sub{font-size:11px; color:var(--txt3); margin-top:2px; display:flex; align-items:center; gap:6px; flex-wrap:wrap}
+  .stop-due{font-family:var(--stamp); font-size:11.5px; color:var(--txt2); margin-top:6px; font-variant-numeric:tabular-nums}
+  .stop-due b{color:var(--txt); font-size:13px}
+  .addr{display:flex; align-items:center; gap:6px; margin-top:7px; color:var(--txt); font-size:12px; text-decoration:none; font-family:var(--font); border-bottom:1.4px solid var(--line); padding-bottom:6px; width:fit-content}
+  .addr svg{width:14px;height:14px;color:var(--accent); flex:none}
+  .stages{display:flex; align-items:center; gap:5px; margin-top:9px; font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); flex-wrap:wrap}
+  .stages .on{color:var(--accent)}
+  .stages .sep{color:var(--line)}
+  .stop-door{margin-top:9px}
+
+  .phone-caption{max-width:334px; font-size:11.5px; color:var(--txt3); text-align:center; font-style:italic}
+  .phone-caption b{color:var(--txt2); font-style:normal}
+
+  .foot{margin-top:24px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:96ch} .foot b{color:var(--txt)}
+  .foot ul{margin:8px 0 0; padding-left:20px} .foot li{margin:4px 0}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Trips · v2 · rebuilt on the dispatch model (spec §8–§8.2) · fixes critique #3 · built to style + wrangler-style</p>
+  <h1>Trips — <span class="hl">a first-class record, planned on its own board</span></h1>
+  <p class="lede">Severed from Rentals (§8): a <b>Trip</b> is a truck+driver outing with its own ordered <b>Stops</b> —
+  <b>Drop · Pickup · Field Call · Repo · Task</b> — each Stop moving one or more Units back to their Rental (a rental
+  can spawn many trips; a trip can serve many rentals). Dispatch is a genuine two-panel planning surface: the
+  <b>schedule</b> (left) groups trips into <b>Field Calls · Today · Tomorrow · This Week</b>, and a
+  <b>To-Dispatch rail</b> (right) holds every Stop that hasn't found a truck yet, sorted by urgency — one schedule,
+  the rail carries the future. <b>Priority fix — critique #3:</b> v1 read as uniform dark-on-dark; this draft steps
+  the surface at every level — board → group → trip card → stops — so one trip reads clean from the next at a
+  glance. The driver phone view (right) keeps the calm, user-scoped <b>NOW + Next Up</b> focus Jac liked.</p>
+  <div class="key"><span><b>Signal</b> read-only state</span><span><b>Gate</b> turnable</span><span><b>Stamp</b> fact</span><span><b>Ref</b> linked</span><span><b>Door</b> action</span><span>· fill = today · colour = state</span></div>
+
+  <!-- ============ +TRIP CREATION SNIPPET (rental-side entry point, §8.1) ============ -->
+  <div class="addtrip">
+    <span class="at-label">On the rental screen — the creation entry point</span>
+    <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>RES-2291 · Boudreaux Marine LLC</a>
+    <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Scout SS-14</a>
+    <span class="door dash">+ Trip</span>
+    <div class="toggle4">
+      <button>Self</button>
+      <button class="on">Round Trip</button>
+      <button>Delivery</button>
+      <button>Pickup</button>
+    </div>
+    <span class="at-cap"><b>Self</b> = customer hauls it, no trip/stop created · <b>Delivery</b> = one Drop stop at
+    rental start · <b>Pickup</b> = one Pickup stop at rental end · <b>Round Trip</b> = both, days/weeks apart — the
+    Delivery lands on today's board below, the Pickup waits in the rail (Aug 10). Units default to the rental's
+    units; every stop inherits this job-site address unless overridden.</span>
+  </div>
+
+  <div class="stage">
+
+    <!-- ============ LEFT — THE SCHEDULE ============ -->
+    <div class="dpanel">
+      <div class="dhead">
+        <div>
+          <div class="dh-name">Today's Board</div>
+          <div class="dh-sub">Jul 20 · 10 trips · 4 drivers · 2 conflicts flagged</div>
+        </div>
+        <div class="viewtoggle">
+          <button class="on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 2v4M16 2v4"/></svg>Dispatch</button>
+          <button><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2.4"/><path d="M11 18h2"/></svg>Driver</button>
+        </div>
+      </div>
+
+      <div class="draglegend">
+        <span class="li"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 8 4 4-4 4"/><path d="M2 12h20"/><path d="m6 8-4 4 4 4"/></svg><b>Rail ↔ trip</b> adds / un-plans a stop</span>
+        <span class="li"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg><b>Drag within a trip</b> reorders stops</span>
+        <span class="li"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg><b>Drag a trip</b> re-times it</span>
+        <span class="li"><b>Empty time</b> spawns a new trip</span>
+      </div>
+
+      <!-- ===== FIELD CALLS ===== -->
+      <div class="dgroup">
+        <div class="dghead green"><span class="dglabel">Field Calls</span><span class="stamp">2 trips · 1 resolved</span></div>
+        <div class="dgbody">
+
+          <div class="trip">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">2:15 PM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Mikey Fontenot</a>
+              <span class="ctl sig o green">resolved</span>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Field Call</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Gator RC-4700</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Broussard Dirt Works</a>
+                <span class="ctl stamp" style="margin-left:auto">WO #1188 · hyd hose</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="trip">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">ETA 2:45 PM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Mikey Fontenot</a>
+              <span class="ctl gate grey"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>en route</span>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Field Call</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Highrise</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Duhon Contracting</a>
+                <span class="ctl stamp" style="margin-left:auto">WO #113 · hyd seal · part arrived</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ===== TODAY ===== -->
+      <div class="dgroup">
+        <div class="dghead red"><span class="dglabel">Today</span><span class="stamp">6 trips · 3 flagged</span></div>
+        <div class="dgbody">
+
+          <div class="trip st-bad">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">9:00–10:30 AM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref warn"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Colby Thibodeaux</a>
+              <span class="ctl gate o grey"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>scheduled</span>
+              <span class="tip"><span class="ctl sig f red" tabindex="0">driver conflict</span><span class="bub"><span class="t">Same driver, two trips</span>Overlaps Colby's Deuce pickup below by 30 min. <span class="go">→ open the Gate to reassign</span></span></span>
+            </div>
+            <div class="driverpick">
+              <div class="dp-cap">Assign Gate — open (each driver's state inline, not a toast)</div>
+              <div class="drow"><span class="dname">Trey Guidry</span><span class="dstate">Available</span></div>
+              <div class="drow sel"><span class="dname">Colby Thibodeaux</span><span class="dstate busy">Busy 9:00–10:30 AM → would overlap</span></div>
+              <div class="drow"><span class="dname">Reggie Comeaux</span><span class="dstate near">On a nearby run (Fontenot Farms, 12 mi)</span></div>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/></svg>Drop</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Ranger ME-08</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Duhon Contracting</a>
+                <span class="ctl stamp" style="margin-left:auto">9:00–10:30 AM</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="trip st-bad">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">10:00–11:00 AM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref warn"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Colby Thibodeaux</a>
+              <span class="ctl gate o grey"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>scheduled</span>
+              <span class="tip"><span class="ctl sig f red" tabindex="0">driver conflict</span><span class="bub"><span class="t">Same driver, two trips</span>Overlaps Colby's Ranger delivery above by 30 min. <span class="go">→ open the Gate to reassign</span></span></span>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 9-6-6-6 6"/><path d="M12 3v14"/><path d="M5 21h14"/></svg>Pickup</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Deuce TL-9</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Boudreaux Marine LLC</a>
+                <span class="ctl stamp" style="margin-left:auto">10:00–11:00 AM</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="trip st-bad">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">3:30–4:15 PM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Reggie Comeaux</a>
+              <span class="ctl gate red"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>trouble</span>
+            </div>
+            <div class="reason">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>
+              Flat tire on the trailer, can't tow — reported 3:40 PM
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 9-6-6-6 6"/><path d="M12 3v14"/><path d="M5 21h14"/></svg>Pickup</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Bandit TL-22</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Fontenot Farms</a>
+                <span class="ctl stamp" style="margin-left:auto">3:30–4:15 PM</span>
+              </div>
+            </div>
+            <div class="tdoor">
+              <span class="ctl door save">Reassign driver</span>
+              <a class="clink"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z"/></svg><span class="v">(337) 555-0177 · Reggie</span></a>
+            </div>
+          </div>
+
+          <div class="trip st-bad">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">4:00 PM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Trey Guidry</a>
+              <span class="ctl gate red"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>trouble</span>
+            </div>
+            <div class="reason">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>
+              Gate locked, no site contact — reported 3:52 PM
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/></svg>Drop</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Bruiser CP-31</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Landry Metal Works</a>
+                <span class="ctl stamp" style="margin-left:auto">4:00 PM</span>
+              </div>
+            </div>
+            <div class="tdoor">
+              <span class="ctl door save">Send help</span>
+              <a class="clink"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13.83 4.4a10.5 10.5 0 0 0 5.77 5.77l1.28-1.28a1 1 0 0 1 1.05-.24 11.4 11.4 0 0 0 3.55.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.51a1 1 0 0 1 1 1 11.4 11.4 0 0 0 .57 3.55 1 1 0 0 1-.24 1.05z"/></svg><span class="v">(337) 555-0142 · Trey</span></a>
+            </div>
+          </div>
+
+          <div class="trip">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">12:15–2:00 PM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Trey Guidry</a>
+              <span class="ctl gate o grey"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>scheduled</span>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11h4"/><path d="M12 16h4"/><path d="M8 11h.01"/><path d="M8 16h.01"/></svg>Task</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Duhon Contracting</a>
+                <span class="ctl stamp" style="margin-left:auto">Drop-off · filters &amp; hose · 12:15 PM</span>
+              </div>
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">2</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 9-6-6-6 6"/><path d="M12 3v14"/><path d="M5 21h14"/></svg>Pickup</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Gator RC-4700</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Broussard Dirt Works</a>
+                <span class="ctl stamp" style="margin-left:auto">1:00–2:00 PM</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="trip">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">8:00–9:00 AM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Trey Guidry</a>
+              <span class="ctl sig o green">delivered · 8:52 AM</span>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/></svg>Drop</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Scout SS-14</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Boudreaux Marine LLC</a>
+                <span class="ctl stamp" style="margin-left:auto">8:00–9:00 AM</span>
+              </div>
+            </div>
+            <div class="futurelink">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+              Round Trip · pickup scheduled <b>Aug 10</b> · waiting in the rail →
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ===== TOMORROW ===== -->
+      <div class="dgroup">
+        <div class="dghead yellow"><span class="dglabel">Tomorrow</span><span class="stamp">1 trip · needs scheduling</span></div>
+        <div class="dgbody">
+
+          <div class="trip st-warn">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl sig f yellow">needs scheduling</span>
+              <span class="trip-spacer"></span>
+              <span class="ctl gate o grey"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>assign driver</span>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/></svg>Drop</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Trooper TR-19</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Landry Metal Works</a>
+                <span class="ctl stamp" style="margin-left:auto">no time set</span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ===== THIS WEEK ===== -->
+      <div class="dgroup">
+        <div class="dghead"><span class="dglabel">This Week</span><span class="stamp">1 trip</span></div>
+        <div class="dgbody">
+
+          <div class="trip">
+            <div class="trip-top">
+              <span class="dragh" title="Drag to re-time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="m15 19-3 3-3-3"/><path d="m19 9 3 3-3 3"/><path d="M2 12h20"/><path d="m5 9-3 3 3 3"/><path d="m9 5 3-3 3 3"/></svg></span>
+              <span class="ctl stamp">Fri Jul 24 · 10:00 AM</span>
+              <span class="trip-spacer"></span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>Reggie Comeaux</a>
+              <span class="ctl gate o grey"><span class="cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></span>scheduled</span>
+            </div>
+            <div class="tstops">
+              <div class="tstop">
+                <span class="dragh" title="Drag to reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+                <span class="seq">1</span>
+                <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 9-6-6-6 6"/><path d="M12 3v14"/><path d="M5 21h14"/></svg>Pickup</span>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Bandit TL-22</a>
+                <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Fontenot Farms</a>
+                <span class="ctl stamp" style="margin-left:auto">10:00 AM</span>
+              </div>
+            </div>
+            <div class="futurelink">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>
+              Re-scheduled — trailer repaired after today's flat tire
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <div class="htail"><div class="h4">History</div><span class="hnote">42 trips this week · 3 driver conflicts caught</span></div>
+    </div>
+
+    <!-- ============ RIGHT — TO-DISPATCH RAIL ============ -->
+    <div class="dpanel">
+      <div class="dhead">
+        <div>
+          <div class="dh-name">To-Dispatch</div>
+          <div class="dh-sub">4 stops waiting for a truck</div>
+        </div>
+      </div>
+      <div class="railcap">Sorted by urgency — drag any of these onto a trip on the left, or onto empty time to start a new one.</div>
+
+      <div class="rbody">
+
+        <div class="railitem">
+          <div class="ri-top">
+            <span class="dragh" title="Drag onto a trip, or onto empty time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+            <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Field Call</span>
+            <span class="ctl sig f yellow">unassigned</span>
+          </div>
+          <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Hebert Logistics</a>
+          <div class="ri-due"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>Due today · 4:30 PM · hyd leak reported</div>
+        </div>
+
+        <div class="railitem">
+          <div class="ri-top">
+            <span class="dragh" title="Drag onto a trip, or onto empty time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+            <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/></svg>Drop</span>
+            <span class="ctl sig f yellow">unassigned</span>
+          </div>
+          <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Broussard Dirt Works</a>
+          <div class="ri-due"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>Due tomorrow · 8:00 AM · new skid steer</div>
+        </div>
+
+        <div class="railitem">
+          <div class="ri-top">
+            <span class="dragh" title="Drag onto a trip, or onto empty time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+            <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22V12"/><path d="M16 17h6"/><path d="M21 13V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.729l7 4a2 2 0 0 0 2 .001l1.675-.955"/><path d="M3.29 7 12 12l8.71-5"/><path d="m7.5 4.27 8.997 5.148"/></svg>Repo</span>
+            <span class="ctl sig f yellow">unassigned</span>
+          </div>
+          <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Fontenot Farms</a>
+          <div class="ri-due"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>Due this week · Fri · overdue account</div>
+        </div>
+
+        <div class="railitem far">
+          <div class="ri-top">
+            <span class="dragh" title="Drag onto a trip, or onto empty time"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="12" r="1"/><circle cx="9" cy="5" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="19" r="1"/></svg></span>
+            <span class="stoptype"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 9-6-6-6 6"/><path d="M12 3v14"/><path d="M5 21h14"/></svg>Pickup</span>
+            <span class="ctl sig o yellow">unassigned</span>
+          </div>
+          <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="M3.3 7.3 12 12l8.7-4.7"/><path d="M12 22V12"/></svg></span>Scout SS-14</a>
+          <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Boudreaux Marine LLC</a>
+          <div class="ri-due"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>Due Aug 10</div>
+          <div class="futurelink" style="margin-top:0; padding-top:6px">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17V3"/><path d="m6 11 6 6 6-6"/><path d="M19 21H5"/></svg>
+            Round Trip · Delivery already ran today, see the board ←
+          </div>
+        </div>
+
+      </div>
+      <div class="railcap" style="border-bottom:0; border-top:1px solid var(--line)">This Pickup won't need a truck for three weeks — it rises here as Aug 10 nears, exactly like every stop above it.</div>
+    </div>
+
+    <!-- ============ DRIVER VIEW (phone, kept) ============ -->
+    <div class="phonewrap">
+      <div class="phone">
+        <div class="phone-status"><span>Trips</span><span>1:15 PM</span></div>
+        <div class="phone-screen">
+
+          <div class="papp-top">
+            <span class="papp-title">Trips</span>
+            <div class="viewtoggle">
+              <button><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M8 2v4M16 2v4"/></svg>Dispatch</button>
+              <button class="on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2.4"/><path d="M11 18h2"/></svg>Driver</button>
+            </div>
+          </div>
+
+          <div class="pdriver">
+            <div><div class="pd-name">Trey Guidry</div><div class="pd-sub">Today · Jul 20 · 4 stops</div></div>
+            <span class="rolebadge" title="Default landing for drivers — same idea as Yard Journey for techs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg>Home</span>
+          </div>
+
+          <div class="nownext">
+            <div class="nn-row"><span class="nn-tag now">Now</span><span class="ctl sig f yellow">next up</span><span class="nn-headline">Broussard Dirt Works — due 2:00 PM</span></div>
+            <div class="nn-row"><span class="nn-tag next">Then</span><span class="nn-sub">Landry Metal Works, due 4:00 PM — flagged trouble, see below</span></div>
+          </div>
+
+          <div class="stops">
+
+            <div class="stop done">
+              <div class="stop-col"><span class="stop-dot"></span><span class="stop-conn"></span></div>
+              <div class="stop-content">
+                <div class="stop-head"><span class="stop-place">Boudreaux Marine LLC</span><span class="ctl sig o green">delivered</span></div>
+                <div class="stop-sub">Drop · Scout <span class="dot">·</span> SS-14</div>
+                <div class="stop-due">Delivered <b>8:52 AM</b></div>
+              </div>
+            </div>
+
+            <div class="stop current">
+              <div class="stop-col"><span class="stop-dot"></span><span class="stop-conn"></span></div>
+              <div class="stop-content">
+                <div class="stop-head"><span class="stop-place">Broussard Dirt Works</span><span class="ctl sig f yellow">next up</span></div>
+                <div class="stop-sub">Pickup · Gator <span class="dot">·</span> RC-4700</div>
+                <div class="stop-due">Due <b>2:00 PM</b> · 14 mi from yard</div>
+                <a class="addr" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>2210 Delcambre Rd, Broussard, LA</a>
+                <div class="stages"><span class="on">Start route</span><span class="sep">›</span><span>Arrived</span><span class="sep">›</span><span>Mark picked up</span></div>
+                <div class="stop-door"><span class="ctl door save">Start route</span></div>
+              </div>
+            </div>
+
+            <div class="stop trouble">
+              <div class="stop-col"><span class="stop-dot"></span><span class="stop-conn"></span></div>
+              <div class="stop-content">
+                <div class="stop-head"><span class="stop-place">Landry Metal Works</span><span class="ctl sig f red">trouble</span></div>
+                <div class="stop-sub">Drop · Bruiser <span class="dot">·</span> CP-31</div>
+                <div class="stop-due">Due <b>4:00 PM</b></div>
+                <a class="addr" href="#"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>860 Industrial Loop, Sulphur, LA</a>
+                <div class="reason"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>Gate locked, no site contact — reported 3:52 PM</div>
+                <div class="stop-door"><span class="ctl door save">Escalate to dispatch</span></div>
+              </div>
+            </div>
+
+            <div class="stop upcoming">
+              <div class="stop-col"><span class="stop-dot"></span></div>
+              <div class="stop-content">
+                <div class="stop-head"><span class="stop-place">Duhon Contracting</span><span class="ctl sig o grey">queued</span></div>
+                <div class="stop-sub">Task · filters &amp; hose</div>
+                <div class="stop-due">Due 4:45 PM</div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+      <p class="phone-caption">User-scoped: Trey sees only <b>his own</b> stops — 2 of the board's 6 Today trips are his
+      (the rest are Colby's and Reggie's). Only the <b>current</b> stop gets an actionable Door — its label cycles
+      <b>Start route → Arrived → Mark picked up/delivered</b>. A stop that hits trouble jumps the queue and gets its
+      own recovery Door regardless of order.</p>
+    </div>
+
+  </div>
+
+  <div class="foot">
+    v2 rebuild — notes for review:
+    <ul>
+      <li><b>Priority #1 — the contrast/separation fix (critique #3):</b> v1 leaned on hairline borders between
+      rows on one flat surface, which is why trips blurred together. v2 steps the surface at every level using
+      <i>only</i> the locked palette (no new hexes): page <b>--bg</b> → board/rail trough <b>--card</b> → each
+      trip card <b>--panel</b> (lighter, bordered, lifted with a soft shadow, real 10–12px gaps instead of 1px
+      dividers) → its stops nested one step brighter still on <b>--cardh</b>, the surface a dispatcher actually
+      reads. Groups get a coloured left rule (rollup = worst trip inside) as a second, cheaper separation cue.
+      Also dropped v1's full-width double-booking banner — one more loud thing shouting at once — in favour of a
+      red Signal + tooltip living directly on the conflicted trip, where the eye already is.</li>
+      <li><b>Trip/Stop model (§8):</b> every trip card holds its own ordered, numbered Stops (Drop · Pickup ·
+      Field Call · Repo · Task), each a Ref to its location + unit — Trey's Today trip is a genuine 2-stop example
+      (Task at Duhon Contracting, then Pickup at Broussard Dirt Works) proving a Trip isn't 1:1 with a rental move.</li>
+      <li><b>Driver Gate, inline (§8.1):</b> the Ranger/Duhon trip's Gate is shown <i>open</i> as a worked example —
+      each driver's state renders right there (Available · <span style="color:var(--red)">Busy 9:00–10:30 AM →
+      would overlap</span> · on a nearby run), never a toast. The red conflict Signal is a separate flag layered on
+      top of the trip's real status (still "scheduled" underneath) — a trip can be both true and flagged at once.</li>
+      <li><b>One schedule, the rail holds the future (§8.2):</b> Boudreaux Marine LLC's Scout SS-14 Round Trip is
+      threaded through all three panels — the <b>+ Trip</b> snippet shows how it was created, its Delivery sits
+      done on today's board, and its Pickup (Aug 10) sits muted/dashed at the bottom of the rail, cross-linked both
+      directions, demonstrating "rises as its window nears" concretely rather than just asserting it.</li>
+      <li><b>Signal palette — dropped blue.</b> I ran the CVD math (deuter+protan, ≥90 floor) on every pair that
+      would actually sit side by side on this board: <b>grey vs blue = 45–48</b> and <b>blue vs green = 72/98</b>
+      both fail. Spec allows blue OR grey for "scheduled & fine" — so v2 uses grey only for that whole bucket,
+      and reuses the <b>fill = today</b> function to carry the distinction instead: <i>scheduled</i> = grey
+      outline, <i>en route</i> = grey filled (it's the "triggered today" case). Zero new hues, zero failing pairs
+      introduced. <b>Grey vs green</b> (scheduled vs done) still measures ~31–69, under the 90 floor — that's the
+      same already-accepted, already-shipped tradeoff flagged in v1/Yard Journey (each always carries its own
+      word), not a new problem; re-flagging it here rather than hiding it.</li>
+      <li><b>Contrast math (WCAG):</b> every new text/fill pair checked ≥4.5 across all three surface steps —
+      worst cases: txt-3 on cardh 4.87, red-text(dstate.busy) on cardh 4.71, dark ink on grey-fill 6.06, the two
+      forced picks re-verified unchanged (on-red-fill/red-fill 4.65, on-commit/commit 4.80).</li>
+      <li><b>Ladder discipline:</b> every new dispatch-side size sits on 9.5/10/11/12/13/15. Left the driver
+      phone view's pre-existing sizes (16px name, 13.5px stop-place, 11.5px captions) untouched — those predate
+      this pass and the brief says keep that view as Jac liked it; didn't want a silent restyle mixed into a kept
+      surface. Nudged shared classes reused on both sides (.stamp 10.5→10, .reason/.tip 11.5→12) since touching
+      them was unavoidable and the drift was trivial.</li>
+      <li>Continuity: Gator RC-4700, Scout SS-14, Boudreaux Marine LLC, Duhon (Contracting), Trey Guidry, Colby
+      Thibodeaux, and Broussard Dirt Works all carry over. Fontenot Farms threads a small story across panels —
+      today's flat-tire trouble, an overdue Repo in the rail, and the same trailer rescheduled clean for Friday.</li>
+    </ul>
+  </div>
+
+</div></div>

--- a/docs/design/reference/trips-ledger.html
+++ b/docs/design/reference/trips-ledger.html
@@ -1,0 +1,618 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Trips · ETA Tracker</title>
+<style>
+:root{
+  --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --card:#12171e; --cardh:#1a212b;
+  --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#838e9c;
+  --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15);
+  --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redFill:#d63636; --onRedFill:#fdfdfd;
+  --blue:#6394cc; --commit:#2f6fd0; --onCommit:#fdfdfd; --gray:#8b94a3; --tan:#c2925a;
+  --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+  --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+  --h:24px;
+  --greenSoft:rgba(52,211,153,.14); --yellowSoft:rgba(238,212,75,.15);
+  --redSoft:rgba(255,66,66,.13); --blueSoft:rgba(99,148,204,.15); --commitSoft:rgba(47,111,208,.16);
+  /* 7-col ledger grid — the numbered spine hangs OUTSIDE the card in a left rail, so it's
+     not a grid column. DEPARTURE·UNIT / TYPE / GATE / ETA / TOWN / CUSTOMER / DEADLINE. */
+  --grid:170px 30px 132px minmax(150px,auto) minmax(94px,1fr) 148px 100px;
+  --gap:12px;
+  --padx:14px;
+  --rail:44px;   /* the outside-the-card numbered-spine gutter */
+}
+*{box-sizing:border-box;}
+html,body{margin:0;padding:0;}
+body{
+  background:var(--bg); color:var(--txt); font-family:var(--font); font-size:13px; line-height:1.4;
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+}
+svg.ic{width:14px;height:14px;flex:0 0 auto;display:block;}
+.board{max-width:1150px;margin:0 auto;padding:26px 20px 90px;}
+a{color:inherit;text-decoration:none;}
+
+/* ============================ PAGE HEAD ============================ */
+.page-head{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:16px;}
+.page-title{font:800 21px/1 var(--stamp);letter-spacing:.055em;text-transform:uppercase;color:var(--txt);}
+.page-sub{font:500 11.5px/1.4 var(--font);color:var(--txt3);margin-top:6px;}
+.page-sub b{color:var(--txt2);font-weight:600;}
+.yard-tag{display:inline-flex;align-items:center;gap:6px;height:var(--h);padding:0 11px;border:1px dashed var(--line);border-radius:999px;font:800 9.5px/1 var(--stamp);letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);}
+.yard-tag svg{width:13px;height:13px;}
+
+/* ============================ TOP ROW ============================ */
+.top-row{display:flex;gap:14px;flex-wrap:wrap;margin-bottom:16px;align-items:stretch;}
+.panel-card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:13px 15px;}
+.panel-label{display:flex;align-items:center;gap:6px;font:800 9.5px/1 var(--stamp);letter-spacing:.08em;text-transform:uppercase;color:var(--txt3);margin-bottom:11px;}
+.panel-label svg{width:13px;height:13px;color:var(--txt3);}
+
+/* --- rental creation inset --- */
+.rental-inset{flex:1 1 380px;min-width:320px;display:flex;flex-direction:column;}
+.ri-top{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;}
+.ri-unit{display:flex;align-items:center;gap:9px;min-width:0;}
+.ri-unit .ref-ic{width:28px;height:28px;border-radius:7px;background:var(--accSoft);display:flex;align-items:center;justify-content:center;color:var(--accent);flex:0 0 auto;}
+.ri-unit .ref-ic svg{width:15px;height:15px;}
+.ri-unit b{font:700 13.5px/1.2 var(--font);color:var(--txt);}
+.ri-unit b .code{font:700 11px/1 var(--stamp);color:var(--txt3);letter-spacing:.02em;}
+.ri-unit span{display:block;font:500 10.5px/1.3 var(--font);color:var(--txt3);margin-top:1px;}
+.toggle4{display:inline-flex;height:var(--h);border:1px solid var(--line);border-radius:999px;overflow:hidden;background:var(--panel);flex:0 0 auto;}
+.toggle4 .seg{display:flex;align-items:center;padding:0 11px;font:700 9px/1 var(--stamp);letter-spacing:.04em;text-transform:uppercase;color:var(--txt3);white-space:nowrap;cursor:pointer;}
+.toggle4 .seg+.seg{border-left:1px solid var(--line);}
+.toggle4 .seg.active{background:var(--accent);color:var(--onAcc);font-weight:800;}
+.ri-reveal{margin-top:12px;padding-top:12px;border-top:1px dashed var(--tan);}
+.ri-addr{display:flex;align-items:center;gap:9px;height:var(--h);padding:0 11px;border:1px solid var(--line);border-radius:8px;background:var(--panel);}
+.ri-addr svg{width:14px;height:14px;color:var(--accent);flex:0 0 auto;}
+.ri-addr span{font:500 11px/1 var(--font);color:var(--txt3);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.ri-addr span b{color:var(--txt2);font-weight:600;}
+.ri-foot{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:10px;}
+.ri-hint{font:500 10px/1.35 var(--font);color:var(--txt3);max-width:230px;}
+.wait-chip{display:inline-flex;align-items:center;height:var(--h);padding:0 10px;border:1px dashed var(--line);border-radius:7px;font:800 9.5px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;color:var(--gray);white-space:nowrap;flex:0 0 auto;}
+
+/* --- driver NOW focus panel --- */
+.nowpanel{flex:0 0 316px;border-color:var(--accent);box-shadow:0 0 0 1px var(--accSoft) inset;display:flex;flex-direction:column;}
+.nu-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;}
+.now-badge{display:inline-flex;align-items:center;gap:5px;height:var(--h);padding:0 10px;border-radius:7px;background:var(--accent);color:var(--onAcc);font:800 10px/1 var(--stamp);letter-spacing:.09em;}
+.now-badge svg{width:12px;height:12px;}
+.nu-driver{display:flex;align-items:center;gap:6px;font:600 11px/1 var(--font);color:var(--txt2);}
+.nu-driver svg{width:13px;height:13px;color:var(--txt3);}
+.nu-stop{display:flex;align-items:baseline;gap:8px;margin:2px 0 2px;}
+.nu-stop b{font:700 15px/1.2 var(--font);color:var(--txt);}
+.nu-stop .nu-type{font:800 9px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;color:var(--txt3);}
+.nu-addr{font:500 11px/1.4 var(--font);color:var(--txt3);margin-bottom:11px;}
+.nu-eta-row{display:flex;align-items:flex-end;justify-content:space-between;gap:10px;margin-bottom:12px;}
+.nu-eta{font:800 28px/.95 var(--stamp);font-variant-numeric:tabular-nums;color:var(--yellow);}
+.nu-eta-lbl{font:800 9px/1 var(--stamp);letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);margin-bottom:3px;display:block;}
+.nu-eta-sub{font:600 10px/1.3 var(--stamp);letter-spacing:.03em;text-transform:uppercase;color:var(--yellow);text-align:right;}
+.nu-next{font:500 10.5px/1.3 var(--font);color:var(--txt3);margin-bottom:12px;}
+.nu-next b{color:var(--txt2);font-weight:600;}
+.nu-actions{display:flex;gap:8px;margin-top:auto;}
+
+/* ============================ DOORS (verb actions — the ONLY place --commit lives) ============================ */
+.door{height:var(--h);border-radius:999px;padding:0 13px;font:700 10px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;display:inline-flex;align-items:center;gap:6px;cursor:pointer;white-space:nowrap;border:1px solid transparent;}
+.door svg{width:13px;height:13px;}
+.door.ghost{background:transparent;border-color:var(--line);color:var(--txt2);}
+.door.commit{background:var(--commit);border-color:var(--commit);color:var(--onCommit);}
+.door.ghost:hover{border-color:var(--txt3);color:var(--txt);}
+.door.commit:hover{filter:brightness(1.08);}
+
+/* ============================ LEGEND ============================ */
+.legend{display:flex;align-items:center;gap:14px;flex-wrap:wrap;background:var(--panel);border:1px solid var(--lineSoft);border-radius:10px;padding:10px 14px;margin-bottom:8px;font:500 11px/1.4 var(--font);color:var(--txt2);}
+.legend .lg-flow{display:flex;align-items:center;gap:7px;}
+.lg-gate{display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 8px 0 6px;border-radius:6px;font:800 8.5px/1 var(--stamp);letter-spacing:.04em;text-transform:uppercase;}
+.lg-gate svg{width:10px;height:10px;}
+.lg-gate.go{background:var(--blueSoft);border:1px solid rgba(99,148,204,.5);color:var(--blue);}
+.lg-gate.na{background:var(--card);border:1px solid var(--line);color:var(--txt3);}
+.legend .lg-arrow{color:var(--txt3);font-weight:700;}
+.legend .lg-div{width:1px;align-self:stretch;background:var(--line);}
+.legend .lg-key{display:flex;align-items:center;gap:11px;flex-wrap:wrap;}
+.legend .lg-k{display:flex;align-items:center;gap:6px;font:700 9.5px/1 var(--stamp);letter-spacing:.03em;text-transform:uppercase;color:var(--txt2);}
+.legend .dot{width:9px;height:9px;border-radius:2px;flex:0 0 auto;}
+.dot.wait{background:var(--blue);} .dot.near{background:var(--yellow);} .dot.late{background:var(--redFill);} .dot.done{background:var(--green);} .dot.na{background:var(--txt3);}
+.legend .lg-note{font:500 10.5px/1.4 var(--font);color:var(--txt3);flex:1 1 260px;min-width:220px;}
+.legend .lg-note b{color:var(--txt2);font-weight:600;}
+.mini-node{display:inline-flex;align-items:center;justify-content:center;width:14px;height:14px;vertical-align:-2px;border:1.5px solid var(--txt3);background:var(--card);margin:0 1px;font:800 8px/1 var(--stamp);color:var(--txt2);}
+.mini-node.num{border-radius:4px;} .mini-node.sq{border-radius:3px;color:transparent;}
+
+/* ============================ COLUMN HEADER (indented to clear the rail) ============================ */
+.col-head{display:grid;grid-template-columns:var(--grid);column-gap:var(--gap);align-items:center;
+  padding:9px var(--padx);margin:14px 0 6px calc(var(--rail) + 4px);background:var(--bg2);border:1px solid var(--line);border-radius:8px;
+  font:800 9px/1 var(--stamp);letter-spacing:.09em;text-transform:uppercase;color:var(--txt3);}
+.col-head .ch-r{text-align:right;}
+.col-head .ch-c{text-align:center;}
+
+/* ============================ GROUP HEADS ============================ */
+.group-head{display:flex;align-items:center;gap:9px;margin:26px 2px 8px calc(var(--rail) + 4px);padding-bottom:6px;border-bottom:1px solid var(--line);}
+.group-head svg{width:15px;height:15px;color:var(--txt3);}
+.group-head h2{font:800 12.5px/1 var(--stamp);letter-spacing:.09em;text-transform:uppercase;color:var(--txt);margin:0;}
+.group-head .g-count{font:700 9.5px/1 var(--stamp);letter-spacing:.03em;color:var(--txt3);background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px 10px;}
+.group-head.g-field svg{color:var(--tan);}
+.group-head.g-field h2{color:var(--txt2);}
+
+/* ============================ TRIP LEDGER — floating card, numbered spine OUTSIDE on the left ============================ */
+.trip{background:var(--card);border-radius:12px;margin:10px 0 10px calc(var(--rail) + 4px);overflow:visible;box-shadow:inset 0 0 0 1px var(--line);}
+.trip-rows{padding:0;}
+
+/* ============================ STOP ROW ============================ */
+.stop-row{position:relative;display:grid;grid-template-columns:var(--grid);column-gap:var(--gap);align-items:center;
+  min-height:48px;padding:8px var(--padx);border-bottom:1px dotted var(--lineSoft);}
+.trip-rows .stop-row:last-child{border-bottom:none;}
+.stop-row.here{background:var(--cardh);}
+
+/* ── the numbered spine RAIL — absolutely positioned OUTSIDE the card's left edge ── */
+.rail{position:absolute;top:0;bottom:0;left:calc(-1 * (var(--rail) + 4px));width:var(--rail);
+  display:flex;align-items:center;justify-content:center;z-index:2;}
+.rail::before,.rail::after{content:'';position:absolute;left:50%;width:2px;background:var(--line);transform:translateX(-50%);z-index:1;}
+.rail::before{top:0;bottom:50%;}
+.rail::after{top:50%;bottom:0;}
+.rail.first::before{display:none;}
+.rail.last::after{display:none;}
+.rail.done-seg::before,.rail.done-below::after{background:var(--green);}
+.node{width:22px;height:22px;border:1.6px solid var(--line);background:var(--bg);position:relative;z-index:2;
+  display:flex;align-items:center;justify-content:center;font:800 10px/1 var(--stamp);color:var(--txt2);font-variant-numeric:tabular-nums;}
+.node.num{border-radius:6px;cursor:grab;}
+.node.num:hover{border-color:var(--accent);}
+.node.box{border-radius:5px;cursor:pointer;color:transparent;border-style:dashed;}
+.node.box:hover{border-color:var(--accent);}
+.node.done{background:var(--greenSoft);border-color:var(--green);color:var(--green);}
+.node.here{border-color:var(--accent);box-shadow:0 0 0 3px var(--accSoft);color:var(--accent);}
+.node.late{border-color:var(--redFill);color:var(--red);}
+
+/* 1 — outside-left prefix (DEPARTURE time + UNIT Ref) */
+.pfx{border-right:1px dashed var(--lineSoft);padding-right:12px;min-width:0;}
+.pfx-dep{display:flex;align-items:baseline;gap:6px;margin-bottom:5px;}
+/* departure time = the "should I leave?" clock — SAME ladder as the deadline chip, vs leave-time:
+   grey = not yet · blue = next up · yellow = gotta leave · red = late · green = departed/done. */
+.pfx-dep .t{font:700 13px/1 var(--stamp);font-variant-numeric:tabular-nums;color:var(--txt3);}
+.pfx-dep.next .t{color:var(--blue);}
+.pfx-dep.soon .t{color:var(--yellow);}
+.pfx-dep.late .t{color:var(--red);}
+.pfx-dep.done .t{color:var(--green);}
+.pfx-dep .l{font:800 7.5px/1 var(--stamp);letter-spacing:.07em;text-transform:uppercase;color:var(--txt3);}
+.pfx-unit{display:flex;align-items:center;gap:5px;min-width:0;}
+.pfx-yard{display:flex;align-items:center;gap:7px;min-width:0;font:italic 400 11.5px/1.25 var(--font);color:var(--txt3);}
+.pfx-yard svg{width:14px;height:14px;flex:0 0 auto;color:var(--txt3);}
+/* Ref element (unit + customer share this) — parent icon in accent-tinted square backing + name */
+.ref{display:inline-flex;align-items:center;gap:6px;max-width:100%;font:600 11.5px/1.15 var(--font);color:var(--txt);
+  background:var(--card);border:1px solid var(--line);border-radius:6px;padding:2px 8px 2px 3px;white-space:nowrap;overflow:hidden;cursor:pointer;}
+.ref .ty{display:inline-flex;align-items:center;justify-content:center;width:19px;height:19px;flex:0 0 auto;color:var(--accent);background:var(--accSoft);border-radius:4px;}
+.ref .ty svg{width:12px;height:12px;}
+.ref .nm{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
+.ref .nm .code{font:700 9.5px/1 var(--stamp);color:var(--txt3);margin-left:3px;}
+.ref:hover{border-color:var(--accent);}
+.ref.sm{font-size:11px;padding:2px 6px 2px 3px;gap:5px;}
+.ref.sm .ty{width:17px;height:17px;} .ref.sm .ty svg{width:11px;height:11px;}
+.ref-more{font:800 8.5px/1 var(--stamp);color:var(--accent);flex:0 0 auto;padding-left:1px;}
+
+/* 2 — stop-type glyph (LEFT of the gate) */
+.glyph{justify-self:center;display:inline-flex;align-items:center;justify-content:center;color:var(--txt3);}
+.glyph.hq{width:28px;height:20px;border:1px solid var(--line);border-radius:5px;font:800 9px/1 var(--stamp);letter-spacing:.05em;color:var(--txt3);}
+.glyph.arrow svg{width:18px;height:18px;}
+
+/* 3 — the Gate = a canon Gate chip: soft Waiting --blue + leading chevron (turnable). Gray when N/A. */
+.gate{display:flex;align-items:center;min-width:0;}
+.gate-chip{height:var(--h);border-radius:7px;padding:0 10px 0 8px;display:inline-flex;align-items:center;gap:5px;
+  font:800 9.5px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;white-space:nowrap;cursor:pointer;border:1px solid transparent;}
+.gate-chip .chev{width:12px;height:12px;flex:0 0 auto;}
+.gate-chip.go{background:var(--blueSoft);border-color:rgba(99,148,204,.5);color:var(--blue);}
+.gate-chip.go:hover{border-color:var(--blue);}
+.gate-chip.na{background:var(--card);border-color:var(--line);color:var(--txt3);cursor:default;}
+.gate-chip.na .chev{opacity:.45;}
+.gate-done{height:var(--h);border-radius:7px;padding:0 10px;display:inline-flex;align-items:center;gap:5px;
+  font:800 9px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;white-space:nowrap;
+  background:var(--greenSoft);border:1px solid rgba(52,211,153,.4);color:var(--green);}
+.gate-done svg{width:11px;height:11px;}
+.gate-wrap{display:flex;flex-direction:column;align-items:flex-start;gap:3px;min-width:0;}
+.sent-undo{display:inline-flex;align-items:center;gap:5px;font:700 8.5px/1 var(--stamp);letter-spacing:.03em;text-transform:uppercase;color:var(--txt3);padding-left:2px;}
+.sent-undo .ok{color:var(--green);display:inline-flex;align-items:center;gap:3px;}
+.sent-undo .ok svg{width:9px;height:9px;}
+.sent-undo a{color:var(--accent);border-bottom:1px solid transparent;cursor:pointer;}
+.sent-undo a:hover{border-bottom-color:var(--accent);}
+/* driver-reassign Gate — rides the START row */
+.driver-chip{display:inline-flex;align-items:center;gap:6px;height:var(--h);padding:0 10px;border-radius:7px;background:var(--panel);border:1px solid var(--line);font:600 11px/1 var(--font);color:var(--txt2);cursor:pointer;max-width:100%;}
+.driver-chip svg{width:13px;height:13px;color:var(--txt3);flex:0 0 auto;}
+.driver-chip .chev{width:11px;height:11px;color:var(--txt3);}
+.driver-chip .nm{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+
+/* 4 — ETA line: +42MIN = 8:22 ETA (drive is first-class inside it) */
+.eta{display:flex;align-items:baseline;justify-content:flex-end;gap:4px;white-space:nowrap;text-align:right;}
+.eta .drv{font:800 11px/1 var(--stamp);font-variant-numeric:tabular-nums;color:var(--txt2);letter-spacing:.01em;}
+.eta .drv .u{font-size:7.5px;color:var(--txt3);margin-left:1px;}
+.eta .eq{font:700 10px/1 var(--stamp);color:var(--txt3);}
+.eta .t{font:800 13px/1 var(--stamp);font-variant-numeric:tabular-nums;color:var(--txt);}
+.eta .lbl{font:800 7.5px/1 var(--stamp);letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);}
+.eta .climb{font:800 9px/1 var(--stamp);letter-spacing:.03em;text-transform:uppercase;color:var(--red);}
+.eta.near .t{color:var(--yellow);}
+.eta.late .t,.eta.late .drv{color:var(--red);}
+.eta.dim .t,.eta.dim .drv{color:var(--txt3);font-weight:600;}
+
+/* 5 — town = R7 "True hyperlink ↗" (off-app → Google Maps): ink + accent underline + trailing ↗ */
+.town{min-width:0;}
+.town a{display:inline-flex;align-items:baseline;gap:3px;font:500 12px/1.2 var(--font);color:var(--txt);
+  text-decoration:underline;text-decoration-color:var(--accent);text-decoration-thickness:1.5px;text-underline-offset:2px;max-width:100%;}
+.town a .nm{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.town a .ext{font:700 10px/1 var(--stamp);color:var(--accent);flex:0 0 auto;}
+.town a:hover{color:var(--accent);}
+.town.dim{font:600 11px/1 var(--stamp);color:var(--txt3);text-transform:uppercase;letter-spacing:.05em;}
+
+/* 6 — customer Ref (shares .ref) */
+.cust{min-width:0;display:flex;}
+
+/* 7 — deadline Signal (deadline TIME + state colour) */
+.dl{display:flex;justify-content:flex-end;}
+.sig{display:inline-flex;align-items:center;gap:5px;height:var(--h);padding:0 9px;border-radius:7px;
+  font:800 9px/1 var(--stamp);letter-spacing:.04em;text-transform:uppercase;white-space:nowrap;font-variant-numeric:tabular-nums;}
+.sig svg{width:11px;height:11px;}
+.sig .tm{font-weight:800;}
+.sig .st{opacity:.85;font-size:8px;}
+.sig.wait{color:var(--blue);background:var(--blueSoft);border:1px solid rgba(99,148,204,.4);}
+.sig.near{color:var(--yellow);background:var(--yellowSoft);border:1px solid rgba(238,212,75,.42);}
+.sig.late{background:var(--redFill);color:var(--onRedFill);border:1px solid rgba(255,66,66,.5);}
+.sig.done{color:var(--green);background:var(--greenSoft);border:1px solid rgba(52,211,153,.4);}
+.dl.dim{justify-content:flex-end;font:700 10px/1 var(--stamp);color:var(--txt3);padding-right:4px;}
+
+/* ============================ LOOSE ROWS ============================ */
+.loose{background:var(--panel);border-radius:10px;margin:8px 0 8px calc(var(--rail) + 4px);overflow:visible;box-shadow:inset 0 0 0 1px var(--lineSoft);}
+.loose.attn{box-shadow:inset 0 0 0 1px var(--lineSoft),inset 3px 0 0 0 var(--redFill);}
+.loose.attn.near{box-shadow:inset 0 0 0 1px var(--lineSoft),inset 3px 0 0 0 var(--yellow);}
+.loose .stop-row{border-bottom:none;}
+.loose-tag{display:flex;align-items:center;gap:6px;padding:0 var(--padx) 8px calc(170px + var(--gap) + var(--padx));font:700 9px/1.3 var(--stamp);letter-spacing:.04em;text-transform:uppercase;color:var(--txt3);}
+.loose-tag.warn{color:var(--yellow);} .loose-tag.hot{color:var(--red);}
+.loose-tag svg{width:11px;height:11px;flex:0 0 auto;}
+.more-row{display:flex;align-items:center;justify-content:center;gap:7px;padding:11px;color:var(--txt3);margin-left:calc(var(--rail) + 4px);
+  font:700 10px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;border:1px dashed var(--line);border-radius:10px;margin-top:8px;margin-bottom:8px;cursor:pointer;}
+.more-row:hover{color:var(--txt2);border-color:var(--txt3);}
+
+@media (max-width:940px){
+  :root{--grid:132px 26px 118px 130px minmax(80px,1fr) 120px 92px;--gap:9px;--padx:11px;--rail:36px;}
+  .loose-tag{padding-left:calc(132px + var(--gap) + var(--padx));}
+  .nowpanel,.rental-inset{flex:1 1 100%;}
+}
+</style>
+</head>
+<body>
+
+<!-- inline SVG sprite — Lucide-style, thin stroke, currentColor -->
+<svg style="display:none" aria-hidden="true">
+  <symbol id="i-truck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 4h13v12H1z"/><path d="M14 9h4l3 3v4h-7V9z"/><circle cx="5.5" cy="18" r="1.8"/><circle cx="17" cy="18" r="1.8"/></symbol>
+  <symbol id="i-box" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8 12 3 3 8v8l9 5 9-5V8Z"/><path d="M3 8l9 5 9-5"/><path d="M12 13v8"/></symbol>
+  <symbol id="i-wrench" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4 4 0 1 1-5.4 5.4L4 17l3 3 5.3-5.3a4 4 0 0 1 5.4-5.4l-3 3-2-2 3-3Z"/></symbol>
+  <symbol id="i-rot" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v5h5"/></symbol>
+  <symbol id="i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></symbol>
+  <symbol id="i-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></symbol>
+  <symbol id="i-pin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s7-7.4 7-12.5A7 7 0 0 0 5 9.5C5 14.6 12 22 12 22Z"/><circle cx="12" cy="9.5" r="2.3"/></symbol>
+  <symbol id="i-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="m19 12-7 7-7-7"/></symbol>
+  <symbol id="i-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="m5 12 7-7 7 7"/></symbol>
+  <symbol id="i-user" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 3.6-7 8-7s8 3 8 7"/></symbol>
+  <symbol id="i-phone" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z"/></symbol>
+  <symbol id="i-play" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 4 14 8-14 8V4Z"/></symbol>
+  <symbol id="i-clock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></symbol>
+  <symbol id="i-alert" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 2 20h20L12 3Z"/><path d="M12 10v4"/><path d="M12 17h.01"/></symbol>
+</svg>
+
+<div class="board">
+
+  <!-- ============================ PAGE HEAD ============================ -->
+  <div class="page-head">
+    <div>
+      <div class="page-title">Trips · ETA Tracker</div>
+      <div class="page-sub">Sulphur, LA yard &nbsp;·&nbsp; <b>Tue Jul 21</b> &nbsp;·&nbsp; each trip = store&nbsp;→&nbsp;stops&nbsp;→&nbsp;store · ETAs accumulate downward (drive&nbsp;+&nbsp;20m load / stop)</div>
+    </div>
+    <div class="yard-tag"><svg class="ic"><use href="#i-truck"/></svg> 3 trucks · 3 drivers on shift</div>
+  </div>
+
+  <!-- ============================ TOP ROW ============================ -->
+  <div class="top-row">
+    <div class="panel-card rental-inset">
+      <div class="panel-label"><svg><use href="#i-box"/></svg> Start a trip from a rental</div>
+      <div class="ri-top">
+        <div class="ri-unit">
+          <span class="ref-ic"><svg class="ic"><use href="#i-box"/></svg></span>
+          <div>
+            <b>Beau <span class="code">260</span></b>
+            <span>Rental #4417 · Doucet Concrete</span>
+          </div>
+        </div>
+        <div class="toggle4">
+          <span class="seg">Self</span>
+          <span class="seg">Round Trip</span>
+          <span class="seg active">Delivery</span>
+          <span class="seg">Pickup</span>
+        </div>
+      </div>
+      <div class="ri-reveal">
+        <div class="ri-addr">
+          <svg><use href="#i-pin"/></svg>
+          <span>1402 <b>Cypress Rd, Lake Charles</b> — type-ahead + map ▾</span>
+        </div>
+        <div class="ri-foot">
+          <span class="ri-hint">Moving off <b>Self</b> reveals the address and drops the stop onto the ledger — no separate +Trip button.</span>
+          <span class="wait-chip">Unscheduled</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel-card nowpanel">
+      <div class="nu-head">
+        <span class="now-badge"><svg><use href="#i-truck"/></svg> NOW</span>
+        <div class="nu-driver"><svg><use href="#i-user"/></svg> J. Thibodeaux · Truck 4</div>
+      </div>
+      <div class="nu-stop"><b>Snappy → Sulphur</b> <span class="nu-type">↓ Drop</span></div>
+      <div class="nu-addr">318 Beglis Pkwy — gate code 4471 · Boudreaux Marine</div>
+      <div class="nu-eta-row">
+        <div><span class="nu-eta-lbl">ETA arrive</span><div class="nu-eta">9:00</div></div>
+        <div class="nu-eta-sub">12 min out<br>deadline 10:30 · near</div>
+      </div>
+      <div class="nu-next">Next → <b>Gator · Vinton</b> · pickup, ETA 9:58</div>
+      <div class="nu-actions">
+        <a class="door ghost" href="tel:+13375550142"><svg><use href="#i-phone"/></svg> (337) 555-0142</a>
+        <span class="door commit"><svg><use href="#i-check"/></svg> Mark Arrived</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================ LEGEND ============================ -->
+  <div class="legend">
+    <div class="lg-flow">
+      <span class="lg-gate go"><svg><use href="#i-chev"/></svg>Start</span><span class="lg-arrow">→</span>
+      <span class="lg-gate go"><svg><use href="#i-chev"/></svg>Arrived?</span><span class="lg-arrow">→</span>
+      <span class="lg-gate go"><svg><use href="#i-chev"/></svg>Dropped?</span><span class="lg-arrow">→</span>
+      <span class="lg-gate na">next Start</span>
+    </div>
+    <div class="lg-div"></div>
+    <div class="lg-key">
+      <span class="lg-k"><span class="dot na"></span>Not yet</span>
+      <span class="lg-k"><span class="dot wait"></span>Waiting / next</span>
+      <span class="lg-k"><span class="dot near"></span>Leave / ≤2h</span>
+      <span class="lg-k"><span class="dot late"></span>Late</span>
+      <span class="lg-k"><span class="dot done"></span>Done</span>
+    </div>
+    <div class="lg-div"></div>
+    <div class="lg-note"><span class="mini-node num">2</span> numbered spine hangs <b>outside</b> the card (drag to reorder) · <span class="mini-node sq"></span> box = unscheduled · <b>drag a row away to untrip</b> · one ladder, two clocks: <b>departure time</b> = when to leave · <b>deadline chip</b> = will it make it · tap <b>town ↗</b> = Maps</div>
+  </div>
+
+  <!-- ============================ COLUMN HEADER ============================ -->
+  <div class="col-head">
+    <span>Departure · Unit</span><span class="ch-c">Type</span><span>Gate</span>
+    <span class="ch-r">ETA</span><span>Town</span><span>Customer</span><span class="ch-r">Deadline</span>
+  </div>
+
+  <!-- ============================ FIELD CALLS ============================ -->
+  <div class="group-head g-field"><svg><use href="#i-wrench"/></svg><h2>Field Calls</h2><span class="g-count">2 · 1 overdue</span></div>
+
+  <div class="loose attn">
+    <div class="stop-row">
+      <div class="rail first last"><span class="node box late" title="Unscheduled — drag onto a trip"></span></div>
+      <div class="pfx">
+        <div class="pfx-dep late"><span class="t">8:20</span><span class="l">Dispatch</span></div>
+        <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-wrench"/></svg></span><span class="nm">Bush<span class="code">MX‑50</span></span></a></div>
+      </div>
+      <span class="glyph arrow"><svg><use href="#i-wrench"/></svg></span>
+      <div class="gate"><span class="gate-chip go"><svg class="chev"><use href="#i-chev"/></svg> Start</span></div>
+      <span class="eta late"><span class="drv">+20<span class="u">MIN</span></span><span class="climb">⧗ climbing</span></span>
+      <span class="town"><a href="https://maps.google.com/?q=Iowa,LA" target="_blank" rel="noopener"><span class="nm">Iowa, LA</span><span class="ext">↗</span></a></span>
+      <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Thibodaux Farms</span></a></span>
+      <span class="dl"><span class="sig late"><svg><use href="#i-alert"/></svg><span class="tm">8:00a</span><span class="st">late</span></span></span>
+    </div>
+    <div class="loose-tag hot"><svg><use href="#i-alert"/></svg> Missed departure — clock counting up · escalated to dispatch + manager + sales (no yard video — service call)</div>
+  </div>
+
+  <div class="loose attn near">
+    <div class="stop-row">
+      <div class="rail first last"><span class="node box" title="Unscheduled — drag onto a trip"></span></div>
+      <div class="pfx">
+        <div class="pfx-dep soon"><span class="t">1:30</span><span class="l">Dispatch</span></div>
+        <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-rot"/></svg></span><span class="nm">Scoot<span class="code">T‑16</span></span></a></div>
+      </div>
+      <span class="glyph arrow"><svg><use href="#i-up"/></svg></span>
+      <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Start</span></div>
+      <span class="eta near"><span class="drv">+40<span class="u">MIN</span></span><span class="eq">=</span><span class="t">2:10</span><span class="lbl">ETA</span></span>
+      <span class="town"><a href="https://maps.google.com/?q=Dequincy,LA" target="_blank" rel="noopener"><span class="nm">Dequincy, LA</span><span class="ext">↗</span></a></span>
+      <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Prejean Co.</span></a></span>
+      <span class="dl"><span class="sig near"><svg><use href="#i-clock"/></svg><span class="tm">3:00p</span><span class="st">near</span></span></span>
+    </div>
+    <div class="loose-tag warn"><svg><use href="#i-rot"/></svg> Repo pickup · assigned M. Fontenot · gate opens after his 1:00 drop</div>
+  </div>
+
+  <!-- ============================ TODAY ============================ -->
+  <div class="group-head"><svg><use href="#i-truck"/></svg><h2>Today</h2><span class="g-count">1 trip in progress · 1 late stop</span></div>
+
+  <div class="trip">
+    <div class="trip-rows">
+
+      <!-- START anchor -->
+      <div class="stop-row">
+        <div class="rail first done-below"><span class="node done" style="border-radius:50%;width:12px;height:12px"></span></div>
+        <div class="pfx">
+          <div class="pfx-dep done"><span class="t">7:40</span><span class="l">Departure</span></div>
+          <div class="pfx-yard"><svg><use href="#i-truck"/></svg> Sulphur yard</div>
+        </div>
+        <span class="glyph hq">HQ</span>
+        <div class="gate"><span class="gate-done"><svg><use href="#i-check"/></svg> Departed</span></div>
+        <span class="eta dim"><span class="t">7:40</span><span class="lbl">Trip 1 · start</span></span>
+        <span class="town dim">Store</span>
+        <span class="cust"><span class="driver-chip"><svg><use href="#i-user"/></svg><span class="nm">J. Thibodeaux</span><svg class="chev"><use href="#i-chev"/></svg></span></span>
+        <span class="dl dim">—</span>
+      </div>
+
+      <!-- Stop 1 — DONE -->
+      <div class="stop-row">
+        <div class="rail done-seg done-below"><span class="node num done" title="Stop 1 · done — drag away to untrip">1</span></div>
+        <div class="pfx">
+          <div class="pfx-dep done"><span class="t">7:40</span><span class="l">Departure</span></div>
+          <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-box"/></svg></span><span class="nm">Beau<span class="code">260</span></span></a><span class="ref-more">+1</span></div>
+        </div>
+        <span class="glyph arrow"><svg><use href="#i-down"/></svg></span>
+        <div class="gate-wrap">
+          <span class="gate-done"><svg><use href="#i-check"/></svg> Done · dropped</span>
+          <span class="sent-undo"><span class="ok"><svg><use href="#i-check"/></svg> sent</span> · <a>undo</a></span>
+        </div>
+        <span class="eta"><span class="drv">+42<span class="u">MIN</span></span><span class="eq">=</span><span class="t">8:22</span><span class="lbl">ETA</span></span>
+        <span class="town"><a href="https://maps.google.com/?q=Lake+Charles,LA" target="_blank" rel="noopener"><span class="nm">Lake Charles, LA</span><span class="ext">↗</span></a></span>
+        <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Doucet Concrete</span></a></span>
+        <span class="dl"><span class="sig done"><svg><use href="#i-check"/></svg><span class="tm">9:30</span><span class="st">done</span></span></span>
+      </div>
+
+      <!-- Stop 2 — ACTIVE -->
+      <div class="stop-row here">
+        <div class="rail"><span class="node num here" title="Stop 2 · current — drag away to untrip">2</span></div>
+        <div class="pfx">
+          <div class="pfx-dep done"><span class="t">8:42</span><span class="l">Departure</span></div>
+          <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-box"/></svg></span><span class="nm">Snappy<span class="code">S‑9</span></span></a></div>
+        </div>
+        <span class="glyph arrow"><svg><use href="#i-down"/></svg></span>
+        <div class="gate"><span class="gate-chip go"><svg class="chev"><use href="#i-chev"/></svg> Arrived?</span></div>
+        <span class="eta near"><span class="drv">+18<span class="u">MIN</span></span><span class="eq">=</span><span class="t">9:00</span><span class="lbl">ETA</span></span>
+        <span class="town"><a href="https://maps.google.com/?q=Sulphur,LA" target="_blank" rel="noopener"><span class="nm">Sulphur, LA</span><span class="ext">↗</span></a></span>
+        <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Boudreaux Marine</span></a></span>
+        <span class="dl"><span class="sig near"><svg><use href="#i-clock"/></svg><span class="tm">10:30</span><span class="st">near</span></span></span>
+      </div>
+
+      <!-- Stop 3 — NEXT UP (blue departure) -->
+      <div class="stop-row">
+        <div class="rail"><span class="node num" title="Stop 3 — drag away to untrip">3</span></div>
+        <div class="pfx">
+          <div class="pfx-dep next"><span class="t">9:20</span><span class="l">Departure</span></div>
+          <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-rot"/></svg></span><span class="nm">Gator<span class="code">ME‑35</span></span></a></div>
+        </div>
+        <span class="glyph arrow"><svg><use href="#i-up"/></svg></span>
+        <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Picked Up?</span></div>
+        <span class="eta"><span class="drv">+38<span class="u">MIN</span></span><span class="eq">=</span><span class="t">9:58</span><span class="lbl">ETA</span></span>
+        <span class="town"><a href="https://maps.google.com/?q=Vinton,LA" target="_blank" rel="noopener"><span class="nm">Vinton, LA</span><span class="ext">↗</span></a></span>
+        <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Fontenot Rentals</span></a></span>
+        <span class="dl"><span class="sig wait"><svg><use href="#i-clock"/></svg><span class="tm">12:30</span><span class="st">waiting</span></span></span>
+      </div>
+
+      <!-- Stop 4 — LATE (grey departure = not yet its turn) -->
+      <div class="stop-row">
+        <div class="rail"><span class="node num" title="Stop 4 — drag away to untrip">4</span></div>
+        <div class="pfx">
+          <div class="pfx-dep"><span class="t">10:18</span><span class="l">Departure</span></div>
+          <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-box"/></svg></span><span class="nm">Diesel<span class="code">D‑20</span></span></a></div>
+        </div>
+        <span class="glyph arrow"><svg><use href="#i-down"/></svg></span>
+        <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Dropped?</span></div>
+        <span class="eta late"><span class="drv">+55<span class="u">MIN</span></span><span class="eq">=</span><span class="t">11:13</span><span class="lbl">ETA</span></span>
+        <span class="town"><a href="https://maps.google.com/?q=Dequincy,LA" target="_blank" rel="noopener"><span class="nm">Dequincy, LA</span><span class="ext">↗</span></a></span>
+        <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Hebert Excavating</span></a></span>
+        <span class="dl"><span class="sig late"><svg><use href="#i-alert"/></svg><span class="tm">11:00</span><span class="st">late</span></span></span>
+      </div>
+
+      <!-- END anchor -->
+      <div class="stop-row">
+        <div class="rail last"><span class="node" style="border-radius:50%;width:12px;height:12px;background:var(--bg)"></span></div>
+        <div class="pfx">
+          <div class="pfx-dep"><span class="t">11:33</span><span class="l">Return</span></div>
+          <div class="pfx-yard"><svg><use href="#i-truck"/></svg> Sulphur yard</div>
+        </div>
+        <span class="glyph hq">HQ</span>
+        <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Return</span></div>
+        <span class="eta dim"><span class="drv">+50<span class="u">MIN</span></span><span class="eq">=</span><span class="t">12:23</span></span>
+        <span class="town dim">Store</span>
+        <span class="cust"></span>
+        <span class="dl dim">—</span>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ============================ TOMORROW ============================ -->
+  <div class="group-head"><svg><use href="#i-truck"/></svg><h2>Tomorrow</h2><span class="g-count">1 trip · not started</span></div>
+
+  <div class="trip">
+    <div class="trip-rows">
+      <div class="stop-row">
+        <div class="rail first"><span class="node" style="border-radius:50%;width:12px;height:12px;background:var(--bg)"></span></div>
+        <div class="pfx">
+          <div class="pfx-dep"><span class="t">8:00</span><span class="l">Departure</span></div>
+          <div class="pfx-yard"><svg><use href="#i-truck"/></svg> Sulphur yard</div>
+        </div>
+        <span class="glyph hq">HQ</span>
+        <div class="gate"><span class="gate-chip go"><svg class="chev"><use href="#i-chev"/></svg> Start</span></div>
+        <span class="eta dim"><span class="t">8:00</span><span class="lbl">Trip 2 · start</span></span>
+        <span class="town dim">Store</span>
+        <span class="cust"><span class="driver-chip"><svg><use href="#i-user"/></svg><span class="nm">R. Guillory</span><svg class="chev"><use href="#i-chev"/></svg></span></span>
+        <span class="dl dim">—</span>
+      </div>
+      <div class="stop-row">
+        <div class="rail"><span class="node num" title="Stop 1 — drag away to untrip">1</span></div>
+        <div class="pfx">
+          <div class="pfx-dep"><span class="t">8:00</span><span class="l">Departure</span></div>
+          <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-rot"/></svg></span><span class="nm">Bush<span class="code">MX‑50</span></span></a></div>
+        </div>
+        <span class="glyph arrow"><svg><use href="#i-up"/></svg></span>
+        <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Picked Up?</span></div>
+        <span class="eta"><span class="drv">+40<span class="u">MIN</span></span><span class="eq">=</span><span class="t">8:40</span><span class="lbl">ETA</span></span>
+        <span class="town"><a href="https://maps.google.com/?q=Iowa,LA" target="_blank" rel="noopener"><span class="nm">Iowa, LA</span><span class="ext">↗</span></a></span>
+        <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Guidry Oilfield</span></a></span>
+        <span class="dl"><span class="sig wait"><svg><use href="#i-clock"/></svg><span class="tm">11:00</span><span class="st">waiting</span></span></span>
+      </div>
+      <div class="stop-row">
+        <div class="rail"><span class="node num" title="Stop 2 — drag away to untrip">2</span></div>
+        <div class="pfx">
+          <div class="pfx-dep"><span class="t">9:00</span><span class="l">Departure</span></div>
+          <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-box"/></svg></span><span class="nm">Boudin<span class="code">B‑7</span></span></a></div>
+        </div>
+        <span class="glyph arrow"><svg><use href="#i-down"/></svg></span>
+        <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Dropped?</span></div>
+        <span class="eta"><span class="drv">+38<span class="u">MIN</span></span><span class="eq">=</span><span class="t">9:38</span><span class="lbl">ETA</span></span>
+        <span class="town"><a href="https://maps.google.com/?q=Vinton,LA" target="_blank" rel="noopener"><span class="nm">Vinton, LA</span><span class="ext">↗</span></a></span>
+        <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Landry Ag Co.</span></a></span>
+        <span class="dl"><span class="sig wait"><svg><use href="#i-clock"/></svg><span class="tm">1:00p</span><span class="st">waiting</span></span></span>
+      </div>
+      <div class="stop-row">
+        <div class="rail last"><span class="node" style="border-radius:50%;width:12px;height:12px;background:var(--bg)"></span></div>
+        <div class="pfx">
+          <div class="pfx-dep"><span class="t">9:58</span><span class="l">Return</span></div>
+          <div class="pfx-yard"><svg><use href="#i-truck"/></svg> Sulphur yard</div>
+        </div>
+        <span class="glyph hq">HQ</span>
+        <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Return</span></div>
+        <span class="eta dim"><span class="drv">+50<span class="u">MIN</span></span><span class="eq">=</span><span class="t">10:48</span></span>
+        <span class="town dim">Store</span>
+        <span class="cust"></span>
+        <span class="dl dim">—</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================ THIS WEEK ============================ -->
+  <div class="group-head"><svg><use href="#i-truck"/></svg><h2>This Week</h2><span class="g-count">5 stops · unscheduled</span></div>
+
+  <div class="loose">
+    <div class="stop-row">
+      <div class="rail first last"><span class="node box" title="Unscheduled — drag onto a trip"></span></div>
+      <div class="pfx">
+        <div class="pfx-dep"><span class="t">Thu</span><span class="l">am</span></div>
+        <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-box"/></svg></span><span class="nm">Tank<span class="code">T‑40</span></span></a></div>
+      </div>
+      <span class="glyph arrow"><svg><use href="#i-down"/></svg></span>
+      <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Dropped?</span></div>
+      <span class="eta dim"><span class="lbl">not on a trip</span></span>
+      <span class="town"><a href="https://maps.google.com/?q=Iowa,LA" target="_blank" rel="noopener"><span class="nm">Iowa, LA</span><span class="ext">↗</span></a></span>
+      <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Broussard Const.</span></a></span>
+      <span class="dl"><span class="sig wait"><svg><use href="#i-clock"/></svg><span class="tm">Thu 4p</span><span class="st">waiting</span></span></span>
+    </div>
+  </div>
+
+  <div class="loose">
+    <div class="stop-row">
+      <div class="rail first last"><span class="node box" title="Unscheduled — drag onto a trip"></span></div>
+      <div class="pfx">
+        <div class="pfx-dep"><span class="t">Fri</span><span class="l">pm</span></div>
+        <div class="pfx-unit"><a class="ref sm"><span class="ty"><svg><use href="#i-rot"/></svg></span><span class="nm">Scoot<span class="code">T‑16</span></span></a></div>
+      </div>
+      <span class="glyph arrow"><svg><use href="#i-up"/></svg></span>
+      <div class="gate"><span class="gate-chip na"><svg class="chev"><use href="#i-chev"/></svg> Picked Up?</span></div>
+      <span class="eta dim"><span class="lbl">not on a trip</span></span>
+      <span class="town"><a href="https://maps.google.com/?q=Lake+Charles,LA" target="_blank" rel="noopener"><span class="nm">Lake Charles, LA</span><span class="ext">↗</span></a></span>
+      <span class="cust"><a class="ref"><span class="ty"><svg><use href="#i-user"/></svg></span><span class="nm">Cormier Rentals</span></a></span>
+      <span class="dl"><span class="sig wait"><svg><use href="#i-clock"/></svg><span class="tm">Fri 5p</span><span class="st">waiting</span></span></span>
+    </div>
+  </div>
+
+  <div class="more-row"><svg class="ic"><use href="#i-chev"/></svg> +3 more stops this week</div>
+
+</div>
+</body>
+</html>

--- a/docs/design/reference/trips-schedule.html
+++ b/docs/design/reference/trips-schedule.html
@@ -1,0 +1,539 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Trips · Dispatch schedule</title>
+<style>
+:root{
+  --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --card:#12171e; --cardh:#1a212b;
+  --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#838e9c;
+  --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15);
+  --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redFill:#d63636; --onRedFill:#fdfdfd;
+  --blue:#6394cc; --commit:#2f6fd0; --onCommit:#fdfdfd; --gray:#8b94a3; --tan:#c2925a;
+  --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+  --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+  --h:24px;
+  /* alpha-derived soft fills of the SAME frozen tokens (same convention as --accSoft above) */
+  --greenSoft:rgba(52,211,153,.15); --yellowSoft:rgba(238,212,75,.16); --redSoft:rgba(255,66,66,.14);
+}
+*{box-sizing:border-box;}
+html,body{margin:0;padding:0;}
+body{
+  background:var(--bg); color:var(--txt); font-family:var(--font); font-size:13px; line-height:1.4;
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+}
+svg.ic{width:14px;height:14px;flex:0 0 auto;display:block;}
+.board{max-width:1100px;margin:0 auto;padding:26px 20px 90px;}
+
+/* ============ PAGE HEAD ============ */
+.page-head{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:16px;}
+.page-title{font:800 22px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;color:var(--txt);}
+.page-sub{font:500 11.5px/1.4 var(--font);color:var(--txt3);margin-top:5px;}
+.page-sub b{color:var(--txt2);font-weight:600;}
+.yard-tag{display:inline-flex;align-items:center;gap:6px;height:var(--h);padding:0 11px;border:1px dashed var(--line);border-radius:999px;font:800 9.5px/1 var(--stamp);letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);}
+.yard-tag svg{width:13px;height:13px;}
+
+/* ============ TOP ROW: rental inset + next-up ============ */
+.top-row{display:flex;gap:14px;flex-wrap:wrap;margin-bottom:18px;}
+.panel-card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:13px 15px;}
+.panel-label{display:flex;align-items:center;gap:6px;font:800 9.5px/1 var(--stamp);letter-spacing:.08em;text-transform:uppercase;color:var(--txt3);margin-bottom:10px;}
+.panel-label svg{width:13px;height:13px;color:var(--txt3);}
+
+/* --- rental inset --- */
+.rental-inset{flex:1 1 340px;min-width:300px;}
+.ri-top{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;}
+.ri-unit{display:flex;align-items:center;gap:8px;}
+.ri-unit .ref-ic{width:26px;height:26px;border-radius:7px;background:var(--accSoft);display:flex;align-items:center;justify-content:center;color:var(--accent);flex:0 0 auto;}
+.ri-unit .ref-ic svg{width:14px;height:14px;}
+.ri-unit b{font:700 13px/1.2 var(--font);color:var(--txt);}
+.ri-unit span{display:block;font:500 10.5px/1.3 var(--font);color:var(--txt3);}
+.toggle4{display:inline-flex;height:var(--h);border:1px solid var(--line);border-radius:999px;overflow:hidden;background:var(--panel);flex:0 0 auto;}
+.toggle4 .seg{display:flex;align-items:center;padding:0 10px;font:700 9px/1 var(--stamp);letter-spacing:.04em;text-transform:uppercase;color:var(--txt3);white-space:nowrap;}
+.toggle4 .seg.active{background:var(--accent);color:var(--onAcc);font-weight:800;}
+.ri-reveal{margin-top:11px;padding-top:11px;border-top:1px dashed var(--tan);opacity:.97;}
+.ri-addr{display:flex;align-items:center;gap:8px;height:var(--h);padding:0 10px;border:1px solid var(--line);border-radius:8px;background:var(--panel);}
+.ri-addr svg{width:14px;height:14px;color:var(--accent);flex:0 0 auto;}
+.ri-addr span{font:500 11px/1 var(--font);color:var(--txt3);}
+.ri-addr span b{color:var(--txt2);font-weight:600;}
+.ri-foot{display:flex;align-items:center;justify-content:space-between;margin-top:9px;}
+.ri-foot .hint{font:500 10px/1.3 var(--font);color:var(--txt3);}
+.stamp-fact{font:800 9.5px/1 var(--stamp);letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);}
+.wait-chip{display:inline-flex;align-items:center;height:var(--h);padding:0 9px;border:1px dashed var(--line);border-radius:7px;font:800 9.5px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;color:var(--gray);}
+
+/* --- next up / NOW panel --- */
+.nextup{flex:0 0 300px;border-color:var(--accent);box-shadow:0 0 0 1px var(--accSoft) inset;}
+.nu-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:9px;}
+.now-badge{display:inline-flex;align-items:center;height:var(--h);padding:0 10px;border-radius:7px;background:var(--accent);color:var(--onAcc);font:800 10px/1 var(--stamp);letter-spacing:.08em;}
+.nu-driver{display:flex;align-items:center;gap:6px;font:600 11px/1 var(--font);color:var(--txt2);}
+.nu-driver svg{width:13px;height:13px;color:var(--txt3);}
+.nu-stop{display:flex;align-items:baseline;gap:8px;margin:4px 0 2px;}
+.nu-stop b{font:700 15px/1.2 var(--font);color:var(--txt);}
+.nu-stop .nu-type{font:800 9px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;color:var(--txt3);}
+.nu-addr{font:500 11px/1.4 var(--font);color:var(--txt3);margin-bottom:9px;}
+.nu-eta-row{display:flex;align-items:flex-end;justify-content:space-between;margin-bottom:11px;}
+.nu-eta{font:800 26px/1 var(--stamp);font-variant-numeric:tabular-nums;color:var(--green);}
+.nu-eta-lbl{font:800 9px/1 var(--stamp);letter-spacing:.06em;text-transform:uppercase;color:var(--txt3);}
+.nu-next{font:500 10.5px/1.3 var(--font);color:var(--txt3);margin-bottom:10px;}
+.nu-next b{color:var(--txt2);font-weight:600;}
+.nu-actions{display:flex;gap:8px;}
+.door{height:var(--h);border-radius:999px;padding:0 13px;font:700 10px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;display:inline-flex;align-items:center;gap:6px;cursor:pointer;white-space:nowrap;}
+.door svg{width:13px;height:13px;}
+.door.ghost{background:transparent;border:1px solid var(--line);color:var(--txt2);}
+.door.commit{background:var(--commit);border:1px solid var(--commit);color:var(--onCommit);}
+.door.commit-outline{background:transparent;border:1.5px dashed var(--commit);color:var(--commit);}
+
+/* ============ LEGEND ============ */
+.legend{display:flex;align-items:center;gap:18px;flex-wrap:wrap;background:var(--panel);border:1px solid var(--lineSoft);border-radius:10px;padding:9px 14px;margin-bottom:6px;font:500 11px/1.4 var(--font);color:var(--txt2);}
+.legend .lg-item{display:flex;align-items:center;gap:7px;}
+.legend svg{width:14px;height:14px;color:var(--accent);flex:0 0 auto;}
+.legend .lg-div{width:1px;align-self:stretch;background:var(--line);}
+.legend .lg-key{display:flex;align-items:center;gap:5px;}
+.legend .dot{width:8px;height:8px;border-radius:2px;}
+.legend .dot.ok{background:var(--green);} .legend .dot.risk{background:var(--yellow);} .legend .dot.late{background:var(--redFill);}
+
+/* ============ COLUMN HEADER ============ */
+.col-head{position:sticky;top:0;z-index:8;display:grid;grid-template-columns:30px 1fr 62px 62px 68px 122px;column-gap:10px;align-items:center;padding:8px 10px;margin:16px 0 4px;background:var(--bg2);border:1px solid var(--line);border-radius:8px;font:800 9px/1 var(--stamp);letter-spacing:.09em;text-transform:uppercase;color:var(--txt3);}
+.col-head .ch-r{text-align:right;}
+
+/* ============ GROUPS ============ */
+.group-head{display:flex;align-items:center;gap:8px;margin:24px 2px 8px;padding-bottom:6px;border-bottom:1px solid var(--line);}
+.group-head svg{width:15px;height:15px;color:var(--txt3);}
+.group-head h2{font:800 12.5px/1 var(--stamp);letter-spacing:.09em;text-transform:uppercase;color:var(--txt);margin:0;}
+.group-head .g-count{font:700 9.5px/1 var(--stamp);color:var(--txt3);background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:3px 9px;}
+.group-head.g-field svg{color:var(--tan);}
+
+/* ============ STOP ROW (shared grid — keeps all 3 time columns aligned) ============ */
+.stop-row{display:grid;grid-template-columns:30px 1fr 62px 62px 68px 122px;column-gap:10px;align-items:center;min-height:42px;padding:7px 10px;border-bottom:1px dotted var(--lineSoft);}
+.stop-row:last-child{border-bottom:none;}
+.meta{display:flex;align-items:center;gap:8px;min-width:0;}
+.meta .m-ic{width:15px;height:15px;flex:0 0 auto;color:var(--txt3);}
+.meta .m-text{min-width:0;}
+.m-title{font:700 12.5px/1.25 var(--font);color:var(--txt);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.m-title .loc{font-weight:400;color:var(--txt2);}
+.m-sub{font:800 9px/1.2 var(--stamp);letter-spacing:.05em;text-transform:uppercase;color:var(--txt3);margin-top:1px;}
+
+.tcell{text-align:right;font:600 11.5px/1.15 var(--stamp);font-variant-numeric:tabular-nums;color:var(--txt2);white-space:nowrap;}
+.tcell .t-delta{display:block;font:700 8.5px/1 var(--stamp);color:var(--txt3);margin-top:2px;}
+.tcell.deadline{color:var(--txt2);}
+.tcell.eta.risk{color:var(--yellow);}
+.tcell.eta.risk .t-delta{color:var(--yellow);}
+.tcell.eta.late{color:var(--red);font-weight:800;}
+.tcell.eta.late .t-delta{color:var(--red);}
+.tcell.dim{color:var(--txt3);}
+
+.state-cell{display:flex;justify-content:flex-end;}
+.sig{display:inline-flex;align-items:center;gap:5px;height:var(--h);padding:0 9px;border-radius:7px;font:800 9px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;white-space:nowrap;}
+.sig svg{width:11px;height:11px;}
+.sig.ok{color:var(--green);background:var(--greenSoft);border:1px solid rgba(52,211,153,.35);}
+.sig.risk{color:var(--yellow);background:var(--yellowSoft);border:1px solid rgba(238,212,75,.4);}
+.sig.late{background:var(--redFill);color:var(--onRedFill);border:1px solid rgba(255,66,66,.5);}
+.sig.conflict{background:var(--redFill);color:var(--onRedFill);border:1px solid rgba(255,66,66,.5);}
+.sig.wait{color:var(--gray);background:transparent;border:1px dashed var(--line);}
+
+/* --- connector / box-connect handle --- */
+.connector{width:17px;height:17px;border-radius:4px;border:1.5px solid var(--line);background:var(--card);position:relative;justify-self:center;z-index:1;}
+.connector.loose{border-style:dashed;border-color:var(--txt3);}
+.connector.linked{border-color:var(--tc);background:var(--tc-soft);}
+.connector.linked::before,.connector.linked::after{content:'';position:absolute;left:50%;width:2px;background:var(--tc);transform:translateX(-50%);}
+.connector.linked::before{bottom:100%;height:12px;}
+.connector.linked::after{top:100%;height:12px;}
+.connector.first::before{display:none;}
+.connector.last::after{display:none;}
+
+/* ============ TRIP TICKET CARD (invoice/YARD-LOG devices, translated to dark tokens) ============ */
+.trip{background:var(--card);border:1px solid var(--line);border-radius:12px;margin:12px 0;overflow:hidden;}
+.trip[data-state="ok"]{--tc:var(--green);--tc-soft:var(--greenSoft);}
+.trip[data-state="risk"]{--tc:var(--yellow);--tc-soft:var(--yellowSoft);}
+.trip[data-state="late"]{--tc:var(--red);--tc-soft:var(--redSoft);}
+.trip-head{padding:13px 15px 10px;}
+.trip-top{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;flex-wrap:wrap;}
+.trip-idline{display:flex;align-items:center;gap:9px;}
+.trip-datestamp{font:800 24px/1 var(--stamp);font-variant-numeric:tabular-nums;color:var(--tc);}
+.trip-id-text .trip-id{font:800 9px/1 var(--stamp);letter-spacing:.08em;color:var(--txt3);text-transform:uppercase;}
+.trip-title{font:800 14px/1.3 var(--stamp);letter-spacing:.03em;text-transform:uppercase;color:var(--txt);margin-top:2px;}
+.stamp-badge{transform:rotate(-8deg);border:2.5px solid var(--tc);border-radius:6px;padding:3px 11px;font:800 11px/1.2 var(--stamp);letter-spacing:.12em;text-transform:uppercase;color:var(--tc);background:var(--tc-soft);white-space:nowrap;flex:0 0 auto;}
+.hazard{height:7px;border-radius:2px;margin:11px 15px 0;background:repeating-linear-gradient(135deg,var(--tc) 0 11px,var(--card) 11px 22px);opacity:.9;}
+.trip-dash{border-bottom:2px dashed var(--tan);margin:9px 15px 0;opacity:.55;}
+.trip-rows{padding:2px 5px 0;}
+.trip-foot{display:flex;align-items:center;justify-content:space-between;padding:9px 15px 12px;}
+.trip-driver{display:flex;align-items:center;gap:6px;}
+.trip-subtotal{font:800 10.5px/1 var(--stamp);letter-spacing:.03em;text-transform:uppercase;color:var(--txt2);font-variant-numeric:tabular-nums;white-space:nowrap;}
+
+.store-row .m-title{color:var(--txt2);font-style:italic;font-weight:600;}
+.store-row .m-sub{color:var(--txt3);}
+.store-row{opacity:.92;}
+
+/* --- capacity-conflict sub row --- */
+.conflict-note{grid-column:1/-1;margin:2px 8px 9px 38px;background:var(--redSoft);border:1px solid rgba(255,66,66,.4);border-left:3px solid var(--red);border-radius:7px;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;}
+.conflict-note p{margin:0;font:500 11.5px/1.4 var(--font);color:var(--txt);max-width:520px;}
+.conflict-note b{color:var(--red);}
+.conflict-note .door{flex:0 0 auto;}
+
+/* --- driver Gate dropdown --- */
+.gate{position:relative;display:inline-block;}
+.gate > summary{list-style:none;cursor:pointer;display:inline-flex;align-items:center;gap:5px;height:var(--h);padding:0 9px 0 8px;border-radius:7px;border:1px solid var(--line);background:var(--panel);font:700 9.5px/1 var(--stamp);letter-spacing:.04em;text-transform:uppercase;color:var(--txt2);}
+.gate > summary::-webkit-details-marker{display:none;}
+.gate > summary svg.chev{width:11px;height:11px;transition:transform .15s;color:var(--txt3);}
+.gate[open] > summary svg.chev{transform:rotate(180deg);}
+.gate-menu{position:absolute;top:calc(100% + 5px);right:0;min-width:238px;background:var(--cardh);border:1px solid var(--line);border-radius:9px;box-shadow:0 14px 30px -10px rgba(0,0,0,.65);padding:6px;z-index:9;}
+.gate-opt{display:flex;flex-direction:column;gap:2px;padding:7px 8px;border-radius:6px;cursor:pointer;}
+.gate-opt:hover{background:var(--panel);}
+.gate-opt .go-name{font:600 12px/1.2 var(--font);color:var(--txt);}
+.gate-warn{display:flex;align-items:flex-start;gap:5px;font:700 9.5px/1.35 var(--stamp);letter-spacing:.02em;text-transform:uppercase;color:var(--yellow);background:var(--yellowSoft);border:1px solid rgba(238,212,75,.4);border-radius:5px;padding:5px 7px;margin-top:4px;}
+.gate-warn svg{width:12px;height:12px;flex:0 0 auto;margin-top:1px;}
+
+/* --- loose / unconnected rows (outside any trip) --- */
+.loose-row{background:var(--panel);border:1px solid var(--lineSoft);border-radius:9px;margin:8px 0;}
+.loose-row.is-warn{border-left:3px solid var(--yellow);}
+.loose-row.is-flat{border-left:3px solid var(--line);opacity:.9;}
+.loose-tag{grid-column:1/-1;display:flex;align-items:center;gap:6px;padding:0 10px 6px 38px;font:700 9px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;color:var(--txt3);}
+.loose-tag.warn{color:var(--yellow);}
+.loose-tag svg{width:11px;height:11px;}
+
+.more-row{display:flex;align-items:center;justify-content:center;gap:6px;padding:9px;color:var(--txt3);font:700 10px/1 var(--stamp);letter-spacing:.05em;text-transform:uppercase;border:1px dashed var(--line);border-radius:9px;margin:8px 0;}
+
+@media (max-width:720px){
+  .col-head,.stop-row{grid-template-columns:26px 1fr 52px 52px 58px 96px;}
+}
+</style>
+</head>
+<body>
+
+<!-- inline SVG sprite — hand-drawn, Lucide-style, no external icon font -->
+<svg style="display:none" aria-hidden="true">
+  <symbol id="i-truck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 4h13v12H1z"/><path d="M14 9h4l3 3v4h-7V9z"/><circle cx="5.5" cy="18" r="1.8"/><circle cx="17" cy="18" r="1.8"/></symbol>
+  <symbol id="i-box" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8 12 3 3 8v8l9 5 9-5V8Z"/><path d="M3 8l9 5 9-5"/><path d="M12 13v8"/></symbol>
+  <symbol id="i-rot" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v5h5"/></symbol>
+  <symbol id="i-wrench" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4 4 0 1 1-5.4 5.4L4 17l3 3 5.3-5.3a4 4 0 0 1 5.4-5.4l-3 3-2-2 3-3Z"/></symbol>
+  <symbol id="i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></symbol>
+  <symbol id="i-alert" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 2 20h20L12 3Z"/><path d="M12 10v4"/><path d="M12 17h.01"/></symbol>
+  <symbol id="i-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></symbol>
+  <symbol id="i-pin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s7-7.4 7-12.5A7 7 0 0 0 5 9.5C5 14.6 12 22 12 22Z"/><circle cx="12" cy="9.5" r="2.3"/></symbol>
+  <symbol id="i-grip" viewBox="0 0 24 24" fill="currentColor"><circle cx="9" cy="6" r="1.5"/><circle cx="15" cy="6" r="1.5"/><circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/><circle cx="9" cy="18" r="1.5"/><circle cx="15" cy="18" r="1.5"/></symbol>
+  <symbol id="i-user" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 3.6-7 8-7s8 3 8 7"/></symbol>
+  <symbol id="i-phone" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 4h4l2 5-2.5 1.5a11 11 0 0 0 5 5L15 13l5 2v4a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2Z"/></symbol>
+  <symbol id="i-split" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v6a3 3 0 0 0 3 3h6a3 3 0 0 0 3-3V3"/><path d="M12 12v9"/></symbol>
+</svg>
+
+<div class="board">
+
+  <!-- ============ PAGE HEAD ============ -->
+  <div class="page-head">
+    <div>
+      <div class="page-title">Trips · Dispatch</div>
+      <div class="page-sub">Sulphur, LA yard &nbsp;·&nbsp; <b>Tue Jul 21</b> &nbsp;·&nbsp; one time-sorted schedule, store&nbsp;→&nbsp;stops&nbsp;→&nbsp;store</div>
+    </div>
+    <div class="yard-tag"><svg class="ic"><use href="#i-truck"/></svg> 3 trucks · 2 drivers on shift</div>
+  </div>
+
+  <!-- ============ TOP ROW: rental-side trigger + Next Up ============ -->
+  <div class="top-row">
+    <div class="panel-card rental-inset">
+      <div class="panel-label"><svg><use href="#i-box"/></svg> Rental creation trigger</div>
+      <div class="ri-top">
+        <div class="ri-unit">
+          <span class="ref-ic"><svg class="ic"><use href="#i-box"/></svg></span>
+          <div>
+            <b>Beau</b> — Skid Steer 260
+            <span>Rental #4417 · Doucet Concrete</span>
+          </div>
+        </div>
+        <div class="toggle4">
+          <span class="seg">Self</span>
+          <span class="seg">Round Trip</span>
+          <span class="seg active">Delivery</span>
+          <span class="seg">Pickup</span>
+        </div>
+      </div>
+      <div class="ri-reveal">
+        <div class="ri-addr">
+          <svg><use href="#i-pin"/></svg>
+          <span>1402 <b>Cypress Rd, Lake Charles</b> — type-ahead + map ▾</span>
+        </div>
+        <div class="ri-foot">
+          <span class="hint">Moving off "Self" reveals the address — no separate +Trip button</span>
+          <span class="wait-chip">Unscheduled</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel-card nextup">
+      <div class="nu-head">
+        <span class="now-badge">NOW</span>
+        <div class="nu-driver"><svg><use href="#i-user"/></svg> J. Thibodeaux · Truck 4</div>
+      </div>
+      <div class="nu-stop"><b>Beau → Lake Charles</b> <span class="nu-type">Drop</span></div>
+      <div class="nu-addr">1402 Cypress Rd — gate code 4471</div>
+      <div class="nu-eta-row">
+        <div><span class="nu-eta-lbl">ETA</span><div class="nu-eta">8:42</div></div>
+        <span class="sig ok"><svg><use href="#i-check"/></svg> On time</span>
+      </div>
+      <div class="nu-next">Next → <b>Roscoe · Sulphur</b> · sched 9:30</div>
+      <div class="nu-actions">
+        <a class="door ghost" href="tel:+13375550142"><svg><use href="#i-phone"/></svg> (337) 555-0142</a>
+        <span class="door commit"><svg><use href="#i-check"/></svg> Mark Arrived</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ LEGEND ============ -->
+  <div class="legend">
+    <div class="lg-item"><svg><use href="#i-grip"/></svg> Click-hold a connector box → drag to the next box to <b>connect a Trip</b>. Click alone = schedule a 1-stop trip.</div>
+    <div class="lg-div"></div>
+    <div class="lg-item">ETA = honest arrival (drive time + <b>20m load/stop</b>) · SCHEDULED = dispatch target · DEADLINE = hard rental-window edge</div>
+    <div class="lg-div"></div>
+    <div class="lg-key"><span class="dot ok"></span>On time <span class="dot risk"></span>At risk <span class="dot late"></span>Past deadline</div>
+  </div>
+
+  <!-- ============ COLUMN HEADER ============ -->
+  <div class="col-head">
+    <span></span><span>Unit · Location · Type</span>
+    <span class="ch-r">ETA</span><span class="ch-r">Sched</span><span class="ch-r">Deadline</span><span class="ch-r">State</span>
+  </div>
+
+  <!-- ============ FIELD CALLS (top group) ============ -->
+  <div class="group-head g-field"><svg><use href="#i-wrench"/></svg><h2>Field Calls</h2><span class="g-count">2</span></div>
+
+  <div class="loose-row is-warn">
+    <div class="stop-row" style="border-bottom:none;">
+      <span class="connector loose"></span>
+      <div class="meta"><svg class="m-ic"><use href="#i-wrench"/></svg>
+        <div class="m-text"><div class="m-title">Gator <span class="loc">— Iowa, LA</span></div><div class="m-sub">Field-Call</div></div>
+      </div>
+      <span class="tcell dim">—</span>
+      <span class="tcell dim">ASAP</span>
+      <span class="tcell dim">—</span>
+      <span class="state-cell"><span class="sig risk"><svg><use href="#i-alert"/></svg>At risk</span></span>
+    </div>
+    <div class="loose-tag warn"><svg><use href="#i-alert"/></svg> Unassigned — customer waiting on a callback slot</div>
+  </div>
+
+  <div class="loose-row is-flat">
+    <div class="stop-row" style="border-bottom:none;">
+      <span class="connector loose"></span>
+      <div class="meta"><svg class="m-ic"><use href="#i-rot"/></svg>
+        <div class="m-text"><div class="m-title">Scoot <span class="loc">— Sulphur, LA</span></div><div class="m-sub">Repo</div></div>
+      </div>
+      <span class="tcell">11:05<span class="t-delta">+5m load</span></span>
+      <span class="tcell">11:00</span>
+      <span class="tcell deadline">5:00p</span>
+      <span class="state-cell"><span class="sig ok"><svg><use href="#i-check"/></svg>On time</span></span>
+    </div>
+  </div>
+
+  <!-- ============ TODAY ============ -->
+  <div class="group-head"><svg><use href="#i-truck"/></svg><h2>Today</h2><span class="g-count">2 trips · 1 unassigned</span></div>
+
+  <!-- Trip 1 — ON TIME -->
+  <div class="trip" data-state="ok">
+    <div class="trip-head">
+      <div class="trip-top">
+        <div class="trip-idline">
+          <div class="trip-datestamp">8:00</div>
+          <div class="trip-id-text"><div class="trip-id">Trip 1 · Truck 4</div><div class="trip-title">Morning run — Beau + Roscoe</div></div>
+        </div>
+        <span class="stamp-badge">On Time</span>
+      </div>
+    </div>
+    <div class="hazard"></div>
+    <div class="trip-dash"></div>
+    <div class="trip-rows">
+      <div class="stop-row store-row">
+        <span class="connector linked first"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-truck"/></svg><div class="m-text"><div class="m-title">Yard — <span class="loc">Store</span></div><div class="m-sub">Start</div></div></div>
+        <span class="tcell">8:00</span><span class="tcell">8:00</span><span class="tcell dim">—</span>
+        <span class="state-cell"></span>
+      </div>
+      <div class="stop-row">
+        <span class="connector linked"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-box"/></svg><div class="m-text"><div class="m-title">Beau <span class="loc">— Lake Charles, LA</span></div><div class="m-sub">Drop</div></div></div>
+        <span class="tcell">8:35</span><span class="tcell">8:35</span><span class="tcell deadline">9:30</span>
+        <span class="state-cell"><span class="sig ok"><svg><use href="#i-check"/></svg>On time</span></span>
+      </div>
+      <div class="stop-row">
+        <span class="connector linked"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-box"/></svg><div class="m-text"><div class="m-title">Roscoe <span class="loc">— Sulphur, LA</span></div><div class="m-sub">Drop</div></div></div>
+        <span class="tcell">9:20<span class="t-delta">+20m load</span></span><span class="tcell">9:00</span><span class="tcell deadline">11:00</span>
+        <span class="state-cell"><span class="sig ok"><svg><use href="#i-check"/></svg>On time</span></span>
+      </div>
+      <div class="stop-row store-row">
+        <span class="connector linked last"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-truck"/></svg><div class="m-text"><div class="m-title">Yard — <span class="loc">Store</span></div><div class="m-sub">End</div></div></div>
+        <span class="tcell">10:00</span><span class="tcell">9:45</span><span class="tcell dim">—</span>
+        <span class="state-cell"></span>
+      </div>
+    </div>
+    <div class="trip-foot">
+      <div class="trip-driver">
+        <details class="gate"><summary><svg><use href="#i-user"/></svg> J. Thibodeaux <svg class="chev"><use href="#i-chev"/></svg></summary>
+          <div class="gate-menu">
+            <div class="gate-opt"><div class="go-name">J. Thibodeaux</div></div>
+            <div class="gate-opt"><div class="go-name">R. Guillory</div></div>
+            <div class="gate-opt"><div class="go-name">M. Fontenot</div></div>
+          </div>
+        </details>
+      </div>
+      <div class="trip-subtotal">2 stops · 1h20 drive · +40 load</div>
+    </div>
+  </div>
+
+  <!-- Unassigned interleaved stop, at its deadline position between Trip 1 and Trip 2 -->
+  <div class="loose-row is-warn">
+    <div class="stop-row" style="border-bottom:none;">
+      <span class="connector loose"></span>
+      <div class="meta"><svg class="m-ic"><use href="#i-box"/></svg>
+        <div class="m-text"><div class="m-title">Boudin <span class="loc">— Dequincy, LA</span></div><div class="m-sub">Drop</div></div>
+      </div>
+      <span class="tcell eta risk">1:55<span class="t-delta">tight</span></span>
+      <span class="tcell">1:40</span>
+      <span class="tcell deadline">2:00</span>
+      <span class="state-cell"><span class="sig risk"><svg><use href="#i-alert"/></svg>At risk</span></span>
+    </div>
+    <div class="loose-tag warn"><svg><use href="#i-alert"/></svg> Not yet connected — click its box to schedule</div>
+  </div>
+
+  <!-- Trip 2 — LATE, with capacity conflict -->
+  <div class="trip" data-state="late">
+    <div class="trip-head">
+      <div class="trip-top">
+        <div class="trip-idline">
+          <div class="trip-datestamp">2:30</div>
+          <div class="trip-id-text"><div class="trip-id">Trip 2 · Truck 2</div><div class="trip-title">Afternoon run — Bush · Snappy · Diesel</div></div>
+        </div>
+        <span class="stamp-badge">Late</span>
+      </div>
+    </div>
+    <div class="hazard"></div>
+    <div class="trip-dash"></div>
+    <div class="trip-rows">
+      <div class="stop-row store-row">
+        <span class="connector linked first"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-truck"/></svg><div class="m-text"><div class="m-title">Yard — <span class="loc">Store</span></div><div class="m-sub">Start</div></div></div>
+        <span class="tcell">2:30</span><span class="tcell">2:30</span><span class="tcell dim">—</span>
+        <span class="state-cell"></span>
+      </div>
+      <div class="stop-row">
+        <span class="connector linked"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-rot"/></svg><div class="m-text"><div class="m-title">Bush <span class="loc">— Iowa, LA</span></div><div class="m-sub">Pickup</div></div></div>
+        <span class="tcell">3:00</span><span class="tcell">3:00</span><span class="tcell dim">—</span>
+        <span class="state-cell"><span class="sig conflict"><svg><use href="#i-alert"/></svg>Conflict</span></span>
+      </div>
+      <div class="conflict-note">
+        <p>Trip 2 can't pick up <b>Bush</b> (3pm) while still carrying <b>Snappy</b> out for its 4pm drop — one trailer only. Bush's pickup splits into its own trip.</p>
+        <span class="door commit-outline"><svg><use href="#i-split"/></svg> Split into new trip</span>
+      </div>
+      <div class="stop-row">
+        <span class="connector linked"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-box"/></svg><div class="m-text"><div class="m-title">Snappy <span class="loc">— Vinton, LA</span></div><div class="m-sub">Drop</div></div></div>
+        <span class="tcell eta late">3:55<span class="t-delta">+20m load</span></span><span class="tcell">3:35</span><span class="tcell deadline">3:45</span>
+        <span class="state-cell"><span class="sig late"><svg><use href="#i-alert"/></svg>Late</span></span>
+      </div>
+      <div class="stop-row">
+        <span class="connector linked"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-box"/></svg><div class="m-text"><div class="m-title">Diesel <span class="loc">— Lake Charles, LA</span></div><div class="m-sub">Drop</div></div></div>
+        <span class="tcell eta late">4:50<span class="t-delta">+20m load</span></span><span class="tcell">4:30</span><span class="tcell deadline">4:45</span>
+        <span class="state-cell"><span class="sig late"><svg><use href="#i-alert"/></svg>Late</span></span>
+      </div>
+      <div class="stop-row store-row">
+        <span class="connector linked last"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-truck"/></svg><div class="m-text"><div class="m-title">Yard — <span class="loc">Store</span></div><div class="m-sub">End</div></div></div>
+        <span class="tcell">5:30</span><span class="tcell">5:10</span><span class="tcell dim">—</span>
+        <span class="state-cell"></span>
+      </div>
+    </div>
+    <div class="trip-foot">
+      <div class="trip-driver">
+        <details class="gate" open><summary><svg><use href="#i-user"/></svg> R. Guillory <svg class="chev"><use href="#i-chev"/></svg></summary>
+          <div class="gate-menu">
+            <div class="gate-opt">
+              <div class="go-name">R. Guillory</div>
+              <div class="gate-warn"><svg><use href="#i-alert"/></svg> Currently assigned</div>
+            </div>
+            <div class="gate-opt">
+              <div class="go-name">M. Fontenot</div>
+              <div class="gate-warn"><svg><use href="#i-alert"/></svg> +15m from last stop — pushes Diesel further past deadline</div>
+            </div>
+            <div class="gate-opt"><div class="go-name">J. Thibodeaux — off shift 4pm</div></div>
+          </div>
+        </details>
+      </div>
+      <div class="trip-subtotal">3 stops · 1h05 drive · +60 load</div>
+    </div>
+  </div>
+
+  <!-- ============ TOMORROW ============ -->
+  <div class="group-head"><svg><use href="#i-truck"/></svg><h2>Tomorrow</h2><span class="g-count">1 trip · 1 unassigned</span></div>
+
+  <div class="loose-row is-flat">
+    <div class="stop-row" style="border-bottom:none;">
+      <span class="connector loose"></span>
+      <div class="meta"><svg class="m-ic"><use href="#i-rot"/></svg>
+        <div class="m-text"><div class="m-title">Ratchet <span class="loc">— Sulphur, LA</span></div><div class="m-sub">Pickup</div></div>
+      </div>
+      <span class="tcell dim">—</span>
+      <span class="tcell dim">PM</span>
+      <span class="tcell dim">—</span>
+      <span class="state-cell"><span class="sig wait">Waiting</span></span>
+    </div>
+  </div>
+
+  <div class="trip" data-state="ok">
+    <div class="trip-head">
+      <div class="trip-top">
+        <div class="trip-idline">
+          <div class="trip-datestamp">9:00</div>
+          <div class="trip-id-text"><div class="trip-id">Trip 3 · Truck 4 · 1-stop trip</div><div class="trip-title">Peanut — single click-to-connect</div></div>
+        </div>
+        <span class="stamp-badge">On Time</span>
+      </div>
+    </div>
+    <div class="hazard"></div>
+    <div class="trip-dash"></div>
+    <div class="trip-rows">
+      <div class="stop-row store-row">
+        <span class="connector linked first"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-truck"/></svg><div class="m-text"><div class="m-title">Yard — <span class="loc">Store</span></div><div class="m-sub">Start</div></div></div>
+        <span class="tcell">9:00</span><span class="tcell">9:00</span><span class="tcell dim">—</span>
+        <span class="state-cell"></span>
+      </div>
+      <div class="stop-row">
+        <span class="connector linked"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-box"/></svg><div class="m-text"><div class="m-title">Peanut <span class="loc">— Vinton, LA</span></div><div class="m-sub">Drop</div></div></div>
+        <span class="tcell">9:35</span><span class="tcell">9:35</span><span class="tcell deadline">11:00</span>
+        <span class="state-cell"><span class="sig ok"><svg><use href="#i-check"/></svg>On time</span></span>
+      </div>
+      <div class="stop-row store-row">
+        <span class="connector linked last"></span>
+        <div class="meta"><svg class="m-ic"><use href="#i-truck"/></svg><div class="m-text"><div class="m-title">Yard — <span class="loc">Store</span></div><div class="m-sub">End</div></div></div>
+        <span class="tcell">10:10</span><span class="tcell">10:05</span><span class="tcell dim">—</span>
+        <span class="state-cell"></span>
+      </div>
+    </div>
+    <div class="trip-foot">
+      <div class="trip-driver"><span class="stamp-fact"><svg class="ic" style="display:inline;vertical-align:-2px;"><use href="#i-user"/></svg> J. Thibodeaux</span></div>
+      <div class="trip-subtotal">1 stop · 40m drive · +20 load</div>
+    </div>
+  </div>
+
+  <!-- ============ THIS WEEK ============ -->
+  <div class="group-head"><svg><use href="#i-truck"/></svg><h2>This Week</h2><span class="g-count">4 unassigned</span></div>
+
+  <div class="loose-row is-flat">
+    <div class="stop-row" style="border-bottom:none;">
+      <span class="connector loose"></span>
+      <div class="meta"><svg class="m-ic"><use href="#i-box"/></svg>
+        <div class="m-text"><div class="m-title">Tank <span class="loc">— Iowa, LA</span></div><div class="m-sub">Drop · Thu</div></div>
+      </div>
+      <span class="tcell dim">—</span>
+      <span class="tcell dim">Thu 10a</span>
+      <span class="tcell deadline">Thu 4p</span>
+      <span class="state-cell"><span class="sig wait">Waiting</span></span>
+    </div>
+  </div>
+
+  <div class="more-row"><svg class="ic"><use href="#i-grip"/></svg> +3 more stops this week</div>
+
+</div>
+</body>
+</html>

--- a/docs/design/reference/yard-journey.html
+++ b/docs/design/reference/yard-journey.html
@@ -1,0 +1,370 @@
+<title>Yard Journey — vertical lifecycle timeline</title>
+
+<style>
+  :root{
+    --bg:#0a0d11; --bg2:#0f1318; --panel:#171d25; --panel2:#1d242d; --card:#12171e; --cardh:#1a212b;
+    --line:#2c343f; --lineSoft:#212834; --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89;
+    --accent:#ff7e1f; --onAcc:#1a1205; --accSoft:rgba(255,126,31,.15); --accLine:rgba(255,126,31,.5);
+    --green:#34d399; --yellow:#eed44b; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --gray:#8b94a3;
+    --tan:#c2925a;
+    --font:-apple-system,"Segoe UI",Roboto,system-ui,sans-serif;
+    --stamp:ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --h:24px;
+  }
+  @media (prefers-color-scheme:light){ :root{
+    --bg:#e6e8ea; --bg2:#dfe3ea; --panel:#fff; --panel2:#eef1f6; --card:#fff; --cardh:#eef1f6;
+    --line:#cfd6e1; --lineSoft:#e1e6ee; --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#fff;
+    --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  } }
+  :root[data-theme="light"]{
+    --bg:#e6e8ea; --panel:#fff; --card:#fff; --cardh:#eef1f6; --line:#cfd6e1; --lineSoft:#e1e6ee;
+    --txt:#141821; --txt2:#414b5a; --txt3:#69727f; --onAcc:#fff; --accent:#cf6000; --red:#d52a2a; --redStrong:#b5241f; --blue:#2f5fb0; --commit:#1f56c0; --green:#0c8f5f; --gray:#566072; --tan:#8a5a2b;
+  }
+  :root[data-theme="dark"]{
+    --bg:#0a0d11; --panel:#171d25; --card:#12171e; --cardh:#1a212b; --line:#2c343f; --lineSoft:#212834;
+    --txt:#eef2f7; --txt2:#aab4c1; --txt3:#717b89; --onAcc:#1a1205; --accent:#ff7e1f; --red:#ff4242; --redStrong:#d63636; --blue:#6394cc; --commit:#2f6fd0; --green:#34d399; --gray:#8b94a3; --tan:#c2925a;
+  }
+  *{box-sizing:border-box} body{margin:0}
+  .wrap{background:var(--bg); color:var(--txt); font-family:var(--font); line-height:1.5; -webkit-font-smoothing:antialiased; padding:clamp(14px,3vw,30px) clamp(10px,3vw,20px) 60px}
+  .sheet{max-width:1180px; margin:0 auto}
+  .eyebrow{font-family:var(--stamp); font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--txt3); margin:0; font-weight:700}
+  h1{font-family:var(--stamp); font-weight:800; font-size:clamp(20px,3.3vw,28px); line-height:1; margin:.26em 0 .32em; letter-spacing:.01em; text-transform:uppercase}
+  h1 .hl{color:var(--accent)}
+  .lede{max-width:88ch; font-size:13px; color:var(--txt2); margin:0} .lede b{color:var(--txt); font-weight:600}
+  .key{display:flex; flex-wrap:wrap; gap:6px 12px; margin:14px 0 2px; font-family:var(--stamp); font-size:10px; letter-spacing:.03em; text-transform:uppercase; color:var(--txt3)}
+  .key b{color:var(--accent)}
+
+  .yard-grid{display:grid; grid-template-columns:1.62fr 1fr; gap:16px; margin-top:20px; align-items:start}
+  @media (max-width:880px){ .yard-grid{grid-template-columns:1fr} }
+
+  .panel{background:var(--panel); border:1px solid var(--line); border-radius:14px; overflow:hidden}
+  .pcap{font-family:var(--stamp); font-size:9.5px; letter-spacing:.13em; text-transform:uppercase; color:var(--txt3); padding:9px 13px 0}
+  .ptitle{padding:1px 13px 11px}
+  .pt-name{font-family:var(--font); font-weight:700; font-size:15px; color:var(--txt); letter-spacing:-.005em; display:flex; align-items:center; gap:8px; flex-wrap:wrap}
+  .pt-sub{font-size:11px; color:var(--txt3); margin-top:2px; font-family:var(--stamp); letter-spacing:.02em}
+
+  /* ---------- controls: the five parts (kept identical to the approved detail-views look) ---------- */
+  .ctl{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; white-space:nowrap; flex:none}
+  .sig{padding:0 8px; border-radius:7px}
+  .sig.f.red{background:var(--redStrong);color:#fff} .sig.o.red{color:var(--red);box-shadow:inset 0 0 0 1.3px var(--red)}
+  .sig.f.yellow{background:var(--yellow);color:#211a05} .sig.o.yellow{color:var(--yellow);box-shadow:inset 0 0 0 1.3px var(--yellow)}
+  .sig.f.blue{background:var(--blue);color:#0a1220} .sig.o.blue{color:var(--blue);box-shadow:inset 0 0 0 1.3px var(--blue)}
+  .sig.f.green{background:var(--green);color:#04140d} .sig.o.green{color:var(--green);box-shadow:inset 0 0 0 1.3px var(--green)}
+  .sig.o.grey{color:var(--gray);box-shadow:inset 0 0 0 1.3px var(--gray)}
+  .gate{padding:0 8px 0 6px; border-radius:7px; gap:2px; cursor:pointer}
+  .gate .cv{display:inline-flex;align-items:center;justify-content:center;width:11px;height:11px} .gate .cv svg{width:11px;height:11px;display:block}
+  .gate.yellow{background:var(--yellow);color:#211a05} .gate.blue{background:var(--blue);color:#0a1220}
+  .stamp{font-family:var(--stamp); font-size:10.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); white-space:nowrap}
+  .dot{color:var(--line); font-family:var(--stamp); font-size:10px} .stamp.more{color:var(--accent)}
+  .ref{height:22px; display:inline-flex; align-items:center; gap:6px; padding:0 8px 0 3px; border-radius:7px; background:var(--card); border:1px solid var(--line); color:var(--txt); font-size:12px; font-weight:600; cursor:pointer; text-decoration:none; white-space:nowrap}
+  .ref .ty{width:16px;height:16px;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);background:var(--accSoft);border-radius:5px} .ref .ty svg{width:10px;height:10px}
+  .door{height:var(--h); display:inline-flex; align-items:center; font-family:var(--stamp); font-size:10.5px; font-weight:800; letter-spacing:.03em; text-transform:uppercase; cursor:pointer; border-radius:999px; padding:0 13px}
+  .door.save{background:var(--commit); color:#fff; border:0}
+  .door.add{background:transparent; color:var(--commit); border:1.4px dashed var(--commit); padding:0 11px}
+  .door.ghost{background:transparent; color:var(--txt2); border:1px solid var(--line)}
+
+  /* ---------- section-chip rail (top row = the item's own tabs; Yard Journey is a full Units section now) ---------- */
+  .secrail{display:flex; align-items:center; gap:6px; padding:9px 10px; border-bottom:1px solid var(--line); border-top:1px solid var(--line); background:var(--bg2)}
+  .scnav{flex:none; width:20px; height:20px; display:inline-flex; align-items:center; justify-content:center; background:transparent; border:1px solid var(--line); border-radius:6px; color:var(--txt3); cursor:pointer}
+  .scnav svg{width:11px;height:11px}
+  .scchips{display:flex; gap:6px; overflow-x:auto; flex:1; scrollbar-width:none}
+  .scchips::-webkit-scrollbar{display:none}
+  .schip{height:var(--h); display:inline-flex; align-items:center; padding:0 10px; border-radius:7px; font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.04em; text-transform:uppercase; white-space:nowrap; flex:none; color:var(--txt3); border:1px solid transparent; cursor:pointer}
+  .schip.dim{opacity:.5}
+  .schip.active{background:var(--accent); color:var(--onAcc)}
+  .scdots{display:flex; gap:4px; padding:0 12px 8px; justify-content:flex-end; background:var(--bg2)}
+  .scdots i{width:5px;height:5px;border-radius:50%;background:var(--line);display:inline-block;font-style:normal}
+  .scdots i.on{background:var(--accent)}
+
+  /* ---------- NOW + NEXT header (doubles as the field-role Signal / To Do summary) ---------- */
+  .nownext{padding:12px 14px; background:var(--cardh); border-bottom:1px solid var(--line); display:flex; flex-direction:column; gap:7px}
+  .nn-row{display:flex; align-items:center; gap:9px; flex-wrap:wrap}
+  .nn-tag{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.08em; text-transform:uppercase; flex:none}
+  .nn-tag.now{color:var(--yellow)}
+  .nn-tag.next{color:var(--commit)}
+  .nn-headline{font-family:var(--font); font-weight:700; font-size:15px; color:var(--txt)}
+  .nn-sub{font-size:12px; color:var(--txt2)}
+  .rolebadge{margin-left:auto; display:inline-flex; align-items:center; gap:5px; font-family:var(--stamp); font-size:9.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--tan); border:1px dashed var(--tan); border-radius:7px; padding:3px 8px; flex:none}
+  .rolebadge svg{width:11px;height:11px}
+
+  /* ---------- vertical timeline ---------- */
+  .timeline{padding:6px 14px 14px}
+  .trow{display:grid; grid-template-columns:20px 1fr; gap:11px}
+  .tdot-col{display:flex; flex-direction:column; align-items:center}
+  .tdot{width:11px; height:11px; border-radius:50%; margin-top:6px; flex:none; background:var(--gray)}
+  .trow.done .tdot{background:var(--green)}
+  .trow.current .tdot{background:var(--yellow); box-shadow:0 0 0 3px rgba(238,212,75,.28)}
+  .trow.upcoming .tdot{background:transparent; border:2px solid var(--line)}
+  .tconn{width:2px; flex:1; min-height:20px; background:var(--line); margin-top:3px}
+  .trow:last-child .tconn{display:none}
+  .tcontent{padding-bottom:16px; border-bottom:1px solid var(--lineSoft); min-width:0}
+  .trow:last-child .tcontent{border-bottom:0; padding-bottom:2px}
+  .thead{display:flex; align-items:center; gap:8px; min-height:var(--h); flex-wrap:wrap}
+  .tlabel{font-family:var(--stamp); font-weight:800; font-size:11px; letter-spacing:.05em; text-transform:uppercase; color:var(--txt)}
+  .trow.upcoming .tlabel{color:var(--txt3)}
+  .twhen{font-family:var(--stamp); font-size:11px; color:var(--txt3); margin-top:4px; font-variant-numeric:tabular-nums; letter-spacing:.01em}
+  .twho{color:var(--txt2)}
+  .twho b{color:var(--txt); font-weight:800}
+  .tevi{display:flex; align-items:center; gap:7px; flex-wrap:wrap; margin-top:7px}
+  .troute{display:flex; align-items:center; gap:7px; margin-top:9px; padding:7px 9px; background:var(--card); border:1px solid var(--line); border-radius:7px; flex-wrap:wrap}
+  .troute .rlabel{font-family:var(--stamp); font-size:9px; font-weight:800; letter-spacing:.07em; text-transform:uppercase; color:var(--txt3); margin-right:2px; flex:none}
+  .rarrow{color:var(--txt3); font-size:12px; flex:none}
+  .tdoor{margin-top:11px; display:flex; align-items:center; gap:8px}
+
+  .htail{padding:9px 12px; border-top:1px solid var(--line)}
+  .h4{font-family:var(--stamp); font-size:11px; font-weight:800; letter-spacing:.05em; text-transform:uppercase; color:var(--txt); margin-bottom:2px}
+  .hc{font-family:var(--stamp); font-size:9px; font-weight:700; text-transform:uppercase; color:var(--txt3)}
+  .hsearch{margin-top:6px; height:var(--h); display:flex; align-items:center; gap:6px; padding:0 9px; background:var(--card); border:1px solid var(--line); border-radius:7px; color:var(--txt3); font-size:11.5px}
+  .hsearch svg{width:12px;height:12px;flex:none}
+
+  /* ---------- dormant "Available" panel ---------- */
+  .dcap{display:flex; align-items:center; gap:7px; padding:9px 13px 0}
+  .dcap .lab{font-family:var(--stamp); font-size:9.5px; letter-spacing:.13em; text-transform:uppercase; color:var(--txt3)}
+  .dnote{font-family:var(--stamp); font-size:9px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--txt3); border:1px solid var(--line); border-radius:7px; padding:2px 7px}
+  .dbody{padding:12px 14px 16px; display:flex; flex-direction:column; gap:12px}
+  .dstate{display:flex; align-items:center; gap:10px}
+  .dstate .txt{display:flex; flex-direction:column; gap:2px}
+  .dstate .headline{font-family:var(--font); font-weight:700; font-size:15px; color:var(--txt)}
+  .dstate .sub{font-size:12px; color:var(--txt2)}
+  .dfoot{display:flex; align-items:center; gap:10px; padding-top:2px}
+
+  .foot{margin-top:24px; padding-top:16px; border-top:1px solid var(--line); font-size:13px; color:var(--txt2); max-width:90ch} .foot b{color:var(--txt)}
+  .foot ul{margin:8px 0 0; padding-left:20px} .foot li{margin:3px 0}
+</style>
+
+<div class="wrap"><div class="sheet">
+
+  <p class="eyebrow">Units · Yard Journey · new own-section redesign · built to style + wrangler-style</p>
+  <h1>Yard Journey — <span class="hl">live vertical lifecycle</span></h1>
+  <p class="lede">Replaces the cramped horizontal node-rail (spec §6, 2026-07-20). Framed here as one section of a Unit's
+  inline-expanded card — the top row is the item's own <b>section-chip rail</b>, greyed for every other Units section,
+  with <b>Yard Journey</b> active. Stages run top→bottom as rows: a state dot (<b>done · current · upcoming</b>),
+  a mono timestamp + who, the stage's captured evidence as <b>Stamps/Refs</b>, and the current stage carries the
+  <b>one</b> next <b>Door</b>. A compact <b>NOW + next</b> header leads it — for drivers &amp; maintenance techs this
+  header <b>is</b> their Signal/To-Do summary. Second panel shows the calm <b>Available</b> (dormant) state side by side.</p>
+  <div class="key"><span><b>Signal</b> state chip</span><span><b>Gate</b> turnable</span><span><b>Stamp</b> fact</span><span><b>Ref</b> linked</span><span><b>Door</b> action</span><span>· fill = today · colour = state</span></div>
+
+  <div class="yard-grid">
+
+    <!-- ============ ACTIVE JOURNEY ============ -->
+    <div class="panel">
+      <div class="pcap">Unit · inline-expanded</div>
+      <div class="ptitle">
+        <div class="pt-name">Gator <span class="ctl sig f yellow">recovery</span></div>
+        <div class="pt-sub">CAT 320 Excavator · S/N CX-2091</div>
+      </div>
+
+      <!-- section-chip rail: other Units sections greyed, Yard Journey active -->
+      <div class="secrail">
+        <button class="scnav" aria-label="previous sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button>
+        <div class="scchips">
+          <span class="schip dim">To Do</span>
+          <span class="schip active">Yard Journey</span>
+          <span class="schip dim">Inspection</span>
+          <span class="schip dim">Services</span>
+          <span class="schip dim">Work Orders</span>
+          <span class="schip dim">Specs</span>
+          <span class="schip dim">Investment</span>
+          <span class="schip dim">GPS</span>
+        </div>
+        <button class="scnav" aria-label="next sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></button>
+      </div>
+      <div class="scdots"><i class="on"></i><i></i></div>
+
+      <!-- NOW + NEXT -->
+      <div class="nownext">
+        <div class="nn-row">
+          <span class="nn-tag now">Now</span>
+          <span class="ctl sig f yellow">recovery</span>
+          <span class="nn-headline">Rental ended — awaiting pickup dispatch</span>
+          <span class="rolebadge" title="Default landing section for drivers + maintenance techs; user can reorder"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/></svg>Driver + tech default</span>
+        </div>
+        <div class="nn-row">
+          <span class="nn-tag next">Next</span>
+          <span class="nn-sub">Saddle up for pickup at Broussard Dirt Works — 14 mi · the door is on the Recovery row below. This header doubles as your <b style="color:var(--txt)">To Do</b>.</span>
+        </div>
+      </div>
+
+      <!-- vertical timeline -->
+      <div class="timeline">
+
+        <div class="trow done">
+          <div class="tdot-col"><span class="tdot"></span><span class="tconn"></span></div>
+          <div class="tcontent">
+            <div class="thead"><span class="tlabel">Reserved</span><span class="ctl sig o green">done</span></div>
+            <div class="twhen">JUL 14 · 9:12 AM · <span class="twho"><b>Denny R.</b> — dispatch</span></div>
+            <div class="tevi">
+              <span class="stamp">6-day booking</span><span class="dot">·</span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg></span>Rental #4482</a>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Broussard Dirt Works</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="trow done">
+          <div class="tdot-col"><span class="tdot"></span><span class="tconn"></span></div>
+          <div class="tcontent">
+            <div class="thead"><span class="tlabel">Out</span><span class="ctl sig o green">done</span></div>
+            <div class="twhen">JUL 15 · 7:40 AM · <span class="twho"><b>Trey Guidry</b> — driver</span></div>
+            <div class="tevi">
+              <span class="stamp">4 photos</span><span class="dot">·</span>
+              <span class="stamp">Signature captured</span><span class="dot">·</span>
+              <span class="stamp">Meter out 1,180 hrs</span>
+            </div>
+            <div class="troute">
+              <span class="rlabel">Route</span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>Yard</a>
+              <span class="rarrow">→</span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Broussard Dirt Works</a>
+              <span class="stamp" style="margin-left:auto">14 mi</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="trow done">
+          <div class="tdot-col"><span class="tdot"></span><span class="tconn"></span></div>
+          <div class="tcontent">
+            <div class="thead"><span class="tlabel">On Rent</span><span class="ctl sig o green">done</span></div>
+            <div class="twhen">JUL 15 → JUL 20 · Day 5 of 6</div>
+            <div class="tevi">
+              <span class="stamp">GPS reporting</span><span class="dot">·</span>
+              <span class="stamp">Meter running</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="trow done">
+          <div class="tdot-col"><span class="tdot"></span><span class="tconn"></span></div>
+          <div class="tcontent">
+            <div class="thead"><span class="tlabel">Field calls</span><span class="ctl sig o green">1 resolved</span></div>
+            <div class="twhen">JUL 17 · 2:30 PM · <span class="twho"><b>Mikey Fontenot</b> — tech</span></div>
+            <div class="tevi">
+              <span class="stamp">2 photos</span><span class="dot">·</span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>WO #1188 · hyd hose</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="trow done">
+          <div class="tdot-col"><span class="tdot"></span><span class="tconn"></span></div>
+          <div class="tcontent">
+            <div class="thead"><span class="tlabel">End Rent</span><span class="ctl sig o green">done</span></div>
+            <div class="twhen">JUL 20 · 8:05 AM · <span class="twho">logged by <b>Denny R.</b></span></div>
+            <div class="tevi">
+              <span class="stamp">Signature captured</span><span class="dot">·</span>
+              <span class="stamp">Meter in 1,410 hrs (+230)</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="trow current">
+          <div class="tdot-col"><span class="tdot"></span><span class="tconn"></span></div>
+          <div class="tcontent">
+            <div class="thead"><span class="tlabel">Recovery</span><span class="ctl sig f yellow">current</span></div>
+            <div class="twhen">JUL 20 · 8:20 AM · <span class="twho">dispatch pending</span></div>
+            <div class="tevi"><span class="stamp">Awaiting driver assignment</span></div>
+            <div class="troute">
+              <span class="rlabel">Route</span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"/><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"/><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"/><path d="M10 6h4M10 10h4M10 14h4M10 18h4"/></svg></span>Broussard Dirt Works</a>
+              <span class="rarrow">→</span>
+              <a class="ref"><span class="ty"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg></span>Yard</a>
+              <span class="stamp" style="margin-left:auto">14 mi</span>
+            </div>
+            <div class="tdoor">
+              <span class="ctl door save">Saddle up for pickup</span>
+              <span class="ctl door ghost">Reassign</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="trow upcoming">
+          <div class="tdot-col"><span class="tdot"></span><span class="tconn"></span></div>
+          <div class="tcontent">
+            <div class="thead"><span class="tlabel">Returned</span><span class="ctl sig o grey">upcoming</span></div>
+            <div class="twhen">—</div>
+            <div class="tevi"><span class="stamp" style="opacity:.7">Awaiting recovery</span></div>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="htail">
+        <div class="h4">History</div>
+        <div class="hsearch"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>History: search…</div>
+      </div>
+    </div>
+
+    <!-- ============ DORMANT / AVAILABLE ============ -->
+    <div class="panel">
+      <div class="dcap"><span class="lab">Unit · inline-expanded</span><span class="dnote">dormant example</span></div>
+      <div class="ptitle">
+        <div class="pt-name">Scout <span class="ctl sig o green">available</span></div>
+        <div class="pt-sub">Skid Steer 70hp · S/N SS-14</div>
+      </div>
+
+      <div class="secrail">
+        <button class="scnav" aria-label="previous sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button>
+        <div class="scchips">
+          <span class="schip dim">To Do</span>
+          <span class="schip active">Yard Journey</span>
+          <span class="schip dim">Inspection</span>
+          <span class="schip dim">Services</span>
+          <span class="schip dim">Specs</span>
+        </div>
+        <button class="scnav" aria-label="next sections"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></button>
+      </div>
+
+      <div class="nownext">
+        <div class="nn-row">
+          <span class="nn-tag" style="color:var(--green)">Now</span>
+          <span class="ctl sig o green">available</span>
+          <span class="nn-headline">Sitting in the yard — no active rental</span>
+        </div>
+        <div class="nn-row">
+          <span class="nn-tag next">Next</span>
+          <span class="nn-sub">Nothing due — no lifecycle rail to show when idle. One move: start a rental.</span>
+        </div>
+      </div>
+
+      <div class="dbody">
+        <div class="dstate">
+          <span class="ctl sig o green" style="height:28px;padding:0 10px">available</span>
+          <div class="txt">
+            <span class="headline">Idle 3 days</span>
+            <span class="sub">Last returned JUL 17 · 1,410 hrs on meter · clean at return</span>
+          </div>
+        </div>
+        <div class="dfoot">
+          <span class="ctl door add">+ Start rental</span>
+        </div>
+      </div>
+
+      <div class="htail">
+        <div class="h4">History</div>
+        <span class="hc">9 Rentals</span>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="foot">
+    <b>Yard Journey</b> is now its own Units section, not a header-strip rail — a live vertical timeline
+    (<b>Reserved → Out → On Rent → Field calls → End Rent → Recovery → Returned</b>) that reads top-to-bottom like a
+    logbook. Notes for review:
+    <ul>
+      <li>Stage rows use the same <b>colour = state</b> function as everywhere else: green dot = done, filled yellow
+      ring = current, hollow grey = upcoming — no new state vocabulary.</li>
+      <li>The <b>NOW + next</b> header is the one place text repeats the current stage in plain language; the actual
+      <b>Door</b> lives once, on the current stage's row (Recovery here) — never duplicated as a second clickable button.</li>
+      <li>Route strips (Out, Recovery only — per spec) are two <b>Refs</b> and a distance <b>Stamp</b>, not a map.</li>
+      <li>The section-chip rail carries the other Units sections <b>greyed</b> (Inspection, Services, Work Orders, Specs,
+      Investment, GPS) plus <b>To Do</b> — Yard Journey sits active among them, so this reads as one section of the
+      larger inline-expand card, not a standalone screen.</li>
+      <li>Dormant units (<b>Scout</b>, right) get a calm <b>Available</b> Stamp + the one <b>+ Start rental</b> Door —
+      never an empty rail.</li>
+      <li>Matte throughout — no glow; the current-stage ring is a flat 3px outline, not a blur. Dimmed CVD-safe
+      <code>--yellow #eed44b</code> used for "current," never the neon value.</li>
+    </ul>
+  </div>
+
+</div></div>

--- a/docs/research/ALL-FINDINGS.md
+++ b/docs/research/ALL-FINDINGS.md
@@ -1,0 +1,1201 @@
+# All 171 findings
+
+Sorted by severity, then card.
+
+### 1. [RED] Calendar / Driver — The live map is hard-coded 260px tall inside the card's single 333px-tall scroll region, so on first paint it occupies 78% of everything the driver can see before a single trip row appears.
+
+- **job:** figure out where he's going next, from the cab, in one glance
+- **primitive:** map panel / shared scroll region · **failure:** invisible · **scope:** density · **role:** driver
+- **cite:** `style.css:903; app.js:9652-9655, 11812`
+- **evidence:** Measured live: .cal-scroll clientHeight 333px, scrollHeight 902px. Map open = 1 of 4 trip rows visible; map collapsed = 3 of 4 visible. tripsMapOpen() defaults true for every user/role/device on first load (v==null?true).
+
+### 2. [RED] Calendar / Driver — The recovery/pickup leg of every trip is hardcoded to time:'' while the delivery leg reads r.startTime — a pickup can never carry a time regardless of what data exists.
+
+- **job:** know when a pickup is due so he can plan his route
+- **primitive:** row time field · **failure:** lying · **scope:** signal · **role:** driver
+- **cite:** `app.js:11297-11298 (vs. delivery-leg convention at app.js:7123)`
+- **evidence:** delivery leg: time: r.startTime || ''; pickup leg: literal time: ''. r.endTime is written by at least one production path (WR_OPERATIONS.startRental) and read in 3 other places in the same file, so the pickup leg ignores data the app already uses elsewhere.
+
+### 3. [RED] Calendar / Driver — tripsFor()/dispatchEvents() apply zero identity filtering — every driver's trips plus the entire unassigned pool render on one shared list, even though the code's own landing comment calls this screen 'the driver's day.'
+
+- **job:** see his own day, not the whole yard's dispatch board
+- **primitive:** trip list / role landing · **failure:** unreachable · **scope:** architecture · **role:** driver
+- **cite:** `app.js:11285-11302, 9674; landing comment at 25636-25644`
+- **evidence:** Grep across the render path for any driver-identity filter: zero matches. myRosterId() already exists (app.js:10582) and is used to scope team-chat visibility, but is never wired into the Trips list.
+
+### 4. [RED] Calendar / Driver — The Trips tab badge only counts stops dated today-or-later that aren't done; any undone stop from a prior day contributes zero to the number the driver glances at.
+
+- **job:** trust the one number that's supposed to say what's still outstanding
+- **primitive:** tab badge count · **failure:** lying · **scope:** signal · **role:** driver
+- **cite:** `app.js:9471-9472`
+- **evidence:** Live: badge read 4, while the collapsed 'Earlier' group held 6 total / 2 done = 4 more undone stops (two 78 days old) that never touch the badge. Comment at 9471 confirms the exclusion is deliberate but nothing distinguishes 'history' from 'never got done.'
+
+### 5. [RED] Calendar / Driver — The 'Earlier' bucket — the only place undone past-day trips live — is the sole group on any card that defaults collapsed, and its color is a hardcoded 'gray' literal that can never receive red/danger styling no matter how many undone jobs it holds.
+
+- **job:** spot the thing actually on fire without opening a closed drawer he doesn't know exists
+- **primitive:** group header / severity color · **failure:** invisible · **scope:** signal · **role:** driver · **SYSTEMIC**
+- **cite:** `app.js:9333, 9340 (color:'gray' hardcoded), 9358 (only default-collapsed group/card combo), 9423 (sec-danger only fires on color==='red')`
+- **evidence:** Live-confirmed: 4 undone runs sat inside a collapsed 'Earlier · 6 · 2 done' group, two 78 days late. 'Today' is separately hardcoded red every day regardless of contents (app.js:9337), so red already carries no reliable signal even before Earlier's gray problem.
+
+### 6. [RED] Calendar / Driver — The app-wide scroll-memory reads/writes .card-body's scrollTop, but on the Trips card .card-body is overflow:hidden — the real scroller is the nested .cal-scroll — so any render() (e.g. after assigning a driver) resets scroll position to 0.
+
+- **job:** keep his place on a list he just scrolled through while dispatch works an assignment
+- **primitive:** scroll position / render cycle · **failure:** inconsistent · **scope:** interaction · **role:** dispatcher
+- **cite:** `style.css:900-901; app.js:17186-17190, 17229-17233; 18614-18615 (assign→render())`
+- **evidence:** The defect actually spans 5 call sites, not 2: render() ×2, renderResults() ×2, and restoreJogScroll() ×1 — all read/write .card-body instead of .cal-scroll. A live control test showed scroll position 120→0 on unpatched code.
+
+### 7. [RED] Calendar / Driver — assignStopDriver()'s only effect on a successful assignment is pushing a line into a hidden per-rental audit array — no toast, no badge write, no push, nothing addressed to the driver.
+
+- **job:** find out he's been given a job without opening the app and reading every row
+- **primitive:** assignment action / notification · **failure:** invisible · **scope:** signal · **role:** driver
+- **cite:** `app.js:11341-11352 (assignStopDriver), 22575 (logAction — push+saveSoon only)`
+- **evidence:** All 3 call sites traced (single-stop picker, drag-and-drop, bulk 'Round up'). The one toast() call anywhere in the chain fires in the DISPATCHER's own browser confirming their bulk action — never addressed to or visible on the assigned driver's device.
+
+### 8. [RED] Calendar / Driver — The Show More handler reads activeSession().cards[card] and bails unless that's truthy — but Calendar is deliberately card-stateless, so the click is a guaranteed no-op. Past the 60-row cap, the rest are permanently unreachable.
+
+- **job:** get to a trip past the visible cutoff on a busy day
+- **primitive:** show more button · **failure:** unreachable · **scope:** interaction · **role:** driver
+- **cite:** `app.js:19246 (handler), 2817 (calendar excluded from GRID_CARDS/card-stateless)`
+- **evidence:** Latent on today's low-volume data but structurally guaranteed to fail the moment volume crosses the cap — confirmed from the card-stateless definition itself, not just observed behavior.
+
+### 9. [RED] Calendar / Driver — The row prints a town name ('Lake Charles'); the full street address exists in the DOM but only as a hover tooltip (data-tip), which a driver in a truck with a glove on will never trigger.
+
+- **job:** find the actual property without guessing or calling the office
+- **primitive:** row address text · **failure:** invisible · **scope:** density · **role:** driver
+- **cite:** `app.js:7366, 9670`
+- **evidence:** Live DOM confirmed: data-tip holds the full address '1700 11th St, Lake Charles, LA 70601, US' sitting unused as a hover-only attribute instead of rendered text.
+
+### 10. [RED] Calendar / Driver — tripTownGo() writes state.dispatchDay to the tapped stop's day but nothing ever resets it — the map can sit on a future day's pins while the list header above it still reads 'TODAY,' with no reset control anywhere on screen.
+
+- **job:** trust that what the map shows matches what the list says he's doing today
+- **primitive:** map panel / day state · **failure:** inconsistent · **scope:** architecture · **role:** driver
+- **cite:** `app.js:11796; scan for any day-reset control returned none`
+- **evidence:** Reproduced live: tapped Monday's town, map showed mapPanelDay:'2026-07-20' while list header still read 'TODAY · 2'; only recovery was a full page reload. Dead, unwired handlers for exactly this reset (.js-disp-day / .js-disp-today, commented Phase 6) already exist in the codebase but are never emitted by any template.
+
+### 11. [RED] Calendar / Driver — tripTownGo() force-opens a collapsed map by calling tripsMapSetOpen(true), which writes to localStorage — a driver who deliberately collapsed the map to see his day has that choice silently and permanently reverted by one unrelated tap on a town.
+
+- **job:** keep a screen preference he deliberately set, without an unrelated tap undoing it
+- **primitive:** map toggle / persisted preference · **failure:** destructive · **scope:** interaction · **role:** driver
+- **cite:** `app.js:11798 (force-open call), 11813 (setter writes localStorage)`
+- **evidence:** Verified live: localStorage key jactec.tripsMap flipped '0'→'1' and visible rows dropped 3→1 after a single town tap — not a session-only override, a permanent write.
+
+### 12. [RED] Calendar / Driver — uploadCaptureMedia posts the walkaround video once; on a network failure the catch only toasts 'saved without it' for two seconds, and the row still stamps green 'Logged' with no distinction from a delivery whose video actually landed.
+
+- **job:** know his proof of condition actually reached the office before he drives away
+- **primitive:** capture / logged status badge · **failure:** lying · **scope:** signal · **role:** driver
+- **cite:** `app.js:20280, 25426`
+- **evidence:** That video is the only defense against a later damage claim; a failed upload and a successful one are visually identical on the row afterward.
+
+### 13. [RED] Calendar / Driver — The log-gate (e.g. 'no invoice on this rental') is only evaluated when the driver taps Log Delivery, not when the row renders — a stop already blocked that morning shows no lock, no red flag, nothing, until he's driven the full distance.
+
+- **job:** know before loading the trailer that a stop can't actually be completed
+- **primitive:** row / block state · **failure:** invisible · **scope:** signal · **role:** driver
+- **cite:** `app.js:20198`
+- **evidence:** The gate check exists in the codebase — it simply runs at the wrong moment (on tap, not render), so the information is computed but never surfaced ahead of time.
+
+### 14. [RED] Calendar / Driver — state.tripsSyncStatus starts null and only flips to 'synced' after a push/pull succeeds — until then the footer defaults to 'Offline — cached' regardless of real connectivity, and nothing re-checks after the first success either, so it can just as easily read false-'Synced' after signal is later lost.
+
+- **job:** trust the one line of chrome that's supposed to say whether his screen is current
+- **primitive:** sync status footer · **failure:** lying · **scope:** signal · **role:** driver · **SYSTEMIC**
+- **cite:** `app.js:2502 (initial null), 11390/11413 (flip to synced), 11499 (footer copy fallback)`
+- **evidence:** The footer is pinned, non-scrolling chrome — one of the few things visible on first paint — so this false reading is prominent, not buried. No code path checks connectivity before a write at all, so a held/failed write in a real dead zone produces no distinct signal either.
+
+### 15. [RED] Calendar / Driver — A failed sync during a capture holds the pending write only in RAM (a code comment states the local cache is never a save baseline) while the banner instructs the driver 'Don't close the app' — an instruction a phone user can't reliably guarantee, since the OS backgrounds/locks apps on its own.
+
+- **job:** have his delivery count as logged even in a signal dead zone, without keeping his phone open and unlocked
+- **primitive:** capture flow / sync banner · **failure:** destructive · **scope:** interaction · **role:** driver
+- **cite:** `app.js:25405-25411 (in-RAM hold, no persistence), 25426 (banner copy), 24576 (comment: cache never a save baseline)`
+- **evidence:** The practical failure this produces is a completed delivery log reverting to undelivered overnight — exactly what the app exists to prevent.
+
+### 16. [RED] Categories — Member day-rate ($120) is stored and edited as a first-class field but never rendered on the mini-card; the card shows only the four retail tiers (1-Day $440 etc.), so a counter rep reading the face he actually looks at overquotes a member by 267%.
+
+- **job:** quote a rental rate to a caller over the phone/counter before they hang up
+- **primitive:** rate tile / mini-card face · **failure:** invisible · **scope:** architecture · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:7271-7275 (mini-card rate() omits memberDaily) vs app.js:8876-8879 (detail priceFld lists memberDaily first) vs app.js:1078 (rentalPrice() short-circuits to days×memberDaily for a member, skipping all four displayed tiers)`
+- **evidence:** Live production: 12k Excavator member day = $120, mini-card shows $440. Second live example: 8k Excavator member $89 vs displayed $320. Not a billing defect — invoices/Rentals/Wrangler all call rentalPrice() correctly — the risk is a rep saying the wrong number out loud, not the invoice being wrong.
+
+### 17. [RED] Categories — The category detail's availability count and the mini-card's availability count disagree because the detail bucket (unitRentalBucket) files any unit with no active rental as "Available" regardless of fleetStatus, while the mini-card correctly restricts to Active fleet.
+
+- **job:** check whether a machine class actually has stock to rent right now
+- **primitive:** status pill / detail availability bar · **failure:** lying · **scope:** signal · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:2300-2305 (unitRentalBucket, no fleetStatus check) vs app.js:7216-7225 (mini-card, fleetStatus==='Active' only); root definition at app.js:2251 isUnitRentable/RENTABLE_SKIP_FLEET`
+- **evidence:** Live-reconfirmed, same category, same second: 12k Excavator mini-card reads "NEXT MON" (zero free), detail reads "9 Available" (11 units total minus 2 on rent = 9, none excluded for Sold/For Sale/Inactive). Second live example: Lift Scissor 19ft mini-card "2 Avail", detail "5 Available" — the 3 extra are sold machines. A comment at app.js:7212 shows this exact bug class was already fixed on the mini-card on 2026-06-25; the fix never reached the detail renderer.
+
+### 18. [RED] Categories — A category with 0 in every rate field still shows a bright green availability pill when units are physically ready — the app internally knows and labels the record "STUB — fill in pricing," but that text lives only in the detail nobody opens.
+
+- **job:** know it's not safe to quote a price before a caller is put on hold
+- **primitive:** status pill (availability lead pill) · **failure:** invisible · **scope:** signal · **role:** counter-sales rep
+- **cite:** `mini-card availability renderer (green lead pill, app.js ~7255-7258) vs detail Fleet Summary "STUB — fill in pricing" text; predicate catRatesUnset() app.js:1113-1115`
+- **evidence:** Live: LIFT SCISSOR 19FT shows a bright green "2 AVAIL" pill, both units inspection-passed, and every rate tile is an em-dash. In production, 7 of the 46 live categories (about 15%) are currently unpriced this way.
+
+### 19. [RED] Categories — A category whose entire fleet has been sold still displays full rack rates on the mini-card ("NONE · SOLD" pill sits directly above quotable dollar figures) — the machine is gone but the price still reads as offerable.
+
+- **job:** avoid promising a machine the yard no longer owns
+- **primitive:** rate tile · **failure:** lying · **scope:** signal · **role:** counter-sales rep
+- **cite:** `mini-card renderer — no gate ties the rate() helper to categoryUnavailReason/allOffFleet`
+- **evidence:** Live: SKID STEER MINI shows "NONE · SOLD" and still lists $280/1-day, $790/7-day beneath it. Verify pass noted the card border isn't even red in this state (falls to neutral) since the Active-only "free" set is empty — the pill is the only warning.
+
+### 20. [RED] Categories — Committing a category rate edit (admin inline-edit or a Wrangler chat write) fires zero toast, team-dock ping, or push to anyone — not even to the person who made the edit; the commit path is reindex + logAction + render only.
+
+- **job:** know that the price you're about to quote was just changed by someone else
+- **primitive:** toast (absent) · **failure:** invisible · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:19658-19668 (generic `kind==='field'` commit closure, shared by every card's efld()); app.js:19213 admin gate; app.js:8876 rate fields route through it; app.js:16113-16136 Wrangler write path, same silent logAction`
+- **evidence:** Contrast: js-lost-demand, js-spe-accept, and js-blacklist all toast the acting user; the generic admin-gated field editor that all 5 rate fields (memberDaily/rate1Day/rate7Day/rate4Wk/weekend) route through is the one edit path in the app that stays silent even to its own author.
+
+### 21. [RED] Categories — Creating a category is completely ungated (no admin/permission check anywhere on the create handler), while editing a rate field on that same category is explicitly admin-gated — the authority matrix is inverted, and it is the mechanism that produces unpriced-but-instantly-rentable $0 records.
+
+- **job:** control who is allowed to introduce a new, instantly-live rentable equipment class
+- **primitive:** authority gate · **failure:** destructive · **scope:** interaction · **role:** owner-operator · **SYSTEMIC**
+- **cite:** `app.js:19008/18946 (create handler, no requireAdmin) → app.js:21174-21251 quickAddCategoryFromSearch (all rates hardcoded 0) vs app.js:19213 + app.js:8876-8931 (admin:true on every rate field)`
+- **evidence:** A non-admin can mint unlimited live categories but cannot price any of them — plausibly how the observed unpriced LIFT SCISSOR 19FT record came to exist. Deliberately left unfixed pending an explicit owner decision (offered, declined for now).
+
+### 22. [RED] Categories — ROI/margin is money-tier-gated in the detail view, but the same categoryStats().roi value is registered as an ungated list column with a colored pill in the card's default layout, AND is an ungated sort key — a below-money-tier user can read the exact percentage off the list or infer the entire fleet's profitability ranking just by sorting on it.
+
+- **job:** keep margin/profitability data restricted to the roles who are supposed to see it
+- **primitive:** list column / sort menu · **failure:** inconsistent · **scope:** architecture · **role:** owner-operator · **SYSTEMIC**
+- **cite:** `app.js:8916 (gated, canMoney()) vs app.js:7487 (ungated list column) + app.js:7562 (default layout includes it) + config.js:432/app.js:9239/19208 (ungated sort key); note canMoney() (app.js:21348) is permissive on a blank role while adminUnlocked() (app.js:19776) is restrictive on the same blank role — the two gates disagree about who a no-role user is`
+- **evidence:** Fixed in this audit's branch (gate now applied to column, cell, and sort-key list) but production still leaks at time of audit. Flagged explicitly as a never-delegate authority/margin-visibility class of bug.
+
+### 23. [RED] Categories — Nothing in the app ever deletes, merges, retires, or splits a category — DATA.categories is push/read/index-only. A typo'd or duplicate category is permanent and pollutes every grid, sort, and picker forever. The de-facto workaround (retagging units one at a time via a bare, unconfirmed select) commits on change/blur with no confirm and silently re-prices every open rental on that unit.
+
+- **job:** clean up or consolidate a mis-created or duplicate equipment category without corrupting a live rental's price
+- **primitive:** form field (select) · **failure:** destructive · **scope:** architecture · **role:** owner-operator · **SYSTEMIC**
+- **cite:** `app.js:19669-19679 (bare `<select>`, commits on change/blur, no confirm); app.js:1119-1123 (unitRentalPrice reads categoryId live, so rentals re-price instantly); contrast Invoices' full merge flow at app.js:9000/19098-19100/mergeInvoiceInto`
+- **evidence:** Orphaning is also unhelpfully handled: a unit pointing at a deleted/nonexistent categoryId renders as literal text "Unknown category" and "—" on the mini-card, neither actionable nor filterable. No bulk "move all N units" action and no search on the reassignment select (a phone user faces a ~50-option native dropdown).
+
+### 24. [RED] Categories — Filters set from one category persist and silently combine with a filter clicked on a different category later — clicking a status pill on 12k Excavator returned a Light Tower because an earlier tally-pill filter from another category was still active, stacking with no warning.
+
+- **job:** trust that the list shown reflects only the filter just clicked, not a leftover one from ten minutes ago
+- **primitive:** filter chip / group bar · **failure:** inconsistent · **scope:** interaction · **role:** dispatcher
+- **cite:** `app.js:3238-3242 addColFilter (never clears cs.filterTerms first) + app.js:19071-19078 (.js-fleet-filter handler skips setAnchor, so the cascaded-card reset at app.js:2586-2596 never fires)`
+- **evidence:** Live-confirmed: two chips ("Not Ready · Light…" + "Ready · 12k Exca…") intersected on screen with Back/Forward vanished; the result looked like a normal list, just of the wrong machine.
+
+### 25. [RED] Categories — The circular icon on a filter chip, which looks like a clear/remove control, actually inverts (negates) the filter instead of removing it — the list visibly changes so a hurried user concludes it cleared, while he is now viewing the exact complement of what he asked for.
+
+- **job:** clear an unwanted filter and see the real unfiltered list
+- **primitive:** filter chip · **failure:** lying · **scope:** interaction · **role:** dispatcher
+- **cite:** `app.js:3287-3297 (filterTermPill) + app.js:19041 (delegated click checks .js-ft-neg first and calls toggleFilterNeg, returning before reaching the actual remove path)`
+- **evidence:** Live-confirmed: clicking the leading circle turned the chip red ("excluding") and the list changed — the natural read is "it worked," but it inverted rather than cleared. No remove control appears on hover either.
+
+### 26. [RED] Customers — No call, text, charge, or follow-up control exists anywhere on a customer row or in the detail record — the card only ever states facts.
+
+- **job:** decide what to do next about a specific customer and do it without leaving the record
+- **primitive:** row / detail action controls · **failure:** invisible · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:7141-7183 (row); app.js:4233-4235 (funnel layer); app.js:8826-8856 (detail)`
+- **evidence:** Measured live: with a customer record open and 71 customer + 34 rental rows rendered, and separately a rental detail open with 59 phone numbers on screen, there were zero tel:, sms:, or mailto: links anywhere. The funnel's only prompt is a dashed "+ action" identical whether a lead is fresh or a year cold.
+
+### 27. [RED] Customers — The row computes an accurate live owed/overdue $ figure from real invoices every render, but the group header, sort field, filter, and pulsing detail-view flag all read a separate stored field written once at signup and never updated by anything in the client — so two contradictory answers to "does this person owe us" sit inches apart on the same screen.
+
+- **job:** decide, at a glance, whether a specific customer can rent right now or needs to be chased for money
+- **primitive:** status pill / group header / sort & filter · **failure:** lying · **scope:** signal · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `live: app.js:7149-7161 · stored: app.js:9317-9319, 8351-8352, 5886, 5897, config.js:430 · only writes: app.js:21102,21144,21238,21309,15804`
+- **evidence:** Repo-wide grep found zero write sites to payStatus outside the five creation paths (all set 'New Customer'). The team's own spec (docs/specs/customers-crm.md:642-650, dated 2026-07-09, nine days before this audit) already documents it: "payStatus remains a stored/seeded field; no derive-from-open-invoices pass exists... STILL an open question." Also confirmed there is no in-app editor for the field at all (a column that looks editable is read-only display) — it can only be changed via the Sheets backend.
+
+### 28. [RED] Customers — "New Customer" is a declared, first-class blue pay-status in config, but the grouping list only lists Unpaid/Partial/Current, so nearly the whole book falls into an unnamed, hard-coded-grey leftover bucket appended last.
+
+- **job:** tell a brand-new lead apart from a live paying account without opening every record
+- **primitive:** group header / bucket · **failure:** invisible · **scope:** architecture · **role:** counter-sales rep
+- **cite:** `app.js:9317-9319 vs config.js:116-121 · fallback app.js:9410-9411`
+- **evidence:** Of 2,265 customers, only 5 sit under the real "Current" group; 2,260 sit under "New Customer," which renders as generic grey overflow rather than its own configured blue section — including customers who have rented for years and owe money right now.
+
+### 29. [RED] Customers — Two of the five customer sort options are dead no-ops that silently fall through to name order while the menu still shows them as selected.
+
+- **job:** find who owes the most money, or whose invoice is oldest, without reading every row
+- **primitive:** sort control · **failure:** lying · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `config.js:430 declares both · app.js:9223-9245 switch has neither case · rendered as real buttons app.js:17145, 19208`
+- **evidence:** Measured live, element by element: sorting by "Pay Status" produced a list byte-identical to sorting by "Name." Sorting by "Last Invoice" produced reverse-alphabetical order (Z names first, then Y, then W), with a real duplicate customer name appearing twice in the captured list — no reference to any invoice date at all.
+
+### 30. [RED] Customers — The money pill and the phone number share one line, and the money wins the truncation — so the more a customer owes, the less of their number she can read.
+
+- **job:** call the specific accounts that owe money
+- **primitive:** row text (phone) · **failure:** invisible · **scope:** density · **role:** counter-sales rep
+- **cite:** `app.js:7147, 7152-7160 (row template, one-line-by-design per style.css .cr/.cr-sub)`
+- **evidence:** Measured across 400 rendered rows on production: 96% of rows carrying a balance had a clipped phone number (22 of 23) vs 25% without one. A customer owing $13,240.52 rendered a phone number of "(337) …" — the exact accounts she most needs to call are the ones she can't read the number for.
+
+### 31. [RED] Customers — Red is the default state of the screen and it never says why a row is red.
+
+- **job:** tell what's actually urgent among 2,265 customers without opening each one
+- **primitive:** name-text tint / flag · **failure:** ambiguous · **scope:** signal · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:5885-5900, 5934-5938, 7144-7146 · measured on production DOM`
+- **evidence:** Measured live: 44 of 60 rendered rows red, 11 of the first 12 in the default view. Inspecting a red row's DOM directly: no flag word in its text, no title attribute; the only tooltip on the row belongs to an unrelated eye-preview toggle. (Self-corrected mid-audit from an overstated "every customer is red" — a name search returned only 4 of 19 red; the saturation is specific to the default view.)
+
+### 32. [RED] Customers — Three separate alert-pulse mechanisms on this card are inverted or hardcoded backwards: the rental-status badge pulses unconditionally for all seven active statuses (none red); the pay-status pulse tests for a 'Paid' value customers can never hold, so every New Customer throbs like a debtor; and the membership billing flag has its booleans swapped so "No Billing" (a setup gap) pulses while "Payment Due" (genuinely overdue) sits calm.
+
+- **job:** notice which customer actually needs attention right now, among ones that just look busy
+- **primitive:** pulse / alert animation · **failure:** lying · **scope:** signal · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:8360 (alert:true unconditional) · app.js:8351-8352 (dead 'Paid' branch) · app.js:3989 vs 3992 (inverted booleans)`
+- **evidence:** All three mechanisms confirmed live in code; a person who scans for whatever blinks is actively misdirected to the calm cases and past the real ones on every one of the three signals this card ships.
+
+### 33. [RED] Customers — A customer's stored "Don't Contact" stage renders correctly as a red pill on the row and on the Sales pipeline board, but the customer-detail popup silently clamps any off-vocabulary legacy value (including this one) to a calm blue "Lead" — so opening the record to check the warning makes the warning disappear.
+
+- **job:** confirm before dialing whether this specific person should be contacted at all
+- **primitive:** flag / funnel-stage pill (detail view) · **failure:** lying · **scope:** signal · **role:** counter-sales rep
+- **cite:** `row: app.js:7164-7167 + config.js:157 · clamp: app.js:212-219 · migration: app.js:326-334`
+- **evidence:** "Don't Contact" is a value Mr. Wrangler chat and CSV import can both write onto a live customer today; the 2026-07-17 funnel-vocabulary migration only rewrites the old Inbound/Outbound Lead labels and never purges this one. A first-party test (ci/logic-test.mjs:1592) asserts the clamp is intentional, but the row-vs-detail contradiction it produces is untested and unreconciled.
+
+### 34. [RED] Customers — Adding a card on file is gated to Office/Admin with a toast; removing one, or changing which card is the default, has zero permission check and zero confirmation, twelve lines below the handler that does check.
+
+- **job:** protect the shop's ability to charge a customer from an accidental or malicious one-click delete
+- **primitive:** remove (X) button on a saved card/bank · **failure:** destructive · **scope:** interaction · **role:** counter-sales rep (any logged-in role, incl. mechanic/driver, can trigger this) · **SYSTEMIC**
+- **cite:** `app.js:858-876 (ungated X at 871 vs gated Add at 875) · app.js:18468-18473 · app.js:803-822 · Stripe detach app.js:820`
+- **evidence:** Measured live off the card-health ring: of 2,265 customers, 124 have a card on file and 2,141 do not (94.5% of the book). Since a valid card is required before On Rent, those 124 are effectively the entire float, and removeCard fires a live Stripe detach — not locally reversible — with no gate and no confirm at all.
+
+### 35. [RED] Customers — "Pay Cancellation" charges the customer's saved card in full the instant it is tapped — the one control on this card most in need of a review step is the only money action that skips the shared payment-review overlay every other charge uses.
+
+- **job:** collect a cancellation fee without risking a fat-finger charge on the wrong customer or amount
+- **primitive:** one-click money action button · **failure:** destructive · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:4100 button · app.js:18452 handler · app.js:4975-4989 charges immediately · contrast app.js:21392 overlay pattern`
+- **evidence:** Every other money action (pay balance, refund) opens a shared payment overlay for amount/card review first; this handler calls membershipReactivate directly with no review step.
+
+### 36. [RED] Customers — Sending an account to collections, and voiding a bad invoice, are both fully built end-to-end (manager gate, confirm popup with reason codes, overlay, auto-blacklist, audit-log entry / money-safe void handler) but their only trigger buttons render inside a standalone Invoices card that was retired and never renders anywhere.
+
+- **job:** send an uncollectable account to the agency, or remove a mistyped/duplicate invoice, with a proper record
+- **primitive:** menu action button · **failure:** unreachable · **scope:** architecture · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `orphaned Collections app.js:8974-8979, Void app.js:8991-8995 · live handlers app.js:18671, 18692, 18712-18716 · retirement config.js:421-426 · reachable menu lacks it app.js:4842-4856`
+- **evidence:** Verified live on production: opening the status menu on a real Late invoice offers exactly three items — Pay, Print, and Send (greyed out). No Void, no Send to Collections, no Recall. The only visible workaround for a bad debt is the raw Blacklist button, which skips agency placement, amount-placed tracking, and reason codes entirely. Two invoices on one real account were already marked VOIDED, implying voiding currently only happens through the Sheets backend, never through any reachable app UI.
+
+### 37. [RED] Customers — A customer's spend chart sums rental list price over a 9-month window while the account stat beside it shows the actual server-computed amount paid — different basis, different period, no label distinguishing either.
+
+- **job:** judge how valuable or active a specific account really is before deciding how to treat them
+- **primitive:** chart / stat tile · **failure:** lying · **scope:** signal · **role:** counter-sales rep
+- **cite:** `app.js:4685-4693 vs app.js:7769-7789`
+- **evidence:** On one real account, observed simultaneously: chart callout "$47,720 · BEST · APR"; Transactions tab "$2,834.84 collected, 1 payment, 0 refunds"; 1-year average $236.24; open balance $13,240.52 — and the caption beneath the chart still read "No rental cadence yet." A roughly 17x overstatement, both numbers on screen at once, nothing telling her which to trust.
+
+### 38. [RED] Customers — Only 60 of 2,265 customer rows load by default; the "Show more" button re-renders the entire list every press instead of appending, so each press gets slower than the last.
+
+- **job:** find a customer who isn't in the first 60 rows without giving up and asking a coworker
+- **primitive:** pagination / "Show more" button · **failure:** unreachable · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `measured on production, timed in-page over four consecutive presses`
+- **evidence:** Timed: 547ms → 658ms → 803ms → 1,044ms for identical 200-row additions; cost tracks total row count (~1.1ms/row), confirming a full re-render each press rather than an append. Reaching the end of the book is roughly eleven presses and over twelve seconds of frozen screen, each requiring a manual scroll back to the button first.
+
+### 39. [RED] Customers — There is no tap-to-call anywhere on this card, and the only real text/email action is hidden behind an undiscoverable right-click/long-press context menu — which itself has no "Call" option at all.
+
+- **job:** call or text a specific customer directly from their record
+- **primitive:** phone/email text vs. right-click context menu · **failure:** unreachable · **scope:** interaction · **role:** counter-sales rep
+- **cite:** `telHref app.js:11742 (only call site app.js:7368, Rentals trip-row) · customer plain text app.js:7147, 8359, 4395-4404 · right-click comms app.js:6377, openCtxMenu 6351-6389`
+- **evidence:** Repo-wide grep: telHref has exactly 3 hits — its definition, one Rentals trip-row call site, and a module re-export — zero uses on Customers. The right-click menu does fire real sms:/mailto: sends via commsOpenConv, but is reachable only by right-click or long-press, and even it never offers a "Call" action anywhere in the app.
+
+### 40. [RED] Customers — Settings has live, saveable toggles for customer reminders and dispatch ETAs, but the engines behind them are inert — the toggle persists, nothing acts on it.
+
+- **job:** trust that turning on a reminder setting actually results in someone getting reminded
+- **primitive:** settings toggle · **failure:** lying · **scope:** signal · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `Settings → Notifications toggles`
+- **evidence:** Anyone flipping these toggles on reasonably believes the app is now chasing customers on a schedule. It isn't — the toggle only writes its own saved state.
+
+### 41. [RED] Customers — Because the pay status never updates, red tints never say why, and only one sort works, counter staff have been typing business state directly into the customer name field — balances, do-not-rent flags, credits, and escalation contacts — and prefixing 23 of 25 with punctuation specifically because punctuation sorts above letters in the one sort (alphabetical) that isn't broken. The same improvisation shows up in free-text note fields on individual accounts, used as an ad hoc, undated "next follow-up" tracker because no structured field exists.
+
+- **job:** flag an urgent, do-not-rent, or credit-holding customer so it actually surfaces, given that the official flag/sort/status systems don't reliably do it
+- **primitive:** name field / free-text notes / sort · **failure:** ambiguous · **scope:** architecture · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `measured on production, names redacted for privacy`
+- **evidence:** Of 860 rendered customer names, 25 carried business state typed into the name field: 13 owed-amount flags (e.g. "!!!Owes $X!!!"), 7 do-not-rent flags, 3 account-credit notes, 2 escalation-contact routings. This is not sloppiness — it's staff actively routing around three separate defects (dead sorts, frozen pay status, the vanishing Don't-Contact flag) every day, by hand, and is the strongest evidence in the whole audit that those defects are real and costing time.
+
+### 42. [RED] RENTALS — On a multi-unit rental, flagging a Field Call on a non-primary unit dispatches the repair to the rental's PRIMARY unit and leaves the actually-broken machine bookable.
+
+- **job:** get the mechanic and a truck to the machine that actually broke down
+- **primitive:** flag (Field Call) + the status action behind it · **failure:** lying · **scope:** interaction · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:20003-20014 ← call sites app.js:20045, app.js:20264`
+- **evidence:** markFieldCall(rentalId) only ever reads r.unitId — documented as the PRIMARY-unit mirror (app.js:345-349, resynced every load at app.js:368) — and never the clicked unitId, which IS in scope at both call sites (setUnitCondition's Fail path, app.js:20045; the +FC yard capture, app.js:20264). The broken non-primary unit never gets inspectionStatus='Failed', so isUnitAvailableFor (app.js:2064-2067) keeps it bookable, while the untouched primary is wrongly flagged Failed and gets the WO (wo.unitId:r.unitId, app.js:20009). Verifier verdict CONFIRMED. Since fixed in PR #740.
+
+### 43. [RED] RENTALS — A rental can be jumped straight to 'Returned' having never been invoiced, closing the job out unbilled.
+
+- **job:** make sure a finished rental actually got billed before it's closed
+- **primitive:** status pill / gate-timeline dropdown · **failure:** destructive · **scope:** interaction · **role:** AR clerk
+- **cite:** `app.js:19906-19925, order app.js:16851`
+- **evidence:** The invoice hard-gate fires only for val==='On Rent' (app.js:19911); blacklist/rental-rules/card/account-block gates are all scoped to BOOKING_STATUSES = ['On Rent','Reserved','Today','Tomorrow'] (app.js:19751) — 'Returned' is in none. The status dropdown is a free-jump timeline (every node a live button, no disabled state), so a dispatcher can open a fresh Reserved rental (invoiceId still null) and click 'Returned' directly; units flip Returned and the rental closes out, never billed. Verifier verdict CONFIRMED, critical.
+
+### 44. [RED] RENTALS — The lane rail + one-tap 'Round up' auto-balance that let a dispatcher assign a whole route were retired — the handlers still exist but nothing renders their buttons.
+
+- **job:** assign a dozen delivery/recovery stops across three trucks in one pass
+- **primitive:** nav control / dispatch rail (unrendered) · **failure:** unreachable · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:11802-11805, app.js:18629-18636`
+- **evidence:** The multi-driver lane rail and the 'Round up' auto-balance handlers are present in code but no UI renders their buttons. With 12 stops and 3 trucks a dispatcher can only tap +Driver one stop at a time — no 'who's carrying what' load view, no one-tap balance. Surfaced by a completeness critic (source-grounded cite, not one of the 15 triple-verified items).
+
+### 45. [RED] RENTALS — A driver can be assigned two overlapping runs with no conflict warning — one driver, two towns, same 9 AM, silently allowed.
+
+- **job:** not double-book one driver into two jobs at the same time
+- **primitive:** flag (missing driver-conflict flag) · **failure:** invisible · **scope:** signal · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:11341-11352, app.js:18636`
+- **evidence:** Units get a pulsing 'Overbooked' flag when double-booked; drivers get nothing. Assign or 'Round up' writes a driver onto a transport leg with no time-conflict check. The asymmetry with the unit-overbooking flag is what makes it look systemic (the signal system covers equipment but not people). Completeness-critic finding, source-grounded.
+
+### 46. [RED] RENTALS — A field delivery blocked by an office-side booking gate silently discards the whole capture — recorded video included — with no way to see or clear the block from Trips.
+
+- **job:** log a delivery from the job site and not lose the proof-of-delivery video
+- **primitive:** status action / toast (missing block-surface) · **failure:** destructive · **scope:** interaction · **role:** driver · **SYSTEMIC**
+- **cite:** `app.js:20256-20261, app.js:529`
+- **evidence:** A driver taps 'Log Delivery'; if the office never finished the card/invoice, the booking gate refuses the status move and the entire capture (including recorded video) is thrown away — no queued retry, no visible block on the Trips side to clear. Completeness-critic finding, source-grounded.
+
+### 47. [RED] RENTALS — Returns capture no damage: 'Log Recovery' flips the unit to Returned with only {date, video, driver} — nothing records condition, opens an inspection, or bills damage.
+
+- **job:** charge for damage found when equipment comes back
+- **primitive:** capture form / handoff (missing) · **failure:** unreachable · **scope:** architecture · **role:** mechanic · **SYSTEMIC**
+- **cite:** `app.js:20259-20261, app.js:4410-4411`
+- **evidence:** The recovery path stamps only {date, video, driver} and sets Returned; there is no condition capture, no inspection open, no damage line. The Rental Protection $1,000 cap can therefore never be exercised from the return path. Completeness-critic finding, source-grounded.
+
+### 48. [RED] RENTALS — An overdue return is invisible to every count, badge and toast in the app — it only tints the row it's already sitting in.
+
+- **job:** know the moment a rental goes overdue so I can chase it
+- **primitive:** flag / bell count · **failure:** invisible · **scope:** signal · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:5846, config.js:245, commsBellCount app.js:10342-10343`
+- **evidence:** off-rent-overdue is a red flag (config.js:245) but feeds only getEntityColor (row pill/border). commsBellCount = unseenNotifs()+visibleTransportAlerts()+wranglerRequests — none reference the flag, and a past-endDate leg drops OUT of the forward-windowed transportAlerts, so it isn't even indirectly counted. The rentals column tab's alert is hardcoded false (app.js:9601, only units get unitsAlertCount). No poll scans flags to fire a toast. Verifier verdict CONFIRMED.
+
+### 49. [RED] UNITS — The hover-preview panel that looks like a glance-only tooltip is actually the full live detail view, every action button wired hot, positioned 10px right of the cursor and centred on it — exactly where the hand is already travelling.
+
+- **job:** glance at a machine to check its state without changing anything
+- **primitive:** hover preview / popup panel · **failure:** destructive · **scope:** interaction · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `style.css:825, app.js:3008, app.js:19134`
+- **evidence:** style.css:825 sets pointer-events:auto explicitly on .hover-preview; app.js:3008 renders the real DETAIL.units() markup — every live control, not a summary — into the floating panel; app.js:3021-3028 positions it 10px right of and centred on the cursor. Live reproduction: hovered a unit tile to look at it, clicked once, got the toast 'Wash logged — countdown reset' — a real production write with no confirmation. The panel holds 13 live controls, none disabled, all pointer-events:auto at z-index:9000, including '✕ Fail' which fails the machine and auto-opens a work order in one click. Jac had already written uncompleteWash and labelled it 'misclick recovery' before this audit — the trap was already known.
+
+### 50. [RED] UNITS — Attaching a machine to a customer rental has exactly one path — drag-and-drop — and the +Unit button, the only visible alternative, does not open a picker; it toasts an instruction to drag instead.
+
+- **job:** build a rental / attach a machine to a customer quote
+- **primitive:** button (+Unit) / drag target · **failure:** unreachable · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:17568`
+- **evidence:** Opened a new quote; clicked +Unit — no picker opens, only a toast: 'Drag a unit from the Units card onto this rental.' Drag is the only path. A user who will not perform a drag gesture (the audited persona, and by extension anyone on a difficult touch surface) cannot build a rental at all.
+
+### 51. [RED] UNITS — The drag-drop filter that governs what can actually be attached to a customer rental checks only fleetStatus==='Active' — a failed inspection, 2,882 hours overdue on service, attaches with no warning, no confirmation, no block.
+
+- **job:** make sure the machine going out the gate is actually fit to rent
+- **primitive:** drag target / missing gate-confirm · **failure:** destructive · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:17568 (picker filter), app.js:2251 (isUnitRentable)`
+- **evidence:** Dragged Worm — failed inspection, 2,882 hrs overdue — onto a quote. It attached instantly. Searched the entire rental detail for 'failed, not ready, overdue, service, inspect, warning, caution, unsafe' — not one appears. Two competing definitions of 'rentable' exist: isUnitRentable (app.js:2251) checks fleet status AND excludes failed inspection but only feeds the availability COUNT; the actual drag-drop attach filter (app.js:17568) checks fleetStatus==='Active' only, and neither checks service-due at all — a grep for any rent-gate referencing past-due returns nothing. A warn-only patch (PR #742) has since shipped ('⚠ FAILED INSPECTION · SERVICE 2732 HRS overdue' on the drop toast, persisted to the rental's log) — but the redesign still needs to decide the real policy: warn, block, or override, and whether it should ever have been possible to attach silently in the first place.
+
+### 52. [RED] UNITS — The mechanic's landing screen correctly opens with the Worklist graph on and countdown-ascending sort — then the first machine he opens turns graphView off permanently, with no restore on close, on Back, on returning to the list, or across sessions.
+
+- **job:** come back to the prioritized worklist after finishing one job
+- **primitive:** graph/panel view-state toggle · **failure:** unreachable · **scope:** interaction · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:2731 (openStandard clears graphView), app.js:25640 (ROLE_LANDING sets it true on arrival)`
+- **evidence:** ROLE_LANDING.mechanic and .mtech both set graphView:true and sort:countdown-asc on every login and trusted-device resume (app.js:25640-25641, applied at 25658/25750) — the app front-loads the work correctly. But openStandard (app.js:2731) sets graphView=false when any unit opens, and nothing ever sets it back — not closing the record, not Back, not returning to list mode, and it is never persisted. Opening the one machine the screen exists to point him to costs him the prioritized view for the rest of the shift.
+
+### 53. [RED] UNITS — A machine that breaks down mid-rental (failed inspection while actively on rent) never lands in the 'Needs Attention' bucket — it is filed under whatever rental stage it's in, indistinguishable from healthy rentals.
+
+- **job:** find the machine that just broke down in the field
+- **primitive:** group/bucket categorization · **failure:** lying · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:9294-9307`
+- **evidence:** unitStageKey() returns on the rental-stage branch (lines 9296-9303) for any unit with an active rental, before it ever reaches the inspectionStatus==='Failed' check on line 9304 — which only fires for units with NO active rental. A field-broken machine sits inside the collapsed 'On Rent · 21' bar, indistinguishable at the group-header level from 21 healthy rentals. This is the single scenario the mechanic role exists for.
+
+### 54. [RED] UNITS — Setting the sort to 'Service Due' does not sort by service due — grouping wins, so the sort only reorders within a bucket; a machine 1,139 hours overdue on service appears at position 9 in the list, and files under the green 'AVAILABLE' bucket.
+
+- **job:** find the most overdue machine to service first
+- **primitive:** sort control + group/bucket · **failure:** lying · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:9294 (grouping), app.js:9304 (bucket by inspection status only)`
+- **evidence:** Measured live with sort explicitly set to Service Due: position 1 Highrise (440 hrs overdue), position 2 Worm (2,882 hrs overdue, shown only as 'No GPS +1'), position 3 Reptar (2,025 hrs overdue), positions 4-8 five machines with nothing wrong at all, and only at position 9, Dirt Dauber at 1,139 hrs overdue — sitting in the AVAILABLE bucket below three clean machines. Buckets are decided by inspection status alone; service urgency never enters bucket assignment.
+
+### 55. [RED] UNITS — The single worst machine in the yard (2,882 hours past service) displays on its tile as 'No GPS +1' — the service number exists only inside a hover-tooltip string, and flag ranking is by color alone with a hardcoded push order that puts GPS ahead of engine service.
+
+- **job:** spot the worst machine at a glance without hovering
+- **primitive:** flag/badge stack, ranking logic · **failure:** invisible · **scope:** signal · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:6989`
+- **evidence:** unitCardFlags shows only the single highest-ranked flag plus a '+N', the rest available only in a title-attribute hover tooltip a lazy/touch user never triggers. Ranking is by color rank, tie-broken by hardcoded push order in the flag-building code — GPS is pushed second, service pushed fourth — so a dead GPS antenna always outranks a seizing engine when both are red. Worm's 2,882-hrs-overdue service number exists nowhere on the tile face, only inside the data-tip string 'No GPS · 2882 HRS overdue.'
+
+### 56. [RED] UNITS — A pending wash silently substitutes for a genuinely overdue service everywhere the app shows service status — card border color, the WO/Service pill, the red 'service-past-due' flag predicate itself, the countdown sort, and two KPI tallies.
+
+- **job:** trust that a calm-looking machine isn't actually overdue on real service
+- **primitive:** card border color, badge/pill, flag predicate, sort key, KPI tally · **failure:** lying · **scope:** signal · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:2206`
+- **evidence:** topServiceForUnit() unconditionally returns the wash task's own row the moment unit.washRequested is true, before ever comparing it to the real worst-active task that unitServiceRows() already sorted worst-first. Consumers of that poisoned value: the card border color (unitWoSoColor, 6970-6974), the WO/Service pill (unitWoSoPill, 6976-6980), the service-past-due flag predicate itself (FLAG_COND.units, line 5857), the countdown sort key (line 9242), and two aggregate KPI tallies which explicitly skip wash-flagged units before counting overdue service (lines 12169, 12682). Concrete case: a unit 40 hrs overdue on engine oil, with a wash also requested, shows a calm yellow 'Wash Due' flag everywhere with the oil overdue invisible. The unit's own detail page gets this right — it independently excludes wash when computing the worst task (app.js:8134) — proving the correct pattern exists one function away from where it's needed. A related bug: snoozing the wash task doesn't silence it either, because the wash early-return in this same function fires BEFORE the snooze filter on the next line.
+
+### 57. [RED] UNITS — Two RED-severity insurance flags — coverage-expired and uninsured-active — are registered in the flag system but never render as a pill anywhere on the Units card face; insurance color comes only from a covered boolean, ignoring expiry date.
+
+- **job:** know a machine's insurance is valid before it goes out the gate
+- **primitive:** flag/badge · **failure:** invisible · **scope:** signal · **role:** mechanic / yard tech
+- **cite:** `app.js:6989`
+- **evidence:** coverage-expired and uninsured-active are registered in FLAG_COND (coverage-expired at RED severity) but unitCardFlags never tests insurance, so neither appears on any card-face pill. They DO silently tint two other surfaces as unlabeled color only — the item-tab chip (app.js:2641) and the R2 entity-stamp pill (app.js:5996) via getEntityColor — which arguably makes it worse: color with no label anywhere naming what it means. An uninsured machine going out looks fine on the one surface anyone actually checks.
+
+### 58. [RED] UNITS — The one alert indicator seen before opening the card watches only 3 of the 10 registered flag conditions.
+
+- **job:** know before opening the card whether anything needs attention
+- **primitive:** badge / alert indicator · **failure:** lying · **scope:** signal · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:9479`
+- **evidence:** unitsAlertCount ignores failed inspection, overbooked, GPS offline, coverage expired, and uninsured-active — five of the ten registered flag conditions, including the two that can put an unsafe or uninsured machine on the road. The tab badge, the card border, the corner-flag pill, and the group bucket each reimplement their own different subset of the 10-flag registry, so four separate mechanisms disagree about what counts as 'needs attention.'
+
+### 59. [RED] UNITS — Every work order's phase pill is frozen at its creation value on the Units card tile — the code that ever advanced it lived in the retired Shop-card renderer and is unreachable from Units.
+
+- **job:** see whether a job you're actively working has progressed
+- **primitive:** status pill (WO phase) · **failure:** lying · **scope:** architecture · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:6978`
+- **evidence:** The tile pill reads raw w.phase, set once at WO creation and never updated by any code path reachable from Units. Elsewhere in the app the WO's displayed status is meant to be a DERIVED value (woBottleneck, by severity) that line edits never write directly (per the code's own comment at app.js:22610-22613) — but the Worklist graph (app.js:12170) and a list filter (app.js:3169) both bucket on the raw frozen phase instead. Two different definitions of 'what phase is this WO in' coexist on the same screen: the unit's own accordion shows the live bottleneck, the graph above it shows the creation-time value. Merle works the job all day and his tile never changes.
+
+### 60. [RED] UNITS — Scanning a unit's own printed QR decal — the most obvious physical affordance in the yard — hijacks the app into a full-screen driver video-capture takeover with no 'open this unit' control and no way back.
+
+- **job:** scan the machine's decal in the yard to pull up its record
+- **primitive:** full-screen modal takeover / scan flow · **failure:** unreachable · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:26647, app.js:26068 (scanActive set true, never reset)`
+- **evidence:** scanActive is set true on scan and never set back to false anywhere in the codebase; render() bails permanently once it's set (app.js:17177). Not one branch of the scan screen (ready / blocked / notfound / error / done) renders an 'open this unit' or 'back to the app' control — only js-scan-again / js-scan-retry. For a yard unit with no active rental, the result is 'Nothing to log for this unit right now' with the entire Units card gone. This directly contradicts the code's own documented intent: app.js:7706 states the QR decal is meant to land mechanics on the Units-card journey.
+
+### 61. [RED] UNITS — The hour meter — the sole input every service countdown derives from — is never captured when a machine returns from rental; the seeded fields for it exist and are humanized for the audit log but have no writer anywhere in the app.
+
+- **job:** keep the service countdown accurate after a machine comes back from a rental job
+- **primitive:** data-capture flow at end-of-rental · **failure:** invisible · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:23088`
+- **evidence:** startHours / returnHours exist on every rental unit entry, are seeded with real values, and are humanized for the audit log (app.js:22577) — but a grep for 'startHours =' / 'returnHours =' across app.js returns zero assignments, and nothing rolls returnHours into unit.currentHours. A unit goes out for three weeks, comes back 180 hours older, and its service countdown does not move by one hour unless someone remembers to hand-type the meter into the one manual field that does write currentHours (app.js:19644).
+
+### 62. [RED] UNITS — The only field that writes the hour meter has zero validation — no range check, no order-of-magnitude guard, no monotonic (forward-only) check — and a 10x fat-finger typo sat in production for 26 days feeding every service decision on that machine.
+
+- **job:** record an accurate hour-meter reading without a typo silently corrupting every downstream number
+- **primitive:** inline text field · **failure:** destructive · **scope:** interaction · **role:** mechanic / yard tech
+- **cite:** `app.js:19644`
+- **evidence:** const v = Number(input.value); u.currentHours = v — no guard of any kind. Live production history on unit SPEECHLESS: 'Jun 17 — Hours: 1732.3 → 17385.5' (entered by Cameron), corrected 'Jul 13 — 17385.5 → 1738.5' (Bri) — a 10x typo that stood for 26 days, feeding every service countdown, the fleet hours average, category ROI, and $/Hr computations, and getting permanently stamped onto any work order opened in that window. A warn-only guard has since shipped (proven live: 'Worm: 31,220 HRS is 10.0× the last reading (3,122) — check for a missed decimal. Saved anyway') — but nothing prevents the write, only flags it after the fact, so the underlying data-integrity question (should the system ever accept a reading like this without stronger confirmation?) remains open for the redesign.
+
+### 63. [RED] UNITS — Two mechanics editing the same unit at once silently lose one person's work — sync is whole-record last-write-wins with no field-level merge and no conflict notice of any kind.
+
+- **job:** have two techs both work the same machine without one person's entry being silently destroyed
+- **primitive:** sync/merge logic (no UI signal) · **failure:** destructive · **scope:** architecture · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:24778`
+- **evidence:** If the local copy of a unit has any unsaved edit, the incoming remote version is discarded entirely and the local record is pushed over it on the next flush — the only reconciliation branch in the whole 18-second poll is a narrow invoice-id collision heal; units get none. Concrete scenario: Merle types an hour-meter reading in the yard (record now dirty); Dale, in the shop, completes the 250-hour oil change on the same unit and sees 'Service completed — countdown reset'; the poll reaches Merle's tablet, discards Dale's version because Merle's copy is dirty; Merle's next save pushes his object over Dale's, and the completed-service log entry — including any photo proof — is gone with no warning to either man. No presence indicator, no soft lock, no conflict notice exists anywhere in the app for this.
+
+### 64. [RED] UNITS — The assignedMechanic field is stored, displayed, searched, and editable in 17 places across the codebase — and is never once used to route, filter, or badge anything. No per-mechanic queue of 'these are yours' exists in any form.
+
+- **job:** know which machines are mine to work on today
+- **primitive:** assignment field / personal queue · **failure:** unreachable · **scope:** architecture · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:20009, 22445, 23005 (17 total appearances)`
+- **evidence:** Exhaustive grep confirms assignedMechanic appears 17 times: stored, displayed, edited, searched — never used to route, filter, badge, or scope a single view. Every auto-created work order is born with it blank (app.js:20009, 22445, 23005). There is no 'assigned to me' filter or badge keyed off the field and the logged-in identity anywhere in the app.
+
+### 65. [ORANGE] Calendar / Driver — A blank time box reads as 'nothing due,' but the code silently treats it as a hard 5:00 PM cutoff (AUTORUN_EOD_DEADLINE_SEC) that is never printed on the row unless a dispatcher has already run Auto-Run for that day.
+
+- **job:** know his real deadline for an unscheduled stop before he's already blown it
+- **primitive:** time field / implicit deadline · **failure:** invisible · **scope:** signal · **role:** driver
+- **cite:** `app.js:11906, 11929-11935, 7407`
+- **evidence:** The 5PM constant only ever reaches the screen via a session-only Auto-Run 'Late' flag. Code comment confirms it's an internal optimizer safety net, not a customer promise — but the row gives no way to tell 'no deadline' from 'undisclosed deadline.'
+
+### 66. [ORANGE] Calendar / Driver — A background poll (every 18 seconds) can also trigger a full render() with no action from the driver at all, hitting the identical scroll-memory bug and silently snapping the card back to the top mid-read.
+
+- **job:** read his list without the screen jumping on him while he isn't even touching it
+- **primitive:** background sync / scroll position · **failure:** inconsistent · **scope:** interaction · **role:** driver
+- **cite:** `app.js:24792`
+- **evidence:** Same root cause as the assignment-triggered reset, but fires purely from office activity elsewhere — a driver reading his list can be reset by someone else's edit with zero visible cause.
+
+### 67. [ORANGE] Calendar / Driver — The service worker has no push listener and no showNotification call anywhere in the codebase — it is an offline-cache shell only, so nothing can reach a driver who isn't already staring at the screen.
+
+- **job:** get told something changed without keeping the app open and watching it
+- **primitive:** push / service worker · **failure:** invisible · **scope:** architecture · **role:** driver · **SYSTEMIC**
+- **cite:** `sw.js (full file — install/activate/fetch/message only)`
+- **evidence:** The one genuinely loud, render()-proof channel that does exist — the R25 sync banner (app.js:25416-25432, role=alert/aria-live=assertive) — instructs the driver 'Don't close the app,' which a phone user can't reliably comply with since the OS backgrounds/locks apps on its own.
+
+### 68. [ORANGE] Calendar / Driver — tripMatches() does one contiguous blob.includes(q) instead of the AND-term matching every other card's search bar uses, so 'lake pick' returns zero rows against a row that is literally 'Pick up' at 'Lake Charles.'
+
+- **job:** find a trip by typing the words he sees on the row, the way search works everywhere else
+- **primitive:** search bar · **failure:** inconsistent · **scope:** interaction · **role:** driver
+- **cite:** `app.js:11746`
+- **evidence:** Reproduced live on production: 0 results for 'lake pick.' Credit: the empty state is handled honestly ('No trips match...') rather than silently, so it fails clearly, just wrongly.
+
+### 69. [ORANGE] Calendar / Driver — The 'Open in Google Maps' button only renders once a stop is focused, nested inside the collapsible map panel — there is no default per-row directions affordance.
+
+- **job:** get turn-by-turn directions to his next stop with one tap, no discovery required
+- **primitive:** directions button · **failure:** unreachable · **scope:** interaction · **role:** driver
+- **cite:** `app.js:9660-9673 (link only builds inside the map panel, gated on mapOpen)`
+- **evidence:** Live-confirmed: the button only materialized after tapping the town link. Collapsing the map by default (the fix for the fold-eating-viewport finding) also removes the only place this link lives, since it's nested in the same collapsible panel — the two fixes need to be reconciled together, not shipped independently.
+
+### 70. [ORANGE] Calendar / Driver — The customer pill replaces the Trips column entirely (navigating into Rentals); the unit pill opens in the left column and leaves Trips mounted. Same row, same visual treatment, opposite consequences.
+
+- **job:** tap a related record without unpredictably losing his place on the card he was using
+- **primitive:** pill / navigation · **failure:** inconsistent · **scope:** interaction · **role:** driver
+- **cite:** `verified live — customer pill swapped the middle column tab, unit pill did not`
+- **evidence:** Only one of the two pills costs the driver his place, with no visual difference warning him in advance which one is about to do it.
+
+### 71. [ORANGE] Calendar / Driver — The row's entire overflow (⋯) menu contains exactly one item — 'Merge trip…' — a dispatcher concept. There is no 'running late,' 'can't complete,' or 'on my way' action anywhere on a driver's own row.
+
+- **job:** tell the office something went wrong without picking up the phone
+- **primitive:** row overflow menu · **failure:** unreachable · **scope:** architecture · **role:** driver
+- **cite:** `app.js:18623`
+- **evidence:** The capability already exists one card over — the Unit card carries a working '+FC' (Field Call) button (app.js:7736) — it simply isn't wired onto the row where the driver is actually standing.
+
+### 72. [ORANGE] Calendar / Driver — The KPI labeled 'On-Time' is computed as delivered-or-handled ÷ scheduled — a completion rate, with no comparison to t.time or the implicit 5PM deadline anywhere in the formula.
+
+- **job:** know whether he's actually running late, from the number the app itself grades him on
+- **primitive:** driver KPI · **failure:** lying · **scope:** signal · **role:** driver
+- **cite:** `config.js:311 (label 'On-Time') vs app.js:10015 (formula)`
+- **evidence:** A driver who is late on every stop but eventually finishes all of them scores 100% on a metric named for punctuality.
+
+### 73. [ORANGE] Calendar / Driver — timeToMin() only accepts colon-formatted times — '9am,' '9 AM,' '0900,' '9,' and 'noon' all parse to null, which is not surfaced as an error; it silently inherits the same invisible 5PM deadline as a truly blank field.
+
+- **job:** set a time the way he'd naturally type it, and get told if it didn't take
+- **primitive:** time input field · **failure:** invisible · **scope:** interaction · **role:** dispatcher
+- **cite:** `app.js:11768-11773`
+- **evidence:** Proven by running production's own regex against each candidate input — every non-colon form returned null with zero warning or correction shown.
+
+### 74. [ORANGE] Calendar / Driver — On a merged trip, the Log Delivery button is hard-scoped to the primary stop's own record but gated on the whole trip's done state — after logging the first of two stops the button still reads 'Log Delivery,' pointing at a capture already completed.
+
+- **job:** know which stop on a doubled-up job still needs logging, without re-shooting proof already captured
+- **primitive:** log action button · **failure:** ambiguous · **scope:** interaction · **role:** driver
+- **cite:** `app.js:7376-7380 (button scoped to primary stop), 11586 (trip-level done requires every stop)`
+- **evidence:** A driver facing this either re-records a video for nothing or has to stop and puzzle out which stop the button is actually talking about — neither is driving.
+
+### 75. [ORANGE] Calendar / Driver — There is no pre-built, always-available dispatch channel a driver lands in — every new Team chat starts with zero members, so warning the office of a delay requires first creating a thread and adding people rather than tapping into something that already exists.
+
+- **job:** warn dispatch he's going to be late before he's already late, instead of calling
+- **primitive:** team chat / dispatch channel · **failure:** unreachable · **scope:** architecture · **role:** driver
+- **cite:** `app.js:10569-10570 (new chat starts members: [])`
+- **evidence:** Corrected from an earlier overstatement: not admin-gated — any user, including the driver, can create a chat and add dispatch in about two taps. The real gap is narrower: no standing pre-populated dispatch thread by default, and no dedicated one-tap 'running late' affordance.
+
+### 76. [ORANGE] Categories — The Time Utilization graph's fleet-count denominator includes every unit ever assigned to a category regardless of fleetStatus (Sold/For Sale/Inactive included), permanently depressing the displayed utilization percentage.
+
+- **job:** judge whether the fleet is being used efficiently enough to justify buying more of a class
+- **primitive:** graph (Time Util bar chart) · **failure:** lying · **scope:** signal · **role:** owner-operator
+- **cite:** `app.js:12740-12741 (ruCatUtilProxy fleet accumulator, no fleetStatus gate)`
+- **evidence:** Live: Time Util tab shows top category at 48%, everything else under 30% — an owner reading this concludes the fleet is under-used when real utilization (excluding dead fleet from the denominator) is higher.
+
+### 77. [ORANGE] Categories — Category revenue/ROI figures (Round-Up strip, categoryStats.roi, Revenue-by-Category graph) still count the derived price of Cancelled and No-Show rentals, and unitRepairCost still summed cancelled work orders — money never actually collected/spent is counted as if it were.
+
+- **job:** judge which equipment category is actually making the business money
+- **primitive:** graph (Round-Up Revenue strip) · **failure:** lying · **scope:** signal · **role:** owner-operator
+- **cite:** `app.js:2227 unitTotalRevenue and app.js:12396 ruCatMoney (no r.status filter) vs app.js:12740 ruCatUtilProxy which already excludes Cancelled/No-Show/Quote; expense side at app.js:2212 unitRepairCost summed cancelled work orders while ruCatMoney's expense loop already skipped them`
+- **evidence:** Live: Round-Up Revenue bars show 8k Excavator $79k, Skid Steer $77k, while the Rentals card beside it shows "NO SHOW · 32" for the same period — money that was never collected sits inside those bars, and the strip carries no canMoney() gate at all so it's visible to everyone.
+
+### 78. [ORANGE] Categories — Eight distinct one-word unavailability reasons (N/A, Sold, For Sale, Inactive, Failed, Overdue, End Dates?, Off fleet) all render through the identical single-color red pill with no legend anywhere — an actionable "Overdue" (a customer is late returning our machine) looks pixel-identical to an inert "N/A" (we never stocked the class).
+
+- **job:** tell an actionable overdue-return situation apart from a simple no-stock situation at a glance
+- **primitive:** status pill (unavailability reason pill) · **failure:** ambiguous · **scope:** signal · **role:** dispatcher
+- **cite:** `app.js:2281-2297 categoryUnavailReason (single badge(...,'red') call for all 8 reasons)`
+- **evidence:** Confirmed live and in code: the reason set is actually slightly larger than first thought (Purchased/Onboard also reachable), all styled identically.
+
+### 79. [ORANGE] Categories — The sort menu offers ROI, Unit Count, and Avg Hours as sort fields, but the default mini-card face never renders any of the three — choosing one of them reshuffles the entire grid with no visible explanation of the new order.
+
+- **job:** understand why the list just reordered after picking a sort option
+- **primitive:** sort menu · **failure:** invisible · **scope:** architecture · **role:** dispatcher
+- **cite:** `config.js:432 SORT_FIELDS.categories; app.js:7225-7318 ROWS.categories (default face: name + pills + 5 rate tiles only)`
+- **evidence:** Live-confirmed: sorting by ROI moved Light Tower to the top with zero ROI value printed on any card — "is that the best one or the worst one?" ROI and Avg Hours are at least reachable one tap into the detail; Unit Count is shown nowhere on the card at all.
+
+### 80. [ORANGE] Categories — Every fresh session and every page reload lands the left column on Units — a card that carries no rate field at all — regardless of where the user was previously working; there is no session-position memory and no role-based landing override for a rate-facing role.
+
+- **job:** resume rate-lookup work immediately after a routine refresh, without re-navigating
+- **primitive:** nav control (column default) · **failure:** unreachable · **scope:** architecture · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `config.js:419 (COLUMNS left default:'units'), app.js:2386 freshSession(); no ROLE_LANDING entry points a counter-facing role at Categories`
+- **evidence:** Live-confirmed: after an entire session working in Categories, a reload dropped straight back to Units. Every single call effectively starts on a screen that structurally cannot answer a price question.
+
+### 81. [ORANGE] Categories — The column-tab alert glow (the dot that says "this tab needs attention") is hardcoded to fire only for the Units member; no other column, including Categories, can ever light the tab up no matter its internal state.
+
+- **job:** notice from across the app, without opening the card, that Categories needs attention
+- **primitive:** nav control (tab alert dot) · **failure:** unreachable · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:9644-9655 (`alert: m === 'units' && unitsAlertCount() > 0`, literal string match); only unitsAlertCount() exists anywhere in the file`
+- **evidence:** Grepping the whole file finds no categoriesAlertCount function. Mitigation: a category with unset rates or fleet trouble does surface an inline flag one click in — but the tab itself can never glow.
+
+### 82. [ORANGE] Categories — Categories has zero entries in the shared flag/badge engine (FLAG_META/FLAG_COND) that every other entity (rentals/units/workOrders/invoices/customers) participates in, so no condition on a category — zero stock, negative ROI, unset pricing — can ever escalate past that one mini-card's own pill.
+
+- **job:** get automatically warned about a category-level problem instead of noticing it by chance
+- **primitive:** flag/badge (registry) · **failure:** unreachable · **scope:** signal · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `config.js:237-297 (FLAG_META, 5 entity keys, no categories); app.js:5833-5924 (FLAG_COND, same 5); getEntityFlags returns [] when the entity key is absent`
+- **evidence:** Confirmed by full grep of both registries plus every call site — no `getEntityFlags('categories', ...)` call exists anywhere in app.js.
+
+### 83. [ORANGE] Categories — The ~18-second background poll patches remote data into local records in place with no diff/changed-field marker anywhere in the codebase, and skips the tick entirely whenever any overlay, drag, or focused input is active.
+
+- **job:** trust that the number on screen right now reflects the latest edit, not a stale one
+- **primitive:** list row / background sync · **failure:** invisible · **scope:** signal · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:24823-24866 refreshFromBackend (guard at 24825 on document.hidden/DRAG/overlay/hoverNode; plain Object.assign+render() at 24848/24863 with no changed-key capture; no CSS class/flag/highlight logic for "recently changed" exists in the file)`
+- **evidence:** A number can change under a rep mid-shift with zero visual cue — and if he has any popup open (a rental, Mr. Wrangler, Settings — all common), the refresh doesn't even run, so he silently stops receiving updates altogether.
+
+### 84. [ORANGE] Categories — The only way to create a category is to type a name into the search box, get zero results, and click the resulting "+ New Category" button — there is no dedicated "+ New" entry point anywhere else on the card, unlike Rentals and Customers which have an always-on new-record row.
+
+- **job:** discover that creating a new equipment category is even possible
+- **primitive:** empty-state button · **failure:** unreachable · **scope:** architecture · **role:** owner-operator
+- **cite:** `app.js:9878-9886/9008 (js-new-cat-search) → app.js:18946 → app.js:21174-21251; contrast Rentals' .newrow (app.js:9913-9917) and Customers' (app.js:9921-9925); a code comment at app.js:10340 documents the header +New menu was explicitly removed`
+- **evidence:** Live-confirmed and not clicked (would mint a real $0 category in production): typing "zzq test category" surfaced "No Category matches... + New Category \"zzq test category\"" as the sole creation path.
+
+### 85. [ORANGE] Categories — A brand-new category is born with every rate field at 0 and zero units, which renders it in the single most visually alarming state the card has (a full red "None · N/A" plate) — identical in appearance to a genuinely dead/retired category, with no "finish setting this up" affordance.
+
+- **job:** tell a brand-new not-yet-priced category apart from one that's actually out of stock or dead
+- **primitive:** status pill · **failure:** ambiguous · **scope:** signal · **role:** counter-sales rep
+- **cite:** `app.js:21174-21184/21241-21251 (birth state, all rates 0); app.js:2283/7255-7258 (renders red "None · N/A")`
+- **evidence:** The most-alarming visual state on the card is also its normal newborn state.
+
+### 86. [ORANGE] Categories — Models (the sub-entity carrying per-model maintenance schedules that override the generic service countdown) are append-only — no rename, delete, or re-parent — and there are two independent creation paths, neither of which does a name-based lookup before minting, despite one path's own code comment claiming it "mirrors" a find-or-create idiom.
+
+- **job:** add or correct a model's maintenance schedule without accumulating duplicate, divergent records
+- **primitive:** add button (+Add Model) · **failure:** inconsistent · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:19682-19683 (comment claims find-or-create), app.js:19708 (no lookup, unconditional `DATA.models.push`), app.js:20509-20511 (Duplicate action reuses taskIds verbatim), app.js:8888-8902 (empty state doesn't explain what a Model is or that it silently changes maintenance behavior)`
+- **evidence:** Contrast: resolveOrCreateVendorByName (app.js:20483-20488) does a proper name-match lookup before creating; Models has no equivalent, so typing the same model name from two different screens produces two divergent records with no way to merge them.
+
+### 87. [ORANGE] Categories — Two lookalike pills an inch apart on the same card produce different Back-navigation outcomes: the availability pill pushes navigation history (Back restores sort/scroll/panel state), while the status-tally pill wipes backStack/fwdStack outright, making the Back/Forward controls disappear from the toolbar entirely.
+
+- **job:** reliably back out of a filtered view no matter which control triggered it
+- **primitive:** nav control (Back/Forward) · **failure:** inconsistent · **scope:** interaction · **role:** dispatcher
+- **cite:** `app.js:19313 (.js-cat-avail) → app.js:2772-2792 showCategoryUnits (pushCardHistory at 2775) vs app.js:19071-19078 (.js-fleet-filter, backStack/fwdStack cleared directly, no pushCardHistory)`
+- **evidence:** Live-confirmed: Avail pill → Back works perfectly, restores state. Tally pill an inch away → Back/Forward arrows vanish from the toolbar entirely (an escape still exists via the removable filter chip, but the control a person reaches for is gone).
+
+### 88. [ORANGE] Categories — Nearly every control on the card exposes to assistive technology as a bare "button" with no accessible name, and the filter-term chips (both the pill and its nested negate-icon button) do not appear in the accessibility tree at all — unreadable and unremovable by a screen-reader user.
+
+- **job:** operate the card at all using a screen reader
+- **primitive:** control (unlabelled button/chip) · **failure:** invisible · **scope:** density · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:3291-3297 filterTermPill (bare `<span class="filt-term js-ft-x">`, no role/tabindex; nested `<button class="ft-neg js-ft-neg">` has zero text content and no aria-label)`
+- **evidence:** Live full-a11y-tree read: refs spanning ref_1826 through ref_1859, plus the entire block ref_2305–ref_2328 (the category pills), all read as bare "button."
+
+### 89. [ORANGE] Categories — Clicking an "Off Fleet" stock-count segment routes to the Units card, but cardListEl strips every non-Active unit from the row set before the per-card filter ever runs, so the click lands on an empty "No Unit" state even though a matching "Out of Fleet" section bucket already exists in the code and is never reached.
+
+- **job:** click through from a stock-count segment to see the actual machines behind that number
+- **primitive:** group bar (mixbar) segment · **failure:** unreachable · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:9884 (unitsVisible strips fleetStatus!=='Active' before filterTerms), app.js:9898 (rowMatches applied after), app.js:3193 (the __fleet matcher itself is correct), app.js:9332-9348 ("Out of Fleet" section bucket, unreachable); app.js:6825-6828 rentalsVisible already has the reveal-when-filtered pattern this doesn't mirror`
+- **evidence:** Live-confirmed after shipping a fix that added the Off Fleet segment: the segment produces a correct filter chip with no console errors, but the resulting Units list renders "No Unit" — a pre-existing scoping defect the new segment simply made visible instead of hiding it inside a wrong "Available" count.
+
+### 90. [ORANGE] Customers — The row's stage/funnel pill only reads the Equipment and Member funnels and never consults the Rental funnel — the one every customer defaults into — so a customer reserved or on rent right now still shows a grey N/A.
+
+- **job:** tell a live renter apart from someone who has never rented, at a glance
+- **primitive:** status pill · **failure:** invisible · **scope:** signal · **role:** counter-sales rep
+- **cite:** `app.js:7162-7167 vs app.js:147-159, 197-199`
+- **evidence:** Confirmed on production: 5 of 6 pay-status pills read N/A on the default view, including on customers who are actively renting equipment right now.
+
+### 91. [ORANGE] Customers — Getting a customer's color collapses distinct red-severity conditions to one identical output.
+
+- **job:** tell a harmless dormant account from an active safety risk by colour alone
+- **primitive:** flag colour (name tint) · **failure:** ambiguous · **scope:** signal · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `config.js:284-296 · app.js:5934-5938 · app.js:7144-7146`
+- **evidence:** Confirmed but narrowed on verify: it's a name-text tint, not a full row background, and only 3 of 5 red-severity flags (no-card, lost, inactive) are genuinely indistinguishable on the row — blacklisted and unpaid each carry their own separate badge elsewhere in the row. Still: "hasn't rented since spring" and "has no card and is about to take a machine" render identically.
+
+### 92. [ORANGE] Customers — "Cancel Membership" ends billing and generates a cancellation invoice for the remaining term on the very first click, with no confirmation — despite an existing arm-to-confirm pattern sitting a few lines away in the same file.
+
+- **job:** cancel a membership without accidentally ending a paying customer's billing on one stray tap
+- **primitive:** destructive action button · **failure:** destructive · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:4099 · app.js:18451 · app.js:4945-4974 · reusable pattern app.js:18639`
+- **evidence:** The blacklist button on this same card already uses a two-click "arm" confirm pattern; Cancel Membership does not reuse it despite mutating billing and generating a real invoice on the first tap.
+
+### 93. [ORANGE] Customers — Dollar figures are deliberately masked to $••• in the History log for roles without money permission, but the invoice list, open-balance strip, Transactions tab, and "total paid" stat on the very same customer screen render live dollar amounts with no role check at all.
+
+- **job:** keep money figures away from staff-tier logins (mechanic, driver) that the app is otherwise careful to keep away from money
+- **primitive:** masked text vs. plain numeric display · **failure:** inconsistent · **scope:** signal · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `masked: app.js:22582, 9165 · unmasked: app.js:4685-4693, 4780-4808, 4887, 4892, 4813-4824`
+- **evidence:** The Customers card itself has no role gate on opening it at all, so a mechanic or driver login sees every customer's live balances and payment history in full — the masking control only ever covers old log text, not the numbers themselves.
+
+### 94. [ORANGE] Customers — No customer-creation path — quick-add, full form, search-add, or the AI's create tool — checks for an existing phone, email, or name before minting a new id.
+
+- **job:** add a new customer without silently splitting their rental/payment history across two records
+- **primitive:** customer creation form(s) · **failure:** destructive · **scope:** interaction · **role:** counter-sales rep
+- **cite:** `app.js:21276-21320, 21231-21250, 21088-21111, 21116-21150, 15801-15807`
+- **evidence:** All five creation paths mint via nextCustomerId() unconditionally with no lookup against existing records. Live corroboration: a captured sort-order snapshot on production showed the identical customer name rendered twice in the list.
+
+### 95. [ORANGE] Customers — Clicking an invoice belonging to a different customer than the one currently open silently spawns a whole new session tab and swaps all three columns, with no cue distinguishing "a new tab opened" from "the view updated."
+
+- **job:** help the walk-in in front of her without losing the customer she was already mid-transaction with
+- **primitive:** invoice pill / tab navigation · **failure:** invisible · **scope:** interaction · **role:** counter-sales rep
+- **cite:** `app.js:2718-2727 (overtake) · app.js:2608-2625 (openInTab) · reached via app.js:3067`
+- **evidence:** Confirmed intentional in-code ("Task 5" comment), not a bug — but ships with no visible signal, and the way back is a small chip she has no reason to notice.
+
+### 96. [ORANGE] Customers — When the invoice-open handler can't resolve the target customer, it doesn't stop — it still fires its scroll-and-glow highlight animation on whatever customer already happens to be on screen.
+
+- **job:** trust that the highlight animation after clicking an invoice is actually pointing at the customer she clicked into
+- **primitive:** scroll + glow highlight animation · **failure:** lying · **scope:** interaction · **role:** counter-sales rep
+- **cite:** `app.js:3057 (unguarded if(recOf(...)) with no else) · app.js:3066-3075`
+- **evidence:** openInvoice() only guards the invoice's customerId being null; it then unconditionally proceeds to mutate state, scroll, and glow-flash even when the target customer record doesn't actually resolve — animating a decoy record instead of the intended one.
+
+### 97. [ORANGE] Customers — The Sales tab — named for her job, sitting one tap from her list — is a permanent "Coming soon" placard, and returning from it re-buries whatever she'd scrolled to.
+
+- **job:** work a lead without losing her place in the customer record she was already reading
+- **primitive:** tab / navigation · **failure:** unreachable · **scope:** architecture · **role:** counter-sales rep
+- **cite:** `app.js:9617-9631 · app.js:10462-10468`
+- **evidence:** Confirmed live: the tab is empty. On desktop, back does restore the record (partial refute of an initial "dead end" read) but resets its scroll to the top, re-burying a balance she'd scrolled down to see; on phone, tapping back resets the card to the list entirely.
+
+### 98. [ORANGE] Customers — A per-customer comms conversation section was fully built but has zero call sites — it renders nowhere, including a stale in-code comment claiming it does.
+
+- **job:** see whether a customer already replied before picking up the phone to call them again
+- **primitive:** comms thread panel · **failure:** unreachable · **scope:** architecture · **role:** counter-sales rep
+- **cite:** `commsCustSectionHtml() — zero call sites anywhere in app.js`
+- **evidence:** The developer's own comment names exactly where it should render; grep confirms it is never invoked. A related comment listing it as a live comms entry point is also stale for the same reason.
+
+### 99. [ORANGE] Customers — The 18-second background poll refreshes app data, team chat, and the Wrangler rail, but never customer comms threads; and a failed comms fetch is fully silent — the catch resets a loading flag nothing reads, leaving stale cached state on screen.
+
+- **job:** know a customer replied, or know the comms system itself is down, without manually refreshing
+- **primitive:** background poll / silent error handling · **failure:** invisible · **scope:** architecture · **role:** counter-sales rep
+- **cite:** `comms thread fetch + catch block`
+- **evidence:** A dead comms backend renders identically to a genuinely quiet day — there is no distinguishing signal.
+
+### 100. [ORANGE] Customers — The notification bell holds engineering tickets addressed to the owner — pricing-engine internals with GitHub links — rendered as raw, unparsed markdown, with nothing customer-facing in it; a dispatch concern ("Transports due") also sits in her alert count.
+
+- **job:** know which of her customers needs a call today
+- **primitive:** notification bell / panel · **failure:** invisible · **scope:** architecture · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `notification/wrangler-rail body render path`
+- **evidence:** Measured live on production: 53 literal ** markdown markers across 17 lines of unrendered text in the bell panel. Nothing in it tells her a customer needs attention.
+
+### 101. [ORANGE] Customers — On a live production customer record, the account header read "Member" while the AR (accounts-receivable) block on the same screen read "NON MEMBER MODE" for the same account.
+
+- **job:** know whether a specific customer's account type entitles them to member pricing/terms before quoting or invoicing them
+- **primitive:** header label vs. AR-section label · **failure:** lying · **scope:** signal · **role:** counter-sales rep
+- **cite:** `observed live, customer detail (session transcript) — not independently re-verified by the adversarial pass`
+- **evidence:** Observed on a real account carrying a $1,306.85 balance with no card on file: the detail header displayed "Member" while the AR block directly below it displayed "NON MEMBER MODE" — a direct on-screen contradiction about the same customer's account type, consistent with the broader two-pay-status-engines pattern but never captured as its own finding or verified independently.
+
+### 102. [ORANGE] RENTALS — Rentals has no 'Needs Attention' bucket: the section header/count never reflects severity, and flagged rows aren't pulled or sorted to the top — so a dispatcher skimming headers on a busy 'On Rent' section can miss the fire.
+
+- **job:** spot the emergency without reading every row in a long list
+- **primitive:** group bar / section header · **failure:** invisible · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:9312-9316 vs UNIT_SECTIONS app.js:9279-9290`
+- **evidence:** GROUP_DEFS.rentals keys buckets off lifecycle status (rentalRevStatus, app.js:1986-1990), which never consults a flag — unlike UNIT_SECTIONS, which has an explicit red 'Attention' bucket fed by unitStageKey. SCOPED by verification: the flagged ROW itself does render red (border+pill, and the pill relabels to 'Overdue'), so it is NOT camouflaged as all-clear — the real gap is at the header/count level and that within-group sort doesn't lift flagged rows. Verifier verdict PARTIAL (structural claim holds; 'green hides the fire' framing was overstated — see retractions). The Units card having the bucket and Rentals not is the systemic tell.
+
+### 103. [ORANGE] RENTALS — The row collapses which-of-seven red conditions fired into one uniform border + generic status pill; the flag's NAME never appears on the row, and two conditions can't be identified without a hover or a hop to the customer.
+
+- **job:** tell at a glance WHY a rental is flagged red
+- **primitive:** flag / status pill · **failure:** ambiguous · **scope:** signal · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:5834-5854, config.js:239-253, app.js:5934-5938`
+- **evidence:** FLAG_COND.rentals defines 7 conditions (fc, overbooked, unpaid-balance, no-card, unsigned-card, unit-failed, off-rent-overdue) ALL severity:'red'; getEntityColor collapses to fl[0].severity, so the row is one uniform red. SCOPED by verification: 3 of 7 do get a distinct on-row echo (overdue relabels the pill to 'Overdue'; unpaid shows a colored balance chip; unit-failed tints the unit name red + tooltip), and opening the record names most via headFlagsHtml — but only no-card and unsigned-card (2 of 7) are genuinely unidentifiable without the desktop hover-preview or navigating to the linked customer. Verifier verdict PARTIAL. See retractions for the overstated original.
+
+### 104. [ORANGE] RENTALS — Customer text/email replies never auto-refresh — refreshCommsThreads is absent from every recurring poll, so a reply can sit unseen until the dispatcher manually clicks the comms chip or reloads.
+
+- **job:** see a customer's reply in time to act on it
+- **primitive:** comms thread badge / poll · **failure:** invisible · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:24796 (startRefreshPoll), refreshCommsThreads app.js:26925`
+- **evidence:** Only two setInterval calls exist in the whole 27,649-line app.js: a GPS-view timer (app.js:24080) and an 18s backend poll (app.js:24796). refreshCommsThreads is in neither, and refreshFromBackend's body never calls it — it fires only at boot, on a manual click into a comms chip, or right after the dispatcher sends an outbound message. Verifier verdict PARTIAL (core claim holds; a document.hidden citation in the original was a red herring and is dropped).
+
+### 105. [ORANGE] RENTALS — On a phone the entire link-a-record system is reachable only through an unsignposted 500ms long-press — and the on-screen hint told the user to 'drag', a gesture retired in June.
+
+- **job:** link a unit / customer / rental to this record on a phone
+- **primitive:** toast / drag target · **failure:** unreachable · **scope:** interaction · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:19046/19054/19082 vs app.js:17813-17826`
+- **evidence:** Touch drag-to-link was retired 2026-06-29 (app.js:17813); a phone finger-drag is silently disarmed (ready stays false, app.js:17892-17904) — no link, no ghost, no feedback. The only path is a 500ms hold → R20 context menu → '+ Rental'/'+ Unit' pick, which nothing signposts. Six empty-slot toasts (app.js:19046, 19054, 19082, 19574, 19579, 19592) said 'drag' with no is-phone branch. Verifier verdict CONFIRMED. The misleading 'drag' copy was fixed in PR #740; the deeper unsignposted-long-press gap remains.
+
+### 106. [ORANGE] RENTALS — Terminal status jumps (Returned/Cancelled/No Show) commit on a single click with no confirm and no undo affordance, and the row vanishes from the list on the next render.
+
+- **job:** finish or void a rental without a fat-finger tap silently pulling a live job off the board
+- **primitive:** status pill / list row (missing confirm + undo toast) · **failure:** destructive · **scope:** interaction · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:18990, app.js:19926-19941, order app.js:16851`
+- **evidence:** The three terminal values sit stacked as the last rows of one dropdown (order app.js:16851), each a plain button; the click handler calls setRentalStatus directly with zero intervening step, and Cancel/No-Show strips billing in the same breath (app.js:19929). rentalCleared+rentalsVisible (app.js:442-443, 6802-6807) then drop the row instantly with no fade. SCOPED by verification: it is NOT unrecoverable — logAction+toast fire and the rental is reachable via the Completed sort/search — so the gap is specifically no confirm + no on-screen undo affordance, not data loss. Verifier verdicts CONFIRMED (terminal-no-confirm, high) + row-vanish CONFIRMED-but-polish. The app already has a confirm precedent for WO completion (app.js:20648) never extended here.
+
+### 107. [ORANGE] RENTALS — Scroll 'preservation' is positional (raw scrollTop keyed by card|view), not record-anchored — so acting on a row in a re-sorted list restores the pixel offset onto a DIFFERENT rental, and the toast names only the new status, not who was hit.
+
+- **job:** keep my place in the list after I change a rental's status
+- **primitive:** list / status toast · **failure:** lying · **scope:** interaction · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:17185-17190 (save), app.js:17229-17234 (restore), toast app.js:19940`
+- **evidence:** scrollMemo is keyed only by card|view and restored by raw pixel; the key never includes the acted-on record id, and list-mode always restores the saved value even when the list re-sorted underneath (status is a selectable sort field, config.js:431). Changing a status from the row re-sorts and lands the viewport on whatever rental now occupies that offset; the confirmation toast says only 'Status → X', giving no cue a different rental was hit. Verifier verdict CONFIRMED. NB this narrows a 'scroll is genuinely preserved' WIN I originally claimed — see retractions.
+
+### 108. [ORANGE] RENTALS — There is no OS-level alerting at all: close or background the app and zero alerts reach the dispatcher.
+
+- **job:** find out about an emergency when I'm not staring at the screen
+- **primitive:** notification / app badge (absent) · **failure:** invisible · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `sw.js (full file, 47 lines); observed live`
+- **evidence:** sw.js is documented 'OFFLINE SHELL ONLY' — 47 lines, only install/activate/fetch/message listeners, no push/notificationclick, no showNotification, no pushManager.subscribe. grep of the 27,649-line app.js for Notification/requestPermission/setAppBadge/pushManager returns zero. NOTIF_DEFAULTS has only in-app bell + sms/email channels, no web-push. Verifier verdict CONFIRMED (documented intentional state, not a defect — but a real gap for the redesign to solve).
+
+### 109. [ORANGE] RENTALS — Every outreach to the driver or customer for a specific rental is a 2-3 screen detour; the only one-tap contact ('Text the Crew') is a Settings-buried whole-roster broadcast.
+
+- **job:** text the driver or customer about THIS rental, right now
+- **primitive:** nav control / action button (missing) · **failure:** unreachable · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `observed live`
+- **evidence:** No per-rental 'text driver' / 'text customer' action exists on the rental row or detail; reaching a thread is a multi-screen navigation, and the nearest one-tap is the roster-wide 'Text the Crew' broadcast in Settings. Contrasts with how central comms is to the dispatcher's job.
+
+### 110. [ORANGE] RENTALS — Recoveries get no bucket or signal until the day AFTER they're late — only deliveries starting today get a 'Today' group.
+
+- **job:** get equipment recovered before it becomes overdue
+- **primitive:** group bar (missing 'Due Back Today') · **failure:** invisible · **scope:** architecture · **role:** dispatcher
+- **cite:** `app.js:2016-2017, app.js:9312-9316`
+- **evidence:** The lifecycle grouping keys off status/start-date, so a unit due back today sits in 'On Rent' with no distinguishing signal; the first time it's grouped as urgent is once off-rent-overdue trips — i.e. after it's already late. The single most predictable dispatcher task (today's recoveries) has no forward-looking bucket.
+
+### 111. [ORANGE] UNITS — The service-flag text truncates with an ellipsis at roughly 9px font size, cutting off exactly the word that distinguishes an emergency from a non-event ('73 HRS…' could be overdue or remaining).
+
+- **job:** tell overdue from not-yet-due at a glance, on a tablet, outdoors
+- **primitive:** flag/badge text, truncation · **failure:** ambiguous · **scope:** density · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `style.css:4806`
+- **evidence:** svcText() emits either 'N HRS overdue' or 'N HRS remain'; style.css:4806 sets the mini-card flag to overflow:hidden, text-overflow:ellipsis at font-size:0.5882rem (~9px). Live production example: 'RUN' unit reads '73 HRS…'. In the seeded demo, the same field truncates at different widths on different tiles — Highrise shows '440 HRS OVERDUE' in full while Reptar shows '2025 H…' and Worm shows 'No GP…' for the identical field.
+
+### 112. [ORANGE] UNITS — The one proactive notification bell shows 'Transports due' (a dispatch concern), and every item in the Notifications panel is invoices or card payments — nothing about units, service, work orders, or inspections, and none of it is role-filtered.
+
+- **job:** get notified about something that actually needs a mechanic's attention
+- **primitive:** notification bell / panel · **failure:** unreachable · **scope:** architecture · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `measured live (Notifications panel), app.js:14050`
+- **evidence:** Bell badge reads 'Transports due · 2.' Opening Notifications shows exactly 6 items, all invoices and card payments, none role-filtered for a mechanic. Notification bodies also render literal '**Verdict:**' with the asterisks showing — confirmed at app.js:14050, the body is esc()'d correctly but only \n→<br>, with no markdown renderer anywhere in the codebase, so authored bold markers show as raw asterisks.
+
+### 113. [ORANGE] UNITS — The 'part ordered, here's when it lands' flag can never fire — its input field has no writer reachable from any UI surface, so its sibling flag is permanently true regardless of actual state.
+
+- **job:** know when an ordered part is arriving
+- **primitive:** flag/badge, dead data pipeline · **failure:** invisible · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:5874, app.js:8016`
+- **evidence:** part-ordered-eta requires w.eta to be set; the partform (the only add/edit surface for a WO line) has no date/ETA input at all, savePartForm initializes eta:'' and never touches it again, and the one ETA editor that does exist lives on the retired workOrders detail renderer that app.js:3052 unconditionally redirects away from. The flag can never be true; its sibling part-ordered-no-eta is always true.
+
+### 114. [ORANGE] UNITS — 58 of 86 interactive controls on the mechanic's screen carry no visible name; 52 of those are explained only by a hover tooltip; zero aria-label exists anywhere in the set.
+
+- **job:** know what a button or icon does without hovering or guessing
+- **primitive:** icon buttons / toolbar controls · **failure:** invisible · **scope:** density · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `measured live in seeded demo`
+- **evidence:** Full inventory of every clickable control on the Units screen: 86 interactive elements, 58 (67%) have no visible text label, 52 of those 58 are labeled only by a title-attribute hover tooltip — a gesture the audited persona (and any touch-primary user) will never trigger — and there is not one aria-label in the set, even though the repo already pairs aria-label with data-tip in 69 other places elsewhere in the codebase, establishing the pattern is known but unapplied here.
+
+### 115. [ORANGE] UNITS — The Tools menu opens downward from a bottom-bar button with no viewport-collision detection and no internal scroll; at a 576px-tall viewport it clips 6 of its 10 items, including the one switch that disables the hover-preview trap.
+
+- **job:** turn off hover previews (or reach any other tool) from a yard tablet in landscape
+- **primitive:** dropdown menu, viewport collision handling · **failure:** unreachable · **scope:** density · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `measured live`
+- **evidence:** Opened the Tools menu at a 576px-tall viewport: a 10-item menu rendered in a box that only showed the GENERAL and GPS/FLEET headers before clipping. Measured the full menu — 6 of 10 items sit below the viewport fold with no scroll affordance, including 'Hover previews: on' at y=592, the exact control that would disarm the trap that caused the misclick finding above. Scoped honestly to short viewports — could not force a taller test viewport to confirm it disappears on a tall desktop, but the mechanism (no collision flip, no scroll) is height-dependent by construction.
+
+### 116. [ORANGE] UNITS — Two view-filtering controls ('Sold/Inactive' and 'All Units (any status)') that change which machines exist are listed under a menu header reading SORT, alongside controls that only reorder.
+
+- **job:** understand whether a control changes what's shown or how it's ordered
+- **primitive:** dropdown menu, control naming · **failure:** ambiguous · **scope:** density · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `measured live`
+- **evidence:** Under a header reading 'SORT' sit 'Sold/Inactive' and 'All Units (any status)' — both filters that change the population of visible machines, not their order. A user picking one expecting a reorder gets a scope change instead, with no visual distinction between the two kinds of control.
+
+### 117. [ORANGE] UNITS — A failed inspection's photo/video report has no visible door to it from the unit's own record — the only link to it is emitted exclusively from the retired Shop-era renderer.
+
+- **job:** review the photos or video from a failed inspection
+- **primitive:** link / detail panel · **failure:** unreachable · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:9127`
+- **evidence:** The js-open-insp link that opens a failed inspection's photo/video report is emitted exclusively by the dead Shop renderer, which is no longer reachable in the shipped card structure; the unit's own Inspection section renders no thumbnail or link to the same content.
+
+### 118. [ORANGE] UNITS — Work-order and inspection links land on the generic top of the unit page — never scrolled, expanded, or highlighted to the specific record clicked — while a sibling flag one line below is a working link and the WOs-open count is not.
+
+- **job:** jump straight to the specific work order or inspection just clicked
+- **primitive:** link / deep-link · **failure:** ambiguous · **scope:** interaction · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:3052, app.js:8334`
+- **evidence:** Contrast with the two places the app gets this right — openInvoice and startNewWorkOrder both scroll, expand, and attnFlash the target record. Unit WO/inspection links instead land generically at the top of the unit page, forcing the user to search for the record they clicked. Separately, the 'N WOs Open' flag on a tile is not a link though its sibling flag one line below it is (app.js:8334).
+
+### 119. [ORANGE] UNITS — The unit history log does not sort chronologically — it sorts on a per-page-load counter that resets to zero on every reload, so entries from different sessions/users interleave at random even though real timestamps are recorded and sit unused.
+
+- **job:** read a machine's service and action history in the order it actually happened
+- **primitive:** list / log ordering · **failure:** lying · **scope:** density · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:9153, app.js:22568 (actionSeq resets to 0)`
+- **evidence:** History sorts on 'seq' (app.js:9153: acts.slice().sort((a,b)=>b.seq-a.seq)); seq comes from a module-level counter, let actionSeq = 0, that resets every page load (app.js:22568), so two different sessions' seq values are independent counters, not a shared ordering. Observed live on real production unit SPEECHLESS: entries rendered in order Jun 17, Jun 17, Jul 18, Jun 22, Jul 18, Jul 13 — a shuffled deck. Real when+clock timestamps sit in every record, unused by the sort. This was subsequently fixed (PR #741, sorts on when+clock now) — flagging it here because it demonstrates a systemic pattern worth checking on any other card's log/history view: does its sort key survive a page reload?
+
+### 120. [ORANGE] UNITS — The mechanic's own Worklist graph and the group-bucket list it filters disagree on the same number for the same label — the graph counts the whole fleet, the list hard-filters to Active units first, so tapping a segment yields fewer rows than the number promised with no explanation.
+
+- **job:** trust that tapping a worklist segment shows the units that number promised
+- **primitive:** graph/chart segment + click-through filter · **failure:** inconsistent · **scope:** signal · **role:** mechanic / yard tech
+- **cite:** `app.js:12167 (graph tally), app.js:9295 (list filter)`
+- **evidence:** Live and in the code: the Worklist graph shows 'NOT READY 28' while the group bar roughly 40px below it on the same screen shows 'NOT READY · 8' — same label. The graph's tallies (app.js:12167-12170) run over every unit in DATA.units unconditionally; the list's grouping (app.js:9295) excludes out-of-fleet and on-rent units before it ever reaches the Not-Ready test. A third, narrower definition lives in unitsAlertCount (app.js:9479). Three different definitions of 'needs attention' coexist on one card, with no escape hatch short of manually switching sort to 'All Units (any status).'
+
+### 121. [ORANGE] UNITS — The mechanic's entire tailored landing (open worklist, service-due sort) is keyed off the hardcoded role name 'mechanic'/'mtech', even though the app's own config states role names are renameable and permissions must not key off them.
+
+- **job:** keep the mechanic's tailored landing screen working after an admin renames or customizes the role
+- **primitive:** role-based configuration lookup · **failure:** inconsistent · **scope:** architecture · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:25639, config.js:342`
+- **evidence:** ROLE_LANDING is a lookup keyed by the literal ids 'mechanic'/'mtech' (app.js:25639-25641), while config.js:342 states roles are runtime-customizable in Settings → Roles & Logins and 'permissions can no longer key off role NAMES.' If the yard renames the Mechanic role or adds a custom one, ROLE_LANDING[currentRole] is undefined, applyRoleLanding returns early (line 25652), and the mechanic silently loses both the open worklist graph and the service-due sort — landing instead on alphabetical Units with collapsed groups, which is exactly the failure state this audit initially (and mistakenly) diagnosed as the shipped default.
+
+### 122. [ORANGE] UNITS — Collapsed group headers show only a bare unit count, with no sub-count of how many units inside are actually flagged, and collapse state persists indefinitely with no urgency override to force a red-carrying group back open.
+
+- **job:** tell whether a collapsed bucket is worth opening without expanding every one
+- **primitive:** group header / bucket count · **failure:** invisible · **scope:** signal · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `app.js:9429, app.js:9358`
+- **evidence:** Group headers render a label and a raw count only — no red/yellow flagged sub-count. groupDefaultCollapsed special-cases only the Calendar's 'Earlier' bucket (app.js:9358); every Units group defaults open, but once a user collapses one, that state persists per device/account forever with no urgency floor to reopen it even when it starts carrying red-flagged units.
+
+### 123. [ORANGE] UNITS — The bucket ordering places the yellow-severity 'Not Ready' group above the red-severity 'Needs Attention' group, inverting the app's own color-severity hierarchy.
+
+- **job:** trust that the worse bucket is always listed first
+- **primitive:** group/bucket ordering · **failure:** inconsistent · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:9280`
+- **evidence:** UNIT_SECTIONS orders 'Not Ready' (yellow) ahead of 'Attention' (red) in the rendered stack, contradicting the severity ranking the rest of the card's color system implies (red always meant to outrank yellow elsewhere).
+
+### 124. [ORANGE] UNITS — The 'N on hand' part-quantity number shown on a work order line is purely decorative — qtyOnHand is never decremented when a part is actually consumed by a repair or service.
+
+- **job:** know if the part I need is actually in stock before I go look for it
+- **primitive:** numeric field / inventory count · **failure:** lying · **scope:** signal · **role:** mechanic / yard tech
+- **cite:** `app.js:6169`
+- **evidence:** qtyOnHand is rendered as if it reflects live stock but is never decremented anywhere in the app when a part is consumed by a work order or a service task — the number is set once and never moves with usage.
+
+### 125. [ORANGE] UNITS — With the Shop card retired, work orders live only inside each individual unit's record — there is no single place to see every open job across the whole fleet at once, and the ex-Shop quick filters built for exactly that view are unreachable, along with completed/cancelled work orders having no home anywhere.
+
+- **job:** see every open work order across the whole yard at a glance
+- **primitive:** card placement / retired-card scar (quick filters, list scope) · **failure:** unreachable · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:3167, app.js:7669, observed live`
+- **evidence:** Merle's own words, driving it live: "the Shop card's gone. Work orders live down inside each unit now. So there's no one place I can stand and see every open job. I gotta open machines one at a time." In code: the ex-Shop quick filters '__wo' (WOs Open / Parts Ordered) and '__svc' (Service Due) are fully implemented with human labels but nothing links to them (app.js:3167); completed and cancelled work orders are filtered out of a unit's own Work Orders section and appear on no card anywhere (app.js:7669). RUS_TABS.units, including the ex-Shop 'Field Calls' panel, is registered in code but unreachable because the stack meant to surface it is gone (app.js:12933).
+
+### 126. [ORANGE] UNITS — The Work Orders bar shows a count of open work orders, but clicking a segment filters by unit — a unit carrying 2 open WOs is one row in the resulting list but counted twice in the bar, so the number on the bar structurally cannot match the rows beneath it.
+
+- **job:** trust that the number on a bar matches what you get when you tap it
+- **primitive:** bar/tally + click-through filter · **failure:** lying · **scope:** signal · **role:** mechanic / yard tech
+- **cite:** `app.js:12170`
+- **evidence:** woByPhase tallies one entry per open work order; the click-through filters the underlying unit list. Any unit with more than one open WO inflates the bar's count relative to the row count it produces when tapped.
+
+### 127. [ORANGE] UNITS — The Round-Up Reports board's Money section — revenue, net sales, top customers, open account balances — renders to every signed-in role with no permission gate, including roles that should never see financial data.
+
+- **job:** keep revenue and balance data restricted to roles that should see it
+- **primitive:** card section / role-based data gate · **failure:** inconsistent · **scope:** architecture · **role:** owner-operator · **SYSTEMIC**
+- **cite:** `app.js:12972`
+- **evidence:** The Money section of the Round-Up Reports board renders unconditionally for every signed-in role, with no check against a money-viewing permission — found while auditing the Units card's board views but affects a shared board surface, worth treating as a data-gate change rather than a simple cleanup for the redesign.
+
+### 128. [ORANGE] UNITS — Multi-unit rentals still trip a legacy single-unit assumption in the cross-card cascade logic: anchoring the non-primary unit of a multi-unit rental cascades to an empty Rentals column instead of the rental it's actually on.
+
+- **job:** click a unit and see its associated rental show up in the linked column
+- **primitive:** cascade / cross-card linking logic · **failure:** unreachable · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `cascade.js:101`
+- **evidence:** cascade.js's addRental still matches rentals by the legacy scalar r.unitId only, ignoring the units[] array that real multi-unit rentals carry — the same anti-pattern that caused markFieldCall to fail the wrong machine on a multi-unit rental (app.js:20006, since fixed independently in PR #740). Anchoring unit #2 or #3 of a multi-unit rental finds nothing and cascades to an empty column. Parked rather than fixed because correcting it changes what appears in every anchored column app-wide — a product decision (should anchoring one unit pull in its sibling units?) rather than a pure bugfix.
+
+### 129. [ORANGE] UNITS — There is no push-notification pipeline of any kind, no 'assigned to me' badge, no auto-post to team chat when a flag condition flips true, and toast confirmations self-clear in ~2.2 seconds with no durable trail — so a uninsured or overdue machine can go out the gate with nothing on the mechanic's tablet ever having said so unless he happened to be staring at the right row at the right moment.
+
+- **job:** get told about something that needs a mechanic's attention without staring at the screen all day
+- **primitive:** push/notification pipeline, toast, chat integration · **failure:** invisible · **scope:** signal · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `grepped — zero PushManager/showNotification/Notification.requestPermission calls in app.js; sw.js registered for offline-cache only`
+- **evidence:** sw.js exists purely for offline-cache + reload-for-new-build; a full grep of app.js turns up zero PushManager, showNotification, or Notification.requestPermission calls anywhere. All ten FLAG_COND.units predicates (service-past-due, inspection-failed, uninsured-active, coverage-expired, wash-requested, etc.) fire silently into data with no messenger. Team chat only ever rings for human-typed messages. Toasts are the only confirmation surface and self-clear in ~2.2 seconds with no durable inbox or log. The 18-second background poll has no change-since-last-look digest of any kind.
+
+### 130. [ORANGE] UNITS — Clicking a unit's own name does not open its detail record — it instead surfaces two tiny, unlabeled icons (an eye and a plus) that the user must then correctly interpret, one of which is the hover-preview trap that causes the destructive misclick finding above.
+
+- **job:** open a machine's record by clicking on it, the way a name/row click is expected to work
+- **primitive:** list row / primary click target · **failure:** ambiguous · **scope:** interaction · **role:** mechanic / yard tech
+- **cite:** `observed live, corroborates app.js:3008 / style.css:825`
+- **evidence:** Live drive: clicking the unit NAME on a mini-card did not open the unit; it revealed two tiny unlabeled icons — a '.js-roweye' (tooltip only: "Hover: preview · Click: previews OFF app-wide") and a '.js-newtab' (tooltip only: "Open in new tab (+)"). Neither icon carries a visible label; the eye's actual click behavior toggles a GLOBAL app-wide setting, while hovering it (not clicking) opens the same live-control preview panel responsible for the misclick finding above. A user expecting a direct 'click the name to open it' affordance instead lands in an unlabeled, easily-misread icon pair.
+
+### 131. [ORANGE] UNITS — Near-identical status text — 'Part Needed,' 'Part Ordered,' 'Part Needed?' — sit side by side on tiles looking almost the same at a glance, and the question-mark variant renders in different colors (red on one tile, amber on the next) for what reads as the identical state.
+
+- **job:** tell apart three closely-worded part-status labels at a glance
+- **primitive:** status label / color-coding consistency · **failure:** ambiguous · **scope:** density · **role:** mechanic / yard tech
+- **cite:** `observed live, corroborated in app.js:6989 flag logic`
+- **evidence:** 'PART NEEDED,' 'PART ORDERED,' and 'PART NEEDED?' render as near-identical text at a glance; the 'PART NEEDED?' variant specifically was observed rendering red on one tile (Worm) and yellow/amber on another tile (Mustache, Snoopy) despite reading as the same status.
+
+### 132. [ORANGE] UNITS — Blank 'hours at completion' when logging a service silently records the service at 0 hours, corrupting the future countdown baseline for that task with no reject and no default to the unit's current reading.
+
+- **job:** log a completed service without corrupting the baseline the next countdown is measured from
+- **primitive:** form field, missing input guard · **failure:** destructive · **scope:** interaction · **role:** mechanic / yard tech
+- **cite:** `service-countdown.js:135`
+- **evidence:** The completion form accepts a blank 'hours at completion' value and records it as 0 with no validation — every future countdown for that specific service task is then measured from a false zero baseline rather than the unit's actual current hours.
+
+### 133. [ORANGE] UNITS — Completing one blocking work order while a second blocking WO remains open reports plain success with no explanation for why the unit is still shown red.
+
+- **job:** understand why a unit is still flagged red after completing the repair I was asked to do
+- **primitive:** completion action / toast · **failure:** ambiguous · **scope:** interaction · **role:** mechanic / yard tech
+- **cite:** `app.js:22594`
+- **evidence:** woCompleteCascade reports success on completing one WO even when a second, independently blocking WO remains open on the same unit — the UI never tells the user the unit is still red because of a different, still-open work order.
+
+### 134. [ORANGE] UNITS — A unit's tile shows only its single newest open work order with no total count, so an older and more severe work order sitting alongside it is masked from view entirely.
+
+- **job:** see the most urgent open work order on a machine, not just the most recent one
+- **primitive:** tile summary field · **failure:** invisible · **scope:** signal · **role:** mechanic / yard tech
+- **cite:** `app.js:2144`
+- **evidence:** The mini-card surfaces only the newest open work order and displays no count of how many total are open on the unit; an older, higher-severity work order existing alongside a newer, benign one is completely hidden from the tile.
+
+### 135. [YELLOW] Calendar / Driver — Every other floating surface on this card closes on Escape via dismissTopSheet(), but no Escape path ever calls closeMenus() — the driver-assignment dropdown is click-outside-only.
+
+- **job:** back out of an accidental menu open with the keyboard, like every other overlay on the card allows
+- **primitive:** dropdown menu / keyboard dismissal · **failure:** inconsistent · **scope:** interaction · **role:** dispatcher
+- **cite:** `app.js:11221, 16889 (click-outside only), 26562-26609 (Escape chain excludes dropdown-menu)`
+- **evidence:** Verified live: after Escape the driver-picker dropdown remained display:block. A later one-line patch attempt was itself downgraded on review — it would desync Escape from the Android hardware-back chain, which the code's own comment says is meant to stay in lockstep.
+
+### 136. [YELLOW] Calendar / Driver — Measured live against its siblings: Units and Customers both carry a 'Name ▲▼' sort control and a graph toggle in their listbar. Trips' listbar is empty — no sort, no global search, no stats toggle.
+
+- **job:** put his own day in the order he wants to work it, the way every other list in the app lets him
+- **primitive:** listbar / sort control · **failure:** inconsistent · **scope:** architecture · **role:** driver
+- **cite:** `measured live in DOM against Units/Customers listbars`
+- **evidence:** Every habit built on any other card (sort, search scope, stats toggle) fails to transfer to Trips.
+
+### 137. [YELLOW] Calendar / Driver — The back control is an unlabeled bare chevron. It functions correctly — round trip verified back to Trips with state restored — but a driver who won't infer has no textual cue it's 'his way back.'
+
+- **job:** recognize, without guessing, which control returns him to where he was
+- **primitive:** back button · **failure:** ambiguous · **scope:** density · **role:** driver
+- **cite:** `verified live round trip from a rental record back to Trips`
+- **evidence:** Corrects an earlier over-read from the lens pass: back is not broken, only undiscoverable — the two failure modes call for different fixes (a label, not a repair).
+
+### 138. [YELLOW] Calendar / Driver — A merged trip is marked done only when every one of its stops is done, and the group header's '· N done' suffix counts whole trips, not individual stops — four stops with three logged still contributes zero to 'done.'
+
+- **job:** see partial progress on a multi-stop run instead of it reading as if nothing happened
+- **primitive:** group header done-count · **failure:** ambiguous · **scope:** signal · **role:** driver
+- **cite:** `app.js:11586 (trip-level done requires every stop), 9343 (group suffix counts trips)`
+- **evidence:** A downstream review flagged this may be intentional per the card's own accounting spec ('Row = one Trip'), so it isn't a clear-cut defect — but the practical read for a driver mid-run is still 'nothing counted,' regardless of intent.
+
+### 139. [YELLOW] Calendar / Driver — driverRoster() filters employees by /driver/i on the role field, then falls back to returning every employee if that filter comes back empty — one blank/mistyped role field would make bookkeepers assignable as drivers.
+
+- **job:** trust that the assign-a-driver list only ever contains actual drivers
+- **primitive:** driver picker dropdown · **failure:** lying · **scope:** signal · **role:** dispatcher
+- **cite:** `app.js:11281`
+- **evidence:** Confirmed real in code, but latent: the live picker on production currently and correctly shows exactly one name — a landmine, not an active fire.
+
+### 140. [YELLOW] Calendar / Driver — When Trips isn't the active tab, its label truncates to a single character ('T'); the full word only exists in a hover tooltip.
+
+- **job:** identify which tab is which by reading a label, not guessing from an icon and a number
+- **primitive:** tab label · **failure:** ambiguous · **scope:** density · **role:** driver
+- **cite:** `style.css:699`
+- **evidence:** Confirmed reproducing on touch-capable tablet/narrow-desktop widths (the 2-3 column layout); phones use a separate icon-only nav that avoids this path, so the affected population is narrower than a driver's own phone but still real on touch-only wide layouts.
+
+### 141. [YELLOW] Calendar / Driver — The graph-icon glyph (I.graph) means 'Graph view / stats' in the first toolbar slot on every other card, but means 'hide the live map' in the identical first-slot position on the Trips toolbar.
+
+- **job:** trust that an icon he's learned on one card means the same thing on another
+- **primitive:** toolbar icon · **failure:** inconsistent · **scope:** signal · **role:** driver
+- **cite:** `app.js:9647`
+- **evidence:** Same glyph, same slot, opposite job — a driver who's learned the icon elsewhere in the app has no correct expectation for what it does here.
+
+### 142. [YELLOW] Calendar / Driver — The tel: href is normalized everywhere, but the visible label renders whatever raw string was originally typed — three of four live rows showed a formatted '(337) 555-0143' shape and one showed a bare '3373046590,' same data type, two presentations.
+
+- **job:** read a phone number in a consistent, scannable format regardless of who entered the record
+- **primitive:** phone number label · **failure:** inconsistent · **scope:** density · **role:** driver · **SYSTEMIC**
+- **cite:** `app.js:7368 (Trips row), 11742 (telHref normalizes only the href); identical pattern confirmed on Vendors app.js:6154`
+- **evidence:** Not Trips-local: no phone-formatting helper exists anywhere in the app for the visible label, and the same raw-vs-formatted split reproduces on the Vendors card — an app-wide display convention gap.
+
+### 143. [YELLOW] Calendar / Driver — The map panel renders whenever mapOpen is true, completely independent of whether there are any trips — a zero-trip day still gets 260px of map with a degenerate marker and no route, over a low-contrast grey-on-grey 'NO HAULS ON THE BOOKS' plate.
+
+- **job:** immediately recognize an empty day as empty, not as a broken or loading screen
+- **primitive:** empty state / map panel · **failure:** invisible · **scope:** density · **role:** driver
+- **cite:** `app.js:9660 (map render gated only on mapOpen), 9678 (independent trips-length check), style.css:875-877 (grey-on-grey empty plate)`
+- **evidence:** The low-contrast treatment is exactly the visual cue this persona reads as 'nothing here, not my problem' — correct on a genuinely empty day, but the screen gives no confident signal that it's empty rather than broken.
+
+### 144. [YELLOW] Calendar / Driver — Settings → Notifications → Crew Alerts already has a toggle named 'Driver Assigned' ('Texts a driver the moment a delivery or pickup is assigned to them') — scoped and named in the settings schema, but defaulted off and explicitly commented in-code as inert until a later phase ships the SMS path.
+
+- **job:** turn on the exact notification he needs using a control already sitting in Settings
+- **primitive:** settings toggle · **failure:** unreachable · **scope:** architecture · **role:** driver · **SYSTEMIC**
+- **cite:** `app.js:5161 (default enabled:false), 5282 (toggle+description), 5291 ("Phase D — the toggles lock in intent now")`
+- **evidence:** The gap isn't a missing idea — the product already named and scoped the fix. It's a build gap, and raises a UI-system question worth checking on other cards: how many other Settings toggles are visible-but-inert stubs.
+
+### 145. [YELLOW] Categories — The four flat rate tiles (1-Day/7-Day/4-Week/Weekend) are the category's reference rates, not an invoice total, but nothing on the card lets a rep derive what an arbitrary-length rental actually bills, and the card gives no signal that mental math is required.
+
+- **job:** quote the total price for a specific rental length (e.g. "ten days")
+- **primitive:** rate tile / mini-card face · **failure:** ambiguous · **scope:** architecture · **role:** counter-sales rep
+- **cite:** `app.js:1070-1107 (rentalPrice blends 4-Week/7-Day/1-Day for cheapest combo) vs app.js:7271-7275/7317 (flat tiles only, no length input, no blend)`
+- **evidence:** Live-tested: a 10-day rental actually bills a blended $2,270; doing it in his head off the four tiles, Dewey quotes $3,600 — a $1,330 (59%) overquote from mental math alone, and "nobody ever tells me I was wrong."
+
+### 146. [YELLOW] Categories — A rate field explicitly set to 0 renders as an em-dash "—" on the mini-card (truthy check on the raw value) but as "$0" in the detail (efld's has-check treats 0 as present) — the same stored value reads as two different things depending which surface you're on.
+
+- **job:** tell whether a price tier exists at all versus was deliberately set to zero
+- **primitive:** rate tile · **failure:** ambiguous · **scope:** density · **role:** counter-sales rep
+- **cite:** `app.js:7271-7275/7292 (`v ? money(v) : '—'`) vs app.js:8876-8879/8929 (efld `has` = `raw !== '' && raw != null`, money(0) → "$0")`
+- **evidence:** Confirmed by direct code read and matches the live "—" seen on unpriced tiers; there is no distinct "no such tier" state in the data model, so the two renderers disagree on the meaning of the identical 0.
+
+### 147. [YELLOW] Categories — The "next available" date switches convention with no visible marker: inside 7 days it shows a bare weekday abbreviation ("Mon"), beyond 7 days it switches to month+day ("Aug 3") — nothing on the pill or its tooltip states which convention is in play or that a switch happened.
+
+- **job:** know exactly which day a machine becomes free next
+- **primitive:** status pill / lead badge · **failure:** ambiguous · **scope:** density · **role:** counter-sales rep
+- **cite:** `app.js:7272 (`daysAhead <= 7 ? DOW3[...] : fmtShortDate(...)`), app.js:7275 (badge text `Next ${when}`, no disambiguating label); config.js:561-565 fmtShortDate`
+- **evidence:** Sibling surfaces use a different, unified "Next Aug 3" style, so the two-format switch is Categories-specific and unlabeled in both the pill and its data-tip.
+
+### 148. [YELLOW] Categories — The Pass/NR/Fail inspection tally sits as the single loudest, most prominent row on the mini-card, and frequently reads 0/0/0 (nothing to report), yet it occupies the visual space that would otherwise carry the one thing the persona needs (price/availability).
+
+- **job:** scan a card face and find the number that actually answers the question in 11 seconds
+- **primitive:** tally chip row · **failure:** ambiguous · **scope:** signal · **role:** counter-sales rep
+- **cite:** `tally() renderer, mini-card top block (Pass/NR/Fail)`
+- **evidence:** Live-observed: "them Pass/NR/Fail chips sit up top, big as life, and half of 'em say zero zero zero. That's the loudest row on the card and it don't help me quote a thing."
+
+### 149. [YELLOW] Categories — The Categories tab label renders truncated to "CATEG…" whenever it isn't the active column, because whichever card isn't currently showing gets its name chopped.
+
+- **job:** find and switch to the Categories card in the first place
+- **primitive:** nav control (column tab) · **failure:** ambiguous · **scope:** density · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `observed live on app.jacrentals.com column-tab strip`
+- **evidence:** "I gotta remember to hit the little gray 'CATEG…' tab — which is cut off, 'cause whichever card ain't showing gets its name chopped."
+
+### 150. [YELLOW] Categories — The "+Lost" demand-tracking button logs to a private per-category array and toasts only the person who clicked it; nobody in purchasing/fleet-planning is ever told, and the dedicated "Lost Demand" rollup board specified in the product docs was never built.
+
+- **job:** escalate "we keep losing this sale" to the person who can actually order more of that machine
+- **primitive:** button (+Lost) / rollup board (absent) · **failure:** unreachable · **scope:** architecture · **role:** counter-sales rep
+- **cite:** `app.js:2108-2114 lostDemandBtn; app.js:18638/18700 handler (logAction + local-only toast); config.js:403-410 BACKOFFICE_BOARDS has no 'demand' entry; docs/specs/market-research.md §6.3 specifies the missing board`
+- **evidence:** The tool to escalate a real signal exists and is used, but the information dead-ends at the tapping user's own device.
+
+### 151. [YELLOW] Categories — Escape does not close open menus — the right-click context menu and the sort menu both survive an Escape keypress and sit open over the rate values underneath; closeMenus() is wired into ~30 click paths but never the keyboard chain.
+
+- **job:** dismiss an open menu quickly to see the data it's covering
+- **primitive:** menu (context/sort) · **failure:** inconsistent · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:26605 (the one global Escape chain: winpicker → overlay → Wrangler dock → chat dock — dropdown menus not in it)`
+- **evidence:** Live-confirmed twice, including a session where the sort menu was found still open from an earlier Escape press.
+
+### 152. [YELLOW] Categories — The colored badge on an open Categories record's tab strip shows a fixed navy fuel-type chip instead of a status-color badge, unlike every sibling card (rentals/units/workOrders/invoices/customers), all of which derive their tab badge from a real getStatus() call.
+
+- **job:** glance at the open-record tab strip and know whether that record needs attention
+- **primitive:** nav control (tab badge) · **failure:** inconsistent · **scope:** signal · **role:** dispatcher
+- **cite:** `app.js:12143/12149 (`rec.fuelType ? badge(rec.fuelType, 'navy') : ''`, no getStatus call, no category status field consulted)`
+- **evidence:** "No color = nothing wrong" is the habit every other tab teaches; here it just means the fuel-type field doesn't apply. Navy isn't in the red/yellow/green urgency vocabulary, which limits (but doesn't eliminate) the real-world risk.
+
+### 153. [YELLOW] Categories — A category with zero units still computes and prints "0 HRS" avg hours and "$0" avg revenue/expense per unit as if they were real measurements, because the divide-by-zero guard (`n = us.length || 1`) produces 0/1=0 instead of null — while ROI, right beside it, correctly returns null/blank in the identical situation.
+
+- **job:** tell whether a displayed stat is real data or just an artifact of an empty category
+- **primitive:** stat tile (kv) · **failure:** lying · **scope:** signal · **role:** owner-operator
+- **cite:** `app.js:2345 (`n = us.length || 1`), app.js:2368-2370 (avgHours/avgRevUnit/avgExpUnit), render sites app.js:8935/8970/7527 (none check count===0); contrast app.js:2363 where roi is correctly gated to null`
+- **evidence:** The app already knows how to represent "no data" for one field (ROI) but not the two right beside it.
+
+### 154. [YELLOW] Categories — The weekend-rate qualifying window (Fri→Sun, Fri→Mon, or Sat→Mon only — Sat→Sun deliberately excluded) is a real, deliberately-coded business rule, but no UI surface states it: the "Weekend" label carries no tooltip on either the mini-card or the detail.
+
+- **job:** tell a caller exactly which weekend stays qualify for the weekend rate
+- **primitive:** rate tile (missing tooltip) · **failure:** invisible · **scope:** density · **role:** counter-sales rep
+- **cite:** `app.js:1079-1085 (rule enforced, explained only in a code comment); app.js:7292/7317 rate() helper has no title/tip param; app.js:8878 detail priceFld has the same gap`
+- **evidence:** The engine — not the counter rep — ultimately prices any booked rental correctly, so this is a communication gap rather than a billing risk, but it forces the rep to guess or call someone.
+
+### 155. [YELLOW] Categories — The Category field on a Unit's detail is rendered as an admin-gated reassignment `<select>` rather than a normal navigable link, unlike Rentals and Work Orders, which render the identical category reference as an ordinary clickable pill any user can follow to the category record.
+
+- **job:** navigate from a unit to its category's pricing/stock without needing admin rights
+- **primitive:** linked-record pill · **failure:** inconsistent · **scope:** architecture · **role:** mechanic / yard tech
+- **cite:** `app.js:8575 (efld editKind:'unitCategory', admin:true, link:true) vs app.js:8523 (Rentals, plain data-pill-card) and app.js:9119 (Work Orders, plain pill)`
+- **evidence:** Appears deliberate (a code comment documents opts.admin gating "Categories and pricing" edits) but functionally blocks a non-admin from reaching category context from the unit they're looking at.
+
+### 156. [YELLOW] Categories — The audit-history redaction that hides dollar amounts from below-money-tier viewers blanks the entire line ("1-Day rate: $••• → $•••"), so a lower-tier viewer can't even see THAT a rate changed, only that some field named "1-Day rate" was touched.
+
+- **job:** confirm from the audit trail that a price changed, even without needing the exact number
+- **primitive:** history log line · **failure:** invisible · **scope:** signal · **role:** counter-sales rep
+- **cite:** `app.js:22578-22582 (auditVal/histText, redacts any `$…` value for non-canMoney() roles)`
+- **evidence:** Only bites a role configured below the money tier, but for that role even the fact-of-change is lost, not just the amount.
+
+### 157. [YELLOW] Categories — No push-notification or service-worker delivery channel exists anywhere in the frontend — sw.js is explicitly documented as an offline-shell cache only, with no push listener or Notification API usage in app.js.
+
+- **job:** get alerted to a price or stock change while the app isn't the focused tab
+- **primitive:** notification channel (absent) · **failure:** unreachable · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `sw.js full read (install/activate/fetch/message listeners only); no `Notification`/`showNotification`/`push` anywhere in app.js`
+- **evidence:** A capability gap, not a wiring gap — even a category rate-change broadcast (finding above) would still only reach a foregrounded, focused tab.
+
+### 158. [YELLOW] Categories — Mr. Wrangler (the in-app assistant) carries the fully correct live rate sheet and computes the real blended price via find_categories/price_rental — but this is pull-only, never volunteered, and reachable only through a right-click context menu, a gesture this persona has never performed.
+
+- **job:** get the correct price without doing mental math or clicking into a gated detail
+- **primitive:** menu (right-click) / chat · **failure:** unreachable · **scope:** interaction · **role:** counter-sales rep
+- **cite:** `app.js:15092-15093 wranglerDigest (bakes live rate sheet into context), app.js:15259-15262/15320-15330 find_categories/price_rental (real pricing engine); right-click menu confirmed live to offer Copy/Paste/Global Search/Add Comment/Ask Mr. Wrangler`
+- **evidence:** "He's had the right answer this whole time. He's just behind a right-click, and I have never right-clicked anything in my life." The accurate answer sits one gesture away from every problem above.
+
+### 159. [YELLOW] Categories — Hovering a category row reveals a quick-view "eye" icon and a "+" icon that render directly over the 1-Day rate value, obscuring the exact number the persona is trying to read.
+
+- **job:** read a rate value without a hover-triggered control covering it
+- **primitive:** hover icon overlay · **failure:** invisible · **scope:** interaction · **role:** counter-sales rep
+- **cite:** `observed live on the Lift Boom 65ft category row during a full click-through pass`
+- **evidence:** Hidden affordances materialize on hover directly on top of the data the reference card exists to show.
+
+### 160. [YELLOW] Categories — The category detail's "$ UTIL" (ROI) tab renders an empty state in live production — "No revenue against a recorded cost basis yet — set true cost or purchase price on units" — because trueCost/purchase price is not populated on units, so the ROI feature is largely inert despite the gate/leak defects existing in its code.
+
+- **job:** see a category's real return-on-investment, not just its revenue
+- **primitive:** graph (empty state) · **failure:** invisible · **scope:** signal · **role:** owner-operator
+- **cite:** `live-observed empty-state copy on the $ UTIL tab`
+- **evidence:** Scopes (does not remove) the ROI-gate-leak finding above: the leak is real in code, but with trueCost largely unset there is currently little live margin data to leak — Revenue, by contrast, is populated and its phantom-count defect is fully live.
+
+### 161. [YELLOW] Customers — Grouping is by pay status only, so the group header a person scans first carries no aggregate danger signal — a blacklisted or no-card customer at $0 owed sits under a calm green "Current" header.
+
+- **job:** scan a whole bucket of customers for danger without opening each row
+- **primitive:** group header · **failure:** invisible · **scope:** signal · **role:** counter-sales rep
+- **cite:** `app.js:9317-9319`
+- **evidence:** Narrowed on verify: individual flagged rows still show their red name-tint inside the bucket (not fully invisible), but the header itself — the thing actually scanned — stays green with no count or colour change.
+
+### 162. [YELLOW] Customers — A dead/missing invoice link returns silently with no toast, no shake, no feedback of any kind.
+
+- **job:** open an invoice referenced elsewhere on the card without wondering if the app froze
+- **primitive:** link / pill · **failure:** invisible · **scope:** interaction · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `app.js:3064 (if (!inv) return;)`
+- **evidence:** Confirmed: the handler exits with no user-facing signal at all when the invoice record can't be found; a repeated click looks identical to the first.
+
+### 163. [YELLOW] Customers — A card control (the global search-scope "globe" toggle) fired from the Customers card silently changed the Units card's search scope as well, with no indication the change was global rather than local.
+
+- **job:** search within Customers without unknowingly changing how a different card behaves
+- **primitive:** global scope toggle · **failure:** invisible · **scope:** architecture · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `observed live during control enumeration — not captured in the artifact or verify JSON`
+- **evidence:** Toggling "search everything" from the Customers card was observed to also flip the Units card's search to the same global scope; the control gives no visible signal that its effect isn't scoped to the card it lives on.
+
+### 164. [YELLOW] Customers — A fixed "new version available" service-worker toast sits directly over the bottom alert-chip row for the entire session, at measured coordinates that put it on top of, not beside, the alerts a person would otherwise glance at.
+
+- **job:** see her own alert chips without a system update banner sitting on top of them
+- **primitive:** fixed toast vs. alert-chip row (z-index stacking) · **failure:** invisible · **scope:** density · **role:** counter-sales rep · **SYSTEMIC**
+- **cite:** `style.css:5580-5583 (.sw-toast, z-index:300) · app.js:17472 (swInit)`
+- **evidence:** Measured precisely on production: the fixed toast (x 500–920) sits at z-index 300 directly occluding the alert-chip row at y 663–681, for the full duration it was on screen.
+
+### 165. [YELLOW] RENTALS — The 'next move' on an open rental is a status noun on a pill, not an action — nothing says 'go get it'.
+
+- **job:** decide and take the next action on a rental
+- **primitive:** status pill / CTA · **failure:** ambiguous · **scope:** signal · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `config.js:63-74, pill app.js:6017-6024`
+- **evidence:** A 22px pill reads 'Off Rent'; there is no verb and no primary CTA on the open rental. 'Off Rent' reads like routine progress even when it means the machine is 3 days overdue. For a dispatcher who won't infer, a noun is not an instruction.
+
+### 166. [YELLOW] RENTALS — Advancing a status straight from the list row works on Rentals but nowhere else, so the muscle memory doesn't transfer to sibling cards.
+
+- **job:** act on a record the same way on every card
+- **primitive:** list row / status pill · **failure:** inconsistent · **scope:** interaction · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:7061 vs app.js:6963-6981`
+- **evidence:** Rentals rows expose the status gate inline (masterGate on the row); Units and the other cards require opening the record first. Nothing signals the difference — a learnable interaction is card-specific for no visible reason.
+
+### 167. [YELLOW] RENTALS — On a day-one/empty roster the dispatcher hits a dead end: the +Driver chip is suppressed when no drivers exist, and the 'add drivers first' hint fires only FROM that suppressed chip.
+
+- **job:** assign my first driver on day one
+- **primitive:** chip / empty-state hint · **failure:** unreachable · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `app.js:7356/7359, app.js:18614/18618`
+- **evidence:** The guidance that would tell a new dispatcher what to do is gated behind the very control that's hidden when the precondition (no drivers) is true — so they see unassignable trips and no explanation. Completeness-critic finding, source-grounded.
+
+### 168. [YELLOW] RENTALS — There is no daily digest / morning brief — nothing summarizes returns due, field calls and unpaid balances at clock-in.
+
+- **job:** see everything that needs me today when I clock in
+- **primitive:** summary view (absent) · **failure:** invisible · **scope:** architecture · **role:** dispatcher · **SYSTEMIC**
+- **cite:** `observed live`
+- **evidence:** No 'here's your day' surface exists; a dispatcher assembles the day by scanning multiple cards. The information all exists in the data but is never composed into a start-of-shift view.
+
+### 169. [YELLOW] RENTALS — The controls that clear an anchor/cascade filter work but are hover-revealed and unlabeled — a touch or lazy user feels stuck after drilling into one record.
+
+- **job:** get back to the full list after drilling into one record
+- **primitive:** nav control / tab close-X (hover-only) · **failure:** unreachable · **scope:** interaction · **role:** dispatcher
+- **cite:** `app.js:2588-2592, app.js:9748-9750`
+- **evidence:** SCOPED by verification: a visible clear DOES exist (the anchored item opens a foreground tab whose close-X is the documented clear path; plus double-click anywhere on the open card clears it), so the original 'no escape at all' was wrong. The residual is only discoverability: nothing is labeled 'clear anchor', the tab-X is hover-revealed, and the double-right-click clear has no affordance. Verifier verdict PARTIAL. See retractions.
+
+### 170. [YELLOW] UNITS — Notification text is escaped correctly but never parsed for markdown, so authored formatting like **Verdict:** renders with the literal asterisks visible to every user, on every card, not just Units.
+
+- **job:** read a notification cleanly, without visual noise
+- **primitive:** notification text rendering · **failure:** ambiguous · **scope:** density · **role:** AR-office clerk · **SYSTEMIC**
+- **cite:** `app.js:14050`
+- **evidence:** Notification bodies are correctly esc()'d for safety and only convert \n to <br> — there is no markdown renderer anywhere in the codebase, so a notification authored with **Verdict:** displays the raw asterisks. Confirmed live in the Notifications panel.
+
+### 171. [YELLOW] UNITS — A pill tap gives no immediate visual feedback while the 220ms double-click discriminator resolves, so an impatient second tap can silently fork a new browser tab instead of registering the intended single action.
+
+- **job:** tap a status pill once and get one predictable result
+- **primitive:** pill/flag tap target · **failure:** ambiguous · **scope:** interaction · **role:** mechanic / yard tech · **SYSTEMIC**
+- **cite:** `backlog item S18`
+- **evidence:** No visual acknowledgment renders on a pill tap before the double-click discriminator (220ms window) resolves; a user who taps again out of impatience triggers the double-click branch, which opens a new tab rather than the single-tap action, with no indication of what just happened.
+

--- a/docs/research/ALL-PATTERNS.md
+++ b/docs/research/ALL-PATTERNS.md
@@ -1,0 +1,911 @@
+# All 48 cross-card patterns
+
+Sorted by how many cards each spans. ⁿ marks patterns only visible once RENTALS became real data.
+
+## 1. Every number has two authors
+
+**5 cards** · scope: `architecture` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+The same fact is computed independently by two or more renderers with different predicates, and both results ship to the same screen. There is no single derive layer, so the app contradicts itself inside one viewport — and the drill-through from a number lands on a differently-filtered set than the number counted.
+
+**Why it persists:** Derivation lives inside renderers instead of in a shared, named selector every surface must call. When someone corrects a definition they correct the renderer in front of them — the mini-card gets the fleetStatus fix, the detail does not — so each fix increases the number of disagreeing definitions rather than reducing it. Nothing in the codebase makes 'availability' or 'amount owed' a single addressable thing, and nothing fails when a fourth caller invents a fifth definition.
+
+**The question a UI system must answer:** *Where does a derived fact live so that every surface showing it — tile, detail, header, graph, sort key, filter, drill-through — is forced to read the same function, and a click on a number is guaranteed to return exactly the rows that number counted?*
+
+**Instances:**
+
+- Customers: the row computes live owed/overdue from real invoices every render while the group header, sort, filter and pulsing detail flag all read a stored payStatus written once at signup — a repo-wide grep found zero write sites outside the five creation paths, and the team's own spec (docs/specs/customers-crm.md:642-650, dated nine days before the audit) already calls it an open question. Two contradictory answers to 'does this person owe us' sit inches apart.
+- Categories: same category, same second — 12k Excavator mini-card reads 'NEXT MON' (zero free) while the detail reads '9 Available'; Lift Scissor 19ft reads '2 Avail' vs '5 Available', the 3 extra being sold machines. A comment at app.js:7212 shows this exact bug class was fixed on the mini-card on 2026-06-25 and the fix never reached the detail renderer.
+- UNITS: the Worklist graph reads 'NOT READY 28' while the group bar ~40px below on the same screen reads 'NOT READY · 8' — the graph tallies all of DATA.units (app.js:12167-12170), the list excludes out-of-fleet and on-rent units first (app.js:9295), and unitsAlertCount (app.js:9479) holds a third, narrower definition.
+- UNITS: the Work Orders bar counts one entry per open WO but the click-through filters units — a unit with 2 open WOs is one row and two counted, so the number structurally cannot match the rows beneath it.
+- Customers: on one real account, a chart callout reading '$47,720 · BEST · APR' sat beside a Transactions tab reading '$2,834.84 collected, 1 payment, 0 refunds' — roughly 17x apart, different basis, different period, both on screen, nothing saying which to trust; the caption beneath still read 'No rental cadence yet.'
+- Customers: on a live account carrying a $1,306.85 balance, the detail header displayed 'Member' while the AR block directly below displayed 'NON MEMBER MODE.'
+- Categories: clicking the 'Off Fleet' stock-count segment routes to Units, but cardListEl strips every non-Active unit before the per-card filter runs — the segment produces a correct filter chip with no console errors and the list renders 'No Unit.'
+- Calendar/Driver: the Trips tab badge counts only stops dated today-or-later that aren't done, so every undone past-day trip contributes zero to the one number the driver glances at.
+- UNITS: WO phase pills render raw w.phase while the app's own comment (app.js:22610-22613) states the displayed status is meant to be derived — the Worklist graph (app.js:12170) and a list filter (app.js:3169) both bucket on the frozen raw value instead.
+
+## 2. Nothing warns you before the point of no return
+
+**5 cards** · scope: `interaction` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+Preconditions and consequences are evaluated at commit time and nowhere before it. The UI never says an action is blocked, irreversible, or wrong until after you've taken it — and the app's own confirm/arm/review patterns are hand-applied conventions, so identical-looking controls a few lines apart behave completely differently.
+
+**Why it persists:** Gates were written as guards inside commit handlers — the correct place to enforce them and the worst place to communicate them. Because the gate's answer is never computed at render time, the control cannot know it is disabled; and because confirm/arm/review are conventions applied by hand rather than properties of a destructive-action primitive, whether a given button asks first is decided one button at a time by whoever wrote it.
+
+**The question a UI system must answer:** *How does an action publish its own preconditions and reversibility to the control that triggers it — so a blocked action renders blocked, a costly one renders armed, and the moment of commit stops being the first time anyone learns either?*
+
+**Instances:**
+
+- RENTALS: the invoice hard-gate fires only for val==='On Rent' (app.js:19911) and the blacklist/rules/card/account-block gates are all scoped to BOOKING_STATUSES ['On Rent','Reserved','Today','Tomorrow'] (app.js:19751) — 'Returned' is in none. The status dropdown is a free-jump timeline, every node a live button with no disabled state, so a fresh Reserved rental with invoiceId still null can be clicked straight to Returned and closed out unbilled.
+- RENTALS: terminal jumps (Returned/Cancelled/No Show) sit stacked as the last rows of one dropdown (order app.js:16851), each a plain button calling setRentalStatus with zero intervening step; Cancel/No-Show strips billing in the same breath (app.js:19929) and the row drops instantly with no fade — while the app already owns a confirm pattern.
+- RENTALS: a driver taps Log Delivery, the office-side booking gate refuses the status move, and the entire capture including recorded video is discarded — no queued retry, no visible block on the Trips side to clear (app.js:20256-20261).
+- Calendar/Driver: the same class from the driver's seat — the log-gate ('no invoice on this rental') is evaluated only on tap, never at row render, so a stop blocked that morning shows no lock and no flag until he has driven the full distance. The check exists in the codebase; it simply runs at the wrong moment.
+- Customers: removeCard fires a live Stripe detach — not locally reversible — with zero permission check and zero confirmation, twelve lines below the handler that does check. Of 2,265 customers only 124 have a card on file (94.5% do not), and a valid card is required before On Rent, so those 124 are effectively the entire float.
+- Customers: 'Pay Cancellation' charges the saved card in full on tap while every other money action (pay balance, refund) opens a shared payment-review overlay first; 'Cancel Membership' ends billing and generates a cancellation invoice on the first click despite an arm-to-confirm pattern a few lines away in the same file.
+- UNITS: the drag-drop attach filter checks fleetStatus==='Active' only (app.js:17568) while isUnitRentable (app.js:2251), which also excludes failed inspections, feeds only the availability count — a machine with a failed inspection and 2,882 hours overdue attached to a quote instantly, and a search of the whole rental detail for 'failed, not ready, overdue, service, inspect, warning, caution, unsafe' returned nothing.
+- Categories: retagging a unit's category commits on change/blur from a bare, unconfirmed select and silently re-prices every open rental on that unit.
+
+## 3. Severity dies on the row it's born on
+
+**5 cards** · scope: `signal` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+Urgency has no path upward. A flag can be true on a row while the group header above it, the tab beside it, and the global count at the top of the app all stay calm — because every level re-implements its own private subset of the flag registry instead of aggregating the level below it.
+
+**Why it persists:** Flags were built as a per-entity registry but consumption was left to each renderer. There is no rollup contract requiring a container to expose the maximum severity of its contents, so every count and header was written by whoever needed one, at the granularity they needed. Severity therefore has no inheritance path, new entities (Categories) join the app without joining the registry, and nothing fails when they don't.
+
+**The question a UI system must answer:** *What is the rollup rule that makes a group header, a tab, and a global count each a strict aggregation of the severity beneath them — and what forbids a container from rendering a count that ignores its own contents' flags?*
+
+**Instances:**
+
+- UNITS: unitsAlertCount ignores 5 of the 10 registered flag conditions — failed inspection, overbooked, GPS offline, coverage expired, uninsured-active — including the two that put an unsafe or uninsured machine on the road. The tab badge, card border, corner-flag pill and group bucket each reimplement a different subset, so four separate mechanisms disagree about what 'needs attention' means.
+- RENTALS: an overdue return (off-rent-overdue, config.js:245) feeds only getEntityColor — it tints the row it already sits in and nothing else. commsBellCount = unseenNotifs()+visibleTransportAlerts()+wranglerRequests references it nowhere, and a past-endDate leg drops OUT of the forward-windowed transportAlerts so it isn't even indirectly counted. The rentals column tab's alert is hardcoded false (app.js:9601).
+- RENTALS: GROUP_DEFS.rentals buckets on lifecycle status (app.js:1986-1990) and never consults a flag, unlike UNIT_SECTIONS (app.js:9279-9290) which has an explicit red 'Attention' bucket — so the header count never reflects severity and flagged rows aren't lifted within the group.
+- Categories: zero entries in FLAG_META/FLAG_COND — a full grep of both registries and every call site finds no getEntityFlags('categories', …) anywhere — so no category condition (zero stock, negative ROI, unset pricing) can escalate past its own mini-card pill. No categoriesAlertCount function exists, and the column-tab alert glow is hardcoded to fire only for Units.
+- Calendar/Driver: the 'Earlier' bucket — the only home for undone past-day trips — is the sole group on any card that defaults collapsed, and its colour is a hardcoded 'gray' literal that can never receive danger styling. Live: 4 undone runs inside a collapsed 'Earlier · 6 · 2 done', two of them 78 days late.
+- Customers: grouping is by pay status only, so the header a person scans first carries no aggregate danger signal — a blacklisted or no-card customer at $0 owed sits under a calm green 'Current.'
+- UNITS: group headers render a label and a raw count with no flagged sub-count, and once collapsed the state persists per device/account forever with no urgency floor to force a red-carrying group back open.
+
+## 4. Nothing reaches you when you're not looking
+
+**5 cards** · scope: `architecture` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+The app has no delivery channel that survives the user not looking at the right pixel: no push, no OS badge, no durable inbox, no role-addressed message. Every alert it produces is a render-time paint on a surface someone must already be on, and the only confirmation primitive — the toast — self-clears in ~2.2 seconds with no trail.
+
+**Why it persists:** Alerting was never modeled as a layer with an address ('who is this for?') and a lifetime ('how long does it stay?'). Each feature that needed to say something reached for the nearest render-time primitive — a colour, a count, a 2.2-second toast — because that is the only primitive the app has. Settings then grew toggles describing an alerting product nobody built, so the UI now promises delivery it structurally cannot perform, and the promise itself hides the gap.
+
+**The question a UI system must answer:** *What is the app's addressable message object — who it is for, which surface it survives on, how long it lives, and what clears it — such that no flag condition can become true without producing one?*
+
+**Instances:**
+
+- RENTALS: sw.js is 47 lines documented 'OFFLINE SHELL ONLY' with no push/notificationclick listener and no showNotification; a grep of the 27,649-line app.js for Notification/requestPermission/setAppBadge/pushManager returns zero. Only two setInterval calls exist in the whole file — a GPS-view timer (app.js:24080) and an 18s backend poll (app.js:24796) — and neither scans flags to fire anything.
+- Calendar/Driver: assignStopDriver's only effect on a successful assignment is a line pushed into a hidden per-rental audit array. All 3 call sites traced (single-stop picker, drag-drop, bulk 'Round up'); the one toast() anywhere in the chain fires in the DISPATCHER's own browser and is never addressed to or visible on the assigned driver's device.
+- Calendar/Driver: Settings → Notifications → Crew Alerts already ships a toggle named 'Driver Assigned' — 'Texts a driver the moment a delivery or pickup is assigned to them' — scoped and named in the settings schema, defaulted off, and explicitly commented in-code as inert until a later phase.
+- UNITS: all ten FLAG_COND.units predicates fire silently into data with no messenger; team chat only rings for human-typed messages; toasts are the only confirmation surface and self-clear in ~2.2 seconds with no durable trail — so an uninsured or overdue machine can go out the gate with nothing on the mechanic's tablet ever having said so.
+- Categories: committing a rate edit (admin inline-edit or a Wrangler chat write) fires zero toast, dock ping, or push — not even to the person who made the edit; the commit path is reindex + logAction + render only, while js-lost-demand, js-spe-accept and js-blacklist all toast their actor.
+- Customers: Settings has live, saveable toggles for customer reminders and dispatch ETAs; the toggle persists its own state and nothing acts on it.
+- Customers: the notification bell holds engineering tickets addressed to the owner — pricing-engine internals with GitHub links, measured live as 53 literal ** markdown markers across 17 lines of unrendered text — with nothing customer-facing in it, plus a dispatch concern ('Transports due') in her alert count.
+- RENTALS: there is no daily digest or morning brief; nothing composes returns due, field calls and unpaid balances into a start-of-shift view even though the data all exists.
+
+## 5. Built but never doored; rendered but never wired
+
+**5 cards** · scope: `architecture` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+There is no binding between a capability and a control. Fully-built features sit in production with no button that reaches them, and fully-rendered buttons sit on screen with no live code behind them — and neither condition produces any signal, so the surface looks complete in both directions.
+
+**Why it persists:** Cards were retired by unmounting a renderer, not by re-homing what they owned; and features were specced with their entry point as an afterthought. Nothing in the build fails when a handler has no call site or a control has no handler, so dead surface accumulates in both directions — and staff invent workarounds (voiding through the Sheets backend, typing state into name fields) that make the gap invisible to whoever measures whether the feature 'exists.'
+
+**The question a UI system must answer:** *What makes a capability and its entry point a single unit that cannot ship half-present — and when a surface is retired, what forces every capability it hosted to declare a new home before the removal lands?*
+
+**Instances:**
+
+- Customers: send-to-collections and void-invoice are built end to end — manager gate, confirm popup with reason codes, overlay, auto-blacklist, audit-log entry, money-safe void handler — and their only trigger buttons render inside a retired standalone Invoices card. Verified live: the status menu on a real Late invoice offers exactly three items — Pay, Print, Send (greyed). Two invoices on one real account already read VOIDED, meaning voids currently happen only through the Sheets backend.
+- RENTALS: the multi-driver lane rail and the one-tap 'Round up' auto-balance handlers exist (app.js:11802-11805, app.js:18629-18636) but nothing renders their buttons — with 12 stops and 3 trucks the dispatcher can only tap +Driver one stop at a time.
+- UNITS: the WO phase pill is frozen because the code that advanced it lived in the retired Shop-card renderer; the failed-inspection photo/video link is emitted exclusively from that same retired renderer; and the ex-Shop quick filters '__wo' and '__svc' are fully implemented with human labels (app.js:3167) with nothing linking to them.
+- Customers: two of five sort options are dead no-ops — sorting by 'Pay Status' produced a list byte-identical to sorting by 'Name'; sorting by 'Last Invoice' produced reverse-alphabetical order with no reference to any invoice date — while the menu still shows them as selected.
+- Calendar/Driver: the Show More handler reads activeSession().cards[card] and bails unless truthy, but Calendar is deliberately card-stateless, so the click is a guaranteed no-op and everything past the 60-row cap is permanently unreachable.
+- Customers: the per-customer comms conversation panel is fully built with zero call sites; the developer's own comment names where it should render, and a second comment listing it as a live comms entry point is stale for the same reason.
+- Categories: the 'Lost Demand' rollup board specified in the product docs was never built, so +Lost logs to a private per-category array and toasts only the clicker; separately an 'Out of Fleet' section bucket exists in code and is never reached.
+- UNITS: startHours/returnHours are seeded on every rental unit entry and humanized for the audit log (app.js:22577), but a grep for their assignment returns zero writers anywhere in the app.
+- Customers: the Sales tab — named for the persona's job, one tap from her list — is a permanent 'Coming soon' placard.
+
+## 6. Colour is the only channel, and it's saturated
+
+**5 cards** · scope: `signal` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+Distinct conditions requiring different responses are mapped onto one visual output — a single red — with no name, no legend, and a ranking that reflects source order rather than consequence. The channel is oversubscribed to the point where alarm is the default state, and the same glyph or colour means different things on different cards.
+
+**Why it persists:** Severity was modeled as a colour rather than as a named condition with a required response. Once red is the only way to say 'important,' every team with something important adds red, and the encoding degrades monotonically — nothing ever removes a red, and nothing arbitrates between two reds, so ranking falls back to whatever order the flags happened to be pushed in.
+
+**The question a UI system must answer:** *What must a condition declare — its name, its consequence, its required response, its priority against other conditions — before it is allowed to claim a colour, and how does a row show WHICH condition fired rather than only THAT one did?*
+
+**Instances:**
+
+- RENTALS: FLAG_COND.rentals defines 7 conditions (fc, overbooked, unpaid-balance, no-card, unsigned-card, unit-failed, off-rent-overdue), ALL severity:'red', and getEntityColor collapses to fl[0].severity so the row renders one uniform red. The flag's NAME never appears on the row, and 2 of the 7 (no-card, unsigned-card) are genuinely unidentifiable without the desktop hover-preview or a hop to the customer record.
+- Categories: eight-plus distinct unavailability reasons (N/A, Sold, For Sale, Inactive, Failed, Overdue, End Dates?, Off fleet, plus Purchased/Onboard) all render through one identical red pill with no legend anywhere — an actionable 'Overdue' (a customer is late returning our machine) is pixel-identical to an inert 'N/A' (we never stocked the class).
+- Customers: measured live, 44 of 60 rendered rows were red and 11 of the first 12 in the default view; inspecting a red row's DOM found no flag word in its text and no title attribute — the only tooltip on the row belongs to an unrelated eye-preview toggle. 'Hasn't rented since spring' and 'has no card and is about to take a machine' render identically.
+- UNITS: flag ranking is by colour rank tie-broken by hardcoded push order — GPS is pushed second, service fourth — so a dead GPS antenna always outranks a seizing engine when both are red; the worst machine in the yard (2,882 hrs past service) displays as 'No GPS +1'. Separately 'Part Needed,' 'Part Ordered,' 'Part Needed?' sit side by side with the question-mark variant rendering red on one tile and amber on the next.
+- Calendar/Driver: the I.graph glyph means 'graph view / stats' in the first toolbar slot on every other card and means 'hide the live map' in the identical slot on Trips; and 'Today' is hardcoded red every day regardless of contents (app.js:9337), so red already carries no signal on that card before 'Earlier' is even considered.
+- Categories: a brand-new category is born with every rate at 0 and zero units, rendering it in the single most alarming state the card has — identical to a genuinely dead one; and the tab badge for an open Categories record shows a fixed navy fuel-type chip instead of the status-derived badge every sibling card (rentals/units/workOrders/invoices/customers) uses.
+- Customers: three alert-pulse mechanisms are inverted or hardcoded — the rental-status badge pulses for all seven active statuses (none red), the pay-status pulse tests a 'Paid' value customers can never hold so every New Customer throbs like a debtor, and the membership billing flag has its booleans swapped so 'No Billing' pulses while 'Payment Due' sits calm.
+
+## 7. View state is scratch paper
+
+**5 cards** · scope: `architecture` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+Sort, filter, grouping, scroll position and navigation history are re-implemented per card with different semantics and different persistence, and none of them is anchored to a record. The list is not a stable addressable thing — it silently reorders, silently combines with filters from ten minutes ago, and silently loses your place.
+
+**Why it persists:** The list is treated as a render output rather than a state object with an owner. Each card grew the scoping controls its first users asked for, keyed to whatever local variable was handy, so there is no shared vocabulary for 'what am I looking at.' And because position is remembered as pixels rather than as a record, any re-sort silently invalidates the only breadcrumb the app keeps — which means the more the app updates itself, the more reliably it loses you.
+
+**The question a UI system must answer:** *What is the single view-state object — scope, order, grouping, anchor record, history — that every card must own, so a list is addressable, a filter is visibly scoped to what produced it, and 'where I was' survives a re-sort, a background poll and a reload?*
+
+**Instances:**
+
+- UNITS: grouping beats sorting. Measured live with sort explicitly set to Service Due — position 1 was 440 hrs overdue, position 2 was 2,882 hrs overdue, position 3 was 2,025, positions 4-8 were five machines with nothing wrong at all, and position 9 was Dirt Dauber at 1,139 hrs overdue, filed under the green AVAILABLE bucket. Buckets are decided by inspection status alone; service urgency never enters bucket assignment.
+- RENTALS: scrollMemo is keyed only by card|view and restored by raw pixel (save app.js:17185-17190, restore app.js:17229-17234) — the key never includes the acted-on record id, and list mode always restores the saved value even when the list re-sorted underneath (status is a selectable sort field, config.js:431). Acting on a row lands the viewport on a different rental, and the toast says only 'Status → X'.
+- Calendar/Driver: the app-wide scroll memory reads and writes .card-body's scrollTop across 5 call sites while the real scroller on Trips is the nested .cal-scroll — a live control test showed position 120→0 — and the 18-second background poll triggers the same render with no user action at all.
+- Categories: filters set from one category persist and silently intersect with a filter clicked on a different one later. Live: two chips ('Not Ready · Light…' + 'Ready · 12k Exca…') intersected with Back/Forward vanished — the result looked like a normal list, just of the wrong machine.
+- Categories: two lookalike pills an inch apart produce opposite navigation outcomes — the availability pill pushes history and Back restores sort/scroll/panel state; the status-tally pill wipes backStack/fwdStack outright and the Back/Forward arrows vanish from the toolbar entirely.
+- Categories: the leading circle on a filter chip looks like a clear control and actually inverts the filter — live, the chip turned red ('excluding') and the list changed, so the natural read is 'it worked' while the user now views the exact complement of what they asked for.
+- Customers: only 60 of 2,265 rows load and 'Show more' re-renders the entire list every press — timed 547ms → 658ms → 803ms → 1,044ms for identical 200-row additions (~1.1ms/row, tracking total row count). Reaching the end of the book is ~eleven presses and over twelve seconds of frozen screen, each requiring a manual scroll back to the button.
+- Categories: every fresh session and every reload lands the left column on Units regardless of where the user was working — live-confirmed, after an entire session in Categories a reload dropped straight back to a card that carries no rate field at all.
+- Calendar/Driver: Trips' listbar is empty — no sort, no global search, no stats toggle — while Units and Customers both carry a 'Name ▲▼' control and a graph toggle; and tripMatches does one contiguous blob.includes(q) instead of the AND-term matching every other card uses, so 'lake pick' returns zero rows against a row literally reading 'Pick up' at 'Lake Charles.'
+
+## 8. The label layer is hover
+
+**5 cards** · scope: `density` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+The app has no naming layer. Controls ship as bare glyphs and the text that would explain them — plus, routinely, the operative data itself — is stored in a title/data-tip attribute, a gesture that does not exist on touch, in gloves, or in a screen reader. Where text does render, it truncates at exactly the character carrying the meaning.
+
+**Why it persists:** Every card face is over-subscribed and hover was available and free. Because a tooltip is a per-element decision rather than a naming contract, what gets demoted is chosen locally and always sacrifices the long string — which is usually the noun carrying the meaning. No layout rule reserves space by importance, so truncation order is an accident of source order, and touch/gloved/assistive use was never a rendering mode the layout had to satisfy.
+
+**The question a UI system must answer:** *What is the naming and overflow contract — every control has a rendered name, every datum has a declared priority, nothing that determines an action lives only in a hover — and how does a card face decide what to drop when it runs out of room?*
+
+**Instances:**
+
+- UNITS: a full inventory of the mechanic's screen found 86 interactive elements, 58 (67%) with no visible text label, 52 of those 58 labelled only by a title-attribute hover tooltip, and not one aria-label in the set — even though the repo already pairs aria-label with data-tip in 69 other places, so the pattern is known and simply unapplied here.
+- Categories: a live full accessibility-tree read found refs ref_1826 through ref_1859 plus the entire block ref_2305–ref_2328 (the category pills) all reading as bare 'button', and the filter-term chips — both the pill and its nested negate-icon button — do not appear in the accessibility tree at all: unreadable and unremovable by a screen-reader user.
+- Calendar/Driver: the row prints a town, 'Lake Charles', while the live DOM shows data-tip holding the full '1700 11th St, Lake Charles, LA 70601, US' as an unused hover-only attribute — for a driver in a truck wearing a glove.
+- UNITS: the worst machine in the yard, 2,882 hours past service, renders on its tile as 'No GPS +1' with the service number existing nowhere on the tile face, only inside the data-tip string; and service-flag text truncates at roughly 9px so '73 HRS…' could mean overdue or remaining.
+- Customers: the money pill and the phone number share one line and money wins the truncation. Measured across 400 production rows: 96% of rows carrying a balance had a clipped phone (22 of 23) vs 25% of rows without one; a customer owing $13,240.52 rendered a phone of '(337) …' — the exact accounts she most needs to call are the ones she can't read.
+- RENTALS: on a phone the entire link-a-record system is reachable only through an unsignposted 500ms long-press — touch drag was retired 2026-06-29 (app.js:17813) and a finger-drag is silently disarmed — while six empty-slot toasts still instructed the user to 'drag' with no is-phone branch. The anchor-clear control is real but hover-revealed and unlabeled.
+- Categories: the tab renders truncated to 'CATEG…' whenever it isn't the active column; the identical rule truncates Trips to a single character 'T' with the full word only in a tooltip. Hovering a category row pops an eye icon and a + icon directly over the 1-Day rate value the card exists to show.
+- Calendar/Driver: the back control is an unlabeled bare chevron — verified to function correctly, round-trip with state restored — that gives a driver no textual cue it is his way back.
+
+## 9. The cards narrate; they don't act
+
+**5 cards** · scope: `architecture` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+Surfaces are built to report state, not to advance work. The record tells you what is true and offers no next move, no way to reach the person involved, and no queue of what is yours — so every real action is a multi-screen detour or a phone call the app never sees.
+
+**Why it persists:** The app's unit of design is the record, not the task. Each card was built to answer 'what is the state of this thing,' and the actions that follow from that state belong to other systems — comms, dispatch, billing — living on other surfaces, so nobody owned the join. Assignment fields exist because records need attributes, not because anyone modeled a person's queue; and when the system offers no place to put an intention, staff put it in the name field.
+
+**The question a UI system must answer:** *What is the app's action layer — the set of next moves a record can offer, addressed to a named person, reachable in one tap from where the state is read — and what makes 'whose is this and what do I do about it' a first-class property of every record rather than a stored attribute nothing consumes?*
+
+**Instances:**
+
+- Customers: no call, text, charge, or follow-up control exists anywhere on a customer row or in the detail record — the card only ever states facts. There is no tap-to-call at all, and the only real text/email action hides behind an undiscoverable right-click/long-press context menu which itself has no 'Call' option.
+- RENTALS: the 'next move' on an open rental is a status noun on a 22px pill — 'Off Rent' reads like routine progress even when it means the machine is 3 days overdue — with no verb and no primary CTA. Every outreach to the driver or customer about a specific rental is a 2-3 screen detour; the nearest one-tap contact is the roster-wide 'Text the Crew' broadcast buried in Settings.
+- Calendar/Driver: the row's entire overflow menu contains exactly one item — 'Merge trip…', a dispatcher concept. No 'running late,' 'can't complete,' or 'on my way' exists anywhere on a driver's own row, even though the capability sits one card over: the Unit card carries a working '+FC' Field Call button at app.js:7736 that simply isn't wired onto the row where the driver is standing. There is also no standing pre-populated dispatch thread to tap into.
+- UNITS: assignedMechanic appears 17 times — stored, displayed, edited, searched — and is never once used to route, filter, badge, or scope a view. Every auto-created work order is born with it blank (app.js:20009, 22445, 23005), and no 'assigned to me' filter or badge keyed off the logged-in identity exists anywhere.
+- Categories: the +Lost demand-tracking button logs to a private per-category array and toasts only the person who clicked — nobody in purchasing or fleet planning is ever told. Meanwhile Mr. Wrangler holds the fully correct live rate sheet and computes the real blended price via find_categories/price_rental, but is pull-only, never volunteered, and reachable only through a right-click.
+- RENTALS: there is no 'here's your day' surface — a dispatcher assembles the shift by scanning multiple cards; the information all exists in the data and is never composed into a start-of-shift view.
+- Customers: the improvisation proves the gap — counter staff type business state directly into the customer NAME field (balances, do-not-rent flags, credits, escalation contacts) and prefix 23 of 25 with punctuation specifically because punctuation sorts above letters in the one sort that isn't broken; the same improvisation appears in free-text notes as an ad hoc, undated follow-up tracker.
+
+## 10. Writes have no integrity layer
+
+**5 cards** · scope: `architecture` · UNITS, Customers, Categories, Calendar / Driver, RENTALS
+
+Records can be created, edited and closed out without the app checking the result is coherent. Nothing dedupes on create, nothing validates magnitude or format on entry, nothing captures the fields the business needs at the moment they exist, and nothing can delete or merge what got made wrong — so bad data is permanent and silently authoritative.
+
+**Why it persists:** Writes were added one form at a time to satisfy one screen's need, and the schema is treated as append-only storage rather than a model with invariants. Validation, dedupe and lifecycle (merge/retire) are each a feature someone would have to request, and nobody requests them until the bad data is already load-bearing — at which point deleting it is more dangerous than living with it, so the workaround (a second record, a 'Unknown category' string) becomes permanent.
+
+**The question a UI system must answer:** *What invariants must a record satisfy before it can be created, advanced or closed — and where do dedupe, magnitude/format validation, required-at-this-moment capture, and merge/retire live so that no single form can decide to skip them?*
+
+**Instances:**
+
+- UNITS: the only field writing the hour meter is `const v = Number(input.value); u.currentHours = v` — no range check, no order-of-magnitude guard, no monotonic check. Live production history on unit SPEECHLESS: 'Jun 17 — Hours: 1732.3 → 17385.5' (Cameron), corrected 'Jul 13 — 17385.5 → 1738.5' (Bri) — a 10x typo that stood 26 days feeding every service countdown, the fleet hours average, category ROI and $/Hr computations, permanently stamped onto every work order opened in that window. Separately, a blank 'hours at completion' records as 0 and sets a false countdown baseline.
+- RENTALS: 'Log Recovery' stamps only {date, video, driver} and sets Returned — no condition capture, no inspection opened, no damage line (app.js:20259-20261) — so the Rental Protection $1,000 cap (app.js:4410-4411) can never be exercised from the return path.
+- UNITS: the same gap upstream — startHours/returnHours exist on every rental unit entry, are seeded with real values and are humanized for the audit log, but have zero writers, so a unit goes out for three weeks, comes back 180 hours older, and its service countdown does not move by one hour.
+- Calendar/Driver: uploadCaptureMedia posts the walkaround video once; on network failure the catch toasts 'saved without it' for two seconds and the row still stamps green 'Logged' — a failed upload and a successful one are visually identical afterward, and that video is the only defense against a later damage claim. A failed sync holds the pending write only in RAM while the R25 banner instructs a phone user 'Don't close the app.'
+- Customers: all five creation paths mint via nextCustomerId() unconditionally with no lookup against existing phone, email or name — a captured production sort-order snapshot showed the identical customer name rendered twice.
+- Categories: nothing in the app ever deletes, merges, retires or splits a category — DATA.categories is push/read/index-only — so a typo'd or duplicate category pollutes every grid, sort and picker forever, and a unit pointing at a nonexistent categoryId renders as literal text 'Unknown category' and '—', neither actionable nor filterable. Models are append-only via two independent creation paths, neither doing a name lookup, despite one path's own comment claiming it mirrors a find-or-create idiom.
+- Calendar/Driver: timeToMin accepts colon-formatted times only — '9am', '9 AM', '0900', '9' and 'noon' all parse to null, never surfaced as an error, silently inheriting the invisible 5PM AUTORUN_EOD_DEADLINE_SEC cutoff.
+
+## 11. One Bell, Owned By Billing And Transport
+
+**5 cards** · scope: `signal` · RENTALS, UNITS, Customers, Categories, Calendar / Driver
+
+There is exactly one proactive alert channel and its payload was claimed by the invoice and transport subsystems; every other subsystem's urgency — overdue returns, failed machines, expired insurance, category stockouts — has no route into it, and one card is hardcoded as the only tab allowed to glow.
+
+**Why it persists:** The bell was built as a feature of the billing rollout and the transport rollout, each appending its own count to one expression, rather than as a subscriber to a severity bus. Because the flag engine and the alert engine were never connected, registering a new red flag is free and produces nothing — the flag author gets a colored border and reasonably assumes the alerting was handled by whoever owns the bell.
+
+**The question a UI system must answer:** *What is the single path from 'a condition became true' to 'a specific person is told', and what forces every registered flag to declare its destination on that path — including which role hears it and what happens when the app is closed?*
+
+**Instances:**
+
+- RENTALS: commsBellCount = unseenNotifs() + visibleTransportAlerts() + wranglerRequests (app.js:10342-10343) — none of the three reference the flag system, and a past-endDate leg drops OUT of the forward-windowed transportAlerts, so an overdue return isn't even indirectly counted. off-rent-overdue is a registered red flag (config.js:245) that feeds only getEntityColor, tinting the row it's already sitting in. The rentals column tab's alert is hardcoded false (app.js:9601).
+- Categories / all cards: the column-tab alert glow is literally `alert: m === 'units' && unitsAlertCount() > 0` (app.js:9644-9655) — a string match on one card name; unitsAlertCount() is the only such function that exists anywhere in the file, so no other column can ever light up no matter its internal state.
+- UNITS: the one alert indicator visible before opening the card watches only 3 of the 10 registered flag conditions (app.js:9479), and the bell itself shows 'Transports due' — a dispatch concern — while every item in the Notifications panel is invoices or card payments, none of it role-filtered (app.js:14050).
+- Customers: the same bell holds engineering tickets addressed to the owner — pricing-engine internals with GitHub links, rendered as raw unparsed markdown so authored **Verdict:** shows its literal asterisks — with nothing customer-facing in it at all.
+- Categories: has zero entries in the shared flag registry — FLAG_META (config.js:237-297) and FLAG_COND (app.js:5833-5924) both carry 5 entity keys and categories is not one, so getEntityFlags returns [] and no category condition (zero stock, unset pricing, negative ROI) can ever escalate past its own mini-card pill.
+- Every card: no OS-level channel exists — sw.js is 47 lines with no push/notificationclick/showNotification, and a grep of the 27,649-line app.js for Notification / requestPermission / setAppBadge / pushManager returns zero. Toasts self-clear in ~2.2s with no durable trail.
+
+## 12. One Red Pill, Eight Meanings
+
+**5 cards** · scope: `signal` · Categories, RENTALS, Customers, UNITS, Calendar / Driver
+
+Distinct conditions from different subsystems are funneled through the same visual channel and the same words, so the pixel a user reads is a collision site: pricing, fleet, dispatch and AR each mean something different by 'red', 'available', 'member', and the row cannot say which one fired.
+
+**Why it persists:** Color and pill shape are the only severity channels the design language exposes, and every subsystem that needed to say 'important' had exactly one way to say it, so red accreted meanings without any of them being wrong. The flag registry stores severity but not identity, so getEntityColor can only return a color — the name of the condition that fired has nowhere to render on a row. And because each card's vocabulary was authored locally, the same word ('available', 'member', 'weekend') was defined independently three times.
+
+**The question a UI system must answer:** *What is the shared vocabulary — of words, colors, and glyphs — that every card must speak, and where does a condition's NAME live on a row so that severity and identity are never collapsed into a single pixel?*
+
+**Instances:**
+
+- Categories: eight distinct unavailability reasons — N/A, Sold, For Sale, Inactive, Failed, Overdue, End Dates?, Off fleet — all render through one identical single-color red pill with no legend, via a single badge(...,'red') call (app.js:2281-2297). An actionable 'Overdue' (a customer is late returning our machine) is pixel-identical to an inert 'N/A' (we never stocked the class).
+- RENTALS: FLAG_COND.rentals defines 7 conditions — fc, overbooked, unpaid-balance, no-card, unsigned-card, unit-failed, off-rent-overdue — ALL at severity 'red' (config.js:239-253), and getEntityColor collapses to fl[0].severity (app.js:5834-5854), so the row is one uniform red. Verified scope: 3 of 7 get a distinct on-row echo, but no-card and unsigned-card are genuinely unidentifiable without a desktop hover-preview or a hop to the customer record.
+- Categories: member day-rate ($120) is a stored, first-class, edited field that the mini-card never renders — the face shows only the four retail tiers (1-Day $440 etc.) while rentalPrice() short-circuits to days × memberDaily for a member, skipping all four displayed tiers (app.js:7271-7275 vs 8876-8879 vs 1078). A rep reading the face he actually looks at overquotes a member by 267%.
+- Customers: on a live production record the account header read 'Member' while the AR block on the same screen read 'NON MEMBER MODE' for the same account. Separately, a stored 'Don't Contact' stage renders as a red pill on the row but the detail popup clamps off-vocabulary values to a calm blue 'Lead' (app.js:212-219) — opening the record to check the warning makes the warning disappear.
+- Calendar / Driver: the I.graph glyph means 'Graph view / stats' in the first toolbar slot on every other card and means 'hide the live map' in the identical first slot on Trips (app.js:9647). Categories: a rate set to 0 renders as '—' on the mini-card and '$0' in the detail (app.js:7271-7275 vs 8876-8879) — the same stored value reading as 'no tier' or 'free' depending on the surface. UNITS: 'Part Needed', 'Part Ordered', 'Part Needed?' sit side by side, and the question-mark variant renders red on one tile and amber on the next.
+- The consequence is documented on Customers: because pay status never updates, red never says why, and only one sort works, counter staff have been typing business state into the customer NAME field — balances, do-not-rent flags, credits, escalation contacts — prefixing 23 of 25 with punctuation specifically because punctuation sorts above letters in the one sort that isn't broken.
+
+## 13. Doors Walled Over
+
+**5 cards** · scope: `architecture` · UNITS, Customers, RENTALS, Categories, Calendar / Driver
+
+When a card was retired, the capabilities that lived on it stayed fully built underneath but lost their only entry point, and no other card adopted the step — so a whole job in the chain has working code, gates, confirms and audit entries, and no button.
+
+**Why it persists:** Cards were retired by deleting a renderer, not by re-homing the jobs that renderer hosted. Because the handlers, permission gates, confirm dialogs and audit writes all survive, every grep and every code review says the feature is present — the only missing piece is a button, which is invisible in the diff. Nothing in the codebase maps a job to the card that owns it, so retiring a surface has no checklist and no failing test.
+
+**The question a UI system must answer:** *When a surface is retired, what names the jobs it was carrying and forces each one to be re-homed to a specific card — and what makes an implemented-but-unreachable capability show up as broken rather than as present?*
+
+**Instances:**
+
+- UNITS: the Shop card is retired and work orders now live inside each unit, so there is no fleet-wide open-jobs view. Merle, driving it live: "the Shop card's gone. Work orders live down inside each unit now. So there's no one place I can stand and see every open job. I gotta open machines one at a time." The ex-Shop quick filters '__wo' (WOs Open / Parts Ordered) and '__svc' (Service Due) are fully implemented with human labels and nothing links to them (app.js:3167); completed and cancelled work orders have no home anywhere (app.js:7669).
+- UNITS: every work order's phase pill is frozen at its creation value because the code that advanced it lived in the retired Shop-card renderer and is unreachable from Units (app.js:6978).
+- UNITS: js-open-insp — the only link to a failed inspection's photo/video report — is emitted exclusively by the dead Shop renderer (app.js:9127); the unit's own Inspection section renders no thumbnail or link.
+- UNITS: the only ETA editor for an ordered part lives on the retired workOrders detail renderer, which app.js:3052 unconditionally redirects away from. The partform has no date input, savePartForm initializes eta:'' and never touches it — so part-ordered-eta can never fire and its sibling part-ordered-no-eta is permanently true (app.js:5874, 8016).
+- Customers: Send to Collections and Void Invoice are built end to end — manager gate, confirm popup with reason codes, overlay, auto-blacklist, audit-log entry, money-safe void handler (app.js:18671, 18692, 18712-18716) — but their only trigger buttons render inside the retired Invoices card (app.js:8974-8979, 8991-8995). Verified live: the status menu on a real Late invoice offers exactly Pay, Print, and Send (greyed). Two invoices on one real account already read VOIDED, so the capability was in use.
+- RENTALS: the multi-driver lane rail and the one-tap 'Round up' auto-balance handlers exist (app.js:11802-11805, 18629-18636) but nothing renders their buttons — with 12 stops and 3 trucks a dispatcher can only tap +Driver one stop at a time, with no 'who's carrying what' load view.
+- Customers: commsCustSectionHtml() — the per-customer conversation panel — has zero call sites, and a stale in-code comment still names where it renders.
+- Calendar / Driver: dead .js-disp-day / .js-disp-today day-reset handlers exist (commented Phase 6) and are emitted by no template, which is why a map stuck on a future day has no recovery but a full page reload (app.js:11796).
+- Categories: the '+Lost' demand button logs to a private per-category array and toasts only the clicker; the 'Lost Demand' rollup board specified in docs/specs/market-research.md §6.3 was never built, so purchasing is never told.
+
+## 14. No One Gets Told
+
+**5 cards** · scope: `architecture` · RENTALS, UNITS, Categories, Calendar / Driver, Customers
+
+The app has no messenger. Every state change writes to data and stops there — nothing crosses to the person on the other card, on the other device, or off the screen — and four independent audits found the same void from four different seats.
+
+**Why it persists:** Notification was scoped as a channel feature (web push, SMS) rather than as the required completion of a write, so it sat behind a phase gate while the writes themselves shipped card by card. Every handler's definition of done is 'the record changed' — logAction + saveSoon — and there is no shared commit path that asks who else is affected. The Settings toggles prove the intent was captured; what is missing is the obligation.
+
+**The question a UI system must answer:** *For every write in the app, who else is affected — and what makes 'the affected party was told' part of the commit itself rather than a separable channel feature that can be deferred indefinitely?*
+
+**Instances:**
+
+- RENTALS: sw.js is 47 lines, documented 'OFFLINE SHELL ONLY' — install/activate/fetch/message listeners only, no push, no notificationclick, no showNotification, no pushManager.subscribe. A grep of the 27,649-line app.js for Notification / requestPermission / setAppBadge / pushManager returns zero. Close or background the app and zero alerts reach the dispatcher. UNITS, Categories and Calendar each rediscovered this independently — four cards, one hole.
+- Calendar / Driver: assignStopDriver()'s only effect on a successful assignment is pushing a line into a hidden per-rental audit array (app.js:11341-11352, 22575). All three call sites traced (single-stop picker, drag-and-drop, bulk 'Round up'); the one toast() anywhere in the chain fires in the DISPATCHER's own browser. The driver is never told he has a job.
+- Calendar / Driver: Settings → Notifications → Crew Alerts already ships a toggle literally named 'Driver Assigned' — 'Texts a driver the moment a delivery or pickup is assigned to them' — defaulted off (app.js:5161) and explicitly commented inert until a later phase ships the SMS path (app.js:5282, 5291). The product already named the fix.
+- Customers: live, saveable Settings toggles for customer reminders and dispatch ETAs whose engines are inert — the toggle only persists its own state, so anyone flipping it on reasonably believes the app is now chasing customers.
+- Categories: committing a rate edit — admin inline-edit or a Mr. Wrangler chat write — fires zero toast, team-dock ping or push, not even to the person who made the edit; the shared efld() 'field' commit closure (app.js:19658-19668) is the one edit path in the app silent to its own author, while js-lost-demand, js-spe-accept and js-blacklist all toast the actor.
+- RENTALS / Customers: refreshCommsThreads appears in neither of the app's only two setInterval calls (GPS timer app.js:24080; 18s backend poll app.js:24796) and refreshFromBackend never calls it — a customer's text or email reply can sit unseen until someone manually clicks a comms chip or reloads. A dead comms backend renders identically to a quiet day.
+- UNITS: all ten FLAG_COND.units predicates — service-past-due, inspection-failed, uninsured-active, coverage-expired, wash-requested — fire silently into data with no messenger, and toast confirmations self-clear in ~2.2 seconds with no durable trail.
+
+## 15. Lifecycle Sorts The List, Danger Doesn't
+
+**4 cards** · scope: `architecture` · RENTALS, UNITS, Customers, Calendar / Driver
+
+Two taxonomies contest the vertical axis of every list — a lifecycle/stage grouping that owns the buckets and headers, and a flag/severity system that owns the colors — and the grouping never consults the flags, so the emergency is filed under whatever calm stage it happens to be in.
+
+**Why it persists:** Grouping, sorting and flagging were built as three independent registries — GROUP_DEFS / UNIT_SECTIONS, SORT_FIELDS, FLAG_META+FLAG_COND — with no contract between them, and grouping is applied before sorting in the render pipeline so it structurally outranks any sort the user picks. Each card's group definition was authored by whoever built that card, against its own domain vocabulary, and nothing forces a group definition to declare how severity affects it.
+
+**The question a UI system must answer:** *Does severity outrank taxonomy in a list — and if so, what single composition rule governs how a flag promotes a row, colors its bucket, and forces a collapsed group back open, so that no card can define a grouping that a red condition cannot escape?*
+
+**Instances:**
+
+- RENTALS: GROUP_DEFS.rentals keys buckets off lifecycle status via rentalRevStatus (app.js:9312-9316, app.js:1986-1990) and never consults a flag — unlike UNIT_SECTIONS (app.js:9279-9290) which has an explicit red 'Attention' bucket fed by unitStageKey. There is no 'Needs Attention' bucket on Rentals, the header count never reflects severity, and flagged rows aren't lifted within their group. Verifier: PARTIAL — the row itself does render red, so the gap is specifically at header/count/sort level.
+- UNITS: setting the sort to 'Service Due' does not sort by service due — grouping wins, so the sort only reorders within a bucket. A machine 1,139 hours overdue sits at position 9, filed under the green 'AVAILABLE' bucket (app.js:9294, 9304). And a machine that fails inspection while actively on rent never reaches 'Needs Attention' at all (app.js:9294-9307).
+- Customers: grouping is by pay status only (app.js:9317-9319), so a blacklisted, no-card customer at $0 owed sits under a calm green 'Current' header — the header a person scans first carries no aggregate danger signal.
+- Calendar / Driver: 'Earlier' — the only bucket where undone past-day trips live — is the sole default-collapsed group on any card (app.js:9358) and its color is a hardcoded 'gray' literal (app.js:9333, 9340) that can never receive sec-danger styling, which only fires on color==='red' (app.js:9423).
+- RENTALS: recoveries get no forward-looking bucket at all — a unit due back today sits in 'On Rent' with no distinguishing signal, and the first time it is grouped as urgent is after off-rent-overdue trips, i.e. the day after it's late (app.js:2016-2017).
+
+## 16. Retired Cards Left Their Work Behind
+
+**4 cards** · scope: `architecture` · UNITS, Customers, RENTALS, Categories
+
+Whole subsystems were retired by deleting their renderer while leaving their handlers, gates, buckets and confirm flows live — so fully built, fully gated capabilities now sit unreachable inside the surface that won the real estate, and the stranded copy still instructs users in the retired idiom.
+
+**Why it persists:** Cards are retired by removing them from the COLUMNS/board config, which unrenders the surface but leaves every delegated click handler, gate, and helper live in the same 27,649-line file. Nothing links a handler to the renderer that was its only entry point, so retirement produces no error, no dead-code warning, and no inventory of what just became unreachable. The receiving card then absorbs the orphaned domain without inheriting its controls.
+
+**The question a UI system must answer:** *When a surface is retired, what forces an explicit disposition for every capability it hosted — rehomed, deliberately dropped, or blocked — so that a card cannot silently inherit a domain without inheriting the controls that domain needs?*
+
+**Instances:**
+
+- Customers: sending an account to collections and voiding a bad invoice are built end-to-end — manager gate, confirm popup with reason codes, overlay, auto-blacklist, audit-log entry, money-safe void handler (live handlers at app.js:18671, 18692, 18712-18716) — but their only trigger buttons render inside a standalone Invoices card that was retired (config.js:421-426) and never renders anywhere; the reachable menu at app.js:4842-4856 lacks them.
+- UNITS: every work order's phase pill is frozen at its creation value on the tile, because the code that ever advanced it lived in the retired Shop-card renderer and is unreachable from Units (app.js:6978). Likewise a failed inspection's photo/video report has no door from the unit's own record — the only link to it is emitted exclusively from the retired Shop renderer (app.js:9127). And with Shop gone there is no place to see every open work order across the fleet, while completed and cancelled WOs have no home at all.
+- RENTALS: touch drag-to-link was retired 2026-06-29 (app.js:17813) and a phone finger-drag is now silently disarmed (ready stays false, app.js:17892-17904) — no link, no ghost, no feedback — while six empty-slot toasts (app.js:19046, 19054, 19082, 19574, 19579, 19592) kept telling the user to 'drag' with no is-phone branch. Copy fixed in PR #740; the unsignposted 500ms long-press is still the only path.
+- Categories: clicking an 'Off Fleet' stock segment routes to Units, but cardListEl strips every non-Active unit before the per-card filter runs (app.js:9884 vs 9898), so the click lands on an empty state — even though a correct 'Out of Fleet' section bucket exists in the code at app.js:9332-9348 and is never reached, and rentalsVisible already has the reveal-when-filtered pattern this doesn't mirror (app.js:6825-6828).
+- Customers: a fully built per-customer comms panel with zero call sites; Categories: a '+Lost' demand button that logs to a private array because the 'Lost Demand' rollup board specified in docs/specs/market-research.md §6.3 was never built (config.js:403-410 has no 'demand' entry).
+
+## 17. Desktop Pointer And Gloved Thumb On One Surface
+
+**4 cards** · scope: `interaction` · UNITS, Calendar / Driver, RENTALS, Customers
+
+The same screen is authored for a mouse with hover and a precise click, and used by a driver in a cab and a tech on a yard tablet — so the meaning of the screen lives in hover states, and the destructive actions live where the hand is already travelling.
+
+**Why it persists:** Hover was treated as free display surface because it costs no layout, so density problems were solved by moving meaning into tooltips — which is an invisible decision on a desktop and a total loss of information on touch. The same reasoning made the hover panel reuse the real detail renderer rather than a read-only summary, since reuse looked like the disciplined choice. Nothing in the codebase distinguishes 'reveal' from 'commit' as classes of interaction, so both live in the same panel.
+
+**The question a UI system must answer:** *What information is allowed to exist only on hover — and what separates a surface that reveals from a surface that commits, given the same screen is used by a mouse at a desk and a glove in a cab?*
+
+**Instances:**
+
+- UNITS: the hover-preview panel that looks like a tooltip is the full live DETAIL.units() markup with pointer-events:auto explicitly set (style.css:825, app.js:3008), positioned 10px right of and centred on the cursor (app.js:3021-3028) — 13 live controls, none disabled, at z-index 9000, including '✕ Fail' which fails the machine and opens a work order in one click. Live repro: hovered a tile to look at it, clicked once, got 'Wash logged — countdown reset' — a real production write, no confirmation.
+- UNITS: 58 of 86 interactive controls on the mechanic's screen carry no visible name; 52 of those are explained only by a hover tooltip; zero aria-label exists anywhere in the set. Meanwhile the Tools menu opens downward from a bottom-bar button with no viewport-collision detection and no internal scroll — at a 576px-tall viewport it clips 6 of its 10 items, including the one switch that disables the hover-preview trap.
+- Calendar / Driver: the row prints a town name ('Lake Charles') while the full street address exists in the DOM only as a hover data-tip (app.js:7366, 9670) — a driver in a truck with a glove will never trigger it. 'Open in Google Maps' only renders once a stop is focused inside the collapsible map panel (app.js:9660-9673). The map itself is hardcoded 260px inside the card's 333px scroll region (style.css:903), occupying 78% of first paint before a single trip row appears.
+- RENTALS: on a phone the entire link-a-record system is reachable only through an unsignposted 500ms long-press → context menu → '+ Rental'/'+ Unit', with nothing signposting it (app.js:19046/19054/19082 vs app.js:17813-17826).
+- UNITS: attaching a machine to a rental has exactly one path — drag-and-drop; the +Unit button opens no picker, it toasts 'Drag a unit from the Units card onto this rental' (app.js:17568). A user who will not drag cannot build a rental at all.
+- UNITS: a pill tap gives no feedback while the 220ms double-click discriminator resolves, so an impatient second tap silently forks a new browser tab instead of registering the intended action.
+
+## 18. Two Truths, One Screen
+
+**4 cards** · scope: `signal` · Customers, Categories, UNITS, Calendar / Driver
+
+The same fact is computed independently at every place it appears — live from source records here, from a stored field or a differently-scoped tally there — so two answers to one question render inches apart with nothing marking which is authoritative.
+
+**Why it persists:** Facts in this app have no owner. There is no single named derivation for "does this customer owe us", "is this unit rentable", or "what phase is this WO in" — each render site computed what it needed at the moment it was written, and a canonical helper existing (isUnitRentable, app.js:2251) does not stop the next surface from re-deriving beside it. Because the duplication is invisible in the code and invisible on the screen, fixes land on exactly one surface: the fleetStatus availability fix reached the mini-card and never travelled the ~5,000 lines to the detail. Nothing makes a second definition visible as a second definition, to a reviewer or to a user.
+
+**The question a UI system must answer:** *What is the one named, single-sourced derivation for each business fact the UI is permitted to display, and how does a surface render a fact it does not own — so that writing a divergent second computation is structurally impossible rather than merely discouraged?*
+
+**Instances:**
+
+- Categories — same category, same second: the 12k Excavator mini-card reads "NEXT MON" (zero free) while the detail reads "9 Available" (11 units minus 2 on rent, nothing excluded for Sold/For Sale/Inactive). Lift Scissor 19ft: mini-card "2 Avail", detail "5 Available" — the 3 extra are sold machines. A comment at app.js:7212 shows this exact bug class was fixed on the mini-card 2026-06-25; the fix never reached the detail renderer (unitRentalBucket, app.js:2300-2305, has no fleetStatus check).
+- Customers — the row computes an accurate live owed/overdue figure from real invoices every render (app.js:7149-7161) while the group header, the sort field, the filter and the pulsing detail flag all read a stored payStatus written once at signup (app.js:9317-9319, 8351-8352, config.js:430). Two contradictory answers to "does this person owe us" sit inches apart.
+- Customers — on one real account, simultaneously on screen: spend-chart callout "$47,720 · BEST · APR" (rental list price over a 9-month window) versus Transactions tab "$2,834.84 collected, 1 payment, 0 refunds", 1-year average $236.24, open balance $13,240.52 — roughly a 17x overstatement, different basis, different period, neither labelled, and the caption beneath still read "No rental cadence yet."
+- Customers — a live production account carrying a $1,306.85 balance showed "Member" in the detail header and "NON MEMBER MODE" in the AR block directly below it (observed live in session; flagged as not independently re-verified by the adversarial pass).
+- Customers — a stored "Don't Contact" stage renders as a red pill on the row and on the Sales pipeline board, but the detail popup clamps off-vocabulary values to a calm blue "Lead" (app.js:212-219), so opening the record to check the warning is what makes the warning disappear.
+- UNITS — every work order's phase pill on the tile reads raw w.phase, frozen at creation, while the unit's own accordion below shows the live derived woBottleneck. Two definitions of "what phase is this WO in" coexist on one screen; the code's own comment (app.js:22610-22613) says the displayed status is meant to be derived.
+
+## 19. The Number Doesn't Own Its List
+
+**4 cards** · scope: `signal` · UNITS, Categories, Calendar / Driver, RENTALS
+
+A count is tallied over one population and then used as the label for a click that produces a different population — or for a list it does not scope at all — so tapping a number is the most reliable way to discover the number was wrong.
+
+**Why it persists:** Counts are written as display strings at the point of render, not as queries over a named record set. A tally and its drill-through are two separate pieces of code with no shared predicate, so agreement is a coincidence that must be re-achieved by hand every time either side changes scope, and nothing tests it. Worse, badges and bells are aggregates of hand-listed sources — adding a condition to the flag registry adds it to no count — so the registry grows and the numbers on the chrome silently keep their old meaning.
+
+**The question a UI system must answer:** *Must every displayed count be the literal length of the exact record set its own click produces — and where a number cannot own a list (a bell, a tab badge), what states on the number itself which population it covers and which it excludes?*
+
+**Instances:**
+
+- UNITS — the Worklist graph reads "NOT READY 28" while the group bar roughly 40px below on the same screen reads "NOT READY · 8", same label. The graph tallies every unit in DATA.units unconditionally (app.js:12167-12170); the list grouping excludes out-of-fleet and on-rent units first (app.js:9295). A third, narrower definition lives in unitsAlertCount (app.js:9479) — three definitions of "needs attention" on one card.
+- UNITS — the Work Orders bar counts one entry per open work order but the click-through filters the unit list, so a unit carrying 2 open WOs is counted twice on the bar and appears once beneath it. The number structurally cannot match its own rows.
+- Categories — clicking an "Off Fleet" stock-count segment routes to Units, where cardListEl strips every non-Active unit before the per-card filter runs, so the click lands on an empty "No Unit" state even though an "Out of Fleet" section bucket exists in code and is never reached.
+- Calendar / Driver — the Trips tab badge read 4 while the collapsed "Earlier" group held 6 stops / 2 done = 4 more undone, two of them 78 days old, none of which touch the badge (app.js:9471-9472). Separately, the group header's "· N done" counts whole trips, so a 4-stop run with 3 logged contributes zero.
+- RENTALS — an overdue return contributes to no count anywhere: commsBellCount = unseenNotifs + visibleTransportAlerts + wranglerRequests (app.js:10342-10343), none of which reference the off-rent-overdue flag, and a past-endDate leg drops OUT of the forward-windowed transportAlerts so it isn't even indirectly counted. The rentals column tab alert is hardcoded false (app.js:9601). The flag tints only the row it is already sitting in.
+
+## 20. A Stored Mirror Nobody Re-Derives ⁿ
+
+**4 cards** · scope: `architecture` · RENTALS, Customers, UNITS, Calendar / Driver
+
+Denormalized fields — a primary-unit pointer, a pay status, a WO phase, an on-hand quantity, an hour meter, a sync flag — are written once and then read as current everywhere, with no invalidation, no re-derive pass, and nothing in the UI distinguishing a mirror from a measurement.
+
+**Why it persists:** Each mirror was introduced for read speed or cross-card convenience, and keeping it fresh was the private responsibility of whatever feature created it. When that feature moved (Shop card retired), was never built (returns capture, hour-meter rollup), or lives only in the backend (payStatus), the mirror keeps rendering its last value at full confidence — a stale field and a live one are byte-identical on screen and nearly identical in code. There is no ownership record saying who re-derives what and on what trigger, so no reviewer can see a mirror going stale, and the app's own spec can document the gap without any surface changing.
+
+**The question a UI system must answer:** *Which values are allowed to be stored rather than derived, what re-derives each one and on what trigger — and how does the UI itself mark a mirror as a mirror, so a value that has not been re-checked can never read as a fresh measurement?*
+
+**Instances:**
+
+- RENTALS — markFieldCall(rentalId) reads only r.unitId, documented as the PRIMARY-unit mirror (app.js:345-349, resynced every load at 368) and never the clicked unitId, which is in scope at both call sites (app.js:20045, 20264). The genuinely broken non-primary machine never gets inspectionStatus='Failed', so isUnitAvailableFor (app.js:2064-2067) keeps it bookable, while the untouched primary is flagged Failed and receives the work order. CONFIRMED; fixed in PR #740 — the mirror pattern it exploited is untouched.
+- Customers — repo-wide grep found zero writes to payStatus outside the five creation paths, all of which set 'New Customer', and there is no in-app editor for the field at all (the column that looks editable is read-only display). The team's own spec, docs/specs/customers-crm.md:642-650, dated nine days before this audit, already records: no derive-from-open-invoices pass exists, "STILL an open question."
+- UNITS — startHours / returnHours exist on every rental unit entry, are seeded with real values and are humanized for the audit log (app.js:22577), but grep for their assignment returns zero sites and nothing rolls returnHours into unit.currentHours. A machine goes out three weeks, comes back 180 hours older, and every service countdown derived from that meter moves by zero unless someone hand-types it into the one manual field that writes currentHours (app.js:19644).
+- UNITS — the WO phase pill is frozen at creation because the only code that advanced it lived in the retired Shop-card renderer; and qtyOnHand renders as live stock on a work-order line but is never decremented when a part is consumed. Merle works a job all day and his tile never changes.
+- Calendar / Driver — state.tripsSyncStatus starts null and only flips to 'synced' after a push/pull succeeds, so the pinned footer reads "Offline — cached" regardless of real connectivity on first paint, and nothing re-checks after that first success, so it reads "Synced" just as readily after signal is lost (app.js:2502, 11390/11413, 11499).
+
+## 21. Names That Don't Describe The Effect
+
+**4 cards** · scope: `interaction` · Categories, UNITS, Calendar / Driver, RENTALS
+
+Controls and metrics are labelled for what someone assumed they did, and the label survives the code changing underneath it — so the user's model of the screen is built from text the screen no longer honours.
+
+**Why it persists:** Labels are string literals at the render site with no link to the predicate, formula, or handler behind them, so changing a behaviour costs nothing and updating its words is a separate act of memory that nothing enforces or tests. Metric names in particular were chosen from the business question the owner asks ('On-Time') rather than from the formula that was actually available, and once shipped the name became the spec that nobody re-read against the code.
+
+**The question a UI system must answer:** *What binds a control's label to the operation it performs and a metric's label to its formula — including its population and its period — so that changing the behaviour forces the words to change with it?*
+
+**Instances:**
+
+- Categories — the circular icon on a filter chip reads as a clear/remove control and actually negates the filter. Live-confirmed: clicking it turned the chip red ("excluding") and the list visibly changed, so the natural read is "it worked" — while the user is now viewing the exact complement of what they asked for. No remove control appears on hover either (app.js:3287-3297 + 19041, which checks .js-ft-neg first and returns before reaching the actual remove path).
+- UNITS — 'Sold/Inactive' and 'All Units (any status)', two controls that change which machines exist, sit under a menu header reading SORT alongside controls that only reorder, with no visual distinction between the two kinds. Picking one expecting a reorder gets a scope change.
+- Calendar / Driver — the KPI labelled 'On-Time' (config.js:311) is computed as delivered-or-handled ÷ scheduled (app.js:10015): a completion rate with no comparison to t.time or the implicit 5PM deadline anywhere in the formula. A driver late on every stop who eventually finishes them all scores 100% on the metric the app grades him on.
+- RENTALS — six empty-slot toasts (app.js:19046, 19054, 19082, 19574, 19579, 19592) instructed the user to 'drag', a touch gesture retired 2026-06-29 (app.js:17813), with no is-phone branch — while a phone finger-drag was silently disarmed and the only real path was an unsignposted 500ms long-press. Copy fixed in PR #740; the label-outlives-behaviour mechanism did not change.
+- Categories — the sort menu offers ROI, Unit Count and Avg Hours as sort fields, none of which the default mini-card face renders, so choosing one reshuffles the entire grid on a criterion the user cannot see.
+
+## 22. Every Card Grades Its Own Homework
+
+**4 cards** · scope: `signal` · UNITS, Categories, RENTALS, Customers
+
+'Is this OK / available / attention-worthy' is recomputed independently on every card from a different subset of the same shared flag registry, so the same machine or customer answers differently depending on which card you are standing on.
+
+**Why it persists:** The flag registry is a shared vocabulary but not a shared computation. Each surface builds its own predicate at the point of render, and each one is individually correct for the question its author had in mind. Nothing forces a new consumer to declare which definition of 'OK' it means, and no test ever compares two surfaces' answers about the same record — so divergence is invisible until two of them appear on screen 40 pixels apart.
+
+**The question a UI system must answer:** *What is the single authority that answers 'can this go out / does this need attention,' and how does every surface — badge, bucket, drag target, count, graph, sort — become a view of that one answer instead of its own private copy?*
+
+**Instances:**
+
+- UNITS: the drag-drop filter that governs what can actually attach to a customer rental checks only fleetStatus==='Active' (app.js:17568). Worm — failed inspection, 2,882 hrs overdue on service — attached instantly, and a search of the entire rental detail for 'failed, not ready, overdue, service, inspect, warning, caution, unsafe' returned nothing. isUnitRentable (app.js:2251) DOES exclude failed inspections but only feeds the availability COUNT. Two competing definitions of rentable, one of which never touches the gate.
+- UNITS: unitsAlertCount (app.js:9479) watches 3 of the 10 registered flag conditions, ignoring failed inspection, overbooked, GPS offline, coverage-expired and uninsured-active — including the two that put an unsafe or uninsured machine on the road. The tab badge, card border, corner-flag pill and group bucket each reimplement their own different subset of the same 10-flag registry.
+- UNITS: the Worklist graph reads 'NOT READY 28' while the group bar roughly 40px below it on the same screen reads 'NOT READY · 8' — the graph tallies every unit in DATA.units (app.js:12167-12170), the list excludes out-of-fleet and on-rent units first (app.js:9295), and a third narrower definition lives elsewhere.
+- Categories: same category, same second — the 12k Excavator mini-card reads 'NEXT MON' (zero free) while the detail reads '9 Available', because unitRentalBucket (app.js:2300-2305) has no fleetStatus check and the mini-card (app.js:7216-7225) restricts to Active. Lift Scissor 19ft: mini-card '2 Avail' vs detail '5 Available' — the 3 extra are sold machines.
+- Categories: Categories has ZERO entries in the shared flag engine (FLAG_META config.js:237-297, FLAG_COND app.js:5833-5924, both carrying the same 5 entity keys) — no getEntityFlags('categories', ...) call exists anywhere, so no condition on a category can ever escalate past its own mini-card pill.
+- RENTALS: GROUP_DEFS.rentals keys buckets off lifecycle status (rentalRevStatus, app.js:1986-1990) and never consults a flag, unlike UNIT_SECTIONS which has an explicit red 'Attention' bucket fed by unitStageKey (app.js:9312-9316 vs 9279-9290).
+- Customers: the row computes an accurate live owed/overdue figure from real invoices every render, while the group header, the sort field, the filter and the pulsing detail flag all read payStatus — a stored field with zero write sites outside the five creation paths, all of which set 'New Customer'. 2,260 of 2,265 customers therefore fall into an unnamed grey leftover bucket; only 5 sit under 'Current'.
+
+## 23. Nobody's Name On Any Job
+
+**4 cards** · scope: `architecture` · UNITS, Calendar / Driver, RENTALS, Customers
+
+Work is never addressed to a person. Assignment fields are stored, displayed, edited and searched, but no view is ever scoped to 'mine' — so every worker reconstructs their own queue by reading the whole board.
+
+**Why it persists:** The app is modelled as a set of entity browsers — units, customers, categories, rentals, trips — where a person is an attribute on an entity rather than a lens over the board. ROLE_LANDING sets a starting view but never a filter, so 'who is this for' has nowhere to live in the render path. Assignment therefore reads as documentation rather than as routing, and nobody's screen changes when it is set.
+
+**The question a UI system must answer:** *What does 'my work' mean for each role, and which surface is authoritative for it — so that assigning a job is a routing decision that changes another person's screen, not a text field on a record?*
+
+**Instances:**
+
+- UNITS: assignedMechanic appears 17 times across the codebase — stored, displayed, edited, searched — and is never once used to route, filter, badge or scope a view. Every auto-created work order is born with it blank (app.js:20009, 22445, 23005). There is no 'assigned to me' filter or badge keyed off the field and the logged-in identity anywhere in the app.
+- Calendar / Driver: tripsFor() / dispatchEvents() apply ZERO identity filtering — every driver's trips plus the entire unassigned pool render on one shared list, even though the code's own landing comment calls this screen 'the driver's day' (app.js:11285-11302, 9674; comment at 25636-25644). myRosterId() already exists (app.js:10582) and is used to scope team-chat visibility, and is never wired into the Trips list.
+- UNITS: the one proactive notification bell a mechanic sees reads 'Transports due · 2' — a dispatch concern — and the panel holds exactly 6 items, all invoices and card payments, none role-filtered for a mechanic.
+- RENTALS: no per-rental 'text driver' or 'text customer' action exists on the row or the detail; reaching a thread is a 2-3 screen detour, and the nearest one-tap contact is the roster-wide 'Text the Crew' broadcast buried in Settings.
+- RENTALS: there is no daily digest or morning brief — nothing summarizes returns due, field calls and unpaid balances at clock-in. The data all exists and is never composed into a start-of-shift view.
+- RENTALS: on a day-one empty roster the +Driver chip is suppressed, and the 'add drivers first' hint fires only FROM that suppressed chip (app.js:7356/7359, 18614/18618) — the guidance is gated behind the control that hides when the precondition is true.
+- Customers: across 400 rendered production rows, 96% of rows carrying a balance had a clipped phone number (22 of 23) versus 25% of rows without one — a customer owing $13,240.52 rendered as '(337) …'. The accounts she most needs to call are precisely the ones whose number she cannot read.
+
+## 24. Last Save Wins, Quietly
+
+**4 cards** · scope: `interaction` · UNITS, Categories, Customers, RENTALS
+
+When two people touch the same record from two cards, one person's work is discarded with no notice to either of them — and the sync that would have revealed the change is skipped at exactly the moment someone is working.
+
+**Why it persists:** The sync layer was built to keep ONE person's screen fresh, not to arbitrate between two people's edits, so its only concept of conflict is 'local is dirty, keep local.' Because the loser is never told and the winner never knows they won, the failure produces no report at all — it reads as somebody forgetting to save, which is why it has survived.
+
+**The question a UI system must answer:** *When two people work the same record from different cards, what does each of them see — and what is the app obliged to say when their edits collide, instead of picking a winner silently?*
+
+**Instances:**
+
+- UNITS: sync is whole-record last-write-wins with no field-level merge and no conflict notice of any kind. If the local copy of a unit has any unsaved edit, the incoming remote version is discarded entirely and the local record is pushed over it on the next flush; the only reconciliation branch in the whole 18-second poll is a narrow invoice-id collision heal — units get none (app.js:24778). Concretely: Merle types an hour-meter reading in the yard while Dale completes the 250-hour service in the shop, and one of the two entries is silently destroyed.
+- Categories: refreshFromBackend patches remote data into local records with a plain Object.assign + render() and no changed-key capture; no 'recently changed' CSS class, flag or highlight logic exists anywhere in the file (app.js:24823-24866, 24848, 24863). A rate can change under a rep mid-shift with zero visual cue — including the rate he is about to quote out loud.
+- Categories: the same poll is guarded at app.js:24825 on document.hidden / DRAG / overlay / hoverNode — so with any popup open (a rental, Mr. Wrangler, Settings, all common) the refresh does not run at all and the user silently stops receiving updates for as long as he is working.
+- Customers: clicking an invoice belonging to a different customer than the one currently open silently spawns a whole new session tab and swaps all three columns, with no cue distinguishing 'a new tab opened' from 'the view updated' (app.js:2718-2727, 2608-2625) — confirmed intentional in a 'Task 5' comment, shipped with no signal.
+- RENTALS: scroll 'preservation' is positional, not record-anchored — scrollMemo is keyed only by card|view and restored by raw pixel offset (app.js:17185-17190, 17229-17234), and status is a selectable sort field (config.js:431). Acting on a row re-sorts the list and lands the viewport on a DIFFERENT rental, while the toast says only 'Status → X' with no cue about who was hit. Verifier CONFIRMED.
+- Calendar / Driver: the app-wide scroll memory reads/writes .card-body's scrollTop across 5 call sites, but on Trips .card-body is overflow:hidden and the real scroller is .cal-scroll — so a driver reading his list is snapped to the top by an 18-second background poll triggered purely by office activity elsewhere, with zero visible cause (style.css:900-901; app.js:17186-17190, 17229-17233, 24792).
+
+## 25. Gates are attached to controls, not to data
+
+**3 cards** · scope: `architecture` · UNITS, Customers, Categories
+
+Permission is enforced wherever someone remembered to enforce it — on a specific button, inside a specific renderer — never on the datum itself. So the same value is masked on one surface and printed on the next, and the authority to create a record is decoupled from the authority to make the created thing safe.
+
+**Why it persists:** There is no classification on the data — no 'this field is money/margin/PII tier' property that every renderer, column definition, sort key, chart and export must consult. Gating is therefore a per-call-site decision made by whoever wrote that call site, and every new surface reading the same field starts ungated by default. The create/edit asymmetry is the identical absence seen from the other side: authority was assigned to handlers, so no one ever compared two handlers on the same object.
+
+**The question a UI system must answer:** *What marks a field as money/margin/PII-tier at the data layer so every surface that can display, sort, chart or export it inherits the gate automatically — and what forces the authority to create a record and the authority to make it safe to use to be the same authority?*
+
+**Instances:**
+
+- Customers: dollar figures are deliberately masked to $••• in the History log for roles without money permission, while the invoice list, open-balance strip, Transactions tab and 'total paid' stat on the very same customer screen render live amounts with no role check at all — and the Customers card has no role gate on opening it, so a mechanic or driver login sees every customer's live balances and payment history in full.
+- Categories: ROI/margin is money-tier-gated in the detail view, but the same categoryStats().roi value is registered as an ungated list column with a coloured pill in the card's default layout AND as an ungated sort key — a below-money-tier user can read the exact percentage off the list or infer the whole fleet's profitability ranking just by sorting on it.
+- UNITS: the Round-Up Reports board's Money section — revenue, net sales, top customers, open account balances — renders unconditionally for every signed-in role with no permission check.
+- Categories: the authority matrix is inverted — creating a category is completely ungated (no admin check anywhere on the create handler) while editing a rate field on that same category is explicitly admin-gated. A non-admin can mint unlimited live categories but cannot price any of them, which is plausibly how the observed unpriced live LIFT SCISSOR 19FT record came to exist and show a bright green availability pill over $0 rates.
+- Customers: adding a card on file is gated to Office/Admin with a toast; removing one, or changing which card is the default, has zero permission check twelve lines below.
+- Categories: the same absence over-gates in the other direction — the Category field on a Unit renders as an admin-gated reassignment select rather than the ordinary navigable pill Rentals and Work Orders use for the identical reference; and the audit-log redaction blanks the entire line ('1-Day rate: $••• → $•••') so a lower-tier viewer cannot even see THAT a rate changed.
+
+## 26. Everything still assumes one record per thing ⁿ
+
+**3 cards** · scope: `architecture` · UNITS, Calendar / Driver, RENTALS
+
+The data model grew multi-unit rentals and merged multi-stop trips; the UI and its logic did not. Wherever a container holds more than one child, the app silently substitutes the primary child for the whole — acting on the wrong record, hiding the worse one, and counting progress as zero until everything is done.
+
+**Why it persists:** Multi-unit rentals and merged trips were introduced as a data change with a compatibility shim — a scalar primary mirrored off the array and resynced every load. Every consumer written before the change kept reading the shim, and because the shim is always populated, nothing ever throws: the wrong record is simply acted on. The failure only becomes visible out in the physical world (the wrong machine gets the truck), which is why it survived until RENTALS was walked against real multi-unit data.
+
+**The question a UI system must answer:** *When a record contains many, what is the rule for which one an action targets, which one a summary reports, and how progress across the set is displayed — and what makes the legacy primary-scalar shim unreadable to new code so this class cannot be reintroduced?*
+
+**Instances:**
+
+- RENTALS: markFieldCall(rentalId) reads only r.unitId — documented as the PRIMARY-unit mirror (app.js:345-349, resynced every load at app.js:368) — and never the clicked unitId, which IS in scope at both call sites (setUnitCondition's Fail path app.js:20045, and the +FC yard capture app.js:20264). The broken non-primary unit never gets inspectionStatus='Failed', so isUnitAvailableFor (app.js:2064-2067) keeps it bookable, while the untouched primary is wrongly flagged Failed and receives the work order (wo.unitId:r.unitId, app.js:20009).
+- UNITS: cascade.js's addRental still matches rentals by the legacy scalar r.unitId only, ignoring the units[] array real multi-unit rentals carry — explicitly noted as the same anti-pattern as markFieldCall. Anchoring unit #2 or #3 of a multi-unit rental finds nothing and cascades to an empty Rentals column.
+- Calendar/Driver: on a merged trip the Log Delivery button is hard-scoped to the primary stop's own record but gated on the whole trip's done state — after logging the first of two stops it still reads 'Log Delivery,' pointing at a capture already completed, so the driver either re-records a video for nothing or stops mid-run to puzzle out which stop it means.
+- Calendar/Driver: a merged trip is marked done only when every one of its stops is done, and the group header's '· N done' suffix counts whole trips rather than stops — four stops with three logged contributes zero to 'done.'
+- UNITS: the same collapse inside a single record — a unit's tile surfaces only its newest open work order with no total count, so an older and more severe WO alongside it is entirely masked; and completing one blocking work order while a second remains open reports plain success with no explanation for why the unit is still red.
+
+## 27. The Status Field Has Two Owners ⁿ
+
+**3 cards** · scope: `architecture` · RENTALS, Calendar / Driver, Customers
+
+One status control is simultaneously dispatch's lifecycle timeline and accounting's authority gate, and the money system only guards the four statuses that mean 'going out' — so every exit path from a rental closes the job with no billing check at all.
+
+**Why it persists:** There is no state machine — status transitions are a list of buttons rendered from an order array (app.js:16851) with the gates hand-written at individual call sites. BOOKING_STATUSES is a booking-team constant that the billing gates borrowed as a convenient scope, which encodes 'protect the front door' as a permanent architectural fact. Every new status added later inherits zero gates by default, because a gate only exists where someone remembered to type one.
+
+**The question a UI system must answer:** *Who owns a status transition — the subsystem that names the status, or every subsystem with a stake in it — and where does a transition's full precondition set live so that adding a new status cannot silently inherit an empty gate list?*
+
+**Instances:**
+
+- RENTALS: the invoice hard-gate fires only for val==='On Rent' (app.js:19911); blacklist / rental-rules / card / account-block gates are all scoped to BOOKING_STATUSES = ['On Rent','Reserved','Today','Tomorrow'] (app.js:19751). 'Returned' is in none of them, and the status dropdown is a free-jump timeline where every node is a live button with no disabled state — so a dispatcher opens a fresh Reserved rental with invoiceId still null, clicks 'Returned', and the job closes out unbilled. Verifier: CONFIRMED, critical.
+- RENTALS: Cancel / No-Show strips billing in the same click that moves the lifecycle (app.js:19929) — one dispatch gesture silently executing an accounting decision, no confirm, no undo affordance, and rentalCleared+rentalsVisible (app.js:442-443, 6802-6807) drop the row instantly with no fade.
+- Calendar / Driver: the log-gate ('no invoice on this rental') is evaluated only when the driver taps Log Delivery, never when the row renders (app.js:20198) — an accounting precondition is enforced at the moment of physical work, hundreds of miles from the person who can satisfy it.
+- Customers: 'Pay Cancellation' charges the saved card in full on tap (button app.js:4100 → handler app.js:18452 → charges at app.js:4975-4989), the only money action on the card that skips the shared payment-review overlay every other charge uses (app.js:21392).
+
+## 28. Every Renderer Computes Its Own Truth
+
+**3 cards** · scope: `signal` · Customers, Categories, UNITS
+
+There is no shared definition of 'available', 'owed', or 'how many' — each renderer derives the number inline against its own filter, so two subsystems print contradictory answers to the same question inches apart on the same screen.
+
+**Why it persists:** The app has no selector or derivation layer. isUnitRentable / RENTABLE_SKIP_FLEET exists at app.js:2251 as a root definition, but nothing obliges a renderer to use it, so each card's author re-derived availability inline against the filter that made their own view look right. Once two inline derivations exist, the divergence is invisible in code review because neither is wrong locally — only the pair is wrong, and the pair only meets on screen.
+
+**The question a UI system must answer:** *Where does a business quantity get defined exactly once — and what makes it structurally impossible for a renderer to compute 'available' or 'owed' itself rather than asking for it?*
+
+**Instances:**
+
+- Customers: the row computes an accurate live owed/overdue $ from real invoices every render (app.js:7149-7161), while the group header, the sort field, the filter, and the pulsing detail-view flag all read a separate stored field written once at signup and never updated by any client code (app.js:9317-9319, 8351-8352, 5886, 5897, config.js:430; the only writes are at app.js:21102, 21144, 21238, 21309, 15804). Two contradictory answers to 'does this person owe us' sit inches apart.
+- Categories: the detail availability count and the mini-card availability count disagree — unitRentalBucket files any unit with no active rental as 'Available' regardless of fleetStatus (app.js:2300-2305), while the mini-card correctly restricts to fleetStatus==='Active' (app.js:7216-7225). Dispatch's 'available' and the counter's 'available' are different words spelled the same.
+- UNITS: the mechanic's Worklist graph tallies the whole fleet (app.js:12167) while the list it filters into hard-filters to Active first (app.js:9295) — tapping a segment yields fewer rows than the number promised, with no explanation. Separately the Work Orders bar counts open WOs but its click filters by unit (app.js:12170), so a unit carrying 2 open WOs is one row and two counts: the bar structurally cannot match the rows beneath it.
+- Customers: the spend chart sums rental list price over a 9-month window (app.js:4685-4693) while the account stat beside it shows the server-computed amount actually paid (app.js:7769-7789) — different basis, different period, neither labeled.
+- Categories: the Time Utilization denominator counts every unit ever assigned to a category including Sold / For Sale / Inactive (app.js:12740-12741), and revenue/ROI still counts the derived price of Cancelled and No-Show rentals (app.js:2227 unitTotalRevenue, app.js:12396 ruCatMoney) — while ruCatUtilProxy, in the same file, already excludes them.
+
+## 29. Permission Is A Per-Renderer Opinion
+
+**3 cards** · scope: `architecture` · Customers, Categories, UNITS
+
+Authority is enforced at individual widgets rather than at the data, so the same value is masked on one strip and printed plainly on the next, and the two gate functions in the app disagree about who an unassigned user even is.
+
+**Why it persists:** Gating is a call-site decorator (admin:true on a field, canMoney() around a block) rather than a property of the data being read. A value therefore carries no classification with it, so the moment the same value appears in a second surface — a list column, a sort key, a chart, an audit line — that surface starts from ungated by default. There is no inventory of where a sensitive value is rendered, so leaks are additive with every new view.
+
+**The question a UI system must answer:** *Does sensitivity attach to the value or to the widget — and if a field is money-tier, what makes it impossible to surface that field in a column, a sort, a graph, or an export without inheriting the gate?*
+
+**Instances:**
+
+- Customers: dollar figures are deliberately masked to $••• in the History log for roles without money permission (app.js:22582, 9165), while the invoice list, open-balance strip, Transactions tab and 'total paid' stat on the very same screen render live amounts with no role check (app.js:4685-4693, 4780-4808, 4887, 4892, 4813-4824).
+- Categories: ROI is money-tier-gated with canMoney() in the detail (app.js:8916), but the identical categoryStats().roi is an ungated list column with a colored pill in the default layout (app.js:7487, 7562) and an ungated sort key (config.js:432, app.js:9239, 19208) — a below-money-tier user reads the exact percentage off the list, or infers the whole fleet's profitability ranking just by sorting. And the two gates disagree at the root: canMoney() (app.js:21348) is permissive on a blank role while adminUnlocked() (app.js:19776) is restrictive on the same blank role.
+- Customers: adding a card on file is gated to Office/Admin with a toast, while removing one or changing the default card has zero permission check and zero confirmation — the ungated X sits at app.js:871, twelve lines above the gated Add at app.js:875, and reaches a live Stripe detach at app.js:820. Any logged-in role, including a mechanic or driver, can fire it.
+- Categories: creating a category is completely ungated (app.js:19008/18946, no requireAdmin) while editing a rate on that same category is explicitly admin-gated (app.js:19213, app.js:8876-8931) — the authority matrix is inverted, and it is the exact mechanism that mints unpriced-but-instantly-rentable $0 records via quickAddCategoryFromSearch (app.js:21174-21251, all rates hardcoded 0).
+- UNITS: the Round-Up Reports Money section — revenue, net sales, top customers, open account balances — renders to every signed-in role with no permission gate at all (app.js:12972).
+
+## 30. Records And Conversations Are Two Different Apps
+
+**3 cards** · scope: `architecture` · Customers, RENTALS, Calendar / Driver
+
+The comms subsystem and the records subsystem share a shell but never touch: no record surface can start a conversation, the built per-record thread panel renders nowhere, replies aren't polled, and Settings sells three notification engines that don't exist.
+
+**Why it persists:** Comms arrived as a self-contained dock with its own fetch, its own render, and its own state — never as a property of a record. Because no record type declares 'this entity has a conversation', wiring a thread into a card is bespoke work each time, and the one place it was done (the trip row) has stayed the only one. Settings toggles were shipped ahead of the engines to 'lock in intent', which means the UI now asserts capabilities the system does not have.
+
+**The question a UI system must answer:** *Is a conversation a first-class attribute of a customer / rental / trip — and if it is, what one component makes 'contact the human attached to this record' available wherever the record is, so that a settings toggle can never describe an engine that isn't wired?*
+
+**Instances:**
+
+- Customers: no call, text, charge, or follow-up control exists anywhere on a customer row or in the detail (row app.js:7141-7183, funnel layer app.js:4233-4235, detail app.js:8826-8856) — the card only ever states facts. telHref is normalized at app.js:11742 and its only call site in the entire app is app.js:7368, the Rentals trip-row.
+- Customers: commsCustSectionHtml() — a fully built per-customer conversation panel — has zero call sites anywhere in app.js, including a stale in-code comment claiming it renders.
+- RENTALS: every outreach to a driver or customer about a specific rental is a 2-3 screen detour; the only one-tap contact in the app is 'Text the Crew', a whole-roster broadcast buried in Settings.
+- RENTALS: refreshCommsThreads (app.js:26925) appears in neither of the only two setInterval calls in the codebase — a GPS-view timer (app.js:24080) and the 18s backend poll (app.js:24796) — and refreshFromBackend never calls it, so a customer reply sits unseen until someone manually clicks a comms chip or reloads. A failed comms fetch is fully silent: the catch resets a loading flag nothing reads.
+- Calendar / Driver: assignStopDriver()'s only effect on success is pushing a line into a hidden per-rental audit array (app.js:11341-11352, 22575) — no toast, no badge, no message to the driver being assigned. And there is no standing dispatch channel to reply on: every new Team chat starts with members: [] (app.js:10569-10570).
+- Settings promises what doesn't exist: 'Driver Assigned' ('Texts a driver the moment a delivery or pickup is assigned to them') ships defaulted off with an in-code comment that it's inert until a later phase (app.js:5161, 5282, 5291), and the customer-reminder and dispatch-ETA toggles persist and save while their engines do nothing.
+
+## 31. The Primary-Unit Mirror Meets Multi-Unit Reality ⁿ
+
+**3 cards** · scope: `architecture` · RENTALS, UNITS, Calendar / Driver
+
+A one-rental-one-unit identity from an earlier era is still the pointer that actions resolve through, so on multi-unit rentals and merged trips the app acts confidently on the wrong machine, the wrong stop, or nothing at all — while the clicked identity sits unused in scope.
+
+**Why it persists:** r.unitId was never retired when multi-unit rentals shipped; it was kept as a denormalized mirror and is resynced on every load, which makes it permanently correct-looking and permanently available. Any handler written since then that needs 'the unit for this rental' finds a field with exactly that name and uses it, and the code reads fine because the mirror is real data — the bug only appears when the rental has a second unit. The same shape recurs wherever a container has a designated primary member: rentals→units, merged trips→stops.
+
+**The question a UI system must answer:** *When one record contains many members, what identity does an action carry — and what makes it structurally impossible for a handler to reach for the container's primary when the user clicked a specific member?*
+
+**Instances:**
+
+- RENTALS: markFieldCall(rentalId) only ever reads r.unitId — documented as the PRIMARY-unit mirror (app.js:345-349, resynced every load at app.js:368) — and never the clicked unitId, which IS in scope at both call sites (setUnitCondition's Fail path app.js:20045, and the +FC yard capture app.js:20264). The broken non-primary unit never gets inspectionStatus='Failed', so isUnitAvailableFor (app.js:2064-2067) keeps it bookable, while the untouched primary is wrongly flagged Failed and receives the work order (wo.unitId: r.unitId, app.js:20009). Verifier: CONFIRMED. Fixed in PR #740 — the mirror remains.
+- UNITS: the same legacy assumption trips the cross-card cascade — anchoring the non-primary unit of a multi-unit rental cascades to an empty Rentals column instead of the rental the unit is actually on (cascade.js:101).
+- Calendar / Driver: on a merged trip the Log Delivery button is hard-scoped to the primary stop's record (app.js:7376-7380) but gated on the whole trip's done state (app.js:11586) — after logging the first of two stops it still reads 'Log Delivery', pointing at a capture already completed.
+- Calendar / Driver: the group header's '· N done' suffix counts whole trips, not stops (app.js:11586, 9343) — four stops with three logged contributes zero to 'done'.
+
+## 32. Machines Are Entities, People Are Not ⁿ
+
+**3 cards** · scope: `architecture` · RENTALS, UNITS, Calendar / Driver
+
+The flag, conflict and queue machinery was built for equipment and paperwork; drivers and mechanics are stored as strings on those records, so the same double-booking that pulses red on a machine is silent on a person, and 'assigned to me' does not exist anywhere in the app.
+
+**Why it persists:** FLAG_META and FLAG_COND enumerate five entity keys — rentals, units, workOrders, invoices, customers — and a person is not one of them, so there is no place to register a person-level condition even if someone wanted to. Staff exist as free-text role strings and name fields on other records, which means every people-shaped question (is this driver free, whose queue is this, is this person actually a driver) has to be answered by string matching at a call site, and usually isn't answered at all.
+
+**The question a UI system must answer:** *Are staff first-class entities with their own capacity, queue, and flag conditions — and what does a person's schedule collide against, given that the conflict engine currently only understands equipment?*
+
+**Instances:**
+
+- RENTALS: units get a pulsing 'Overbooked' flag when double-booked; drivers get nothing. Assign or 'Round up' writes a driver onto a transport leg with no time-conflict check at all (app.js:11341-11352, 18636) — one driver, two towns, same 9 AM, silently allowed. The asymmetry with the unit flag is the tell.
+- UNITS: assignedMechanic is stored, displayed, searched and editable in 17 places across the codebase (app.js:20009, 22445, 23005 among them) and is never once used to route, filter, or badge anything — no per-mechanic queue of 'these are yours' exists in any form.
+- Calendar / Driver: tripsFor() / dispatchEvents() apply zero identity filtering (app.js:11285-11302, 9674) — every driver's trips plus the entire unassigned pool render on one shared list, even though the code's own landing comment at app.js:25636-25644 calls this screen 'the driver's day'.
+- Calendar / Driver: driverRoster() filters employees by /driver/i on the role field then falls back to returning every employee if that filter comes back empty (app.js:11281) — one blank or mistyped role makes bookkeepers assignable as drivers.
+- RENTALS: the multi-driver lane rail and the one-tap 'Round up' auto-balance are still in the code (app.js:11802-11805, 18629-18636) but nothing renders their buttons, so with 12 stops and 3 trucks a dispatcher can only tap +Driver one stop at a time, with no 'who's carrying what' load view.
+- UNITS: the mechanic's whole tailored landing is keyed off the hardcoded role strings 'mechanic'/'mtech' (app.js:25639) even though config.js:342 states role names are renameable and permissions must not key off them.
+
+## 33. The Blink Points At The Calm One
+
+**3 cards** · scope: `signal` · Customers, UNITS, Categories
+
+Attention signals are wired to the wrong side of their own condition — pulses that fire unconditionally, predicates tested against values the data can never hold, booleans swapped — so the loudest thing on the screen is reliably the least urgent thing on it.
+
+**Why it persists:** Alert conditions are ad-hoc booleans written inline at the render site, so no predicate is ever exercised against real values before it ships, and no test asks the only question that catches this class: does anything on this screen ever NOT pulse? An always-on animation looks correct in a screenshot and correct in review; it takes watching a whole list of production records to learn it means nothing. The same absence of a shared predicate layer means an inversion is a one-character mistake with no second reader.
+
+**The question a UI system must answer:** *What is the single predicate registry that decides urgency, and what evidence must exist — that a predicate can both fire and not fire against production data — before any surface is allowed to animate, tint, or pulse on it?*
+
+**Instances:**
+
+- Customers — three separate pulse mechanisms are inverted or hardcoded backwards on one card: the rental-status badge pulses unconditionally for all seven active statuses, none of them red (app.js:8360); the pay-status pulse tests for a 'Paid' value customers can never hold, so every New Customer throbs like a debtor (app.js:8351-8352); and the membership billing flag has its booleans swapped, so "No Billing" (a setup gap) pulses while "Payment Due" (genuinely overdue) sits calm (app.js:3989 vs 3992).
+- Customers — the red name tint saturates the default view at 44 of 60 rows (11 of the first 12), while a name search returned only 4 of 19 red. Where red is densest it carries the least information.
+- UNITS — a pending wash unconditionally substitutes for the real worst service task in topServiceForUnit() (app.js:2206), poisoning five surfaces at once: card border colour, the WO/Service pill, the red service-past-due predicate itself, the countdown sort key, and two KPI tallies which explicitly skip wash-flagged units. A unit 40 hrs overdue on engine oil with a wash also requested shows a calm yellow "Wash Due" everywhere. The unit's own detail page (app.js:8134) gets it right by excluding wash — the correct pattern exists one function away.
+- Categories — SKID STEER MINI shows "NONE · SOLD" directly above $280/1-day and $790/7-day, and the card border isn't even red in that state (it falls to neutral, because the Active-only free set is empty), so a single pill is the only warning against quoting a machine the yard no longer owns.
+
+## 34. The Confirmation Doesn't Name The Record ⁿ
+
+**3 cards** · scope: `interaction` · RENTALS, Customers, Categories
+
+Actions commit against a record other than the one clicked, and the receipt — a toast, a highlight, a restored scroll position — is generic enough to endorse the wrong one.
+
+**Why it persists:** Actions are addressed by whatever id is nearest in scope at the call site — rentalId when unitId was also available — and feedback is written as a state string rather than as a statement about a record, so a receipt can never contradict the action even when the action was wrong. Positional rather than identity-based view restoration is the same mistake one layer up: the app remembers where the user was looking instead of what they were looking at. Both survive review because the happy path (single-unit rental, unsorted list, resolvable target) is the path anyone testing takes.
+
+**The question a UI system must answer:** *What forces every mutation and every confirmation to carry the identity of the record it actually touched — the clicked id, not an ambient one — so that "which one did I just change" is always answerable from the screen alone?*
+
+**Instances:**
+
+- RENTALS — flagging a Field Call on a non-primary unit of a multi-unit rental dispatches the mechanic and the work order to the rental's PRIMARY unit (wo.unitId: r.unitId, app.js:20009) and leaves the machine that actually broke down bookable, because it never receives inspectionStatus='Failed'. The clicked unitId was in scope at both call sites and was never read. CONFIRMED.
+- RENTALS — scroll "preservation" is positional: scrollMemo is keyed by card|view and restored by raw pixel (app.js:17185-17190, 17229-17234), never by record id. Status is a selectable sort field (config.js:431), so changing a status from the row re-sorts the list and lands the viewport on whatever rental now occupies that offset — while the confirmation toast reads only "Status → X" (app.js:19940), naming no rental. The one cue that would catch the substitution is the one that was never written. CONFIRMED.
+- Customers — openInvoice() guards only the invoice's customerId being null (app.js:3057), then unconditionally mutates state, scrolls and glow-flashes even when the target customer record does not resolve — animating whatever decoy record already happens to be on screen (app.js:3066-3075).
+- Categories — a filter chip set on one category persists and silently intersects with a pill clicked on a different category later: clicking a status pill on 12k Excavator returned a Light Tower, with two chips ("Not Ready · Light…" + "Ready · 12k Exca…") stacked and Back/Forward vanished. Live-confirmed. The result "looked like a normal list, just of the wrong machine."
+
+## 35. Order Is A Claim Too
+
+**3 cards** · scope: `signal` · UNITS, Customers, RENTALS
+
+Sorting and grouping are presented as the answer to "what is most urgent", but the sort either doesn't run, is silently overridden by grouping, or is keyed on something that isn't time — and the control still reads as applied.
+
+**Why it persists:** Grouping and sorting were built as two independent layers that were never given a precedence rule, so the one the user chose loses to the one they didn't. And sort keys are registered in config.js separately from the switch that implements them, which means a key can be advertised in the menu with no case behind it and fall through to the default in perfect silence. Nothing in the UI ever states the effective order, so a wrong order is visually indistinguishable from a right one — the only way to catch it is to already know the correct answer.
+
+**The question a UI system must answer:** *What makes the effective ordering of a list legible and checkable on screen — including which axis won when grouping and sorting disagree — and what structurally prevents a sort option from being offered that no code implements?*
+
+**Instances:**
+
+- UNITS — measured live with sort explicitly set to Service Due: position 1 Highrise (440 hrs overdue), position 2 Worm (2,882 hrs overdue, shown only as "No GPS +1"), position 3 Reptar (2,025 hrs overdue), positions 4-8 five machines with nothing wrong at all, and only at position 9 Dirt Dauber at 1,139 hrs overdue — sitting inside the green AVAILABLE bucket. Grouping wins; buckets are decided by inspection status alone and service urgency never enters bucket assignment.
+- UNITS — a machine that fails inspection mid-rental never reaches the Failed check at all, because unitStageKey() returns on the rental-stage branch (app.js:9296-9303) before line 9304 ever runs. It sits inside the collapsed "On Rent · 21" bar, indistinguishable at the header from 21 healthy rentals — the single scenario the mechanic role exists for.
+- UNITS — the unit history log sorted on a module-level counter that resets to 0 on every page load (app.js:9153, 22568), so on production unit SPEECHLESS entries rendered Jun 17, Jun 17, Jul 18, Jun 22, Jul 18, Jul 13 — a shuffled deck, with real when+clock timestamps sitting unused in every record. Fixed in PR #741; the class of question it raises (does this sort key survive a reload?) applies to every other log view.
+- Customers — measured element by element: sorting by "Pay Status" produced a list byte-identical to sorting by "Name"; sorting by "Last Invoice" produced reverse-alphabetical order with a duplicate customer name appearing twice and no reference to any invoice date. Both are declared in config.js:430, neither has a case in the switch at app.js:9223-9245, and both render as real, selectable buttons.
+- RENTALS — flagged rows are never pulled or sorted to the top of their group, so a dispatcher skimming section headers on a busy "On Rent" section has no ordering signal pointing at the fire.
+
+## 36. Silence Is Rendered As Success
+
+**3 cards** · scope: `architecture` · Calendar / Driver, RENTALS, Customers
+
+Failures, staleness and non-delivery produce no distinct state. A write that never landed, a poll that never runs, a fetch that errored, and a toggle whose engine was never built all leave a screen identical to the working case.
+
+**Why it persists:** Error handling was written to the standard of "don't crash the render", and the app has no vocabulary for degraded state — no per-value freshness stamp, no queued/failed/confirmed distinction, no visual difference between "loaded" and "loaded a long time ago." Optimistic UI without a reconciliation channel means the happy path is the only path the screen can draw. The Settings toggles are the same failure one level up: intent shipped as UI against a pipeline that was never built, and because a toggle that does nothing looks exactly like a toggle that works, nobody could tell from the screen which kind they had.
+
+**The question a UI system must answer:** *What does every value on screen carry to say when it was last known good and whether the last write to it was confirmed, queued or lost — and what is the single visual grammar for degraded, so that no failure anywhere in the app can render as a success?*
+
+**Instances:**
+
+- Calendar / Driver — uploadCaptureMedia posts the walkaround video once; on network failure the catch toasts "saved without it" for two seconds and the row still stamps green "Logged", visually identical afterward to a delivery whose video landed (app.js:20280, 25426). That video is the only defence against a later damage claim.
+- Calendar / Driver — the pinned, non-scrolling sync footer is one of the few things visible on first paint, and it reads "Offline — cached" before any real connectivity check and "Synced" indefinitely after the first success, including after signal is later lost. No code path checks connectivity before a write at all, so a held or failed write in a dead zone produces no distinct signal either.
+- RENTALS — a driver's field delivery blocked by an office-side booking gate silently discards the entire capture, recorded video included, with no queued retry and no visible block on the Trips side to see or clear (app.js:20256-20261, 529).
+- RENTALS — refreshCommsThreads (app.js:26925) appears in neither of the only two setInterval calls in the entire 27,649-line app.js (a GPS timer at 24080 and the 18s backend poll at 24796) and is never reached from refreshFromBackend, so a customer's text or email reply can sit unseen until someone manually clicks a comms chip or reloads.
+- Customers — a failed comms fetch resets a loading flag nothing reads and leaves stale cached state on screen with no error; and Settings ships live, saveable toggles for customer reminders and dispatch ETAs whose engines are inert, so the toggle persists its own state and nothing is ever sent to anyone.
+
+## 37. Closed Without Proof ⁿ
+
+**3 cards** · scope: `architecture` · RENTALS, UNITS, Categories
+
+Terminal states are recorded as accomplished facts without the app ever capturing the evidence that would make them true, and every downstream aggregate inherits the hole silently.
+
+**Why it persists:** Status is modelled as a free enum on a record rather than as a transition with preconditions and required artifacts, so every value is one click from every other value, and the gates that do exist were bolted onto the single transition someone remembered ('On Rent') rather than onto the state machine. Nothing binds "this rental is closed" to "these things were captured", so a close is cheap, unverified and instantaneous — and every aggregate downstream is summing records that were never substantiated, with no way to tell a real close from an empty one.
+
+**The question a UI system must answer:** *What must be captured and true before a record is allowed into a terminal state, and where does the UI show a close that is missing its evidence — rather than counting it, billing from it, and reporting it as complete?*
+
+**Instances:**
+
+- RENTALS — the invoice hard-gate fires only for val==='On Rent' (app.js:19911), and the blacklist/rental-rules/card/account-block gates are all scoped to BOOKING_STATUSES ['On Rent','Reserved','Today','Tomorrow'] (app.js:19751), which does not include 'Returned'. The status dropdown is a free-jump timeline with every node a live button and no disabled state, so a fresh Reserved rental with invoiceId still null can be clicked straight to 'Returned' — units flip and the job closes out, never billed. CONFIRMED, critical.
+- RENTALS — 'Log Recovery' flips the unit to Returned stamping only {date, video, driver} (app.js:20259-20261): no condition capture, no inspection opened, no damage line. The Rental Protection $1,000 cap (app.js:4410-4411) can therefore never be exercised from the return path at all.
+- RENTALS — the three terminal jumps (Returned / Cancelled / No Show) sit stacked as the last rows of one dropdown (order app.js:16851), each a plain button calling setRentalStatus with zero intervening step and no undo affordance, with Cancel/No-Show stripping billing in the same breath (app.js:19929) and the row dropping instantly from the list. The app already has a confirm precedent for WO completion (app.js:20648) that was never extended here.
+- UNITS — because the hour meter is never captured on return, a rental can close as complete while the service countdown that governs whether that machine is safe to send out again has not moved by a single hour.
+- Categories — nothing filters Cancelled and No-Show rentals out of revenue, so Round-Up Revenue reads 8k Excavator $79k and Skid Steer $77k while the Rentals card beside it shows "NO SHOW · 32" for the same period; unitRepairCost summed cancelled work orders on the expense side (app.js:2227, 12396, 2212), even though ruCatUtilProxy at app.js:12740 already excludes Cancelled/No-Show/Quote correctly.
+
+## 38. Late Is the First Warning ⁿ
+
+**3 cards** · scope: `signal` · RENTALS, Calendar / Driver, UNITS
+
+Urgency is computed from deadlines that have already passed. Nothing buckets, counts or signals work that is due — only work that is overdue, and often not even that.
+
+**Why it persists:** Grouping is keyed off lifecycle status — the noun a record currently is — and lifecycle status has no clock inside it. Deadlines live in date fields read only by the row renderer, so the only place time can express itself is a tint on a row someone is already looking at. Every card independently chose status as its grouping axis because status is the field that is always present; time is the field that requires a comparison.
+
+**The question a UI system must answer:** *What is the app's model of 'due' as distinct from 'late,' and which surface is obliged to show it before the deadline rather than after — uniformly across returns, trips, services and inspections?*
+
+**Instances:**
+
+- RENTALS: an overdue return is invisible to every count, badge and toast in the app. off-rent-overdue is a red flag (config.js:245) that feeds only getEntityColor (row pill/border); commsBellCount = unseenNotifs() + visibleTransportAlerts() + wranglerRequests references none of it, and a past-endDate leg drops OUT of the forward-windowed transportAlerts so it is not even indirectly counted. The rentals column tab's alert is hardcoded false (app.js:9601) — only units get unitsAlertCount. No poll scans flags to fire a toast. Verifier CONFIRMED.
+- RENTALS: recoveries get no bucket or signal until the day AFTER they are late — lifecycle grouping keys off status/start-date (app.js:2016-2017, 9312-9316), so a unit due back today sits in 'On Rent' with no distinguishing signal. The single most predictable dispatcher task of the day has no forward-looking bucket.
+- Calendar / Driver: the Trips tab badge read 4 while the collapsed 'Earlier · 6 · 2 done' group held 4 more undone stops, two of them 78 days old — the badge counts only stops dated today-or-later (app.js:9471-9472). Nothing distinguishes 'history' from 'never got done.'
+- Calendar / Driver: 'Earlier' is the only default-collapsed group/card combination in the entire app (app.js:9358) and its color is a hardcoded 'gray' literal that can never receive danger styling, since sec-danger only fires on color==='red' (app.js:9333, 9340, 9423). 'Today' is separately hardcoded red every day regardless of contents (app.js:9337), so red already carries no reliable signal.
+- UNITS: a machine that breaks down mid-rental never lands in 'Needs Attention' — unitStageKey() returns on the rental-stage branch (app.js:9296-9303) before it ever reaches the inspectionStatus==='Failed' check on line 9304, which only fires for units with no active rental. The field-broken machine sits inside the collapsed 'On Rent · 21' bar, indistinguishable at the header from 21 healthy rentals.
+- Calendar / Driver: a blank time box reads as 'nothing due' but the code silently treats it as a hard 5:00 PM cutoff (AUTORUN_EOD_DEADLINE_SEC) that never reaches the row unless a dispatcher has already run Auto-Run for that day (app.js:11906, 11929-11935, 7407).
+
+## 39. Locks on Doors, Not on Jobs
+
+**3 cards** · scope: `architecture` · Customers, Categories, UNITS
+
+Permission is attached to individual controls rather than to the job those controls perform, so the same job is gated on one card, ungated on another, and inverted within a single file — and the gate does not travel with the work.
+
+**Why it persists:** Gates are written at the call site by whoever builds the control, so the authority model is the sum of many local decisions with no registry of which JOBS are privileged. A job reachable from two cards gets two independent answers, and reaching it from a third is a fresh judgement call every time. Because the additive path (add a card, create a category) feels like the risky one, the gates land there and the destructive path a dozen lines below is left open.
+
+**The question a UI system must answer:** *What is the enumerated list of privileged jobs — take money, remove a payment method, change a price, see margin, retire a record — and how does the gate travel with the job to every surface that can trigger it, including surfaces built later?*
+
+**Instances:**
+
+- Customers: adding a card on file is gated to Office/Admin with a toast; removing one — a live Stripe detach, not locally reversible — has zero permission check and zero confirmation, twelve lines below the gated Add (app.js:858-876, ungated X at 871 vs gated Add at 875, detach at 820). Measured off the card-health ring: 124 of 2,265 customers have a card and 2,141 do not (94.5%), and since a valid card is required before On Rent, those 124 are effectively the entire float — deletable by any logged-in role including a mechanic or driver.
+- Categories: creating a category is completely ungated (app.js:19008/18946, no requireAdmin) while editing a rate on that same category is explicitly admin-gated (app.js:19213, admin:true on every rate field at 8876-8931). A non-admin can mint unlimited instantly-live rentable classes and price none of them — 7 of 46 live categories (~15%) are currently unpriced this way, and LIFT SCISSOR 19FT shows a bright green '2 AVAIL' pill above five em-dash rate tiles.
+- Categories: ROI is canMoney()-gated in the detail (app.js:8916) but ungated as a list column (7487), included in the default layout (7562), and ungated as a sort key (config.js:432 / app.js:9239 / 19208) — a below-money-tier user can read the exact percentage or infer the whole fleet's profitability ranking by sorting. canMoney() (app.js:21348) is permissive on a blank role while adminUnlocked() (app.js:19776) is restrictive on the same blank role: the two gates disagree about who a no-role user is.
+- UNITS: the Round-Up Reports Money section — revenue, net sales, top customers, open account balances — renders unconditionally for every signed-in role with no money-permission check (app.js:12972).
+- Customers: dollar figures are deliberately masked to $••• in the History log for roles without money permission (app.js:22582, 9165), while the invoice list, open-balance strip, Transactions tab and 'total paid' stat on the very same screen render live amounts with no role check (app.js:4685-4693, 4780-4808, 4887, 4892). The Customers card has no role gate on opening it at all.
+- Customers: 'Pay Cancellation' charges the saved card in full the instant it is tapped — the one control most in need of review is the only money action that skips the shared payment-review overlay every other charge uses (app.js:4100/18452/4975-4989 vs the 21392 overlay pattern). 'Cancel Membership' ends billing and generates a real cancellation invoice on the first click, despite an arm-to-confirm pattern sitting a few lines away on the same card's blacklist button (app.js:18639).
+
+## 40. The Truck Loses To The Desk ⁿ
+
+**2 cards** · scope: `interaction` · RENTALS, Calendar / Driver
+
+Field capture and office bookkeeping share one status action, and when they disagree the office wins by destroying the field's work — the driver's evidence is thrown away, the block is invisible on his surface, and no queue holds the write.
+
+**Why it persists:** The capture flow was built as a thin client of the office's write path rather than as its own durable system with its own queue. Because the gate is evaluated inside the status-setter and not before the capture UI opens, the only place it can fail is after the driver has already done the physical work — and the failure branch returns rather than persisting, since there is no offline write queue anywhere in the app (sw.js is 47 lines, documented 'OFFLINE SHELL ONLY').
+
+**The question a UI system must answer:** *When a field action and an office precondition conflict, which one is allowed to lose — and what durable object holds the field's work, plus a visible block the field can see before loading the trailer, until the office clears it?*
+
+**Instances:**
+
+- RENTALS: a driver taps 'Log Delivery'; if the office never finished the card/invoice, the booking gate refuses the status move and the entire capture — recorded video included — is discarded (app.js:20256-20261, app.js:529). No queued retry, no visible block on the Trips side to clear, no way to even see the block from the field.
+- Calendar / Driver: a failed sync during capture holds the pending write only in RAM while the banner instructs the driver 'Don't close the app' (in-RAM hold app.js:25405-25411, banner copy app.js:25426), against a code comment stating the local cache is never a save baseline (app.js:24576) — an instruction a phone user cannot honor, since the OS backgrounds and locks apps on its own.
+- Calendar / Driver: uploadCaptureMedia posts the walkaround video once; on network failure the catch toasts 'saved without it' for two seconds and the row still stamps green 'Logged', visually identical to a delivery whose video actually landed (app.js:20280, 25426).
+- RENTALS: the return path is worse — 'Log Recovery' stamps only {date, video, driver} and sets Returned (app.js:20259-20261), with no condition capture, no inspection open, no damage line, so the $1,000 Rental Protection cap can never be exercised from the return path at all (app.js:4410-4411).
+
+## 41. Zero Is Not "I Don't Know"
+
+**2 cards** · scope: `signal` · Categories, UNITS
+
+The app has no representation for unknown. Divide-by-zero guards, falsy defaults and blank inputs all resolve to a confident 0, $0, an em-dash or a green all-clear that is typographically identical to a real measurement.
+
+**Why it persists:** Falsy-coalescing (`|| 0`, `|| 1`, `v ? money(v) : '—'`) is the cheapest way to stop a renderer crashing on missing data, and it silently converts every absence into a value. Because it lives inside formatting helpers rather than at the data boundary, "we don't have this" never survives far enough to reach a surface — and the choice of which falsy shorthand to use is made independently at each render site, which is why the same 0 becomes "—" on one card face and "$0" on another. No reviewer sees a formatter inventing a number; the screen looks complete either way.
+
+**The question a UI system must answer:** *What is the app-wide representation of "not known" and "not applicable", distinct from zero and from each other, and at what point in the pipeline is absence required to survive — so that a formatter can never manufacture a number the data does not contain?*
+
+**Instances:**
+
+- Categories — a category with zero units prints "0 HRS" avg hours and "$0" avg revenue/expense as if measured, because the guard `n = us.length || 1` makes 0/1 = 0 (app.js:2345, 2368-2370). ROI sitting right beside it correctly returns null and renders blank in the identical situation (app.js:2363). The app already knows how to say "no data" one line away from where it doesn't.
+- Categories — a rate explicitly set to 0 renders as an em-dash "—" on the mini-card (truthy check, app.js:7271-7275) and as "$0" in the detail (efld's has-check treats 0 as present, app.js:8876-8879). The same stored value reads as two different things depending which surface you are on, and the data model has no distinct "no such tier" state at all.
+- Categories — 7 of 46 live categories (about 15%) have every rate field unset and still show a bright green availability pill: LIFT SCISSOR 19FT reads "2 AVAIL" with both units inspection-passed and every rate tile an em-dash. The app internally labels the record "STUB — fill in pricing" (catRatesUnset, app.js:1113-1115) but that text lives only in a detail nobody opens.
+- UNITS — a blank "hours at completion" when logging a service silently records the service at 0 hours, corrupting the countdown baseline for that task, with no reject and no default to the unit's current reading.
+- UNITS — the "N on hand" part quantity on a work-order line is rendered as live stock but was never a measurement of anything: qtyOnHand is set once and never moves with usage.
+
+## 42. One Red For Seven Reasons
+
+**2 cards** · scope: `signal` · RENTALS, UNITS
+
+Severity is stored per-condition but rendered as a single collapsed value, so a row can say "something is wrong" and not what — and each surface independently picks its own subset of the condition registry, so the surfaces disagree about whether anything is wrong at all.
+
+**Why it persists:** A flag registry exists (config.js FLAG_COND) but it is a source of colours, not a source of truth: every consumer reads it through a hand-written filter, and severity is a flat enum per condition with no notion of which condition won or why it won. Because adding a condition to the registry adds it to no count, no badge and no bucket, the registry can grow indefinitely while the indicators keep their original, narrower meaning — and each new surface author, seeing four existing subsets, has no basis to pick one, so they write a fifth.
+
+**The question a UI system must answer:** *When more than one condition is true on a record, what decides which the user is shown and how the record names its own reason — and what guarantees every count, badge, bucket and border across every card reads the same condition set, so that "no flag" means the same thing everywhere?*
+
+**Instances:**
+
+- RENTALS — FLAG_COND.rentals defines 7 conditions (fc, overbooked, unpaid-balance, no-card, unsigned-card, unit-failed, off-rent-overdue), ALL severity 'red'; getEntityColor collapses to fl[0].severity so the row renders one uniform red and the flag's name never appears on it (app.js:5834-5854, config.js:239-253). Verification scoped this honestly: 3 of 7 do get a distinct on-row echo (overdue relabels the pill, unpaid shows a coloured balance chip, unit-failed tints the unit name red), and 2 of 7 — no-card and unsigned-card — are genuinely unidentifiable without a desktop hover-preview or a hop to the linked customer.
+- UNITS — unitsAlertCount, the only indicator visible before the card is opened, watches 3 of the 10 registered flag conditions (app.js:9479), ignoring failed inspection, overbooked, GPS offline, coverage expired and uninsured-active — including the two that can put an unsafe or uninsured machine on the road. The tab badge, the card border, the corner-flag pill and the group bucket each reimplement a different subset of the same 10-flag registry, so four mechanisms on one card disagree about "needs attention."
+- RENTALS — GROUP_DEFS.rentals buckets on lifecycle status via rentalRevStatus (app.js:1986-1990, 9312-9316), which never consults a flag, unlike UNIT_SECTIONS (app.js:9279-9290) which has an explicit red "Attention" bucket fed by unitStageKey. Header counts never reflect severity and flagged rows are not lifted within their group. The Units card having the bucket and Rentals not is the systemic tell.
+- UNITS — collapsed group headers render a label and a raw count only, with no red/yellow flagged sub-count, and collapse state persists per device/account indefinitely with no urgency floor to force a group carrying red back open (app.js:9429, 9358).
+
+## 43. The Parallel Ledger
+
+**2 cards** · scope: `architecture` · Customers, RENTALS
+
+Where the official number cannot be trusted, staff have rebuilt it by hand in free-text fields — which is simultaneously the strongest proof the trust failures are real and a second, unvalidated source of truth the redesign now has to absorb rather than delete.
+
+**Why it persists:** Every trust failure above has a cheap manual workaround available in some text field, and the workaround is completely invisible to the system: it throws no error, fails no validation, and appears in no metric. The defect therefore generates zero pressure — the app's own instrumentation reports a healthy screen while the real ledger migrates into strings. Over time the improvisation becomes infrastructure, which inverts the risk: fixing the broken sort or normalising the name field would now break the mechanism people actually depend on.
+
+**The question a UI system must answer:** *For each state staff are currently encoding by hand, what is the structured, sortable, first-class field that replaces it — and how does the system detect that a workaround is forming, so a trust failure surfaces as a signal instead of quietly becoming someone's daily routine?*
+
+**Instances:**
+
+- Customers — of 860 rendered customer names on production, 25 carry business state typed into the name field: 13 owed-amount flags (e.g. "!!!Owes $X!!!"), 7 do-not-rent flags, 3 account-credit notes, 2 escalation-contact routings. This is not sloppiness — it is staff routing around three specific defects (two dead sorts, the frozen pay status, the vanishing Don't-Contact flag) by hand, every day.
+- Customers — 23 of those 25 are prefixed with punctuation specifically because punctuation sorts above letters in alphabetical order, the one sort on the card that isn't broken. The workaround is load-bearing: it is a manual priority-sort mechanism built out of the name field.
+- Customers — free-text note fields on individual accounts are used as an undated, ad-hoc "next follow-up" tracker, because no structured field for it exists anywhere on the card.
+- RENTALS — the dispatcher assembles the day by scanning multiple cards because no daily digest or start-of-shift summary exists, even though every input (returns due, field calls, unpaid balances) is already in the data; and every outreach about a specific rental is a 2-3 screen detour whose nearest one-tap alternative is a Settings-buried whole-roster "Text the Crew" broadcast.
+
+## 44. The Mirror Unit ⁿ
+
+**2 cards** · scope: `architecture` · RENTALS, UNITS
+
+A rental's identity as a set of machines is stored twice — the real units[] array and a scalar r.unitId 'primary' mirror — and every cross-card consumer reads the mirror, so work aimed at machine #2 or #3 silently lands on machine #1.
+
+**Why it persists:** The scalar mirror was the original data model and is kept resynced on every load, so it is always non-null and always looks correct. Every new cross-card consumer reaches for the guaranteed-populated field instead of the array, which would force a loop and an explicit which-one decision. Nothing in the UI ever renders a rental as more than one machine, so the wrong answer never looks wrong to the person who caused it.
+
+**The question a UI system must answer:** *When a rental holds more than one machine, which machine is the user pointing at — and how does that choice travel with every cross-card action (flag, work order, cascade, availability) instead of being re-derived from a mirror field?*
+
+**Instances:**
+
+- RENTALS: markFieldCall(rentalId) reads only r.unitId — documented as the PRIMARY-unit mirror (app.js:345-349, resynced every load at 368) — and never the clicked unitId, which is in scope at BOTH call sites (setUnitCondition's Fail path app.js:20045; the +FC yard capture app.js:20264). Flagging a Field Call on a non-primary unit fails the wrong machine, opens the work order against it (wo.unitId:r.unitId, app.js:20009), and leaves the actually-broken machine bookable because isUnitAvailableFor (app.js:2064-2067) never sees inspectionStatus='Failed'. Verifier CONFIRMED; fixed in PR #740.
+- UNITS: cascade.js:101 addRental still matches rentals by the legacy scalar r.unitId, ignoring units[] — anchoring unit #2 or #3 of a multi-unit rental cascades to an EMPTY Rentals column. Explicitly noted as the same anti-pattern as markFieldCall, and parked pending the RENTALS audit.
+- The boundary is UNITS→RENTALS→work order: the mechanic flags the machine he is standing at, and the repair is dispatched against a different machine, on a different card, with no on-screen contradiction anywhere.
+
+## 45. The Empty Return ⁿ
+
+**2 cards** · scope: `architecture` · RENTALS, UNITS
+
+The end of a rental is the densest handoff in the business — machine, hours, condition, damage, money — and the return path records only {date, video, driver}, so three downstream cards derive their numbers from readings nobody was ever asked for.
+
+**Why it persists:** The return is modelled as a status change on the rental, not as a data-collection event jointly owned by Rentals, Units and Invoices. The fields the next three cards need already exist in the schema and are even formatted for display — they were designed as read surfaces with no writer, because no screen ever asks the person physically standing at the returning machine for them. Status transitions are cheap to add; capture moments require deciding whose screen owns them.
+
+**The question a UI system must answer:** *What single moment does the system treat as 'the machine came back,' and what is the complete set of readings — hours, condition, damage, invoice state — it must refuse to close without, regardless of which card or device the person is standing on?*
+
+**Instances:**
+
+- RENTALS: 'Log Recovery' stamps only {date, video, driver} and sets the unit Returned (app.js:20259-20261). No condition capture, no inspection opened, no damage line — so the Rental Protection $1,000 cap (app.js:4410-4411) can never be exercised from the return path at all.
+- UNITS: startHours / returnHours exist on every rental unit entry, are seeded with real values and are humanized for the audit log (app.js:22577) — but a grep for 'startHours =' / 'returnHours =' across app.js returns ZERO assignments, and nothing rolls returnHours into unit.currentHours (app.js:23088). A unit goes out for three weeks, comes back 180 hours older, and its service countdown does not move by one hour.
+- UNITS: the one field that does write the hour meter has zero validation — const v = Number(input.value); u.currentHours = v (app.js:19644). Live production on unit SPEECHLESS: Jun 17, 1732.3 → 17385.5 (Cameron); corrected Jul 13, 17385.5 → 1738.5 (Bri). A 10x typo stood for 26 days feeding every service countdown, the fleet hours average, category ROI and $/Hr, and got permanently stamped onto work orders.
+- UNITS: a blank 'hours at completion' when logging a service records 0 with no reject and no default to the unit's current reading, permanently falsifying that task's countdown baseline (service-countdown.js:135).
+- RENTALS: a rental can be jumped straight to 'Returned' having never been invoiced — the invoice hard-gate fires only for val==='On Rent' (app.js:19911), and the blacklist/rental-rules/card/account-block gates are all scoped to BOOKING_STATUSES = ['On Rent','Reserved','Today','Tomorrow'] (app.js:19751), which does not include 'Returned'. The job closes out unbilled. Verifier CONFIRMED, critical.
+- UNITS: qtyOnHand is rendered on a work-order line as if it were live stock but is never decremented when a part is actually consumed (app.js:6169) — the same missing-write pattern one link further down the parts chain.
+
+## 46. The Gate Fires in the Field ⁿ
+
+**2 cards** · scope: `interaction` · RENTALS, Calendar / Driver
+
+Office-side booking gates are evaluated at the instant of the field action, in the field worker's browser, against data he cannot see or fix — so the block destroys the field work instead of preventing the trip.
+
+**Why it persists:** Gates were written as guards on a status transition rather than as preconditions on a job, so the only moment they can speak is the instant of the transition — by which point the driver is at the site with the capture already in memory. Office and field share one status machine but not one view of why it is blocked, and the field surface has no representation for 'blocked, and here is who clears it.'
+
+**The question a UI system must answer:** *Where does a blocking condition become visible — at the moment of the block or at the moment the trip is planned — who owns clearing it, and what guarantees that field capture is never the thing discarded when a gate fires?*
+
+**Instances:**
+
+- RENTALS: a driver taps 'Log Delivery'; if the office never finished the card or invoice, the booking gate refuses the status move and the ENTIRE capture — including the recorded proof-of-delivery video — is discarded. No queued retry, no visible block on the Trips side to clear (app.js:20256-20261, 529).
+- Calendar / Driver: the log-gate ('no invoice on this rental') is only evaluated when the driver taps Log Delivery, never when the row renders (app.js:20198) — a stop already blocked that morning shows no lock, no red flag, nothing, until he has driven the full distance. The information is computed; it is simply computed at the wrong moment.
+- Calendar / Driver: uploadCaptureMedia posts the walkaround video once; on network failure the catch toasts 'saved without it' for two seconds and the row still stamps green 'Logged' — visually identical to a delivery whose video actually landed (app.js:20280, 25426). That video is the only defense against a later damage claim.
+- Calendar / Driver: a failed sync during a capture holds the pending write in RAM only — a code comment states the local cache is never a save baseline — while the R25 banner instructs 'Don't close the app,' an instruction a phone OS will not honour (app.js:25405-25411, 25426, 24576). The practical result is a completed delivery log reverting to undelivered overnight.
+- Calendar / Driver: state.tripsSyncStatus starts null and only flips to 'synced' after a push/pull succeeds, so the pinned, non-scrolling footer reads 'Offline — cached' regardless of real connectivity, and nothing re-checks after the first success — so it can equally read a false 'Synced' after signal is lost (app.js:2502, 11390/11413, 11499).
+- RENTALS: the same gate family scoped to BOOKING_STATUSES lets a rental jump to 'Returned' with no gate at all — so the gates are simultaneously too aggressive in the field and absent at the close-out.
+
+## 47. Born, Never Buried
+
+**2 cards** · scope: `architecture` · Customers, Categories
+
+Records mint from many paths with no lookup and can never be merged, retired or deleted — so a duplicate created at one card boundary permanently splits the history the next card needs.
+
+**Why it persists:** Creation was added wherever a user hit a dead end — search-add, quick-add, chat-add — and each path was built to unblock that specific moment, not to reconcile with the book. Because a duplicate is a perfectly valid record, nothing ever errors; the cost lands weeks later on a different card, where a balance or a service schedule is simply missing rather than wrong.
+
+**The question a UI system must answer:** *What is the identity rule for each entity — what makes two records the same thing — and where does a person go to reconcile, retire or merge when that rule was broken?*
+
+**Instances:**
+
+- Customers: no creation path — quick-add, full form, search-add, or the AI's create tool — checks for an existing phone, email or name before minting an id; all five mint via nextCustomerId() unconditionally (app.js:21276-21320, 21231-21250, 21088-21111, 21116-21150, 15801-15807). A captured production sort snapshot showed the identical customer name rendered twice, which means the rental attaches to one record and the payment history lives on the other.
+- Categories: nothing in the app ever deletes, merges, retires or splits a category — DATA.categories is push/read/index-only. A typo'd or duplicate category is permanent and pollutes every grid, sort and picker forever. The de-facto workaround is retagging units one at a time through a bare <select> that commits on change/blur with no confirm and silently re-prices every open rental on that unit, since unitRentalPrice reads categoryId live (app.js:19669-19679, 1119-1123). A unit pointing at a nonexistent categoryId renders as literal text 'Unknown category' and '—' — neither actionable nor filterable.
+- Categories: Models — the sub-entity carrying per-model maintenance schedules that OVERRIDE the generic service countdown — are append-only with no rename, delete or re-parent, and two independent creation paths neither of which does a name lookup, despite one path's own comment claiming it 'mirrors' find-or-create (app.js:19682-19683, 19708). Typing the same model name from two screens produces two divergent maintenance schedules with no way to merge them.
+- The same codebase demonstrably knows how: Invoices ships a full merge flow (app.js:9000, 19098-19100, mergeInvoiceInto) and resolveOrCreateVendorByName (app.js:20483-20488) does a proper name-match lookup before creating. The entities built first got identity rules; the entities built later did not.
+- Customers: 'New Customer' is a declared first-class blue pay-status in config (config.js:116-121) but the grouping list only names Unpaid/Partial/Current (app.js:9317-9319), so 2,260 of 2,265 customers fall into an unnamed hard-coded-grey leftover bucket appended last (app.js:9410-9411) — including customers who have rented for years and owe money right now.
+
+## 48. The Name Field Ledger
+
+**2 cards** · scope: `signal` · Customers, Categories
+
+Where the system drops the baton, staff have already built a replacement by hand — typing business state into free-text fields and exploiting sort order to make it surface — which is the sharpest available map of what the handoff is missing.
+
+**Why it persists:** Each card was built to display its own entity well. The state that spans cards — this customer is a credit risk, this account is escalated, this quote needs a blended rate — has no field anywhere, and no card claims it. The name field is the only thing that appears on every surface, in every sort, in every search result and in every picker, so it became the shared channel by default. The workaround is stable and effective, which is exactly why it will outlast any fix that does not replace it.
+
+**The question a UI system must answer:** *What is the surface for state that belongs to no single card — the standing warning, the running note, the 'handle this one carefully' — and how does it travel with the record onto every card that displays it?*
+
+**Instances:**
+
+- Customers: of 860 rendered production customer names, 25 carried business state typed directly into the NAME field — 13 owed-amount flags (e.g. '!!!Owes $X!!!'), 7 do-not-rent flags, 3 account-credit notes, 2 escalation-contact routings — and 23 of the 25 were punctuation-prefixed specifically because punctuation sorts above letters in the one sort (alphabetical) that isn't broken. Free-text note fields on individual accounts are used as an undated 'next follow-up' tracker because no structured field exists.
+- Customers: they are routing around three separate defects simultaneously — payStatus frozen at signup (the team's own spec, docs/specs/customers-crm.md:642-650 dated 2026-07-09, already documents it as 'STILL an open question'); red never saying why (44 of 60 rendered rows red, 11 of the first 12); and two of five sorts being dead no-ops that silently fall through to name order while the menu still shows them selected — 'Pay Status' produced a list byte-identical to 'Name', 'Last Invoice' produced reverse-alphabetical order.
+- Customers: a customer's stored 'Don't Contact' stage renders as a red pill on the row and on the Sales pipeline board, but the customer-detail popup clamps the off-vocabulary value to a calm blue 'Lead' (app.js:212-219) — so opening the record to check the warning makes the warning disappear, which is precisely the kind of vanishing signal that pushes state into the name field.
+- Categories: Mr. Wrangler has carried the correct answer the whole time — wranglerDigest bakes the live rate sheet into context (app.js:15092-15093) and find_categories / price_rental run the real blended pricing engine (app.js:15259-15262, 15320-15330) — but it is pull-only, never volunteered, and reachable only through a right-click, a gesture the counter persona has never performed. Meanwhile a 10-day rental that actually bills a blended $2,270 gets quoted at $3,600 off the four flat tiles, a $1,330 / 59% overquote, and 'nobody ever tells me I was wrong.'
+- Categories: member day-rate ($120 on the 12k Excavator, $89 on the 8k) is a first-class stored, admin-editable field that is never rendered on the mini-card face — which shows only the four retail tiers ($440, $320) — so a rep reading the surface he actually looks at overquotes a member by 267%.
+- Categories: every fresh session and every reload lands the left column on Units (config.js:419, app.js:2386), a card that carries no rate field at all, with no session-position memory and no role landing for a rate-facing role — so every price call begins on a screen that structurally cannot answer it.
+

--- a/docs/research/COMBINED-INVENTORY.md
+++ b/docs/research/COMBINED-INVENTORY.md
@@ -1,0 +1,527 @@
+# The Combined UI Inventory
+
+**171 findings · 5 cards · 48 cross-card patterns · 80 findings flagged systemic**
+
+Every finding came from a persona-driven audit that walked the live app as the laziest, least-sharp version of the person who actually works in that card, and verified each claim against production bytes. This combines all five, with RENTALS at full fidelity.
+
+> **This is a gathering, not a design.** Nothing below proposes a solution. Its job is to define the scope of what a UI system has to solve.
+
+---
+
+## Read this first — there are two apps, and only one was audited
+
+All five audits ran the **desktop build (>640px)**. Below 640px the app is structurally a different product: the 3-column grid becomes a 5-card swipe ribbon, the toolbar moves to a footer, popups become bottom sheets, sections become swipe decks, and global search disappears.
+
+Three consequences that change how you read everything else:
+
+1. **The tooltip layer does not exist on touch devices.** Both the tooltip and hover-preview engines early-return on `!HOVER_CAPABLE`. Every finding of the form *"the answer is only in a hover tooltip"* is worse than recorded — on the tablet in the yard that information is **absent, with no fallback path**.
+2. **The UNITS headline finding does not fire on touch.** The hover-preview misclick trap needs a hover; on a tablet the same control instead globally disables previews app-wide.
+3. **Drag-to-link was retired on phones in June 2026** in favour of long-press. *"Drag is the only way to attach a machine to a rental"* is a **desktop** truth; phones have a second, equally undiscoverable grammar nobody has audited.
+
+**Nobody has walked the phone build.** That is the single largest gap in this research.
+
+---
+
+## The six root problems
+
+The 48 patterns cluster into six roots. Each is stated as the question a redesigned UI system has to answer.
+
+| | Root | The question it must answer | Patterns |
+|---|---|---|---|
+| **R1** | The app has no addressee | Who is this for, and how does it reach them? | 13 |
+| **R2** | No fact has one owner | Where does a derived fact live so every surface reads the same function, and clicking a number returns exactly what it counted? | 11 |
+| **R3** | Urgency has nowhere to live | Where does urgency live, how is it ranked, and how does it travel up to the surfaces people actually glance at? | 11 |
+| **R4** | Guards are attached per-widget, not per-consequence | How does an action publish its own preconditions and reversibility to the control that triggers it? | 6 |
+| **R5** | Capability without a door | For every capability: where is its door? For every screen: what can I actually DO here? | 6 |
+| **R6** | Every card invented its own dialect | What is the one interaction grammar, and what enforces it? | 1 |
+
+### R1 · The app has no addressee
+
+It knows who is signed in and uses that for almost nothing — not to route work, not to scope a list, not to tell anyone anything. Assignment identity is captured in dozens of places and consumed nowhere. Every alert lands in one undifferentiated bell with no concept of who it is for.
+
+**The question to answer:** *Who is this for, and how does it reach them?*
+
+| Pattern | Cards | The systemic rule being broken |
+|---|---|---|
+| **Nothing reaches you when you're not looking** | 5 | The app has no delivery channel that survives the user not looking at the right pixel: no push, no OS badge, no durable inbox, no role-addressed message. Every alert it produces is a render-time paint on a surface someone must already be on, and the only confirmation primitive — the toast — self-clears in ~2.2 seconds with no trail. |
+| **One Bell, Owned By Billing And Transport** | 5 | There is exactly one proactive alert channel and its payload was claimed by the invoice and transport subsystems; every other subsystem's urgency — overdue returns, failed machines, expired insurance, category stockouts — has no route into it, and one card is hardcoded as the only tab allowed to glow. |
+| **No One Gets Told** | 5 | The app has no messenger. Every state change writes to data and stops there — nothing crosses to the person on the other card, on the other device, or off the screen — and four independent audits found the same void from four different seats. |
+| **Names That Don't Describe The Effect** | 4 | Controls and metrics are labelled for what someone assumed they did, and the label survives the code changing underneath it — so the user's model of the screen is built from text the screen no longer honours. |
+| **Nobody's Name On Any Job** | 4 | Work is never addressed to a person. Assignment fields are stored, displayed, edited and searched, but no view is ever scoped to 'mine' — so every worker reconstructs their own queue by reading the whole board. |
+| **Last Save Wins, Quietly** | 4 | When two people touch the same record from two cards, one person's work is discarded with no notice to either of them — and the sync that would have revealed the change is skipped at exactly the moment someone is working. |
+| **Records And Conversations Are Two Different Apps** | 3 | The comms subsystem and the records subsystem share a shell but never touch: no record surface can start a conversation, the built per-record thread panel renders nowhere, replies aren't polled, and Settings sells three notification engines that don't exist. |
+| **The Primary-Unit Mirror Meets Multi-Unit Reality** ⁿ | 3 | A one-rental-one-unit identity from an earlier era is still the pointer that actions resolve through, so on multi-unit rentals and merged trips the app acts confidently on the wrong machine, the wrong stop, or nothing at all — while the clicked identity sits unused in scope. |
+| **Machines Are Entities, People Are Not** ⁿ | 3 | The flag, conflict and queue machinery was built for equipment and paperwork; drivers and mechanics are stored as strings on those records, so the same double-booking that pulses red on a machine is silent on a person, and 'assigned to me' does not exist anywhere in the app. |
+| **Silence Is Rendered As Success** | 3 | Failures, staleness and non-delivery produce no distinct state. A write that never landed, a poll that never runs, a fetch that errored, and a toggle whose engine was never built all leave a screen identical to the working case. |
+| **Closed Without Proof** ⁿ | 3 | Terminal states are recorded as accomplished facts without the app ever capturing the evidence that would make them true, and every downstream aggregate inherits the hole silently. |
+| **Zero Is Not "I Don't Know"** | 2 | The app has no representation for unknown. Divide-by-zero guards, falsy defaults and blank inputs all resolve to a confident 0, $0, an em-dash or a green all-clear that is typographically identical to a real measurement. |
+| **The Empty Return** ⁿ | 2 | The end of a rental is the densest handoff in the business — machine, hours, condition, damage, money — and the return path records only {date, video, driver}, so three downstream cards derive their numbers from readings nobody was ever asked for. |
+
+<details><summary><b>Why the 3 five-card patterns here persist</b></summary>
+
+**Nothing reaches you when you're not looking** — Alerting was never modeled as a layer with an address ('who is this for?') and a lifetime ('how long does it stay?'). Each feature that needed to say something reached for the nearest render-time primitive — a colour, a count, a 2.2-second toast — because that is the only primitive the app has. Settings then grew toggles describing an alerting product nobody built, so the UI now promises delivery it structurally cannot perform, and the promise itself hides the gap.
+
+- RENTALS: sw.js is 47 lines documented 'OFFLINE SHELL ONLY' with no push/notificationclick listener and no showNotification; a grep of the 27,649-line app.js for Notification/requestPermission/setAppBadge/pushManager returns zero. Only two setInterval calls exist in the whole file — a GPS-view timer (app.js:24080) and an 18s backend poll (app.js:24796) — and neither scans flags to fire anything.
+- Calendar/Driver: assignStopDriver's only effect on a successful assignment is a line pushed into a hidden per-rental audit array. All 3 call sites traced (single-stop picker, drag-drop, bulk 'Round up'); the one toast() anywhere in the chain fires in the DISPATCHER's own browser and is never addressed to or visible on the assigned driver's device.
+- Calendar/Driver: Settings → Notifications → Crew Alerts already ships a toggle named 'Driver Assigned' — 'Texts a driver the moment a delivery or pickup is assigned to them' — scoped and named in the settings schema, defaulted off, and explicitly commented in-code as inert until a later phase.
+- UNITS: all ten FLAG_COND.units predicates fire silently into data with no messenger; team chat only rings for human-typed messages; toasts are the only confirmation surface and self-clear in ~2.2 seconds with no durable trail — so an uninsured or overdue machine can go out the gate with nothing on the mechanic's tablet ever having said so.
+
+**One Bell, Owned By Billing And Transport** — The bell was built as a feature of the billing rollout and the transport rollout, each appending its own count to one expression, rather than as a subscriber to a severity bus. Because the flag engine and the alert engine were never connected, registering a new red flag is free and produces nothing — the flag author gets a colored border and reasonably assumes the alerting was handled by whoever owns the bell.
+
+- RENTALS: commsBellCount = unseenNotifs() + visibleTransportAlerts() + wranglerRequests (app.js:10342-10343) — none of the three reference the flag system, and a past-endDate leg drops OUT of the forward-windowed transportAlerts, so an overdue return isn't even indirectly counted. off-rent-overdue is a registered red flag (config.js:245) that feeds only getEntityColor, tinting the row it's already sitting in. The rentals column tab's alert is hardcoded false (app.js:9601).
+- Categories / all cards: the column-tab alert glow is literally `alert: m === 'units' && unitsAlertCount() > 0` (app.js:9644-9655) — a string match on one card name; unitsAlertCount() is the only such function that exists anywhere in the file, so no other column can ever light up no matter its internal state.
+- UNITS: the one alert indicator visible before opening the card watches only 3 of the 10 registered flag conditions (app.js:9479), and the bell itself shows 'Transports due' — a dispatch concern — while every item in the Notifications panel is invoices or card payments, none of it role-filtered (app.js:14050).
+- Customers: the same bell holds engineering tickets addressed to the owner — pricing-engine internals with GitHub links, rendered as raw unparsed markdown so authored **Verdict:** shows its literal asterisks — with nothing customer-facing in it at all.
+
+**No One Gets Told** — Notification was scoped as a channel feature (web push, SMS) rather than as the required completion of a write, so it sat behind a phase gate while the writes themselves shipped card by card. Every handler's definition of done is 'the record changed' — logAction + saveSoon — and there is no shared commit path that asks who else is affected. The Settings toggles prove the intent was captured; what is missing is the obligation.
+
+- RENTALS: sw.js is 47 lines, documented 'OFFLINE SHELL ONLY' — install/activate/fetch/message listeners only, no push, no notificationclick, no showNotification, no pushManager.subscribe. A grep of the 27,649-line app.js for Notification / requestPermission / setAppBadge / pushManager returns zero. Close or background the app and zero alerts reach the dispatcher. UNITS, Categories and Calendar each rediscovered this independently — four cards, one hole.
+- Calendar / Driver: assignStopDriver()'s only effect on a successful assignment is pushing a line into a hidden per-rental audit array (app.js:11341-11352, 22575). All three call sites traced (single-stop picker, drag-and-drop, bulk 'Round up'); the one toast() anywhere in the chain fires in the DISPATCHER's own browser. The driver is never told he has a job.
+- Calendar / Driver: Settings → Notifications → Crew Alerts already ships a toggle literally named 'Driver Assigned' — 'Texts a driver the moment a delivery or pickup is assigned to them' — defaulted off (app.js:5161) and explicitly commented inert until a later phase ships the SMS path (app.js:5282, 5291). The product already named the fix.
+- Customers: live, saveable Settings toggles for customer reminders and dispatch ETAs whose engines are inert — the toggle only persists its own state, so anyone flipping it on reasonably believes the app is now chasing customers.
+
+</details>
+
+### R2 · No fact has one owner
+
+The same business fact is re-derived at every render site, each encoding its own filters and window. Nothing carries provenance, freshness or authority — so the screen contradicts itself inside one viewport, and a count does not return the rows it counted.
+
+**The question to answer:** *Where does a derived fact live so every surface reads the same function, and clicking a number returns exactly what it counted?*
+
+| Pattern | Cards | The systemic rule being broken |
+|---|---|---|
+| **Every number has two authors** | 5 | The same fact is computed independently by two or more renderers with different predicates, and both results ship to the same screen. There is no single derive layer, so the app contradicts itself inside one viewport — and the drill-through from a number lands on a differently-filtered set than the number counted. |
+| **Desktop Pointer And Gloved Thumb On One Surface** | 4 | The same screen is authored for a mouse with hover and a precise click, and used by a driver in a cab and a tech on a yard tablet — so the meaning of the screen lives in hover states, and the destructive actions live where the hand is already travelling. |
+| **Two Truths, One Screen** | 4 | The same fact is computed independently at every place it appears — live from source records here, from a stored field or a differently-scoped tally there — so two answers to one question render inches apart with nothing marking which is authoritative. |
+| **The Number Doesn't Own Its List** | 4 | A count is tallied over one population and then used as the label for a click that produces a different population — or for a list it does not scope at all — so tapping a number is the most reliable way to discover the number was wrong. |
+| **Every Card Grades Its Own Homework** | 4 | 'Is this OK / available / attention-worthy' is recomputed independently on every card from a different subset of the same shared flag registry, so the same machine or customer answers differently depending on which card you are standing on. |
+| **Everything still assumes one record per thing** ⁿ | 3 | The data model grew multi-unit rentals and merged multi-stop trips; the UI and its logic did not. Wherever a container holds more than one child, the app silently substitutes the primary child for the whole — acting on the wrong record, hiding the worse one, and counting progress as zero until everything is done. |
+| **The Status Field Has Two Owners** ⁿ | 3 | One status control is simultaneously dispatch's lifecycle timeline and accounting's authority gate, and the money system only guards the four statuses that mean 'going out' — so every exit path from a rental closes the job with no billing check at all. |
+| **Every Renderer Computes Its Own Truth** | 3 | There is no shared definition of 'available', 'owed', or 'how many' — each renderer derives the number inline against its own filter, so two subsystems print contradictory answers to the same question inches apart on the same screen. |
+| **The Truck Loses To The Desk** ⁿ | 2 | Field capture and office bookkeeping share one status action, and when they disagree the office wins by destroying the field's work — the driver's evidence is thrown away, the block is invisible on his surface, and no queue holds the write. |
+| **The Parallel Ledger** | 2 | Where the official number cannot be trusted, staff have rebuilt it by hand in free-text fields — which is simultaneously the strongest proof the trust failures are real and a second, unvalidated source of truth the redesign now has to absorb rather than delete. |
+| **The Name Field Ledger** | 2 | Where the system drops the baton, staff have already built a replacement by hand — typing business state into free-text fields and exploiting sort order to make it surface — which is the sharpest available map of what the handoff is missing. |
+
+<details><summary><b>Why the 1 five-card pattern here persists</b></summary>
+
+**Every number has two authors** — Derivation lives inside renderers instead of in a shared, named selector every surface must call. When someone corrects a definition they correct the renderer in front of them — the mini-card gets the fleetStatus fix, the detail does not — so each fix increases the number of disagreeing definitions rather than reducing it. Nothing in the codebase makes 'availability' or 'amount owed' a single addressable thing, and nothing fails when a fourth caller invents a fifth definition.
+
+- Customers: the row computes live owed/overdue from real invoices every render while the group header, sort, filter and pulsing detail flag all read a stored payStatus written once at signup — a repo-wide grep found zero write sites outside the five creation paths, and the team's own spec (docs/specs/customers-crm.md:642-650, dated nine days before the audit) already calls it an open question. Two contradictory answers to 'does this person owe us' sit inches apart.
+- Categories: same category, same second — 12k Excavator mini-card reads 'NEXT MON' (zero free) while the detail reads '9 Available'; Lift Scissor 19ft reads '2 Avail' vs '5 Available', the 3 extra being sold machines. A comment at app.js:7212 shows this exact bug class was fixed on the mini-card on 2026-06-25 and the fix never reached the detail renderer.
+- UNITS: the Worklist graph reads 'NOT READY 28' while the group bar ~40px below on the same screen reads 'NOT READY · 8' — the graph tallies all of DATA.units (app.js:12167-12170), the list excludes out-of-fleet and on-rent units first (app.js:9295), and unitsAlertCount (app.js:9479) holds a third, narrower definition.
+- UNITS: the Work Orders bar counts one entry per open WO but the click-through filters units — a unit with 2 open WOs is one row and two counted, so the number structurally cannot match the rows beneath it.
+
+</details>
+
+### R3 · Urgency has nowhere to live
+
+Every list has one grouping slot and a lifecycle taxonomy already claimed it. The only thing anyone scans for — what is on fire — is left to a single colour channel with no ranking and no complete registry, and severity has no path upward from the row it is born on.
+
+**The question to answer:** *Where does urgency live, how is it ranked, and how does it travel up to the surfaces people actually glance at?*
+
+| Pattern | Cards | The systemic rule being broken |
+|---|---|---|
+| **Severity dies on the row it's born on** | 5 | Urgency has no path upward. A flag can be true on a row while the group header above it, the tab beside it, and the global count at the top of the app all stay calm — because every level re-implements its own private subset of the flag registry instead of aggregating the level below it. |
+| **Colour is the only channel, and it's saturated** | 5 | Distinct conditions requiring different responses are mapped onto one visual output — a single red — with no name, no legend, and a ranking that reflects source order rather than consequence. The channel is oversubscribed to the point where alarm is the default state, and the same glyph or colour means different things on different cards. |
+| **The label layer is hover** | 5 | The app has no naming layer. Controls ship as bare glyphs and the text that would explain them — plus, routinely, the operative data itself — is stored in a title/data-tip attribute, a gesture that does not exist on touch, in gloves, or in a screen reader. Where text does render, it truncates at exactly the character carrying the meaning. |
+| **One Red Pill, Eight Meanings** | 5 | Distinct conditions from different subsystems are funneled through the same visual channel and the same words, so the pixel a user reads is a collision site: pricing, fleet, dispatch and AR each mean something different by 'red', 'available', 'member', and the row cannot say which one fired. |
+| **Lifecycle Sorts The List, Danger Doesn't** | 4 | Two taxonomies contest the vertical axis of every list — a lifecycle/stage grouping that owns the buckets and headers, and a flag/severity system that owns the colors — and the grouping never consults the flags, so the emergency is filed under whatever calm stage it happens to be in. |
+| **The Blink Points At The Calm One** | 3 | Attention signals are wired to the wrong side of their own condition — pulses that fire unconditionally, predicates tested against values the data can never hold, booleans swapped — so the loudest thing on the screen is reliably the least urgent thing on it. |
+| **The Confirmation Doesn't Name The Record** ⁿ | 3 | Actions commit against a record other than the one clicked, and the receipt — a toast, a highlight, a restored scroll position — is generic enough to endorse the wrong one. |
+| **Order Is A Claim Too** | 3 | Sorting and grouping are presented as the answer to "what is most urgent", but the sort either doesn't run, is silently overridden by grouping, or is keyed on something that isn't time — and the control still reads as applied. |
+| **Late Is the First Warning** ⁿ | 3 | Urgency is computed from deadlines that have already passed. Nothing buckets, counts or signals work that is due — only work that is overdue, and often not even that. |
+| **One Red For Seven Reasons** | 2 | Severity is stored per-condition but rendered as a single collapsed value, so a row can say "something is wrong" and not what — and each surface independently picks its own subset of the condition registry, so the surfaces disagree about whether anything is wrong at all. |
+| **The Mirror Unit** ⁿ | 2 | A rental's identity as a set of machines is stored twice — the real units[] array and a scalar r.unitId 'primary' mirror — and every cross-card consumer reads the mirror, so work aimed at machine #2 or #3 silently lands on machine #1. |
+
+<details><summary><b>Why the 4 five-card patterns here persist</b></summary>
+
+**Severity dies on the row it's born on** — Flags were built as a per-entity registry but consumption was left to each renderer. There is no rollup contract requiring a container to expose the maximum severity of its contents, so every count and header was written by whoever needed one, at the granularity they needed. Severity therefore has no inheritance path, new entities (Categories) join the app without joining the registry, and nothing fails when they don't.
+
+- UNITS: unitsAlertCount ignores 5 of the 10 registered flag conditions — failed inspection, overbooked, GPS offline, coverage expired, uninsured-active — including the two that put an unsafe or uninsured machine on the road. The tab badge, card border, corner-flag pill and group bucket each reimplement a different subset, so four separate mechanisms disagree about what 'needs attention' means.
+- RENTALS: an overdue return (off-rent-overdue, config.js:245) feeds only getEntityColor — it tints the row it already sits in and nothing else. commsBellCount = unseenNotifs()+visibleTransportAlerts()+wranglerRequests references it nowhere, and a past-endDate leg drops OUT of the forward-windowed transportAlerts so it isn't even indirectly counted. The rentals column tab's alert is hardcoded false (app.js:9601).
+- RENTALS: GROUP_DEFS.rentals buckets on lifecycle status (app.js:1986-1990) and never consults a flag, unlike UNIT_SECTIONS (app.js:9279-9290) which has an explicit red 'Attention' bucket — so the header count never reflects severity and flagged rows aren't lifted within the group.
+- Categories: zero entries in FLAG_META/FLAG_COND — a full grep of both registries and every call site finds no getEntityFlags('categories', …) anywhere — so no category condition (zero stock, negative ROI, unset pricing) can escalate past its own mini-card pill. No categoriesAlertCount function exists, and the column-tab alert glow is hardcoded to fire only for Units.
+
+**Colour is the only channel, and it's saturated** — Severity was modeled as a colour rather than as a named condition with a required response. Once red is the only way to say 'important,' every team with something important adds red, and the encoding degrades monotonically — nothing ever removes a red, and nothing arbitrates between two reds, so ranking falls back to whatever order the flags happened to be pushed in.
+
+- RENTALS: FLAG_COND.rentals defines 7 conditions (fc, overbooked, unpaid-balance, no-card, unsigned-card, unit-failed, off-rent-overdue), ALL severity:'red', and getEntityColor collapses to fl[0].severity so the row renders one uniform red. The flag's NAME never appears on the row, and 2 of the 7 (no-card, unsigned-card) are genuinely unidentifiable without the desktop hover-preview or a hop to the customer record.
+- Categories: eight-plus distinct unavailability reasons (N/A, Sold, For Sale, Inactive, Failed, Overdue, End Dates?, Off fleet, plus Purchased/Onboard) all render through one identical red pill with no legend anywhere — an actionable 'Overdue' (a customer is late returning our machine) is pixel-identical to an inert 'N/A' (we never stocked the class).
+- Customers: measured live, 44 of 60 rendered rows were red and 11 of the first 12 in the default view; inspecting a red row's DOM found no flag word in its text and no title attribute — the only tooltip on the row belongs to an unrelated eye-preview toggle. 'Hasn't rented since spring' and 'has no card and is about to take a machine' render identically.
+- UNITS: flag ranking is by colour rank tie-broken by hardcoded push order — GPS is pushed second, service fourth — so a dead GPS antenna always outranks a seizing engine when both are red; the worst machine in the yard (2,882 hrs past service) displays as 'No GPS +1'. Separately 'Part Needed,' 'Part Ordered,' 'Part Needed?' sit side by side with the question-mark variant rendering red on one tile and amber on the next.
+
+**The label layer is hover** — Every card face is over-subscribed and hover was available and free. Because a tooltip is a per-element decision rather than a naming contract, what gets demoted is chosen locally and always sacrifices the long string — which is usually the noun carrying the meaning. No layout rule reserves space by importance, so truncation order is an accident of source order, and touch/gloved/assistive use was never a rendering mode the layout had to satisfy.
+
+- UNITS: a full inventory of the mechanic's screen found 86 interactive elements, 58 (67%) with no visible text label, 52 of those 58 labelled only by a title-attribute hover tooltip, and not one aria-label in the set — even though the repo already pairs aria-label with data-tip in 69 other places, so the pattern is known and simply unapplied here.
+- Categories: a live full accessibility-tree read found refs ref_1826 through ref_1859 plus the entire block ref_2305–ref_2328 (the category pills) all reading as bare 'button', and the filter-term chips — both the pill and its nested negate-icon button — do not appear in the accessibility tree at all: unreadable and unremovable by a screen-reader user.
+- Calendar/Driver: the row prints a town, 'Lake Charles', while the live DOM shows data-tip holding the full '1700 11th St, Lake Charles, LA 70601, US' as an unused hover-only attribute — for a driver in a truck wearing a glove.
+- UNITS: the worst machine in the yard, 2,882 hours past service, renders on its tile as 'No GPS +1' with the service number existing nowhere on the tile face, only inside the data-tip string; and service-flag text truncates at roughly 9px so '73 HRS…' could mean overdue or remaining.
+
+**One Red Pill, Eight Meanings** — Color and pill shape are the only severity channels the design language exposes, and every subsystem that needed to say 'important' had exactly one way to say it, so red accreted meanings without any of them being wrong. The flag registry stores severity but not identity, so getEntityColor can only return a color — the name of the condition that fired has nowhere to render on a row. And because each card's vocabulary was authored locally, the same word ('available', 'member', 'weekend') was defined independently three times.
+
+- Categories: eight distinct unavailability reasons — N/A, Sold, For Sale, Inactive, Failed, Overdue, End Dates?, Off fleet — all render through one identical single-color red pill with no legend, via a single badge(...,'red') call (app.js:2281-2297). An actionable 'Overdue' (a customer is late returning our machine) is pixel-identical to an inert 'N/A' (we never stocked the class).
+- RENTALS: FLAG_COND.rentals defines 7 conditions — fc, overbooked, unpaid-balance, no-card, unsigned-card, unit-failed, off-rent-overdue — ALL at severity 'red' (config.js:239-253), and getEntityColor collapses to fl[0].severity (app.js:5834-5854), so the row is one uniform red. Verified scope: 3 of 7 get a distinct on-row echo, but no-card and unsigned-card are genuinely unidentifiable without a desktop hover-preview or a hop to the customer record.
+- Categories: member day-rate ($120) is a stored, first-class, edited field that the mini-card never renders — the face shows only the four retail tiers (1-Day $440 etc.) while rentalPrice() short-circuits to days × memberDaily for a member, skipping all four displayed tiers (app.js:7271-7275 vs 8876-8879 vs 1078). A rep reading the face he actually looks at overquotes a member by 267%.
+- Customers: on a live production record the account header read 'Member' while the AR block on the same screen read 'NON MEMBER MODE' for the same account. Separately, a stored 'Don't Contact' stage renders as a red pill on the row but the detail popup clamps off-vocabulary values to a calm blue 'Lead' (app.js:212-219) — opening the record to check the warning makes the warning disappear.
+
+</details>
+
+### R4 · Guards are attached per-widget, not per-consequence
+
+Whoever wrote a control decided its guard, so the confirmation lands on the reversible action while the irreversible one beside it commits on first tap. Preconditions are evaluated at commit time and nowhere before it, so the control cannot render blocked.
+
+**The question to answer:** *How does an action publish its own preconditions and reversibility to the control that triggers it?*
+
+| Pattern | Cards | The systemic rule being broken |
+|---|---|---|
+| **Nothing warns you before the point of no return** | 5 | Preconditions and consequences are evaluated at commit time and nowhere before it. The UI never says an action is blocked, irreversible, or wrong until after you've taken it — and the app's own confirm/arm/review patterns are hand-applied conventions, so identical-looking controls a few lines apart behave completely differently. |
+| **Writes have no integrity layer** | 5 | Records can be created, edited and closed out without the app checking the result is coherent. Nothing dedupes on create, nothing validates magnitude or format on entry, nothing captures the fields the business needs at the moment they exist, and nothing can delete or merge what got made wrong — so bad data is permanent and silently authoritative. |
+| **Gates are attached to controls, not to data** | 3 | Permission is enforced wherever someone remembered to enforce it — on a specific button, inside a specific renderer — never on the datum itself. So the same value is masked on one surface and printed on the next, and the authority to create a record is decoupled from the authority to make the created thing safe. |
+| **Permission Is A Per-Renderer Opinion** | 3 | Authority is enforced at individual widgets rather than at the data, so the same value is masked on one strip and printed plainly on the next, and the two gate functions in the app disagree about who an unassigned user even is. |
+| **Locks on Doors, Not on Jobs** | 3 | Permission is attached to individual controls rather than to the job those controls perform, so the same job is gated on one card, ungated on another, and inverted within a single file — and the gate does not travel with the work. |
+| **The Gate Fires in the Field** ⁿ | 2 | Office-side booking gates are evaluated at the instant of the field action, in the field worker's browser, against data he cannot see or fix — so the block destroys the field work instead of preventing the trip. |
+
+<details><summary><b>Why the 2 five-card patterns here persist</b></summary>
+
+**Nothing warns you before the point of no return** — Gates were written as guards inside commit handlers — the correct place to enforce them and the worst place to communicate them. Because the gate's answer is never computed at render time, the control cannot know it is disabled; and because confirm/arm/review are conventions applied by hand rather than properties of a destructive-action primitive, whether a given button asks first is decided one button at a time by whoever wrote it.
+
+- RENTALS: the invoice hard-gate fires only for val==='On Rent' (app.js:19911) and the blacklist/rules/card/account-block gates are all scoped to BOOKING_STATUSES ['On Rent','Reserved','Today','Tomorrow'] (app.js:19751) — 'Returned' is in none. The status dropdown is a free-jump timeline, every node a live button with no disabled state, so a fresh Reserved rental with invoiceId still null can be clicked straight to Returned and closed out unbilled.
+- RENTALS: terminal jumps (Returned/Cancelled/No Show) sit stacked as the last rows of one dropdown (order app.js:16851), each a plain button calling setRentalStatus with zero intervening step; Cancel/No-Show strips billing in the same breath (app.js:19929) and the row drops instantly with no fade — while the app already owns a confirm pattern.
+- RENTALS: a driver taps Log Delivery, the office-side booking gate refuses the status move, and the entire capture including recorded video is discarded — no queued retry, no visible block on the Trips side to clear (app.js:20256-20261).
+- Calendar/Driver: the same class from the driver's seat — the log-gate ('no invoice on this rental') is evaluated only on tap, never at row render, so a stop blocked that morning shows no lock and no flag until he has driven the full distance. The check exists in the codebase; it simply runs at the wrong moment.
+
+**Writes have no integrity layer** — Writes were added one form at a time to satisfy one screen's need, and the schema is treated as append-only storage rather than a model with invariants. Validation, dedupe and lifecycle (merge/retire) are each a feature someone would have to request, and nobody requests them until the bad data is already load-bearing — at which point deleting it is more dangerous than living with it, so the workaround (a second record, a 'Unknown category' string) becomes permanent.
+
+- UNITS: the only field writing the hour meter is `const v = Number(input.value); u.currentHours = v` — no range check, no order-of-magnitude guard, no monotonic check. Live production history on unit SPEECHLESS: 'Jun 17 — Hours: 1732.3 → 17385.5' (Cameron), corrected 'Jul 13 — 17385.5 → 1738.5' (Bri) — a 10x typo that stood 26 days feeding every service countdown, the fleet hours average, category ROI and $/Hr computations, permanently stamped onto every work order opened in that window. Separately, a blank 'hours at completion' records as 0 and sets a false countdown baseline.
+- RENTALS: 'Log Recovery' stamps only {date, video, driver} and sets Returned — no condition capture, no inspection opened, no damage line (app.js:20259-20261) — so the Rental Protection $1,000 cap (app.js:4410-4411) can never be exercised from the return path.
+- UNITS: the same gap upstream — startHours/returnHours exist on every rental unit entry, are seeded with real values and are humanized for the audit log, but have zero writers, so a unit goes out for three weeks, comes back 180 hours older, and its service countdown does not move by one hour.
+- Calendar/Driver: uploadCaptureMedia posts the walkaround video once; on network failure the catch toasts 'saved without it' for two seconds and the row still stamps green 'Logged' — a failed upload and a successful one are visually identical afterward, and that video is the only defense against a later damage claim. A failed sync holds the pending write only in RAM while the R25 banner instructs a phone user 'Don't close the app.'
+
+</details>
+
+### R5 · Capability without a door
+
+Finished, permission-gated, audited features sit unreachable because their only entry point was on a retired card, in a state that can never occur, or on a board specced and never built. The cards describe state exhaustively and offer almost nothing to do about it.
+
+**The question to answer:** *For every capability: where is its door? For every screen: what can I actually DO here?*
+
+| Pattern | Cards | The systemic rule being broken |
+|---|---|---|
+| **Built but never doored; rendered but never wired** | 5 | There is no binding between a capability and a control. Fully-built features sit in production with no button that reaches them, and fully-rendered buttons sit on screen with no live code behind them — and neither condition produces any signal, so the surface looks complete in both directions. |
+| **The cards narrate; they don't act** | 5 | Surfaces are built to report state, not to advance work. The record tells you what is true and offers no next move, no way to reach the person involved, and no queue of what is yours — so every real action is a multi-screen detour or a phone call the app never sees. |
+| **Doors Walled Over** | 5 | When a card was retired, the capabilities that lived on it stayed fully built underneath but lost their only entry point, and no other card adopted the step — so a whole job in the chain has working code, gates, confirms and audit entries, and no button. |
+| **Retired Cards Left Their Work Behind** | 4 | Whole subsystems were retired by deleting their renderer while leaving their handlers, gates, buckets and confirm flows live — so fully built, fully gated capabilities now sit unreachable inside the surface that won the real estate, and the stranded copy still instructs users in the retired idiom. |
+| **A Stored Mirror Nobody Re-Derives** ⁿ | 4 | Denormalized fields — a primary-unit pointer, a pay status, a WO phase, an on-hand quantity, an hour meter, a sync flag — are written once and then read as current everywhere, with no invalidation, no re-derive pass, and nothing in the UI distinguishing a mirror from a measurement. |
+| **Born, Never Buried** | 2 | Records mint from many paths with no lookup and can never be merged, retired or deleted — so a duplicate created at one card boundary permanently splits the history the next card needs. |
+
+<details><summary><b>Why the 3 five-card patterns here persist</b></summary>
+
+**Built but never doored; rendered but never wired** — Cards were retired by unmounting a renderer, not by re-homing what they owned; and features were specced with their entry point as an afterthought. Nothing in the build fails when a handler has no call site or a control has no handler, so dead surface accumulates in both directions — and staff invent workarounds (voiding through the Sheets backend, typing state into name fields) that make the gap invisible to whoever measures whether the feature 'exists.'
+
+- Customers: send-to-collections and void-invoice are built end to end — manager gate, confirm popup with reason codes, overlay, auto-blacklist, audit-log entry, money-safe void handler — and their only trigger buttons render inside a retired standalone Invoices card. Verified live: the status menu on a real Late invoice offers exactly three items — Pay, Print, Send (greyed). Two invoices on one real account already read VOIDED, meaning voids currently happen only through the Sheets backend.
+- RENTALS: the multi-driver lane rail and the one-tap 'Round up' auto-balance handlers exist (app.js:11802-11805, app.js:18629-18636) but nothing renders their buttons — with 12 stops and 3 trucks the dispatcher can only tap +Driver one stop at a time.
+- UNITS: the WO phase pill is frozen because the code that advanced it lived in the retired Shop-card renderer; the failed-inspection photo/video link is emitted exclusively from that same retired renderer; and the ex-Shop quick filters '__wo' and '__svc' are fully implemented with human labels (app.js:3167) with nothing linking to them.
+- Customers: two of five sort options are dead no-ops — sorting by 'Pay Status' produced a list byte-identical to sorting by 'Name'; sorting by 'Last Invoice' produced reverse-alphabetical order with no reference to any invoice date — while the menu still shows them as selected.
+
+**The cards narrate; they don't act** — The app's unit of design is the record, not the task. Each card was built to answer 'what is the state of this thing,' and the actions that follow from that state belong to other systems — comms, dispatch, billing — living on other surfaces, so nobody owned the join. Assignment fields exist because records need attributes, not because anyone modeled a person's queue; and when the system offers no place to put an intention, staff put it in the name field.
+
+- Customers: no call, text, charge, or follow-up control exists anywhere on a customer row or in the detail record — the card only ever states facts. There is no tap-to-call at all, and the only real text/email action hides behind an undiscoverable right-click/long-press context menu which itself has no 'Call' option.
+- RENTALS: the 'next move' on an open rental is a status noun on a 22px pill — 'Off Rent' reads like routine progress even when it means the machine is 3 days overdue — with no verb and no primary CTA. Every outreach to the driver or customer about a specific rental is a 2-3 screen detour; the nearest one-tap contact is the roster-wide 'Text the Crew' broadcast buried in Settings.
+- Calendar/Driver: the row's entire overflow menu contains exactly one item — 'Merge trip…', a dispatcher concept. No 'running late,' 'can't complete,' or 'on my way' exists anywhere on a driver's own row, even though the capability sits one card over: the Unit card carries a working '+FC' Field Call button at app.js:7736 that simply isn't wired onto the row where the driver is standing. There is also no standing pre-populated dispatch thread to tap into.
+- UNITS: assignedMechanic appears 17 times — stored, displayed, edited, searched — and is never once used to route, filter, badge, or scope a view. Every auto-created work order is born with it blank (app.js:20009, 22445, 23005), and no 'assigned to me' filter or badge keyed off the logged-in identity exists anywhere.
+
+**Doors Walled Over** — Cards were retired by deleting a renderer, not by re-homing the jobs that renderer hosted. Because the handlers, permission gates, confirm dialogs and audit writes all survive, every grep and every code review says the feature is present — the only missing piece is a button, which is invisible in the diff. Nothing in the codebase maps a job to the card that owns it, so retiring a surface has no checklist and no failing test.
+
+- UNITS: the Shop card is retired and work orders now live inside each unit, so there is no fleet-wide open-jobs view. Merle, driving it live: "the Shop card's gone. Work orders live down inside each unit now. So there's no one place I can stand and see every open job. I gotta open machines one at a time." The ex-Shop quick filters '__wo' (WOs Open / Parts Ordered) and '__svc' (Service Due) are fully implemented with human labels and nothing links to them (app.js:3167); completed and cancelled work orders have no home anywhere (app.js:7669).
+- UNITS: every work order's phase pill is frozen at its creation value because the code that advanced it lived in the retired Shop-card renderer and is unreachable from Units (app.js:6978).
+- UNITS: js-open-insp — the only link to a failed inspection's photo/video report — is emitted exclusively by the dead Shop renderer (app.js:9127); the unit's own Inspection section renders no thumbnail or link.
+- UNITS: the only ETA editor for an ordered part lives on the retired workOrders detail renderer, which app.js:3052 unconditionally redirects away from. The partform has no date input, savePartForm initializes eta:'' and never touches it — so part-ordered-eta can never fire and its sibling part-ordered-no-eta is permanently true (app.js:5874, 8016).
+
+</details>
+
+### R6 · Every card invented its own dialect
+
+The same control, gesture and glyph mean different things card to card, because each was authored against that card’s own state model rather than drawn from a shared grammar. A habit learned in one place is actively wrong in the next.
+
+**The question to answer:** *What is the one interaction grammar, and what enforces it?*
+
+| Pattern | Cards | The systemic rule being broken |
+|---|---|---|
+| **View state is scratch paper** | 5 | Sort, filter, grouping, scroll position and navigation history are re-implemented per card with different semantics and different persistence, and none of them is anchored to a record. The list is not a stable addressable thing — it silently reorders, silently combines with filters from ten minutes ago, and silently loses your place. |
+
+<details><summary><b>Why the 1 five-card pattern here persists</b></summary>
+
+**View state is scratch paper** — The list is treated as a render output rather than a state object with an owner. Each card grew the scoping controls its first users asked for, keyed to whatever local variable was handy, so there is no shared vocabulary for 'what am I looking at.' And because position is remembered as pixels rather than as a record, any re-sort silently invalidates the only breadcrumb the app keeps — which means the more the app updates itself, the more reliably it loses you.
+
+- UNITS: grouping beats sorting. Measured live with sort explicitly set to Service Due — position 1 was 440 hrs overdue, position 2 was 2,882 hrs overdue, position 3 was 2,025, positions 4-8 were five machines with nothing wrong at all, and position 9 was Dirt Dauber at 1,139 hrs overdue, filed under the green AVAILABLE bucket. Buckets are decided by inspection status alone; service urgency never enters bucket assignment.
+- RENTALS: scrollMemo is keyed only by card|view and restored by raw pixel (save app.js:17185-17190, restore app.js:17229-17234) — the key never includes the acted-on record id, and list mode always restores the saved value even when the list re-sorted underneath (status is a selectable sort field, config.js:431). Acting on a row lands the viewport on a different rental, and the toast says only 'Status → X'.
+- Calendar/Driver: the app-wide scroll memory reads and writes .card-body's scrollTop across 5 call sites while the real scroller on Trips is the nested .cal-scroll — a live control test showed position 120→0 — and the 18-second background poll triggers the same render with no user action at all.
+- Categories: filters set from one category persist and silently intersect with a filter clicked on a different one later. Live: two chips ('Not Ready · Light…' + 'Ready · 12k Exca…') intersected with Back/Forward vanished — the result looked like a normal list, just of the wrong machine.
+
+</details>
+
+*ⁿ = pattern only visible once RENTALS became real data (12 of 48).*
+
+---
+
+## What each card said
+
+### UNITS — 42 findings
+
+**Persona:** Merle Boudreaux — "the Yard Mechanic," 52, Sulphur yard maintenance tech. 22 years turning wrenches, 3 weeks on this app, didn't read the training email. Won't scroll, won't hover, won't perform a gesture; reads colors and numbers, never prose. If the screen doesn't name his next move in ~4 seconds he sets the tablet down and walks out to eyeball the machines himself.
+
+> The screen built to tell a mechanic what to touch next survives exactly one click, and a machine with a failed inspection 2,882 hours overdue on service attaches to a customer's rental by drag-and-drop with zero warning, zero confirmation, zero block.
+
+*4 findings existed only in conversation. 6 claims were retracted under verification.*
+
+### Customers — 32 findings
+
+**Persona:** Robin — seven-months-in front-desk / counter-sales rep. Reads colour first, then the biggest word, then nothing. Won't scroll, won't hover, won't right-click, won't remember a shortcut. Needs the screen to spell out the next move.
+
+> The card tells her what a customer IS, never what to DO about them, and the one number she'd actually act on — does this person owe us money right now — has two contradictory answers on screen at once, one of which has been frozen since the day they signed up.
+
+*8 findings existed only in conversation. 7 claims were retracted under verification.*
+
+### Categories — 40 findings
+
+**Persona:** Dewey "Dew" Fontenot — counter &amp; dispatch rate-reader, 14 months on the counter/radio; reads the first number his eye lands on, never scrolls/hovers/right-clicks to discover anything, has ~11 seconds before a caller hangs up and dials the competitor
+
+> The one screen built to answer "what do I charge this guy" quotes the wrong number by default (267% over on a member), tells him stock is available when it's sold, shows a green go-signal on machines that have no price at all, and never tells anyone — including the person who made the change — that a price just moved.
+
+*9 findings existed only in conversation. 7 claims were retracted under verification.*
+
+### Calendar / Driver — 36 findings
+
+**Persona:** Dewey, 34 — the driver who runs the rollback and lowboy out of Sulphur; checks the app in the cab, engine running, one glove on; won't scroll, won't read past two lines, won't infer
+
+> The one screen the code itself calls "the driver's day" shows him the whole yard's unfiltered board under a map that eats 78% of his screen, with a badge that silently excludes overdue work and zero way to tell anyone he's running late.
+
+*10 findings existed only in conversation. 9 claims were retracted under verification.*
+
+### RENTALS — 21 findings
+
+**Persona:** Denny — the lazy, not-very-sharp dispatcher: won't scroll, won't read, won't hunt menus or right-click; needs the screen to spell out the next move and misreads ambiguous cues.
+
+> The busiest, most cross-system card in the app shows every emergency as the same flat red inside an all-clear-green header — and the actual dispatch tools (crew lanes, driver-conflict, returns damage) were quietly retired or never built.
+
+*5 findings existed only in conversation. 7 claims were retracted under verification.*
+
+---
+
+## The shape of the problem
+
+| By scope | n |
+|---|---|
+| architecture | 52 |
+| signal | 51 |
+| interaction | 48 |
+| density | 20 |
+
+| By failure mode | n |
+|---|---|
+| invisible | 45 |
+| unreachable | 34 |
+| lying | 30 |
+| ambiguous | 24 |
+| inconsistent | 22 |
+| destructive | 16 |
+
+| By severity | n |
+|---|---|
+| orange | 70 |
+| red | 64 |
+| yellow | 37 |
+
+**The largest failure mode is `invisible` (45).** The information exists and the user never sees it — the data layer works, the presentation layer does not.
+
+**Only 20 of 171 findings concern density or legibility** — the thing most people mean by "UI". The mass is architecture (52) and signal (51). This is not a styling problem.
+
+**The pattern layer is even more lopsided:** of 48 cross-card patterns, 26 are architectural and 1 concern density.
+
+---
+
+## Retractions — do not resurrect these
+
+36 claims did not survive adversarial verification. Several are seductive and wrong.
+
+- UNITS: "The card opens as six collapsed drawers." — the session's own live observation, later retracted: this is stored device/account state on the admin account driving the audit, not shipped behavior. The code's default is OPEN for every Units group (app.js:9358); groupDefaultCollapsed special-cases only the Calendar's 'Earlier' bucket.
+- UNITS: "The Worklist graph is buried behind an icon-only toggle" and "default sort is alphabetical" — both false for the mechanic role specifically. ROLE_LANDING.mechanic (app.js:25640) already opens the graph and sets countdown-ascending sort on every login. The real defect (retained above) is that this correct landing does not survive the first click, not that it's buried at first paint.
+- UNITS: "Units retrains the mechanic's scan pattern versus other cards" — refuted; Rentals is also a grid layout (style.css:4557), so there is no reading-direction habit-break against the card he'd most compare to.
+- UNITS: "A collapsed bucket hiding trouble looks visually identical to a clean one" — overstated/scoped down; group bars do stamp sec-danger and tint the chevron/label/rule by severity, so red buckets already read differently from clean ones at the header level. The real, narrower gap (retained above) is the missing sub-count of how many flagged units hide inside.
+- UNITS: "/promote is hard-blocked — production and trunk share no common git history" — explicitly retracted as FALSE by the session itself. This was caused by reading git merge-base/rev-list inside a SHALLOW clone, which lies at the graft boundary; GitHub's compare API showed production is a direct ancestor of trunk with behind_by:0. This is a process/tooling retraction, not a UI finding, and was never treated as one.
+- UNITS: The initial claim that markFieldCall's wrong-unit bug on multi-unit rentals was unaddressed — it was independently fixed by a concurrent session (PR #740, targetId = unitId || r.unitId) before this session's identical fix could land; the identical fix was dropped as redundant rather than duplicated.
+- Customers: "Every customer name renders red" — self-corrected after measurement. The correct figure is 44 of 60 rows red in the default view (11 of the first 12); a name search returned only 4 of 19 red, so it saturates the default view, not the whole customer base.
+- Customers: "Rentals gives the dispatcher a real tel: link while Customers is the only surface that lacks one" (an asymmetry framing from one lens) — narrowed. The code fact stands (telHref is used at exactly one call site, a Rentals trip-row), but a live drive with a rental detail open and 59 phone numbers on screen found zero tappable links there either, so the stronger, unqualified claim ("no tap-to-call anywhere on Customers") is what should stand, not the Rentals-vs-Customers asymmetry.
+- Customers: "Ghost text" observed behind a tab bar on a customer record — turned out on inspection to be a transient scroll-rendering artifact, not a real rendering bug. Dropped entirely, not carried into any finding.
+- Customers: An early claim that app.js:7465 was a manual, staff-facing editor for payStatus — corrected. It is a read-only display column; there is no in-app way to edit a customer's payStatus at all (only via the Sheets backend outside the client).
+- Customers: "The .unavailable red-row CSS class means one thing on Customers (permanent blacklist) and something else on Units (temporary booking-window unavailability), creating on-screen ambiguity" — downgraded to code-hygiene on verify. Each red row on both cards carries its own distinguishing text pill, so a person is not actually misled in practice; only the underlying class name is reused.
+- Customers: The dead-code sweep's claim that the `c.accountType === 'Member'` check was purely dead code, safe to delete outright — corrected. It is dead, but because of a typo (the real status key is 'Non-Business Member'; 'Member' is only that status's display label), which means Non-Business Members currently never receive the intended green member-name tint. Deleting the branch as originally proposed would have cemented that bug rather than fixing it.
+- Customers: Revenue/ROI rollup findings surfaced mid-session (unitTotalRevenue and ruCatMoney counting cancelled/no-show rentals and cancelled work orders as real revenue, causing category ROI to sign-flip) are excluded from this inventory — they belong to the Categories/Units card, not Customers, and were out of this card's scope despite surfacing during the same working session.
+- Categories: "Background sync destroys a tooltip mid-read" — dropped outright. refreshFromBackend early-returns on a hovered node (app.js:24755) and gates its render on the same condition (app.js:24795); the truncated category name cited as the example carries class r-title, which is exactly what arms that guard. The mechanism protects the case the finding used against it.
+- Categories: "A double-click anywhere on a category row anchors and cascades to Units/Rentals/Customers/Invoices" — right effect, wrong mechanism. The global dblclick handler explicitly bails on rows (app.js:26599); the real path is the click-based deferOrAnchor discriminator (app.js:2971-2981), and most of the row face is buttons that stopPropagation, so "anywhere" overstates it.
+- Categories: "Desktop has no way back / no back affordance at all" — contradicted by the code comment it quoted (app.js:2879): desktop deliberately keeps the search-bar clear control and right-click → List View as escapes; the phone-only jog-back trick was simply never generalized, not absent.
+- Categories: "Member rate hidden" and "blended pricing not derivable" were originally raised as two separate CRITICAL findings — verification reduced them to one underlying design decision and downgraded both from critical, since every surface that actually commits money (Rentals, invoices, Mr. Wrangler) calls the real pricing engine correctly; the risk is a misspoken quote, not a wrong invoice.
+- Categories: An early claim that right-click routes to List View was refuted live — right-click actually opens a Copy/Paste/Global Search/Add Comment/Ask Mr. Wrangler context menu.
+- Categories: An implication that ROI/$-UTIL numbers are live and actively misleading fleet-wide was self-corrected on the live drive: the $ UTIL tab is mostly an empty state in production because trueCost isn't populated on units, so the ROI leak is real in code but has little live data behind it right now (kept as a scoped finding above); Revenue phantom-counting, by contrast, is fully live and unaffected by this correction.
+- Categories: "The detail view counts everything, full stop" was narrowed: the detail is deliberately whole-fleet by design (it shows a For Sale badge and lists every unit on purpose) — the actual, narrower defect is that unitRentalBucket specifically mislabels a Sold/Inactive unit as "Available."
+- Calendar / Driver: "Back navigation is broken" — retracted. Back returns cleanly to Trips with state restored; the only real defect is that the control is an unlabeled bare chevron (kept as a milder, corrected finding: undiscoverable, not broken).
+- Calendar / Driver: "The map renders blank/broken during a focus transition" — retracted. That was transient map-tile loading during a zoom/focus change, not a defect.
+- Calendar / Driver: "'Frankenstein' and 'Mace Windu' are driver names" — retracted. They are unit names; one finding's illustrative wording inherited this wrong fact fed to the lens agents, but the underlying no-driver-scoping claim was independently confirmed live in the DOM and is kept.
+- Calendar / Driver: "driverRoster()'s all-employee fallback is currently affecting the live driver picker" — retracted/scoped down to latent. The bug is real in code but production's picker currently and correctly shows exactly one driver.
+- Calendar / Driver: "Fixing the map-eats-the-screen problem requires restructuring the DOM (moving the map out of the shared scroll region)" — retracted. The collapse mechanism already exists and persists per-device; the actual fix is a one-expression default change (tripsMapOpen()'s null-default), not a structural rebuild.
+- Calendar / Driver: "Wiring Escape to close the dropdown menu is a safe, one-line, no-judgment-call fix" — downgraded to NEEDS-DECISION on a later challenge. A narrow Escape-only patch would create a new inconsistency with the Android hardware-back chain, which the codebase documents as meant to stay in lockstep with Escape.
+- Calendar / Driver: "The group header's 'N done' counting trips instead of stops is an unambiguous bug" — softened. A separate downstream review found the card's own spec explicitly defines the accounting unit as the trip ('Row = one Trip'), so this may be intentional; kept only as a legibility observation, not a hard defect claim.
+- Calendar / Driver: "The sticky map-failure state (never auto-retries) is an unambiguous bug" — narrowed. Code comments document manual-retry-on-reopen as intended behavior; the part that survives as a genuine defect is that the map's script-load has no timeout at all, so a hung (not failed) connection spins forever with no route to the retry state.
+- Calendar / Driver: "Raw/inconsistent phone number rendering is a Trips-card-specific bug" — rescoped. Confirmed the identical raw-label pattern on the Vendors card with no formatter anywhere in the app; this is an app-wide convention gap, not local to this card.
+- RENTALS: REFUTED — 'Only the Overbooked flag pulses; Field Call and Overdue Return never pulse and are out-shouted by it.' Verification: Overbooked's alert:true pulse (app.js:8344) fires only in the standard/anchored card-head, never on the list row; the list row (ROWS.rentals) has NO pulse for any condition. Hovering the row's always-present eye icon opens a preview that pulses EVERY red-severity flag — including Field Call (fc) and Overdue Return (off-rent-overdue). So both conditions the claim said 'never pulse' do pulse, via a different path. Pulled from the artifact for integrity.
+- RENTALS: SCOPED DOWN — 'Every red condition renders identical and the reason is visible ONLY on a desktop hover.' Verification: 3 of 7 conditions get a distinct on-row echo (overdue relabels the pill to 'Overdue'; unpaid shows a balance chip; unit-failed tints the unit name red + tooltip), and opening the record names most. Only no-card and unsigned-card genuinely require the hover-preview or a hop to the customer. Kept as a scoped 'ambiguous' finding, not the original absolute.
+- RENTALS: SCOPED DOWN — 'A field-call/overdue rental is camouflaged inside an all-clear-green bucket, indistinguishable from a clean row.' Verification: the ROW itself renders red (flag-driven border + pill, 'Overdue' relabel) — getEntityColor is independent of the group's static header color. The real defect is narrower: the section HEADER/count never reflects severity and flagged rows aren't sorted to the top.
+- RENTALS: REFUTED/SCOPED — 'There is no visible control on desktop to clear an anchor / no escape from a cascade filter.' Verification: anchoring always opens a foreground tab whose hover-reveal close-X is the documented, intended clear path; double-clicking anywhere on the open anchored card also clears it. The residual is only that these are unlabeled/hover-revealed — a discoverability nit, not an absence.
+- RENTALS: REFUTED — 'The reminder engine is entirely absent / not built (only a settings pane exists).' Verification: runReminderSweep_ (start/return/balance templates, dedup, dry-run) is BUILT, adversarially reviewed (5 fixes), deployed to backend v98/v99, and proven end-to-end — 4 SMS templates + 4 emails delivered to a real handset. What's actually missing is only the daily cron trigger + the Settings toggles, deliberately withheld pending Jac's supervised go-live (a buggy sweep would text 2,257 real customers). The frontend copy the audit read ('the sweep isn't installed yet', app.js:5279) is stale and caused the mischaracterization.
+- RENTALS: SCOPED DOWN — 'A terminal status change is unrecoverable / silently deletes a live job.' Verification: it is recoverable — logAction records it, a toast fires, and the rental stays reachable via the Completed sort/search/cascade. The genuine gap is no confirm step and no on-screen undo affordance, not data loss.
+- RENTALS: SCOPED DOWN (my own WIN) — 'Scroll position is genuinely preserved across renders.' Verification of scrollmemo-positional CONFIRMED the memo is raw-pixel by card|view, not record-anchored, so after a status change re-sorts the list the viewport can land on a different rental. The preservation is real for a static list but breaks exactly when the list reorders — so it's a finding, not an unqualified win.
+
+---
+
+## Rescued from conversation
+
+36 findings existed **only** in a session transcript and never reached any artifact. A re-read of the artifacts alone would have lost every one.
+
+- UNITS: Clicking the unit's own NAME on a mini-card does not open its detail record — it does nothing visible except reveal two tiny unlabeled icons (an eye and a plus). This specific interaction detail was observed live during the drive and is folded into a finding above, but the artifact and structured task outputs never state it as its own distinct line item — it's subsumed into the general 'unlabeled controls' count.
+- UNITS: In the seeded demo, the same overdue-hours field was observed truncating at visibly different pixel widths across different tiles in the same list — Highrise rendered '440 HRS OVERDUE' in full, Reptar showed '2025 H…', and Worm showed 'No GP…' — suggesting the truncation width isn't even consistent per-column, only per available space. This specific multi-tile comparison lives only in the conversation transcript.
+- UNITS: The session's own initial three-click misclick-and-recovery sequence (wash logged → uncompleteWash → re-queue) was walked in detail live, including the exact residual history lines left behind ('Serviced: Wash/Detail…', 'Wash un-marked (undo)', 'Wash requested') as unremovable audit-trail residue from an accidental click — this level of blow-by-blow detail on the recovery mechanics did not carry into the artifact, which reports only the high-level misclick finding.
+- UNITS: A live process note (not a UI finding, included for completeness since it shaped what got verified): four concurrent Claude sessions were simultaneously editing the same shared app.js across different cards (Units, Calendar, Categories, Customers) during this audit, and one of this session's fixes (the multi-unit field-call bug) was independently duplicated and shipped first by another session's PR #740 — meaning some 'systemic pattern' findings above (e.g., the cascade.js multi-unit anti-pattern) may already be in flux by the time this document is read.
+- Customers: Live-observed contradiction: a customer detail header read "Member" while the AR block on the same screen read "NON MEMBER MODE" for the same account (on a real record carrying a $1,306.85 balance, no card on file) — never written into the artifact or the verified-findings JSON.
+- Customers: A live customer record showed "LATE: 370" alongside apparently garbled free text in a notes-type field; separately, a different high-balance account's only visible "what to do next" tracking was an undated free-text note where a structured follow-up field should exist — both observed live, neither reached the artifact.
+- Customers: The global search-scope "globe" toggle, fired from the Customers card, was observed silently switching the Units card's search scope to "Search everything" as well — a cross-card side effect never reported as a finding.
+- Customers: The service-worker update toast's exact overlap with the alert-chip row was measured live in pixels (toast x 500–920, z-index 300, over the alert-chip row at y 663–681) and observed persisting for the entire session; the underlying issue is in the raw JSON sweep (F32) but this specific live measurement and duration only appear in conversation.
+- Customers: A live capture of the "Last Invoice" sort order showed the identical customer name rendered twice in the results list — concrete corroborating evidence for the no-duplicate-check finding that was not restated with this specific proof in the artifact.
+- Customers: Two invoices on one real customer's record were already marked VOIDED even though no reachable in-app control can void an invoice — implying voiding currently happens only through the Sheets backend, never through the app UI. This corroboration of the Void-unreachable finding did not make the artifact.
+- Customers: The comms rail was described live as "a flat list in the bottom bar, disconnected from the record," with an unanswered inbound customer reply sitting in it while an unrelated customer's account was open on screen — a concrete illustration of the artifact's general comms-gap findings that wasn't itself quoted into it.
+- Customers: A background/classification agent modified app.js's revenue and ROI math (excluding cancelled work orders and cancelled/no-show/quote rentals from revenue rollups) without authorization mid-session; this was caught, reverted, and preserved as a patch rather than shipped — a process incident on the Categories/Units card, not a Customers-card UI finding, so excluded from findings but noted here since it happened during this session.
+- Categories: The Categories tab renders truncated to "CATEG…" while inactive — observed live during the very first click on the card, never written into the shipped artifact's report sections (only into the in-character Q&A prose).
+- Categories: Hovering a category row on production revealed an eye/quick-view icon and a '+' icon rendering directly over the 1-Day rate value on Lift Boom 65ft — described in prose during the live click-through but never promoted to its own artifact finding.
+- Categories: The '$ UTIL' (ROI) detail tab was found live to render an empty state — 'No revenue against a recorded cost basis yet — set true cost or purchase price on units' — a self-correction to the assistant's own earlier framing that ROI numbers were live and misleading; this scoping nuance stayed in chat only.
+- Categories: Concrete Round-Up Revenue bar values from the live drive: 8k Excavator ~$79k, Skid Steer ~$77k, observed alongside the Rentals card showing 'NO SHOW · 32' for the same period — the specific dollar figures never made it into the artifact text (only the general phantom-revenue claim did).
+- Categories: Concrete Time Util percentages from the live drive: top category at 48%, every other category under 30% — cited in chat as evidence the utilization-denominator bug is visibly distorting the graph, not just a theoretical code defect.
+- Categories: The accessibility sweep enumerated specific ref ranges (ref_1826 through ref_1859, plus the whole ref_2305–ref_2328 block, the category pills) all exposing as bare 'button' — the artifact states the general finding but drops these specific ref identifiers.
+- Categories: A production statistic surfaced only while discussing whether to pulse a new 'No rates' flag: 7 of the 46 live categories (~15%) are currently unpriced — used in chat to justify NOT pulsing the flag (too many simultaneous alerts), never stated in the artifact.
+- Categories: A second live member-rate example beyond the headline 12k Excavator case: 8k Excavator shows $89 member vs $320 displayed 1-day rate — mentioned only while verifying the eventual fix, not in the original findings text.
+- Categories: The assistant noticed, while driving the live Customers card as an aside during this same session, that staff have been typing customer balances directly into the customer NAME field (e.g. '!!!OWES $…!!!', '($140 CREDIT)') as a workaround for the system not surfacing that number where they need it — flagged explicitly as 'the same disease as this card, different organ' but is a Customers-card observation, out of scope for this Categories inventory, and was deliberately left undetailed to avoid exposing real customer data.
+- Calendar / Driver: The 18-second background poll (app.js:24792) can trigger the same full render()-driven scroll reset as a user-initiated assignment, snapping a driver's screen to the top purely from someone else's edit elsewhere in the office.
+- Calendar / Driver: On a zero-trip day the map still renders full height (independent of trip count) over a low-contrast grey-on-grey 'NO HAULS ON THE BOOKS' plate — the exact visual signature this persona reads as 'nothing here.'
+- Calendar / Driver: If the map's script load hangs rather than fails outright, there is no timeout anywhere in the loader — the panel can spin indefinitely with no path to the offline/retry state.
+- Calendar / Driver: On a merged (doubled-up) trip, the Log Delivery button is hard-scoped to the primary stop's own record but gated on the whole trip's done state, so after logging the first of two stops the button still reads 'Log Delivery' — pointing the driver at a capture he already completed.
+- Calendar / Driver: A failed sync during a capture holds the pending write only in RAM (app.js:24576 comments the cache is 'never a save baseline') while the banner instructs the driver 'Don't close the app' — an instruction a phone user can't reliably guarantee; the practical failure is a completed delivery log reverting to undelivered overnight.
+- Calendar / Driver: The sync footer starts at a null status and defaults to displaying 'Offline — cached' on every fresh load regardless of actual connectivity, and never re-checks after the first successful sync either — so it can just as easily read false-'Synced' after connectivity is later lost.
+- Calendar / Driver: Two real production units showed deliveries never logged in 78 days, and a third was delivered 8 days ago with pickup 6 days overdue — none of it reached any badge, count, or alert anywhere in the app. Flagged to the owner as an operational question ('is this equipment physically accounted for'), not a code bug, but it's the concrete real-world proof of the 'overdue work has no owner' gap.
+- Calendar / Driver: The scroll-reset bug initially looked like 2 call sites but was actually 5 (render() ×2, renderResults() ×2, restoreJogScroll() ×1) — the same visible symptom (driver loses his place) was reachable from five different code paths.
+- Calendar / Driver: myRosterId() already exists and is already used to scope team-chat visibility per logged-in person — true driver-scoping ('my trips') is materially cheaper to build than it first appears, since the identity-resolution half of the problem is already solved elsewhere in the codebase.
+- Calendar / Driver: A driver-assignment SMS toggle already exists in Settings (defaulted off, explicitly commented as an inert stub pending a later phase) — the fix for 'assignment makes zero noise' has already been named and scoped by the product, just not built.
+- RENTALS: Undated quotes sort FIRST instead of last, pushing the quotes a dispatcher can actually act on below dead placeholders (noted during segmentation; not verified, not in the artifact).
+- RENTALS: No toast queue — rapid successive toasts clobber each other, so a confirmation can be wiped by the next one before it's read (noted in conversation; not verified).
+- RENTALS: Touch targets on the gate-timeline rows (.gt-row) can fall below the ~44px iOS minimum on phone (noted in conversation; not measured).
+- RENTALS: The dispatcher graph view isn't the default, so the at-a-glance timeline a dispatcher would benefit from is a mode he has to go find (noted; not verified).
+- RENTALS: Rental detail runs low-density — lots of vertical scroll for information that could be composed tighter for a won't-scroll persona (noted; subjective, not verified).
+
+---
+
+## What we still do not know
+
+# WHAT THE FIVE AUDITS MISSED
+
+*Scope-gathering pass. Everything below is read from `C:\Users\opera\rw-units-fixes\app.js`, `config.js`, `sw.js`, `agreements.js` and `style.css` unless marked otherwise. Where I could only read code and not drive the app, I say so.*
+
+---
+
+## 1. The device blind spot — there are two apps, and only one was audited
+
+This is the largest gap, and it silently invalidates or inverts several existing findings.
+
+`app.js:25973` sets the entire mobile build off one line: `document.body.classList.toggle('is-phone', window.matchMedia('(max-width: 640px)').matches)`. Below 640px the app is structurally a different product — no global search (`app.js:10244`), no close-all tabs, the toolbar moves to a footer (`mobileToolbarEl`, `app.js:10535`), popups become bottom sheets (`app.js:13013`), sections become swipe decks (R36, `app.js:6257-6287`), and the 3-column grid becomes a 5-card swipe ribbon `['categories','units','rentals','customers','sales']` (`app.js:10458`). All five audits ran the >640px build. Nobody has walked the phone.
+
+Three consequences the audits could not have seen:
+
+**The hover-tooltip layer does not exist on the devices these personas actually hold.** `HOVER_CAPABLE = window.matchMedia('(hover: hover)').matches` (`app.js:17419`), and both the tooltip engine (`app.js:17403, 17425`) and the hover-preview engine (`app.js:26655`) early-return on `!HOVER_CAPABLE`. Every audit wrote some version of "he won't hover." The truth is harder: on a touchscreen yard tablet or a phone in a truck cab **he cannot hover, and the information is not merely demoted — it is absent from the device.** That reframes the *The Answer Is In The Tooltip* pattern from a laziness assumption into a hard capability failure. The 52 controls explained only by a tooltip (Units), the service number that "exists only inside a hover-tooltip string" (Units), the driver's full street address held in `data-tip` (Calendar, `app.js:7366`), the "Next available" date convention (Categories), the truncated "T" tab label (Calendar, `style.css:699`) — on touch, none of those have a fallback path at all.
+
+It also means the Units audit's single red headline finding — the hover-preview panel as a destructive misclick trap — **does not fire on a touch device**, and in its place is a different defect: the row eye button's only touch behaviour is `app.js:18745`, which globally toggles previews off app-wide and toasts "every eye runs red." On a tablet the eye is a control for a feature that never worked there.
+
+**Drag-to-link, the Units audit's "exactly one path," was retired on phones a year ago.** `app.js:17833-17839`: "PHONE: drag-to-link is RETIRED on phones (2026-06-29). A long-press now opens…" and `app.js:17819` calls the long-press "the PRIMARY linking entry (menu-driven linking replaced drag)." The app even phrases its own error copy per device (`app.js:19075`, `app.js:19101`). So the same job — attach a machine to a rental — has two entirely different, entirely undiscoverable grammars depending on screen width, and the audits documented one of them. Whether the phone path carries the same missing fitness gate is unverified.
+
+**Nobody owns the 641–1024px band.** A yard tablet in landscape is roughly 1024px wide and is *not* `is-phone`. It therefore receives the desktop build — drag-and-drop performed with a finger, hover-dependent chrome with no hover, no swipe rail, no footer toolbar — while getting none of the mobile accommodations. Merle's actual device is in a band the code has no branch for. `style.css:333` has a `max-width:1024px` block, but the JS behaviour switch is binary at 640.
+
+---
+
+## 2. Whole surfaces no audit touched
+
+**Settings — eleven panes, ten live (`app.js:5006-5018`), zero audited.** This is not a peripheral surface; it is the *authoring layer for the exact systems all five audits critiqued*. `Statuses & Icons` lets an admin rewrite status labels, colours and icons at runtime. `Flags & Alerts` writes `settings.flagOverrides` (`app.js:5909`). `Custom Fields` mints new fields (`CF_ENTITIES`, `app.js:5475`) — wired only for Customers, storing defs for Units/Rentals/Invoices whose forms are "coming." `Inspections` builds per-family checklists that can be marked Required, which triggers a full-screen takeover (`app.js:14446-14510`). `Rental Rules` is a real hard-block engine. `Team Roster` is the login list. Every audit treated signal semantics as fixed in code; they are configurable, and no one has asked whether an owner using this board can make the signal system *worse*, or whether renaming a status breaks the hardcoded role/landing lookups the Units audit already flagged (`app.js:25639` vs `config.js:342`).
+
+**The Rental Rules engine is real — and it has no concept of the machine.** `RENTAL_RULES_READY` (`app.js:5444-5451`) offers exactly six requirements: card on file, signed agreement, selfie, driver's licence/ID, payment terms, PO number. All six are *customer paperwork*. `rentalRuleBlock()` (`app.js:19911-19926`) enforces them as a hard stop on `On Rent`. There is not one rule about whether the machine is fit — no inspection-pass rule, no service-overdue rule, no insurance rule. The Units audit found that a failed-inspection machine 2,882 hours overdue attaches with no block; the deeper finding is that **the gate system that exists is structurally incapable of expressing that rule.** The pane's own copy promises "a unit **cannot go On Rent** until it's met — a hard stop, no override."
+
+**The money-execution layer, and with it the AR-office clerk.** The roles list names an AR-office clerk; no audit ran as one, and the Invoices card was retired into Customer Details (`config.js:436`). Unexamined: Stripe charge (`app.js:21776`), **ACH with multi-day settlement** (`achProcessing`, `pendingPaymentIntentId`, `app.js:14726`, `21780`, `21733-21734`), refunds (`refundInvoiceFlow`, `app.js:21801`; `refundSectionHtml`, `21496`), invoice void and merge (`app.js:23316`, `23351`), and collections. ACH deserves specific attention: it is the app's only genuinely *pending* state — money in flight for days — and the whole UI vocabulary the audits catalogued is built on instant, optimistic writes. The user must press "Check ACH status" manually (`app.js:14726`). Nothing polls it, nothing notifies on settle or return.
+
+A refinement to the Customers audit while I'm here: it reported Collections as fully built but unreachable. Half right. The **destination** is live — `BACKOFFICE_BOARDS` includes a `collections` board (`config.js:408`) rendering `DATA.invoices.filter(invoiceCollectionsActive)` (`app.js:16618`). It is the **on-ramp** (queue/recall pills at `app.js:8976`) that renders inside the retired invoices renderer. So an AR clerk can see the collections queue and cannot put anything into it or pull anything out.
+
+**The six back-office boards — Parts, Vendors, Expenses & Receipts, Company Files, Collections, Sales Pipeline (`config.js:403-410`).** None audited. They are not cards; they render as popups (`app.js:14166-14186`) reachable only from a dropdown (`app.js:21016`). Two of them are load-bearing for findings already raised: the Units audit's decorative `qtyOnHand` lives in Parts, and the "escalate lost demand to purchasing" gap terminates in Vendors. Company Files also hosts the Fleet QR print sheet (`app.js:18925`) that the Units audit's broken decal-scan flow depends on.
+
+**The account/agreements/signing packet.** `agreements.js` carries two full legal instruments, versioned (`AGREEMENT_VERSIONS`, `AGREEMENT_CURRENT`), signed in-app with signature capture and a **selfie** (`captureSignature`, `app.js:698`; `scheduleFinalizeSign`, `app.js:707`), frozen into immutable signings (`app.js:627`), Drive-uploaded, and reprintable as PDF (`openSignedPdf`, `app.js:740-766`). Clause 13 of the agreement itself requires "sending us a selfie while holding the new card." This is the app's most legally consequential flow and no persona walked it.
+
+**Print / PDF output is an entire unaudited render target.** Independent stylesheets at `app.js:758` and `app.js:792`, a `#print-root` swap under `@media print` (`style.css:5409-5413`), invoice "Yard Log" print (`app.js:21914`), membership agreement print (`app.js:769`), signed-agreement PDF, fleet QR sheet. These are what the customer physically receives, they share none of the app's design system, and the tooling relies on the user disabling Chrome's headers and footers (per the tip copy at `app.js:4863`).
+
+**The Wrangler AI dock as a mutation surface.** The audits treated it as a pull-only oracle. It is a write path. The system prompt (`app.js:15090`) grants create/update/bulk-import across customers, units, categories, vendors, parts, expenses, inspections and work orders, plus `billRental`, `recordPayment`, `unlinkInvoice` and `startRental`. And `WR_OPERATIONS.startRental` carries `autoApply: true` — commented "a reservation just happens — no Apply tap (Jac)" (`app.js:16022`). **A parsed sentence in a chat box commits fleet to a customer with no confirmation step.** `app.js:15620` confirms operate-ops otherwise gate by default. This is the One-Click Cliff extended to a surface where the trigger is not even a control — it is natural-language interpretation, with the app's own prompt instructing the model "DON'T INTERROGATE" and "don't ask the user to confirm an obvious date reading."
+
+**Public, customer-facing pages.** `about.html`, `sample-quote.html`, `opt-in.html`, `privacy.html`, `sms-terms.html` — deliberately excluded from the SPA shell in `sw.js` (`PUBLIC_SET`) after a real incident: A2P carrier vetting saw the login wall instead of the opt-in page (2026-07-13, per the sw.js comment). `opt-in.html` is a live consent form. `sample-quote.html` is the quote page a customer opens from a text. These have their own visual language, their own light/dark handling, and a regulatory function. Untouched.
+
+**Login, identity, and day one.** `phoneIdentity` mode makes the Team Roster the login list; hands set a PIN from a texted code; there is a customisable crew-welcome SMS and a "Round up the crew" blast (`app.js:5110-5132`, `18671`). `roleFromRoster()` (`app.js:10594`) binds the typed login name to a roster entry by **lowercased string match**, and `app.js:10603` states an unbound login "sees all." The comment at `app.js:2429-2433` records a prior bug where session state leaked "straight into the next operator's session." Nobody audited signing in, being a new hire, or being an unrostered login.
+
+**The Sales card.** `salesCardEl` (`app.js:9636`) is a "Coming soon" placard. On desktop it is one tab away. On the phone rail it consumes **one of five swipe stops** (`app.js:10458`), and the ribbon wraps past it to a Categories clone. The Customers audit found returning from it re-buries scroll position; nobody has looked at what it costs on a phone.
+
+---
+
+## 3. Work that spans cards — where the baton drops
+
+Following two jobs end-to-end surfaces failures no card owns.
+
+**A machine breaks in the field, comes back, gets repaired, goes out again.** The chain crosses Rentals → Calendar/Driver → Units → back to Rentals. Two clean drops:
+
+*The end-of-rental capture records a video and nothing else.* `yardCapture(… 'end' …)` → `openYardCamera` → `commitYardCapture` (`app.js:20208-20270`) writes a stamp, a Drive URL and a driver id. No hour-meter prompt, no condition assessment, no damage form. This is the mechanical root of the Units finding that the hour meter has no writer at end-of-rental, and of the Rentals finding that field-captured damage never reaches a work order — one function is the seam for both, and neither audit could see it from its own card.
+
+*Delivery gates fire at the camera, not at the commitment.* `app.js:20220-20232` runs the invoice check, blacklist check, `rentalRuleBlock`, card gate and account-block gate at the moment the driver taps Log Delivery — explicitly so "a blocked delivery never opens the camera." Sound intent, but it places every gate at the *end* of the driver's trip. The Calendar audit found the log-gate is only evaluated on tap; the cross-card version is that the whole gate battery lives there, while the attach/booking moment the counter rep performs has none of it.
+
+**A defect that spans everything: `flashOr` silently discards the reason.** `app.js:6320`:
+
+```js
+function flashOr(sel, msg) {
+  if (document.querySelector(sel)) return attnFlash(sel);
+  toast(msg);
+}
+```
+
+If the target control is on screen, **the message is never shown** — by design (R19: "a glow that points AT the next action — replaces an error message"). It is used at 15+ blocking sites. The damage is worst at `app.js:19934` and `app.js:20225`, where **all six rental-rule failures flash `.js-add-card`.** A blocked delivery caused by a missing PO number, a missing driver's licence, or a missing selfie silently glows the *Add Card* button and states nothing. This is *The Predicate Isn't The Label* operating at the level of the error-reporting helper itself.
+
+**A lead becomes a customer becomes a rental becomes an invoice becomes a payment.** The Customers audit covered the front of this and the Rentals audit the middle; the back half — invoice → charge → ACH settle → collections → recall — has no audit at all, and it is where the retired Invoices card did the most damage. Note also that `On Rent` requires a linked invoice (`app.js:19932`) while the invoice requires a customer (`app.js:18259`), so the chain has hard ordering the UI never states up front.
+
+---
+
+## 4. What single-role, lazy-desktop personas hid
+
+Every persona was one role, one card, one uninterrupted session, one screen size, online. That excludes:
+
+- **Role switching.** `setRole` is exposed on the debug surface (`app.js:26825`) and roles are renameable and re-tierable in Settings, but no audit asked what a counter rep who covers dispatch after 4pm sees, or what happens to the hardcoded `'mechanic'/'mtech'` landing when one person holds two hats.
+- **Handoff between people.** Every audit was a solo session. The Units audit caught silent last-write-wins on one record (`app.js:24778`); nobody looked at the shift-change case — what a mechanic leaves behind that the next mechanic must pick up. `assignedMechanic` routes nothing, and there is no per-person queue.
+- **Day one.** No onboarding flow, no empty states audited, no "what does this screen look like before the yard has data." A brand-new category is born red (Categories audit) — but nobody checked whether a brand-new *company* is.
+- **Interruption and resumption.** The Calendar audit found the 18-second poll resets scroll (`app.js:24792`); nobody tested returning after ten minutes, a phone lock, or a backgrounded tab. `refreshFromBackend` skips its tick entirely when an overlay, drag or focused input is active (`app.js:24825`), which means the longer you work, the staler you get, silently.
+- **Offline.** The R25 "Not saving" banner exists (`app.js:25442`), `sw.js` caches the shell only, and the Calendar audit found a capture held in RAM with a "Don't close the app" banner. No audit ran offline, and the yard is exactly where signal fails.
+
+---
+
+## 5. What we still do not know
+
+Honest gaps, so this inventory does not read as more complete than it is.
+
+- **The Rentals audit is reconstructed, not run.** Its nine findings carry no file:line citations and were rebuilt from a skill's own account. Rentals is the busiest card in the app and is effectively unaudited at the fidelity of the other four.
+- **Nothing was measured on a real device.** Every "measured live" note came from a desktop browser. No touch device, no sunlight, no gloves, no cab. The `is-phone` build has never been walked at all, by anyone.
+- **No real user was observed.** The personas are constructed. The one piece of genuine field evidence in the whole corpus is the Customers audit's discovery that counter staff type business state into the name field and prefix 23 of 25 with punctuation to game the sort — that is worth more than most of the code findings, and it was found by accident. Nobody went looking for more workarounds of that kind, and there are certainly more.
+- **Settings has never been exercised against the rest of the app.** Ten live panes can rewrite statuses, flags, fields, checklists and gates at runtime. Every finding in this document was measured against shipped defaults. We do not know what Jac's production settings actually are, nor what breaks when an admin uses these panes as intended.
+- **The backend is out of scope entirely.** Everything here is frontend. Sync semantics, the Sheets 50k-char cell limit that forces media out of records (`app.js:20264`), the server-side comms gates (`app.js:14859`), and the GAS deploy are unexamined.
+- **Concurrency was never observed, only read.** Last-write-wins was found by reading `app.js:24778`. No one has actually had two sessions edit one record and watched what the screen does.
+- **The AI dock's write path was read, not driven.** I have not confirmed empirically that `startRental` auto-applies without a confirm, only that it is flagged and commented to.

--- a/docs/research/CORPUS-CORRECTIONS.md
+++ b/docs/research/CORPUS-CORRECTIONS.md
@@ -1,0 +1,74 @@
+# Corpus corrections & retractions — the detail-audit wave
+
+**2026-07-19.** The four detail-view audits (and their v2 persona-seat passes) corrected the
+existing corpus in ways a reader must honor. Retractions are load-bearing here exactly as they were
+in round one: a resurrected wrong claim costs more than a missing one.
+
+## Retract from the existing 171-finding inventory
+
+- **Finding #130 — "Clicking a unit's own name does not open its detail record" — FALSE at
+  `0fac0069`. RETRACT.** Left-click resolves at `app.js:19525-19539` with no `.r-title` exclusion
+  and calls `openStandard()`; the `.r-title` leaf at `app.js:6425` belongs to the *right-click*
+  context-menu path. Verified live at the mechanic seat: clicking a unit's name opened the record.
+  **What survives** (do not lose it): the eye/plus row icons are unlabeled (supports #114), and the
+  eye's click is a global app-wide preview toggle, not a row action — re-filed as **UNITS UD-070**.
+
+## Re-file within the corpus (right finding, wrong location)
+
+- **Findings #27 and #32 are DETAIL-view-resident, not row/list problems.** Both cite lines inside
+  `headFlagsHtml`, which has one render site — `app.js:9718`, inside `if (inStandard)`. List mode
+  renders no card header at all (`app.js:9705`). The customer billing/pay-status warning they
+  describe is a standard-view-only signal. The list audit filed them as row problems; whoever
+  consolidates the axis should move them to the detail surface.
+- **Finding #18's mechanism is wrong.** It states the app "internally knows and labels the record
+  `STUB — fill in pricing`." It does not — a *person* typed that text into the category
+  `description`, a field the detail view cannot even edit (CATEGORIES F-02). The $0-rentable
+  exposure is real (and re-confirmed live: two categories quotable at $0 today); the "app knows"
+  framing is not.
+
+## A corpus-wide measurement warning — re-measure before trusting
+
+**Any density / "% below the fold" number taken through the Chrome-extension browser tool is
+suspect.** That tool runs a viewport locked short (≈640px tall) and silently ignores resize calls.
+Two independent sessions filed a "~58–68% of the record is below the fold" finding through it, and
+both **retracted it** on Playwright re-measurement of the same bytes:
+
+- **CATEGORIES F-14 — RETRACTED.** Pass-1 "58% below fold" was the viewport artifact. Playwright:
+  60.6% visible at 1366×768 with *zero* section headers below the fold; 100% at 2560×1440.
+- **CUSTOMERS** self-corrected the identical artifact (its first "21.5% visible / 68% below fold").
+  What survives is narrower and data-dependent: record height scales with content, so the
+  customers with the most invoices/cards/history are the ones that overflow — not a fixed layout
+  fact.
+
+Corollary the sessions themselves drew, worth adopting as corpus method: **DOM-present ≠
+user-visible, and rulebook-registered ≠ rendered.** CUSTOMERS nearly filed "a card-detach control
+is clickable" — both remove buttons measure **0px wide** on production (the unclickability
+accidentally does the gating the code forgot to). CUSTOMERS also found two R-rulebook-registered
+components on one card (`js-view-agreement`, and the comms panel) that *never render*.
+`querySelectorAll().length` is not evidence a user can see or reach something. Measure the app, not
+the instrument.
+
+## Claims killed before filing (recorded so they are not re-derived)
+
+- **CUSTOMERS** — "the three invoice view tabs render identical content" and "the Transactions tab
+  is dead": both were an instrumentation bug (a cached node reference reading a detached tree after
+  `render()` swapped the card). Re-tested against a freshly-queried live node, the tabs work.
+- **UNITS** — an hour-meter "renders as unlabeled `— HRS` on a machine with no reading": the
+  no-reading state is unreachable (all creation paths default `currentHours: 0`; the editor refuses
+  an empty commit). What renders on a new unit is a plausible `0 HRS`, a milder defect overlapping
+  existing findings.
+- **CATEGORIES** — "the 18s poll clobbers an open rate editor mid-edit": refuted, it returns early
+  on a focused `INPUT` (`app.js:24756`). Filed as a *win*, not a defect.
+
+## Scope corrections carried in the findings themselves
+
+- **The `canMoney()` blank-role fail-open** was first written as red / "sees every money figure."
+  Held at **orange** after verification: only 2 of 6 money figures on a category are gated at all,
+  and two of the three paths to a blank role are documented intent (`#local` demo; pre-roles
+  single-password mode). The genuine defect is the third — a swallowed `auth` failure on a
+  role-aware backend leaves a *fully-authenticated* session silently degraded to single-password
+  privileges. Verified live on three surfaces (UNITS, CATEGORIES, CUSTOMERS).
+- **The Beau "field call" contradiction** between the UNITS and RENTALS folders is resolved, and it
+  is a real finding: `app.js:6944` prints "Field Call" purely from `inspectionStatus === 'Failed'
+  while on rent` and never reads `r.fieldCall` — so the mechanic sees a field call the dispatcher on
+  the same job does not.

--- a/docs/research/DETAIL-FINDINGS-BY-JOB.md
+++ b/docs/research/DETAIL-FINDINGS-BY-JOB.md
@@ -1,0 +1,243 @@
+# Detail-view findings, indexed by job
+
+**130 findings · 4 cards · second audit wave (detail/standard views) · 2026-07-19**
+
+The four card detail views were deep-audited after the list-view gathering, each walked from the
+persona's real low-tier seat (achieved via `#local` + `setRole` on pinned production bytes), every
+load-bearing claim adversarially verified. Findings keep their session ids (UNITS `UD-`/`N-`,
+RENTALS `RD-`, CUSTOMERS `F-`, CATEGORIES `F-`/`N-`); full evidence + cites live in each
+`contrib/<card>-detail/findings.json`.
+
+**Every one of the 130 maps to exactly one of the 25 jobs — zero off-vocabulary, in a wave with no
+contact with the taxonomy authors.** The controlled vocabulary held across an independent second
+pass, which is the strongest available evidence it is the right backbone.
+
+**Damage profile inverts from the list view.** The list wave was led by `spot-the-fire`; the detail
+wave is led by **`trust-the-screen` (54)** — the detail is the dense, authoritative surface where
+two systems' answers to one number render inches apart. Damage = 3R + 2O + 1Y.
+
+| Job | n | R/O/Y | Damage |
+|---|---|---|---|
+| `trust-the-screen` | 25 | 7/15/3 | **54** |
+| `whats-next-to-wrench` | 14 | 10/2/2 | **36** |
+| `clean-records` | 11 | 3/6/2 | **23** |
+| `no-surprises` | 9 | 4/4/1 | **21** |
+| `spot-the-fire` | 9 | 3/6/0 | **21** |
+| `keep-the-keys` | 8 | 1/6/1 | **16** |
+| `got-one-free` | 8 | 0/6/2 | **14** |
+| `no-fat-fingers` | 7 | 1/4/2 | **13** |
+| `whats-making-money` | 6 | 2/2/2 | **12** |
+| `get-our-money` | 5 | 2/3/0 | **12** |
+| `quote-the-caller` | 4 | 1/3/0 | **9** |
+| `get-to-it` | 4 | 0/2/2 | **6** |
+| `line-up-the-runs` | 3 | 1/1/1 | **6** |
+| `work-the-wrench-job` | 2 | 1/1/0 | **5** |
+| `field-trouble` | 2 | 1/1/0 | **5** |
+| `log-it-from-the-field` | 2 | 1/1/0 | **5** |
+| `keep-my-place` | 3 | 0/1/2 | **4** |
+| `works-in-gloves` | 3 | 0/1/2 | **4** |
+| `reach-the-person` | 2 | 1/0/1 | **4** |
+| `get-it-back` | 1 | 1/0/0 | **3** |
+| `run-my-route` | 1 | 0/1/0 | **2** |
+| `size-up-the-customer` | 1 | 0/0/1 | **1** |
+
+Totals: 130 findings · 40R / 66O / 24Y · UNITS 74 · CATEGORIES 24 · RENTALS 16 · CUSTOMERS 16.
+
+---
+
+## `trust-the-screen` — "Trust what the screen says" (n=25, damage 54)
+
+- **UNITS UD-007** [R] — The unit history's tab counters contradict the history content and the record's own header badge on one screen — '0 Inspections' renders dir
+- **UNITS UD-023** [R] — UNITS detail (sibling of existing finding #57, new surface + new root): the unit detail page's ONLY coverage surface is the Investment secti
+- **UNITS UD-027** [R] — Re-opening a passed inspection re-enters the same fully-live checklist with no result pill, no pass date, and no locked controls — its X and
+- **UNITS UD-036** [R] — Sibling root to finding 56: the Services task row is the ONLY surface that still names a snoozed past-due service, and it is structurally un
+- **UNITS UD-042** [R] — A unit with a physical tracker but no API mapping shows a green 'Reporting' chip and green GPS section border on the same header bar whose b
+- **UNITS UD-056** [R] — The inspection/work-order half of a unit's history log is ordered by string-comparing a year-less "MMM DD" display value, so it sorts by mon
+- **UNITS UD-063** [R] — Service completions are keyed by bare taskId, and taskIds are not unique across schedules — so an admin changing a unit's model silently tra
+- **UNITS UD-008** [O] — The unit history log renders in non-chronological order on production data, interleaving months.
+- **UNITS UD-010** [O] — An explicit 'don't wash' suppression on a unit does not suppress its wash task, which continues to accrue and render as past due.
+- **UNITS UD-011** [O] — The Specs section stamps a green 'OK' chip beside the hour meter on a machine the same screen reports 526 hours past due, and renders its fi
+- **UNITS UD-020** [O] — The Specs section stamps a hardcoded green "OK" chip and sec-green border with no data dependency — visually identical to the derived greens
+- **UNITS UD-034** [O] — A cancelled work order is filtered out of the unit's Work Orders section but not out of its History, where it is labelled with its raw store
+- **UNITS UD-040** [O] — The unit detail view's Services list renders manufacturer-sourced intervals and the module's self-declared pre-production placeholder interv
+- **UNITS UD-048** [O] — The unit detail carries no rental history — historyFor('units') returns only inspections and work orders — yet it emits an "N Rentals" chip 
+- **UNITS UD-057** [O] — All four history count-chips on the unit detail take their number from a DATA collection but filter a merged log built from a different sour
+- **UNITS UD-066** [O] — LATENT: the model maintenance-schedule task form validates only the task name — a blank interval saves as null with no guard, then reads two
+- **RENTALS RD-02** [O] — The history money counter classifies by regex over human prose, so it counts a non-payment and misses a real one
+- **RENTALS RD-13** [O] — The history chip's count and the chip's own filter run over different populations — it reads 0 and reveals 1 when tapped
+- **CUSTOMERS CUS-04** [O] — The customer-level 'view agreement' button reads legacy fields that the current card-level signing flow never writes, so a customer who sign
+- **CUSTOMERS CUS-07** [O] — The detail header is a single nowrap flex row whose only overflow protection is on the title, so on narrower viewports and heavily-flagged c
+- **CATEGORIES F-03** [O] — An empty category's record header renders a green 'All Passed' while the same record's mini-card renders a red 'None · N/A' — so opening the
+- **CATEGORIES F-04** [O] — A category whose entire fleet has been sold also renders the green 'All Passed' header flag, because the inspection tally counts every unit 
+- **UNITS UD-035** [Y] — UNITS — The confirm dialog gating "Complete WO" recomputes its own list with a looser filter than the check that opened it, so lines the mec
+- **UNITS UD-046** [Y] — Once a tracker is mapped, the unit's GPS state forks into two never-reconciled reads: the mini-card flag corner and the detail chip go live-
+- **UNITS UD-074** [Y] — The Services section is the one unit-detail block wired to a bespoke toggle handler with no section identifier, while every sibling section 
+
+## `whats-next-to-wrench` — "Figure out which machine to wrench on next" (n=14, damage 36)
+
+- **UNITS UD-002** [R] — The unit detail's Work Orders bar reads a green 'CLEAR / 0 open' on a machine the same screen simultaneously badges 'Failed', flags with an 
+- **UNITS UD-003** [R] — The headline 'HRS OVERDUE' figure that drives the tile colour, the flag, the countdown sort and the mechanic's worklist order is manufacture
+- **UNITS UD-016** [R] — The service baseline (`purchaseHours`) is seeded to 0 by all three create paths but is exposed ONLY inside the Investment section labeled "H
+- **UNITS UD-032** [R] — An open 'Part in Stock' line is the greenest possible bottleneck a work order can have: WO_SEV ranks it more-blocking than 'No Part Needed' 
+- **UNITS UD-037** [R] — The wash task's 100-HRS interval is 2.5x tighter than any real service, so on any used machine the never-logged wash always wins topServiceF
+- **UNITS UD-044** [R] — On the UNITS detail view the GPS section defaults an untracked unit to the same red as a dead tracker — the gpsStatus registry has no 'untra
+- **UNITS UD-053** [R] — The photo-backdrop feature is wired end to end but never invoked: woBackdrop's value is computed and discarded at app.js:8022, `bg` is the o
+- **UNITS UD-061** [R] — Retagging a unit's category leaves its modelId pointing at the old category's model, and the Model picker then pre-selects '— No model —' wi
+- **UNITS UD-065** [R] — On the unit detail view's Services section, a unit with no `modelId` (or a model with an empty task list) silently falls back to the generic
+- **UNITS UD-073** [R] — A cosmetic wash task masks the machine's real safety overrun: on the worst unit in the seed the top service is a detailing job at 2882 hrs, 
+- **UNITS UD-012** [O] — The machine carries a live telematics tracker reporting engine state, yet the hour meter driving all 24 service countdowns is a manual text 
+- **UNITS UD-049** [O] — UNITS detail — the date-derived half of the unit History log (inspections + work orders) sorts on a month-NAME string, so it renders in reve
+- **UNITS UD-015** [Y] — Only 6 of a unit's 24 service tasks render before a 'Show all 24 tasks' control.
+- **UNITS UD-030** [Y] — Marking a passed unit "Not Ready" creates no inspection record, so the section flips yellow and stamps today's date while the only prose on 
+
+## `clean-records` — "Get data in right, fix what got in wrong, don't lose anyone's work" (n=11, damage 23)
+
+- **UNITS UD-052** [R] — Photo evidence on an inspection can be deleted with no history line, no confirm and no undo — the add path logs (app.js:20970, 20973), both 
+- **UNITS UD-064** [R] — On the CATEGORIES detail view (not Units), the Models section and its schedule popup are the one unconditionally ungated write surface on th
+- **UNITS UD-069** [R] — The app self-destructs abandoned empty drafts — for invoices and rentals only. Work orders are created carrying the same mock:true draft fla
+- **UNITS UD-028** [O] — Tapping Pass on an already-Passed unit that has no inspection record writes and syncs a brand-new inspection dated today — flipping the unit
+- **UNITS UD-029** [O] — Rental Wrangler ships ~350 lines of real per-family inspection checklists (INSP_DEFAULTS, app.js:3489-3838) that are wired to exactly one th
+- **UNITS UD-071** [O] — Passing a unit requires no checklist at all — the shipped per-family inspection checklists resolve to nothing for every category, so one tap
+- **CATEGORIES F-09** [O] — The three fields that produce this record's most misleading output — description, fuelType and name — have no editor anywhere on the record 
+- **CATEGORIES F-08** [O] — Creating or duplicating a model writes its audit entry onto the model record, whose history has no viewer anywhere in the application — the 
+- **CATEGORIES F-21** [O] — The category record's History can only ever show what somebody typed on this screen — the shared history engine has no categories branch, so
+- **RENTALS RD-09** [Y] — Opening a rental's detail view writes to the record
+- **CATEGORIES F-13** [Y] — History names a rate field by its raw camelCase identifier, giving one field three different names inside one record.
+
+## `no-surprises` — "Controls do what they look like they do" (n=9, damage 21)
+
+- **UNITS UD-005** [R] — A unit out on rent to a real customer displays 'UNINSURED', and coverage is a bare two-button toggle with no confirmation sitting in the sam
+- **UNITS UD-031** [R] — "Cancel WO" is an unconfirmed R18 ghost pill — the app's own "quiet action / Cancel / Close" style (app.js:6510) — sitting between +Invoice 
+- **UNITS UD-043** [R] — The GPS section's own comment says "an untracked unit reads red — no visibility is the worst tracking state" (app.js:8565), but the stored-f
+- **RENTALS RD-04** [R] — Returned is terminal but is the only terminal status with no visual distinction from the reversible rows beside it
+- **UNITS UD-038** [O] — Snooze is sold in calendar days but the alarm it mutes is measured in engine hours, with no cap on re-snoozing — and on the Units list tile 
+- **UNITS UD-058** [O] — The unit history's blue "N Rentals" chip structurally cannot be fulfilled: its count comes from DATA.rentals while its filter (/rent/i) runs
+- **UNITS UD-072** [O] — Snooze is offered in calendar days (7 / 14 / 30) and stored as a calendar date, while the alarm it silences is measured in engine hours — a 
+- **CATEGORIES F-06** [O] — Three controls in one record follow three different gate/confirm/log policies, and the only one that touches money is the only one that says
+- **CUSTOMERS CUS-06** [Y] — The button labelled 'Pay Cancellation $X' also re-enrols the member and marks them prepaid through the full commitment term. The label names
+
+## `spot-the-fire` — "Spot what's on fire without reading every row" (n=9, damage 21)
+
+- **UNITS UD-006** [R] — The unit tile and the unit detail header state contradictory part status for the same machine at the same moment — the tile's reassuring 'NO
+- **UNITS UD-068** [R] — The UNITS card prints 'FIELD CALL' on a unit's tile purely because its inspection is Failed while on a rental — the rental record itself car
+- **RENTALS RD-01** [R] — The status gate's word and its colour come from two different systems, so the healthiest label in the app ships in the alarm colour
+- **UNITS UD-009** [O] — The service task list is not ordered by urgency, and the collapsed section header names a task that is neither the first row nor the worst.
+- **UNITS UD-033** [O] — Inside the unit's Work Orders section, collapsed rows carry no work-order TYPE — with several WOs open, a Field Call, a failed-inspection jo
+- **UNITS UD-039** [O] — On a unit with a real per-model schedule (19 tasks for MOD002 'Yanmar ViO35'), the Services list shows only 6 rows and one of those six is p
+- **UNITS UD-045** [O] — Related to finding 58 (sibling, opposite direction): the unit detail's GPS section hard-defaults to RED for any unit with no GPS mapping and
+- **RENTALS RD-14** [O] — A quote with nothing billed and nothing owed renders its balance in the alarm red
+- **RENTALS RD-15** [O] — A mixed-status rental is the only kind whose colour is discarded — the state that most needs attention renders neutral gray
+
+## `keep-the-keys` — "Keep money numbers & admin switches with the right people" (n=8, damage 16)
+
+- **UNITS UD-067** [R] — The money tier is computed correctly and then never consulted by the unit's Investment block — a mechanic (canMoney()===false) reads the mac
+- **UNITS UD-022** [O] — Inside the unit's Investment section, four derived dollar figures — Total Revenue, Monthly, Work Orders and Profit — render with no tier che
+- **CUSTOMERS CUS-05** [O] — The `!currentRole ||` fail-open is applied inconsistently across six privilege gates, so a signed-in person whose role string is empty recei
+- **CUSTOMERS CUS-12** [O] — Only ADDING a payment method is money-gated: the sign, make-default and remove handlers carry no privilege check at all. The removal is curr
+- **CUSTOMERS CUS-13** [O] — Money VISIBILITY on the customer detail is not tier-gated at all — only money CONTROLS are. Every dollar figure on the record renders identi
+- **CATEGORIES N-02** [O] — canMoney() is the one privilege gate in the app that fails OPEN on a blank role, and a genuinely signed-in user can reach that blank state t
+- **CATEGORIES N-03** [O] — The category detail carries a SECOND blank-role fail-open, and this one writes: for a role-less session both the visibility guard and the cl
+- **RENTALS RD-07** [Y] — The per-unit status gate and the date-split control exist only on multi-unit rentals, so the habit formed on one rental does not transfer to
+
+## `got-one-free` — "Find out if we've actually got one to rent" (n=8, damage 14)
+
+- **RENTALS RD-10** [O] — The empty-unit slot instructs a drag gesture and names a control that was retired
+- **CATEGORIES F-18** [O] — The record you open to get more detail is a strictly worse answer than the card you opened it from: the mini-card's next-available date and 
+- **CATEGORIES F-20** [O] — Green means opposite things in the two bars stacked on top of each other: in the upper bar green is 'passed inspection', and in the lower ba
+- **CATEGORIES F-17** [O] — The app's own canonical 'is this rentable' predicate counts a machine that has never passed inspection as available — it excludes only Faile
+- **CATEGORIES F-10** [O] — A Sold, For Sale or Inactive machine appears in the category detail's unit list wearing a green 'Passed' inspection pill — mislabelled rathe
+- **CATEGORIES F-16** [O] — The record opens with two unlabelled full-width bars stacked on top of each other that measure different taxonomies, so on a one-machine cat
+- **UNITS UD-014** [Y] — Unit search matches on a field that is never rendered, returning rows with no visible reason for the match.
+- **CATEGORIES F-15** [Y] — Category search matches against description and notes — fields that exist only in the detail and never render on the grid — so a search retu
+
+## `no-fat-fingers` — "One stray tap can't wreck a charge, a record, or a job" (n=7, damage 13)
+
+- **UNITS UD-001** [R] — A single click in the Work Orders accordion created and persisted a real work order on a live unit — no confirmation, no draft state, no und
+- **UNITS UD-019** [O] — The sole field that writes the hour meter silently discards the entry whenever the number widget can't parse it — including the comma-groupe
+- **UNITS UD-055** [O] — On a checklist evidence photo the remove button is clipped by its own parent's `overflow: hidden` to a ~12×12 unlabeled red corner wedge — a
+- **UNITS UD-070** [O] — Every list row carries an unlabeled eye icon whose click is not a per-row action at all — it toggles hover previews OFF for the entire app, 
+- **CATEGORIES F-11** [O] — +Lost is a one-tap, ungated, unconfirmed write that stamps a hardcoded narrative sentence into permanent history — a sentence that can be, a
+- **UNITS UD-013** [Y] — Two numbers carrying the same 'HRS' unit and within 2% of each other, meaning entirely different things, appear on the same record across ti
+- **CUSTOMERS CUS-08** [Y] — Two saved payment methods can be visually identical — same brand, last four and expiry — separated only by status words, and the destructive
+
+## `whats-making-money` — "See what's making us money and what's bleeding us" (n=6, damage 12)
+
+- **UNITS UD-004** [R] — The unit's Investment block prints a confident 'Profit' figure identical to gross revenue whenever the cost fields are empty — no empty stat
+- **UNITS UD-060** [R] — For an Admin/Owner only, retagging a unit's category instantly repaints the machine's entire lifetime Total Revenue, Monthly and Profit with
+- **UNITS UD-050** [O] — SIBLING/ROOT of existing finding #77 — the revenue guard that is missing is per-UNIT-ENTRY (`unitVoided`), not per-rental, so #77's implied 
+- **CATEGORIES N-01** [O] — The money gate on the category record covers two of its six money figures: ROI and bottom dollar are hidden below money tier, while MSRP, as
+- **UNITS UD-051** [Y] — On a unit with rental revenue but no purchase date, the Investment block prints 'Monthly $0' on the line directly beneath a non-zero 'Total 
+- **CATEGORIES F-07** [Y] — Two of the Investment block's per-unit dollar figures are divide-by-zero artifacts printed as confident measurements beside the literal word
+
+## `get-our-money` — "Get our money — billed, chased, collected" (n=5, damage 12)
+
+- **UNITS UD-026** [R] — The bill-to-customer question is a label, not a gate — but the auto-created inspection record is the only one of six creators that seeds bil
+- **CUSTOMERS CUS-15** [R] — A customer can be charged the membership cancellation fee through the ordinary Invoices route, but the code that reactivates the membership 
+- **UNITS UD-062** [O] — Retagging a unit's category re-prices what the rental screen *displays* but never re-prices the invoice line, so the rental detail contradic
+- **CUSTOMERS CUS-01** [O] — The customer detail's Open KPI counts a REFUNDED invoice as money owed, so the detail view reports a larger balance than the list row for th
+- **CUSTOMERS CUS-02** [O] — In the Transactions view a refund recorded inside inv.payments[] is counted as a payment — inflating 'Collected' and the payment count, and 
+
+## `quote-the-caller` — "Work out what to charge this caller" (n=4, damage 9)
+
+- **CATEGORIES F-02** [R] — The only warning in production that a category has no prices is a sentence a human typed into the free-text `description` field; the app's o
+- **CATEGORIES F-19** [O] — The Pricing block leads with the member discount rate and renders all five rate fields at identical visual weight, so the first number a rat
+- **CATEGORIES F-01** [O] — The first chip in a category record's header is the raw fuelType string, which for every non-powered attachment is literally the word 'None'
+- **CATEGORIES F-12** [O] — The toast that greets a newly created category names a rate tier the app does not have and omits two it does — including the one field most 
+
+## `get-to-it` — "Get to the thing — record, list, button, door" (n=4, damage 6)
+
+- **RENTALS RD-06** [O] — When a rental's units diverge, the master gate silently becomes inert and the only explanation is a hover tooltip
+- **CUSTOMERS CUS-16** [O] — The agreements window is unreachable from the running app: its only entry point is a function that is never called, so the signed-agreement 
+- **UNITS UD-021** [Y] — Tapping the Model row in Specs raises an Admin-approval overlay reading "Categories and pricing are Admin-only. needs Admin approval." — Mod
+- **RENTALS RD-11** [Y] — The month calendar is the largest thing in the record, taking 58% of the rental section, above the units and the route
+
+## `line-up-the-runs` — "Line up today's hauls" (n=3, damage 6)
+
+- **RENTALS RD-03** [R] — The driver is stored on the rental's own unit entry and never displayed anywhere in the rental's detail view
+- **RENTALS RD-08** [O] — On a multi-unit delivery, only the primary unit inherits the rental's address; the others render an empty +Address
+- **RENTALS RD-16** [Y] — The route rail renders identically for every role but refuses to work below the money tier, and the refusal is a toast fired after the tap
+
+## `work-the-wrench-job` — "Work a repair through — parts, progress, proof" (n=2, damage 5)
+
+- **UNITS UD-017** [R] — The Specs Model row is the only control that links a unit to its real manufacturer service schedule — and it is admin-gated, so the mechanic
+- **CATEGORIES F-05** [O] — Full create, edit and delete of the maintenance schedule that decides when machines get serviced is completely ungated, while changing a rat
+
+## `field-trouble` — "Handle trouble in the field" (n=2, damage 5)
+
+- **UNITS UD-024** [R] — Failing a unit that's on rent red-flags the customer's live rental (r.fieldCall), and nothing on the unit record ever clears that flag — the
+- **UNITS UD-047** [O] — On the four units that carry GPS hardware, the GPS section prints the tracker brand 'GPSWOX' as a bare unlabeled string on the line immediat
+
+## `log-it-from-the-field` — "Log the job from the field and have it stick" (n=2, damage 5)
+
+- **UNITS UD-025** [R] — Failing an on-rent unit skips the forced §12.8 photo/notes capture that the identical tap on a yard unit fires three lines away — the field-
+- **UNITS UD-054** [O] — Every unit's detail header carries a functionless flag labelled 'QR' — styled cursor:pointer with a hover underline but wired to nothing — w
+
+## `keep-my-place` — "Keep my place — scroll, filters, view" (n=3, damage 4)
+
+- **UNITS UD-059** [O] — UNITS — A history-log search query survives onto the NEXT unit opened in the same tab (after backing out to the list; a direct standard→stan
+- **CUSTOMERS CUS-11** [Y] — The record's height scales with how much the customer has done, so the customers most worth reading are the ones whose Invoices, Payment Met
+- **CATEGORIES F-14** [Y] — Models, Investment, the unit list and the entire History log are the last four blocks of a record roughly 2.4× taller than the viewport, so 
+
+## `works-in-gloves` — "Works in the hands that hold it" (n=3, damage 4)
+
+- **CUSTOMERS CUS-14** [O] — The remove control on every saved card and bank row renders zero pixels wide, so a saved payment method cannot be removed by mouse — while i
+- **RENTALS RD-05** [Y] — Every gate-timeline row is 40px tall, below the 44px minimum touch target
+- **RENTALS RD-12** [Y] — Three of 54 interactive controls in the rental detail carry an accessible name
+
+## `reach-the-person` — "Call, text, or message the person this is about" (n=2, damage 4)
+
+- **CUSTOMERS CUS-03** [R] — A fully-built Comms section for the customer record exists, is named in the render order by the section's own current spec comment, and is n
+- **CUSTOMERS CUS-10** [Y] — The customer detail view offers no way to contact the customer — zero tel: links, zero mailto:, no text/email/send control — on a record tha
+
+## `get-it-back` — "Get the machine back when it’s due" (n=1, damage 3)
+
+- **UNITS UD-041** [R] — On the three seeded units that carry a stored gpsStatus but no device mapping, the GPS section stamps a green "Reporting"/"Verify" chip and 
+
+## `run-my-route` — "Run my route" (n=1, damage 2)
+
+- **UNITS UD-018** [O] — Units' Specs `weight` is the only field the Wrangler writer declares numeric (WR_NUMERIC, app.js:15594) whose human editor declares it text 
+
+## `size-up-the-customer` — "Size up this customer before I hand them iron" (n=1, damage 1)
+
+- **CUSTOMERS CUS-09** [Y] — Customers with the same name are indistinguishable on the row: the record id is never rendered as row text, and a customer with no phone on 
+

--- a/docs/research/FINDINGS-BY-JOB.md
+++ b/docs/research/FINDINGS-BY-JOB.md
@@ -1,0 +1,315 @@
+# All 171 findings, re-indexed by job
+
+The controlled vocabulary is defined in `JOB-TAXONOMY.md`. Findings keep their numbers from
+`ALL-FINDINGS.md` (1–64 red, 65–134 orange, 135–171 yellow). One job per finding; forced
+calls are listed at the bottom of the taxonomy. Ordered by job damage rank.
+
+## 1 · `spot-the-fire` — "Spot what's on fire without reading every row" (n=14, damage 29)
+
+- **#31 [R] Customers** — red is the default: 44 of 60 rows red, and no row ever says why
+- **#32 [R] Customers** — three alert-pulse mechanisms inverted or hardcoded backwards
+- **#41 [R] Customers** — staff type balances/do-not-rent into the NAME field, punctuation-gamed to sort on top
+- **#58 [R] Units** — the one pre-card alert indicator watches 3 of 10 registered flags
+- **#78 [O] Categories** — eight unavailability reasons, one identical red pill, no legend
+- **#81 [O] Categories** — the column-tab alert glow is hardcoded to fire for Units only
+- **#91 [O] Customers** — one red tint for a dormant account and an active safety risk
+- **#102 [O] RENTALS** — no 'Needs Attention' bucket; headers and counts never reflect severity
+- **#103 [O] RENTALS** — seven red conditions collapse to one uniform border; 2 of 7 unidentifiable without hover
+- **#122 [O] Units** — collapsed group headers show no flagged sub-count; collapse persists forever
+- **#123 [O] Units** — yellow 'Not Ready' ordered above red 'Needs Attention'
+- **#152 [Y] Categories** — the open-record tab badge is a navy fuel chip, not a status colour
+- **#161 [Y] Customers** — group headers carry no aggregate danger signal
+- **#164 [Y] Customers** — the service-worker update toast sits on top of the alert-chip row all session
+
+## 2 · `get-told` — "Hear about it when something needs me" (n=12, damage 24)
+
+- **#7 [R] Calendar/Driver** — a successful driver assignment writes only a hidden audit line; the driver is never told
+- **#20 [R] Categories** — a rate edit fires zero toast or ping to anyone, including its own author
+- **#40 [R] Customers** — reminder/ETA settings toggles save state; the engines behind them are inert
+- **#67 [O] Calendar/Driver** — sw.js has no push listener; nothing reaches a driver who isn't staring at the screen
+- **#82 [O] Categories** — categories have zero entries in the flag registry; no category condition can escalate
+- **#100 [O] Customers** — the bell holds engineering tickets in raw markdown; nothing customer-facing
+- **#108 [O] RENTALS** — no OS-level alerting: background the app, zero alerts reach the dispatcher
+- **#112 [O] Units** — the bell shows dispatch and billing items; nothing a mechanic needs, none role-filtered
+- **#129 [O] Units** — all ten unit flag predicates fire silently into data; toasts self-clear in 2.2s
+- **#144 [Y] Calendar/Driver** — the 'Driver Assigned' SMS toggle exists in Settings, defaulted off, commented inert
+- **#157 [Y] Categories** — no push/notification channel exists anywhere in the frontend
+- **#170 [Y] Units** — notification text renders markdown asterisks raw to every user
+
+## 3 · `keep-my-place` — "Keep my place — my scroll, my filters, my view" (n=10, damage 24)
+
+- **#6 [R] Calendar/Driver** — scroll memory reads the wrong scroller on Trips; any render resets to 0
+- **#11 [R] Calendar/Driver** — one town tap force-opens the collapsed map and persists it to localStorage
+- **#24 [R] Categories** — filters from different categories persist and silently intersect
+- **#25 [R] Categories** — the filter chip's circle icon negates the filter while reading as 'clear'
+- **#66 [O] Calendar/Driver** — the 18-second poll snaps the driver's scroll to top with no user action
+- **#79 [O] Categories** — sorting by ROI/Unit-Count/Avg-Hours reshuffles the grid with none of the three rendered
+- **#80 [O] Categories** — every reload lands the left column on Units; rate work restarts from scratch
+- **#95 [O] Customers** — clicking another customer's invoice silently spawns a new session tab, swapping all three columns
+- **#97 [O] Customers** — the Sales tab is a 'Coming soon' placard, and returning re-buries the scroll position
+- **#107 [O] RENTALS** — scroll restore is positional, so acting on a re-sorted list lands on a different rental
+
+## 4 · `get-to-it` — "Get to the thing — record, list, button, door" (n=12, damage 24)
+
+- **#8 [R] Calendar/Driver** — Show More is a guaranteed no-op on the card-stateless Calendar; rows past 60 unreachable
+- **#38 [R] Customers** — 'Show more' re-renders the whole list each press, slower every time; ~11 presses to reach the end
+- **#60 [R] Units** — scanning a unit's QR decal hijacks the app into a capture takeover with no way back
+- **#68 [O] Calendar/Driver** — trip search is one blob.includes; 'lake pick' returns zero rows
+- **#70 [O] Calendar/Driver** — customer pill navigates away, unit pill doesn't — same look, opposite cost
+- **#84 [O] Categories** — creating a category is only discoverable via a zero-result search
+- **#87 [O] Categories** — two lookalike pills an inch apart: one pushes Back history, the other erases it
+- **#118 [O] Units** — WO/inspection links land at the generic top of the unit page, never at the record clicked
+- **#128 [O] Units** — anchoring a non-primary unit of a multi-unit rental cascades to an empty column
+- **#149 [Y] Categories** — the Categories tab renders truncated to 'CATEG…' whenever inactive
+- **#155 [Y] Categories** — unit→category is an admin-gated select where sibling cards render a plain link
+- **#162 [Y] Customers** — a dead invoice link returns silently, indistinguishable from a frozen app
+
+## 5 · `trust-the-screen` — "Trust what the screen says" (n=10, damage 20)
+
+- **#10 [R] Calendar/Driver** — the map's day-state never resets; future-day pins under a 'TODAY' header
+- **#14 [R] Calendar/Driver** — the sync footer defaults to 'Offline — cached' and never re-checks after first success
+- **#72 [O] Calendar/Driver** — the KPI labelled 'On-Time' is a completion rate; punctuality never enters the formula
+- **#83 [O] Categories** — the poll patches data in place with no changed-marker, and skips whenever an overlay is open
+- **#96 [O] Customers** — a failed invoice-open still glow-flashes whatever customer is on screen
+- **#119 [O] Units** — unit history sorts on a per-load counter; entries render as a shuffled deck
+- **#120 [O] Units** — the Worklist graph says 'NOT READY 28'; the list 40px below says 'NOT READY · 8'
+- **#126 [O] Units** — the WO bar counts work orders but the click filters units; the numbers can't match
+- **#138 [Y] Calendar/Driver** — three of four stops logged still counts zero 'done' at the group header
+- **#143 [Y] Calendar/Driver** — a zero-trip day renders a full-height map over a grey-on-grey empty plate
+
+## 6 · `clean-records` — "Get data in right, fix what got in wrong, don't lose anyone's work" (n=8, damage 19)
+
+- **#23 [R] Categories** — categories can never be deleted/merged; the retag workaround silently re-prices live rentals
+- **#62 [R] Units** — the hour-meter field has zero validation; a 10× typo stood 26 days feeding every downstream number
+- **#63 [R] Units** — last-write-wins whole-record sync silently destroys one tech's work
+- **#73 [O] Calendar/Driver** — non-colon times parse to null with no error, silently inheriting the hidden 5PM cutoff
+- **#85 [O] Categories** — a newborn category renders identical to a dead one (full red 'None · N/A')
+- **#86 [O] Categories** — models are append-only with two creation paths and no dedupe
+- **#94 [O] Customers** — five customer-creation paths, zero duplicate check on phone/email/name
+- **#132 [O] Units** — a blank 'hours at completion' records as 0, corrupting the next countdown's baseline
+
+## 7 · `get-it-back` — "Get the machine back when it's due — and take it in right" (n=6, damage 17)
+
+- **#4 [R] Calendar/Driver** — the Trips badge excludes past-day undone stops; two were 78 days old
+- **#5 [R] Calendar/Driver** — the only home for undone past work is the sole default-collapsed, hardcoded-gray bucket
+- **#47 [R] RENTALS** — 'Log Recovery' stamps {date, video, driver}; no condition, no inspection, no damage line
+- **#48 [R] RENTALS** — an overdue return is invisible to every count, badge and toast; it only tints its own row
+- **#61 [R] Units** — the hour meter is never captured at return; the service countdown doesn't move
+- **#110 [O] RENTALS** — recoveries get no bucket or signal until the day AFTER they're late
+
+## 8 · `whats-next-to-wrench` — "Figure out which machine to wrench on next" (n=6, damage 16)
+
+- **#52 [R] Units** — the mechanic's correct landing (graph + service-due sort) dies on the first record opened
+- **#54 [R] Units** — grouping beats the Service-Due sort; a 1,139-hr-overdue machine sits ninth, under green
+- **#55 [R] Units** — the worst machine in the yard displays as 'No GPS +1'; the service number is tooltip-only
+- **#56 [R] Units** — a pending wash masks genuinely overdue service across five surfaces
+- **#111 [O] Units** — service-flag text truncates at exactly the word that distinguishes overdue from remaining
+- **#125 [O] Units** — no fleet-wide open-jobs view exists; the ex-Shop quick filters are fully built and unreachable
+
+## 9 · `work-the-wrench-job` — "Work a repair through — parts, progress, proof" (n=7, damage 15)
+
+- **#59 [R] Units** — every WO phase pill is frozen at creation; the advancing code lived on the retired Shop card
+- **#113 [O] Units** — the part-ETA flag can never fire; its input field has no writer anywhere
+- **#117 [O] Units** — a failed inspection's photo/video report has no door from the unit's own record
+- **#124 [O] Units** — 'N on hand' part quantities are decorative; nothing ever decrements them
+- **#131 [O] Units** — 'Part Needed' / 'Part Ordered' / 'Part Needed?' near-identical, colours varying tile to tile
+- **#133 [O] Units** — completing one blocking WO reports plain success while a second keeps the unit red
+- **#134 [O] Units** — a tile shows only the newest open WO; an older, worse one is masked entirely
+
+## 10 · `reach-the-person` — "Call, text, or message the person this is about" (n=7, damage 15)
+
+- **#26 [R] Customers** — no call, text, charge or follow-up control exists anywhere on row or detail
+- **#39 [R] Customers** — no tap-to-call at all; text/email hides behind an undiscoverable right-click
+- **#98 [O] Customers** — the per-customer comms thread panel is fully built with zero call sites
+- **#99 [O] Customers** — the poll never refreshes comms; a dead comms backend looks like a quiet day
+- **#104 [O] RENTALS** — customer replies never auto-refresh; a reply sits unseen until a manual click
+- **#109 [O] RENTALS** — texting the driver or customer about THIS rental is a 2–3 screen detour
+- **#142 [Y] Calendar/Driver** — phone labels render as-typed; only the href is normalized, app-wide
+
+## 11 · `quote-the-caller` — "Work out what to charge this caller" (n=9, damage 14)
+
+- **#16 [R] Categories** — the member day-rate is never on the mini-card face; a rep overquotes a member 267%
+- **#18 [R] Categories** — an unpriced category still shows a bright green availability pill
+- **#101 [O] Customers** — header says 'Member', the AR block on the same screen says 'NON MEMBER MODE'
+- **#145 [Y] Categories** — four flat tiles, no way to derive a 10-day price; 59% mental-math overquote
+- **#146 [Y] Categories** — a 0 rate renders '—' on the card and '$0' in the detail
+- **#148 [Y] Categories** — a 0/0/0 inspection tally is the loudest row on the rate card
+- **#154 [Y] Categories** — the weekend-rate qualifying window is enforced in code and stated nowhere
+- **#158 [Y] Categories** — Mr. Wrangler computes the correct blended price — behind a right-click only
+- **#159 [Y] Categories** — hover icons render directly on top of the 1-Day rate value
+
+## 12 · `size-up-the-customer` — "Size up this customer before I hand them iron" (n=5, damage 14)
+
+- **#27 [R] Customers** — live owed-$ and frozen payStatus give two contradictory answers inches apart
+- **#28 [R] Customers** — 2,260 of 2,265 customers sit in an unnamed grey leftover bucket
+- **#33 [R] Customers** — the detail popup clamps 'Don't Contact' to a calm blue 'Lead'
+- **#37 [R] Customers** — spend chart vs paid stat: 17× apart, no label saying which to trust
+- **#90 [O] Customers** — the stage pill never consults the Rental funnel; a live renter shows N/A
+
+## 13 · `log-it-from-the-field` — "Log the job from the field and have it stick" (n=5, damage 14)
+
+- **#12 [R] Calendar/Driver** — a failed video upload still stamps the row green 'Logged'
+- **#13 [R] Calendar/Driver** — the log-gate runs on tap, not render; a blocked stop shows no lock until he's driven there
+- **#15 [R] Calendar/Driver** — a failed-sync capture is held only in RAM behind a 'Don't close the app' banner
+- **#46 [R] RENTALS** — a gate-blocked field delivery silently discards the whole capture, video included
+- **#74 [O] Calendar/Driver** — on a merged trip, 'Log Delivery' points at a stop already logged
+
+## 14 · `run-my-route` — "Run my route — where to, when, how to get there" (n=5, damage 13)
+
+- **#1 [R] Calendar/Driver** — the map occupies 78% of everything the driver can see before the first trip row
+- **#2 [R] Calendar/Driver** — pickup legs are hardcoded time:''; a pickup can never carry a time
+- **#9 [R] Calendar/Driver** — the row prints a town; the full address exists only in a hover tooltip
+- **#65 [O] Calendar/Driver** — a blank time box silently means a hard 5:00 PM cutoff, printed nowhere
+- **#69 [O] Calendar/Driver** — 'Open in Google Maps' only exists nested inside the focused map panel
+
+## 15 · `keep-the-keys` — "Keep money numbers and admin switches with the right people" (n=6, damage 13)
+
+- **#21 [R] Categories** — creating a rentable class is ungated while pricing it is admin-gated — inverted authority
+- **#22 [R] Categories** — ROI is money-gated in the detail and ungated as a list column and sort key
+- **#93 [O] Customers** — History masks $ for low roles while four sibling surfaces print live money
+- **#121 [O] Units** — the mechanic landing is keyed to a hardcoded role name a rename silently kills
+- **#127 [O] Units** — the Round-Up Money section renders to every signed-in role
+- **#156 [Y] Categories** — audit redaction blanks the whole line; even the fact a price changed is lost
+
+## 16 · `no-fat-fingers` — "One stray tap can't wreck a charge, a record, or a job" (n=5, damage 13)
+
+- **#34 [R] Customers** — removing a saved card: zero gate, zero confirm, live Stripe detach
+- **#35 [R] Customers** — 'Pay Cancellation' charges the saved card instantly, skipping the shared review overlay
+- **#49 [R] Units** — the hover preview is the full live detail: 13 hot controls placed under the travelling cursor
+- **#92 [O] Customers** — 'Cancel Membership' ends billing and invoices the remaining term on the first click
+- **#106 [O] RENTALS** — terminal status jumps commit on one click, no confirm, no undo, row vanishes
+
+## 17 · `get-our-money` — "Get our money — billed, chased, collected" (n=4, damage 12)
+
+- **#29 [R] Customers** — the 'Pay Status' and 'Last Invoice' sorts are dead no-ops shown as selected
+- **#30 [R] Customers** — the money pill wins the truncation; the more owed, the less phone number
+- **#36 [R] Customers** — collections and void are built end-to-end; their buttons render only on the retired Invoices card
+- **#43 [R] RENTALS** — a Reserved rental can jump straight to 'Returned', closing out unbilled
+
+## 18 · `hook-it-to-the-rental` — "Put a machine on the rental — only one fit to go" (n=4, damage 11)
+
+- **#50 [R] Units** — attach has exactly one path: drag; the +Unit button toasts an instruction to drag
+- **#51 [R] Units** — the attach filter checks fleetStatus only; a failed, 2,882-hr-overdue machine attaches silently
+- **#57 [R] Units** — the two red insurance flags never render a pill on the card face
+- **#105 [O] RENTALS** — on a phone, linking is an unsignposted 500ms long-press; the hint copy said 'drag'
+
+## 19 · `no-surprises` — "Controls do what they look like they do — same everywhere" (n=9, damage 11)
+
+- **#116 [O] Units** — two population filters sit under a menu header reading SORT
+- **#130 [O] Units** — clicking a unit's name doesn't open it; it reveals two unlabeled icons, one of them the trap
+- **#135 [Y] Calendar/Driver** — Escape closes every overlay on the card except dropdown menus
+- **#136 [Y] Calendar/Driver** — Trips' listbar is empty: no sort, no search, no stats toggle
+- **#141 [Y] Calendar/Driver** — the same glyph means 'graph view' on every card and 'hide the map' here
+- **#151 [Y] Categories** — Escape doesn't close the context or sort menus
+- **#163 [Y] Customers** — the global search-scope globe silently changes other cards' search too
+- **#166 [Y] RENTALS** — advancing status from the list row works on Rentals and nowhere else
+- **#171 [Y] Units** — no feedback while the 220ms double-click discriminator resolves; a second tap forks a tab
+
+## 20 · `field-trouble` — "Handle trouble in the field" (n=4, damage 10)
+
+- **#42 [R] RENTALS** — a Field Call on a non-primary unit dispatches the repair to the wrong machine
+- **#53 [R] Units** — a machine that breaks mid-rental never lands in 'Needs Attention'
+- **#71 [O] Calendar/Driver** — the driver row's overflow menu holds one item: 'Merge trip…'
+- **#75 [O] Calendar/Driver** — no standing dispatch channel; a new chat starts with zero members
+
+## 21 · `got-one-free` — "Find out if we've actually got one to rent" (n=4, damage 9)
+
+- **#17 [R] Categories** — mini-card and detail availability disagree on the same screen at the same second
+- **#19 [R] Categories** — a fully sold category still displays quotable rack rates
+- **#89 [O] Categories** — the Off-Fleet stock segment clicks through to an empty list
+- **#147 [Y] Categories** — 'next available' silently switches date convention at the 7-day mark
+
+## 22 · `works-in-gloves` — "Works in my hands — touch, gloves, small screen, no hover, no eyes" (n=6, damage 9)
+
+- **#88 [O] Categories** — controls expose as bare 'button'; filter chips invisible to a screen reader
+- **#114 [O] Units** — 58 of 86 controls have no visible name; 52 are tooltip-only; zero aria-labels
+- **#115 [O] Units** — the Tools menu clips 6 of 10 items at tablet height — including the hover-off switch
+- **#137 [Y] Calendar/Driver** — the back control is an unlabeled bare chevron
+- **#140 [Y] Calendar/Driver** — an inactive tab truncates to a single character 'T'
+- **#169 [Y] RENTALS** — the anchor-clear controls work but are hover-revealed and unlabeled
+
+## 23 · `line-up-the-runs` — "Line up today's hauls — who's driving what where" (n=4, damage 8)
+
+- **#44 [R] RENTALS** — the lane rail and one-tap 'Round up' auto-balance exist in code; nothing renders their buttons
+- **#45 [R] RENTALS** — one driver, two towns, same 9 AM — silently allowed; machines flag, people don't
+- **#139 [Y] Calendar/Driver** — driverRoster falls back to every employee when the role filter comes back empty
+- **#167 [Y] RENTALS** — day-one dead end: the +Driver chip is suppressed and the hint lives behind it
+
+## 24 · `whats-mine-today` — "Know what's mine to do today — and my next move" (n=4, damage 8)
+
+- **#3 [R] Calendar/Driver** — 'the driver's day' renders every driver's trips plus the whole unassigned pool
+- **#64 [R] Units** — assignedMechanic exists in 17 places and routes, filters or badges nothing
+- **#165 [Y] RENTALS** — the next move is a status noun on a 22px pill; no verb, no CTA
+- **#168 [Y] RENTALS** — no daily digest; a dispatcher assembles the day by scanning cards
+
+## 25 · `whats-making-money` — "See what's making us money and what's bleeding us" (n=5, damage 7)
+
+- **#76 [O] Categories** — the Time-Util denominator counts sold and inactive fleet
+- **#77 [O] Categories** — revenue and ROI count cancelled and no-show rentals as collected money
+- **#150 [Y] Categories** — '+Lost' demand logs locally and toasts the tapper; the rollup board was never built
+- **#153 [Y] Categories** — a zero-unit category prints '0 HRS' and '$0' as if measured
+- **#160 [Y] Categories** — the $ UTIL tab is an empty state in production; trueCost is unset
+
+---
+
+## Flat index (finding → job)
+
+| # | job | # | job | # | job |
+|---|---|---|---|---|---|
+| 1 | run-my-route | 58 | spot-the-fire | 115 | works-in-gloves |
+| 2 | run-my-route | 59 | work-the-wrench-job | 116 | no-surprises |
+| 3 | whats-mine-today | 60 | get-to-it | 117 | work-the-wrench-job |
+| 4 | get-it-back | 61 | get-it-back | 118 | get-to-it |
+| 5 | get-it-back | 62 | clean-records | 119 | trust-the-screen |
+| 6 | keep-my-place | 63 | clean-records | 120 | trust-the-screen |
+| 7 | get-told | 64 | whats-mine-today | 121 | keep-the-keys |
+| 8 | get-to-it | 65 | run-my-route | 122 | spot-the-fire |
+| 9 | run-my-route | 66 | keep-my-place | 123 | spot-the-fire |
+| 10 | trust-the-screen | 67 | get-told | 124 | work-the-wrench-job |
+| 11 | keep-my-place | 68 | get-to-it | 125 | whats-next-to-wrench |
+| 12 | log-it-from-the-field | 69 | run-my-route | 126 | trust-the-screen |
+| 13 | log-it-from-the-field | 70 | get-to-it | 127 | keep-the-keys |
+| 14 | trust-the-screen | 71 | field-trouble | 128 | get-to-it |
+| 15 | log-it-from-the-field | 72 | trust-the-screen | 129 | get-told |
+| 16 | quote-the-caller | 73 | clean-records | 130 | no-surprises |
+| 17 | got-one-free | 74 | log-it-from-the-field | 131 | work-the-wrench-job |
+| 18 | quote-the-caller | 75 | field-trouble | 132 | clean-records |
+| 19 | got-one-free | 76 | whats-making-money | 133 | work-the-wrench-job |
+| 20 | get-told | 77 | whats-making-money | 134 | work-the-wrench-job |
+| 21 | keep-the-keys | 78 | spot-the-fire | 135 | no-surprises |
+| 22 | keep-the-keys | 79 | keep-my-place | 136 | no-surprises |
+| 23 | clean-records | 80 | keep-my-place | 137 | works-in-gloves |
+| 24 | keep-my-place | 81 | spot-the-fire | 138 | trust-the-screen |
+| 25 | keep-my-place | 82 | get-told | 139 | line-up-the-runs |
+| 26 | reach-the-person | 83 | trust-the-screen | 140 | works-in-gloves |
+| 27 | size-up-the-customer | 84 | get-to-it | 141 | no-surprises |
+| 28 | size-up-the-customer | 85 | clean-records | 142 | reach-the-person |
+| 29 | get-our-money | 86 | clean-records | 143 | trust-the-screen |
+| 30 | get-our-money | 87 | get-to-it | 144 | get-told |
+| 31 | spot-the-fire | 88 | works-in-gloves | 145 | quote-the-caller |
+| 32 | spot-the-fire | 89 | got-one-free | 146 | quote-the-caller |
+| 33 | size-up-the-customer | 90 | size-up-the-customer | 147 | got-one-free |
+| 34 | no-fat-fingers | 91 | spot-the-fire | 148 | quote-the-caller |
+| 35 | no-fat-fingers | 92 | no-fat-fingers | 149 | get-to-it |
+| 36 | get-our-money | 93 | keep-the-keys | 150 | whats-making-money |
+| 37 | size-up-the-customer | 94 | clean-records | 151 | no-surprises |
+| 38 | get-to-it | 95 | keep-my-place | 152 | spot-the-fire |
+| 39 | reach-the-person | 96 | trust-the-screen | 153 | whats-making-money |
+| 40 | get-told | 97 | keep-my-place | 154 | quote-the-caller |
+| 41 | spot-the-fire | 98 | reach-the-person | 155 | get-to-it |
+| 42 | field-trouble | 99 | reach-the-person | 156 | keep-the-keys |
+| 43 | get-our-money | 100 | get-told | 157 | get-told |
+| 44 | line-up-the-runs | 101 | quote-the-caller | 158 | quote-the-caller |
+| 45 | line-up-the-runs | 102 | spot-the-fire | 159 | quote-the-caller |
+| 46 | log-it-from-the-field | 103 | spot-the-fire | 160 | whats-making-money |
+| 47 | get-it-back | 104 | reach-the-person | 161 | spot-the-fire |
+| 48 | get-it-back | 105 | hook-it-to-the-rental | 162 | get-to-it |
+| 49 | no-fat-fingers | 106 | no-fat-fingers | 163 | no-surprises |
+| 50 | hook-it-to-the-rental | 107 | keep-my-place | 164 | spot-the-fire |
+| 51 | hook-it-to-the-rental | 108 | get-told | 165 | whats-mine-today |
+| 52 | whats-next-to-wrench | 109 | reach-the-person | 166 | no-surprises |
+| 53 | field-trouble | 110 | get-it-back | 167 | line-up-the-runs |
+| 54 | whats-next-to-wrench | 111 | whats-next-to-wrench | 168 | whats-mine-today |
+| 55 | whats-next-to-wrench | 112 | get-told | 169 | works-in-gloves |
+| 56 | whats-next-to-wrench | 113 | work-the-wrench-job | 170 | get-told |
+| 57 | hook-it-to-the-rental | 114 | works-in-gloves | 171 | no-surprises |

--- a/docs/research/JOB-TAXONOMY.md
+++ b/docs/research/JOB-TAXONOMY.md
@@ -1,0 +1,219 @@
+# The Job Taxonomy
+
+**25 jobs · every one of the 171 findings assigned to exactly one · built 2026-07-19**
+
+The inventory's stated primary axis is *the work* — but the `job` field was collected as free
+text, so all 171 findings were uniquely worded and never clustered. This document is the
+controlled vocabulary that fixes that, and `FINDINGS-BY-JOB.md` is the full re-index against it.
+
+## How the vocabulary was built
+
+- Each finding's free-text `job` line was read against its evidence and collapsed to the real
+  work it blocks, phrased the way the person doing it would say it.
+- **15 jobs are business work** — a specific person doing a specific thing (quote a caller,
+  run a route, wrench on a machine).
+- **10 jobs are table stakes** — work every role does all day on every card (hear about
+  things, trust the screen, keep your place, not wreck things). These are still jobs a yard
+  worker would name — "I just need the thing to tell me when something needs me" — but they
+  don't belong to any one card or role. Forcing them into business jobs would have been
+  arbitrary: a screen-reader failure or a lying count blocks *all* work equally.
+- **One assignment per finding.** When a finding could sit in two jobs, the specific business
+  job won over the table-stakes job, and the *damaged work* won over the *mechanism*.
+  Forced calls are listed at the bottom so nobody mistakes them for clean fits.
+
+**Damage score = 3×red + 2×orange + 1×yellow.** Total damage across all 171 findings = 369.
+
+## The headline numbers
+
+- **The table-stakes layer carries 51% of all damage** (188 of 369, 93 of 171 findings).
+  Before any specific job can be fixed, the app fails at hearing-about-it, trusting-it,
+  finding-it, and not-wrecking-it. This matches the failure-mode table: `invisible` (45) is
+  the largest mode, and only 20 findings are density/legibility.
+- **The back half of the rental carries more damage than the front half.** Getting a machine
+  back, deciding what to fix, and working the repair (get-it-back 17 + what's-next-to-wrench 16 +
+  work-the-wrench-job 15 + field-trouble 10 + log-it-from-the-field 14 = **72**) outweighs
+  quoting, stock, sizing-up, attaching and dispatching (56). The rental's *end* — the densest
+  handoff in the business — is where the UI system loses the most.
+- **The single most damaged business job is "get the machine back"** — overdue returns
+  invisible to every count, recoveries with no bucket until the day *after* late, a return
+  path that captures no hours, no condition, no damage.
+- **The most systemic job is "hear about it"** — 11 of its 12 findings are systemic. The app
+  has no delivery channel at all; every card rediscovered the same hole.
+
+## The 25 jobs, ranked by damage
+
+| # | Job | Said as | n | R/O/Y | Systemic | Damage |
+|---|---|---|---|---|---|---|
+| 1 | `spot-the-fire` | "Spot what's on fire without reading every row" | 14 | 4/7/3 | 10 | **29** |
+| 2 | `get-told` | "Hear about it when something needs me — without staring at the screen" | 12 | 3/6/3 | 11 | **24** |
+| 3 | `keep-my-place` | "Keep my place — my scroll, my filters, my view" | 10 | 4/6/0 | 2 | **24** |
+| 4 | `get-to-it` | "Get to the thing — the record, the list, the button, the door" | 12 | 3/6/3 | 5 | **24** |
+| 5 | `trust-the-screen` | "Trust what the screen says — the numbers, the counts, the freshness" | 10 | 2/6/2 | 3 | **20** |
+| 6 | `clean-records` | "Get data in right, fix what got in wrong, don't lose anyone's work" | 8 | 3/5/0 | 2 | **19** |
+| 7 | `get-it-back` | "Get the machine back when it's due — and take it in right" | 6 | 5/1/0 | 3 | **17** |
+| 8 | `whats-next-to-wrench` | "Figure out which machine to wrench on next" | 6 | 4/2/0 | 4 | **16** |
+| 9 | `work-the-wrench-job` | "Work a repair through — parts, progress, proof" | 7 | 1/6/0 | 1 | **15** |
+| 10 | `reach-the-person` | "Call, text, or message the person this is about — from the thing itself" | 7 | 2/4/1 | 4 | **15** |
+| 11 | `quote-the-caller` | "Work out what to charge this caller" | 9 | 2/1/6 | 1 | **14** |
+| 12 | `size-up-the-customer` | "Size up this customer before I hand them iron" | 5 | 4/1/0 | 1 | **14** |
+| 13 | `log-it-from-the-field` | "Log the job from the field and have it stick" | 5 | 4/1/0 | 1 | **14** |
+| 14 | `run-my-route` | "Run my route — where to, when, how to get there" | 5 | 3/2/0 | 0 | **13** |
+| 15 | `keep-the-keys` | "Keep money numbers and admin switches with the right people" | 6 | 2/3/1 | 5 | **13** |
+| 16 | `no-fat-fingers` | "One stray tap can't wreck a charge, a record, or a job" | 5 | 3/2/0 | 5 | **13** |
+| 17 | `get-our-money` | "Get our money — billed, chased, collected" | 4 | 4/0/0 | 2 | **12** |
+| 18 | `hook-it-to-the-rental` | "Put a machine on the rental — and only one that's fit to go out the gate" | 4 | 3/1/0 | 3 | **11** |
+| 19 | `no-surprises` | "Controls do what they look like they do — same on every card" | 9 | 0/2/7 | 5 | **11** |
+| 20 | `field-trouble` | "Handle trouble in the field — breakdowns, delays, can't-complete" | 4 | 2/2/0 | 1 | **10** |
+| 21 | `got-one-free` | "Find out if we've actually got one to rent" | 4 | 2/1/1 | 2 | **9** |
+| 22 | `works-in-gloves` | "Works in my hands — touch, gloves, small screen, no hover, no eyes" | 6 | 0/3/3 | 3 | **9** |
+| 23 | `line-up-the-runs` | "Line up today's hauls — who's driving what where" | 4 | 2/0/2 | 3 | **8** |
+| 24 | `whats-mine-today` | "Know what's mine to do today — and my next move" | 4 | 2/0/2 | 3 | **8** |
+| 25 | `whats-making-money` | "See what's making us money and what's bleeding us" | 5 | 0/2/3 | 0 | **7** |
+
+Checksums: n sums to 171; R/O/Y sums to 64/70/37; systemic sums to 80; damage sums to 369.
+All four match the inventory's own totals.
+
+---
+
+## The jobs, defined
+
+### Business jobs (15) — 78 findings, 181 damage
+
+**`quote-the-caller`** — Work out what to charge this caller, before they hang up. The counter
+rep reading the card face they actually look at. Findings: 16, 18, 101, 145, 146, 148, 154,
+158, 159. *The face shows the wrong number (member rate absent, 267% over), can't derive an
+arbitrary-length total (59% over), and the correct answer sits behind a right-click.*
+
+**`got-one-free`** — Find out if we've actually got one to rent. Stock truth. Findings: 17,
+19, 89, 147. *Two availability counts disagree on the same screen; sold fleet still shows rack
+rates; the click-through to see the machines lands empty.*
+
+**`size-up-the-customer`** — Size up this customer before I hand them iron: member or not, lead
+or renter, do-not-contact or fine, worth chasing or not. Findings: 27, 28, 33, 37, 90.
+*Every signal that answers "who is this" is frozen, clamped, contradicted, or grey.*
+
+**`get-our-money`** — Get our money: make sure the rental got billed, chase what's owed, send
+the dead ones to collections. Findings: 29, 30, 36, 43. *All four red. A rental closes out
+unbilled; collections and void are built with no door; the who-owes-most sorts are dead.*
+
+**`hook-it-to-the-rental`** — Put a machine on the rental — and only one that's fit, insured,
+and legal to go out the gate. The attach moment and its gates. Findings: 50, 51, 105, 57.
+*One undiscoverable path per device (drag / long-press), and no fitness gate on either.*
+
+**`line-up-the-runs`** — Line up today's hauls: who's driving what where, no one double-booked.
+Findings: 44, 45, 139, 167. *The multi-truck tools exist unrendered; people can be
+double-booked silently where machines can't.*
+
+**`run-my-route`** — Run my route: where to, when it's due, how to get there, from the cab.
+Findings: 1, 2, 9, 65, 69. *The map eats the screen; pickups can never carry a time; the
+address is hover-only; the real deadline is a secret.*
+
+**`log-it-from-the-field`** — Log the job from the field and have it stick: the capture, the
+video, the proof. Findings: 12, 13, 15, 46, 74. *A failed upload stamps green; a blocked stop
+discards the capture, video included; the pending write lives in RAM.*
+
+**`field-trouble`** — Handle trouble in the field: a breakdown on a customer's site, running
+late, can't complete. Findings: 42, 53, 71, 75. *The repair dispatches to the wrong machine;
+the broken machine files under a calm bucket; the driver's row offers only 'Merge trip…'.*
+
+**`get-it-back`** — Get the machine back when it's due — and take it in right: hours, condition,
+damage, money. Findings: 4, 5, 47, 48, 61, 110. *Highest-damage business job. Overdue is
+invisible to every count; recoveries have no bucket until after they're late; the return
+captures nothing the next three cards need.*
+
+**`whats-next-to-wrench`** — Figure out which machine to wrench on next, and get back to that
+list after each job. Findings: 52, 54, 55, 56, 111, 125. *The correct prioritized landing
+exists and dies on the first click; grouping beats the sort; a wash masks an overdue engine.*
+
+**`work-the-wrench-job`** — Work a repair through: parts, progress, proof, and knowing when
+it's actually done. Findings: 59, 113, 117, 124, 131, 133, 134. *The phase pill is frozen;
+part ETA can never fire; stock counts are decorative; completing one WO hides the other.*
+
+**`whats-mine-today`** — Know what's mine to do today — my queue, my day, my next move.
+Findings: 3, 64, 165, 168. *No view is ever scoped to 'mine'; assignment fields route
+nothing; there is no morning brief; the next move is a noun.*
+
+**`whats-making-money`** — See what's making us money and what's bleeding us, well enough to
+buy and sell fleet. Findings: 76, 77, 150, 153, 160. *Revenue counts phantom rentals;
+utilization counts dead fleet; the lost-demand signal dead-ends at the tapper's own device.*
+
+**`keep-the-keys`** — Keep money numbers and admin switches with the right people — and let
+the boss configure the shop without breaking it. Findings: 21, 22, 93, 121, 127, 156.
+*Authority is inverted (anyone can mint a rentable class, only admin can price it), margin
+leaks through ungated columns, and a role rename silently kills a tailored landing.*
+
+### Table-stakes jobs (10) — 93 findings, 188 damage
+
+**`get-told`** — Hear about it when something needs me — without staring at the screen.
+Findings: 7, 20, 40, 67, 82, 100, 108, 112, 129, 144, 157, 170. *The app has no messenger:
+no push, no badge, no durable inbox. Settings sells three notification engines that don't
+exist. 11 of 12 systemic — every card found the same void.*
+
+**`reach-the-person`** — Call, text, or message the person this thing is about — from the
+thing itself. Findings: 26, 39, 98, 99, 104, 109, 142. *No tap-to-call anywhere; the built
+per-record thread panel renders nowhere; replies are never polled.*
+
+**`spot-the-fire`** — Spot what's on fire without reading every row. Findings: 31, 32, 41,
+58, 78, 81, 91, 102, 103, 122, 123, 152, 161, 164. *Highest-damage job in the app. Red is
+the default state and never says why; severity dies on the row it's born on; the blinks
+point at the calm ones. Includes the name-field ledger — staff hand-building the signal
+system the app doesn't have.*
+
+**`trust-the-screen`** — Trust what the screen says: the number is right, tapping it shows
+what it counted, the data is current, the history is in order. Findings: 10, 14, 72, 83,
+96, 119, 120, 126, 138, 143. *Counts disagree inches apart; the sync footer lies in both
+directions; history renders as a shuffled deck.*
+
+**`keep-my-place`** — Keep my place: my scroll, my filters, my view, the record I was on.
+Findings: 6, 11, 24, 25, 66, 79, 80, 95, 97, 107. *View state is scratch paper — renders,
+polls, taps and reloads all silently move, stack, or wipe what I was looking at.*
+
+**`get-to-it`** — Get to the thing: the record past the cutoff, the linked record, the door
+to the capability. Findings: 8, 38, 60, 68, 70, 84, 87, 118, 128, 149, 155, 162. *Show More
+is a no-op; links land at the generic top; whole capabilities have no entry point; the QR
+decal — the yard's most obvious affordance — hijacks the app.*
+
+**`no-surprises`** — Controls do what they look like they do, and the same thing on every
+card. Findings: 116, 130, 135, 136, 141, 151, 163, 166, 171. *Filters live under SORT; the
+same glyph means opposite things; Escape works everywhere except menus; a habit learned on
+one card is wrong on the next.*
+
+**`works-in-gloves`** — Works in the hands that actually hold it: touch, gloves, small
+screens, no hover, screen readers. Findings: 88, 114, 115, 137, 140, 169. *67% of controls
+have no visible name; the label layer is hover; menus clip at tablet heights. The phone walk
+(07-phone-walk/) tests how much worse this is below 640px.*
+
+**`no-fat-fingers`** — One stray tap can't wreck a charge, a record, or a job — and the app
+warns me before the point of no return. Findings: 34, 35, 49, 92, 106. *Card removal, full
+charges, membership cancellation and terminal status jumps all commit on first tap while the
+reversible actions carry the confirms.*
+
+**`clean-records`** — Get data in right, fix what got in wrong, and don't lose anyone's work.
+Findings: 23, 62, 63, 73, 85, 86, 94, 132. *No dedupe, no validation, no merge, no delete —
+and last-write-wins sync silently throws away a coworker's entries.*
+
+---
+
+## Forced calls — read before re-using the taxonomy
+
+Single-assignment forces judgment where a finding genuinely spans jobs. The material ones:
+
+- **4 and 5** (badge excludes past-day undone stops; the collapsed gray 'Earlier' bucket) are
+  filed under `get-it-back`, not `trust-the-screen`/`spot-the-fire` — the damaged work is
+  overdue recoveries (two stops were 78 days old), and they travel with 48/110.
+- **41** (the name-field ledger) is filed under `spot-the-fire`: it is the staff's hand-built
+  replacement for the surfacing the flag system doesn't do. It is equally evidence for
+  `clean-records` (free text in the name field) and `size-up-the-customer`.
+- **165** ("next move is a noun") is filed under `whats-mine-today` — the job is knowing and
+  taking your next move — though its example (Off Rent = 3 days overdue) touches `get-it-back`.
+- **17** (two availability counts) sits in `got-one-free`, not `trust-the-screen`, because the
+  damaged work is a stock answer; the same two-authors mechanism appears in `trust-the-screen`
+  findings 120/126.
+- **63** (last-write-wins) is filed under `clean-records` ("don't lose anyone's work") rather
+  than a separate two-people-one-yard job; the *Last Save Wins* pattern says four cards share
+  the mechanism, so the redesign should treat it as bigger than its single-finding count here.
+- **100** (the bell full of engineering tickets) is `get-told`, not `spot-the-fire` — the bell
+  is the delivery channel, not the scan surface.
+- Cross-cutting jobs would multiply-index if allowed: nearly every business-job finding also
+  damages `trust-the-screen` or `get-told`. The single-assignment rule keeps the damage sums
+  honest; the pattern layer (ALL-PATTERNS.md, the six roots) is where the overlaps live.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,112 @@
+# Rental Wrangler — UI System Research
+
+**Private.** Contains app-weakness detail and internal findings. Do not mirror into the public
+`rental-wrangler` repo.
+
+This repository is the combined output of **five persona-driven usability audits** ("lazy-audit"),
+each run against a different card of the live app and verified against production's real bytes.
+It exists to answer one question:
+
+> **What is the full scope of problems a redesigned UI *system* has to solve?**
+
+"UI system" here does not mean prettiness. In Jac's words: *"I'm referring to all the WORK that has
+to be done and how UI helps it all get done."* The app is a large set of competing systems — rentals,
+units, customers, categories, dispatch, invoicing, service, comms — sharing one screen. No coherent
+UI system was settled up front, because it could not be. The app is now nearly built, so it can be.
+
+**This is a gathering, not a design.** Nothing here proposes a solution. The next session's job is to
+finish the gathering and present the completed scope — then stop for review.
+
+---
+
+## ⚠️ Clone this repo blobless — do not do a plain `git clone`
+
+`03-screenshots/` holds ~17MB of JPEGs. A full clone of that through a cloud proxy is slow and has
+already timed out one session. Nothing here needs the image bytes up front — the captions in
+`04-screenshot-index/` carry what the images showed.
+
+```bash
+git clone --filter=blob:none https://github.com/operations-jacrentals/rental-wrangler-ui-research.git
+```
+
+`--filter=blob:none` fetches file *contents* lazily, so text lands immediately and an image only
+transfers if you actually open it. If you only need to contribute and never read the research, narrow
+it further:
+
+```bash
+git clone --filter=blob:none --sparse <url> && cd rental-wrangler-ui-research
+git sparse-checkout set contrib
+```
+
+If git still struggles, skip cloning and write through the API instead:
+`gh api --method PUT repos/operations-jacrentals/rental-wrangler-ui-research/contents/<path> -f message="…" -f content="$(base64 -w0 <file>)"`
+
+## What's in here
+
+| Folder | What it is | How to use it |
+|---|---|---|
+| `SCOPE.md` | **Start here.** The completed scope: the whole corpus (≈269 verified findings), the 25-job backbone, what the gathering closed, and what remains unknown. | The capstone — read first, then drill into the folders it cites. |
+| `01-inventory/` | The combined, deduplicated problem inventory — every finding from all five audits, tagged by the job it blocks, the UI primitive implicated, the failure mode, and severity. Plus cross-card patterns, a blind-spot analysis, **the job taxonomy (`JOB-TAXONOMY.md`) and the full re-index (`FINDINGS-BY-JOB.md`)**. | Read `COMBINED-INVENTORY.md` in full; use the taxonomy as the primary axis. |
+| `07-phone-walk/` | The first-ever walk of the <640px phone build + the 641–1024 touch-tablet band, live-driven with real touch events against production bytes. 17 findings, a hover re-grade table, 12 screenshots. | The phone gap, closed. Adversarially verified in place. |
+| `08-unaudited-surfaces/` | The 12 surfaces no audit touched — Settings, Rental Rules, money/ACH, back-office boards, agreements/signing, print, the Wrangler write path, public pages, login/day-one, offline. 62 findings. | Adversarially verified in place; corrections marked. |
+| `09-cross-card-traces/` | Five end-to-end job traces across card boundaries; 15 orphaned arrows no card owns, ranked by business consequence. | Adversarially verified in place (10/10 confirmed). |
+| `02-source-artifacts/` | The four finished audit documents, exactly as each session shipped them. Self-contained HTML with the persona, an as-is vs should-be mock, a report card, and a retractions section. | Open in a browser when you need one card's full argument. |
+| `03-screenshots/` | 138 unique screenshots captured live against production during the audits. Deduplicated by content hash. | **Read the index first — don't open these blind.** |
+| `04-screenshot-index/` | For every screenshot: the browser action that produced it, and **what the auditing session said immediately after seeing it**. 100% coverage. | This is the point: the images were already analysed once. Use the captions; open a `.jpg` only when you need the actual pixels. |
+| `05-raw-transcripts/` | The four audit conversations, stripped of tool noise. ~130KB each. | Source of truth for anything the artifacts left out. Search these when a finding seems thin. |
+| `06-structured-findings/` | 11 raw workflow outputs — the verified finding sets, with citations, evidence, adversarial verdicts and corrections. JSON. | Parse with node, don't cat them whole. Use when you need the exact evidence behind a claim. |
+
+---
+
+## The five audits
+
+| Card | Persona | Fidelity |
+|---|---|---|
+| **UNITS** | Merle — lazy yard mechanic | Full |
+| **CUSTOMERS** | counter/sales rep | Full |
+| **CATEGORIES** | — | Full |
+| **CALENDAR / DRIVER** | dispatcher/driver | Full |
+| **RENTALS** | Denny — dispatcher | ⚠️ **Partial** — reconstructed |
+
+**On RENTALS:** it was the *reference* run — the lazy-audit skill was written from it — but its session
+does not exist on the authoring machine. Its findings were reconstructed from the skill text (which
+quotes the run's biggest finds verbatim) plus PR #740 and the `rentals-dispatch/*` branches. It is
+marked lower-fidelity throughout. **If the original RENTALS artifact turns up, fold it in at equal
+footing — that is the single biggest known gap in this research.**
+
+---
+
+## How findings are tagged
+
+Every finding carries four tags so the inventory can be read along any axis:
+
+- **job** — the real-world task it blocks (*"get a machine ready to rent"*, *"chase an unpaid invoice"*).
+  This is the primary axis.
+- **primitive** — the UI element implicated (flag, status pill, group bar, mini-card, popup, toast,
+  drag target, nav control…). This is the cross-index.
+- **failureMode** — one of: `invisible` · `ambiguous` · `unreachable` · `inconsistent` · `lying` ·
+  `destructive`
+- **scope** — one of: `signal` (flags/colour/severity) · `architecture` (what lives where, reachability)
+  · `interaction` (drag/hover/gesture/guards) · `density` (size, truncation, labelling)
+
+---
+
+## Read this before trusting anything
+
+**Retractions are load-bearing.** Every audit ran an adversarial verify pass, and several headline
+claims did not survive it. The inventory carries a retractions list. Findings that were refuted must
+**not** be resurrected — some are seductive and wrong. Two examples worth knowing up front:
+
+- *"The UNITS card opens as six collapsed drawers"* — false. That was stored device state on the
+  account being driven; the shipped default is open.
+- *"The worklist graph is buried / the default sort is alphabetical"* — false for the mechanic role.
+  `ROLE_LANDING` already opens the graph and sorts by service-due. The real defect is that this good
+  default does not *survive* opening a record.
+
+**The app repo is a shallow clone** on the authoring machine, which makes local `git merge-base`,
+`rev-list --count` and `rebase` lie at the graft boundary. This produced a false "production is
+broken, nothing can ship" alarm in one session. Use the GitHub compare API for any ancestry question.
+
+**Figma:** a parked project recreated the current UI in Figma. It was deliberately set aside for this
+gathering so the findings stay uninfluenced by the existing structure. It is the best available
+*as-is* record and should be un-parked at design time, not before.

--- a/docs/research/SCOPE.md
+++ b/docs/research/SCOPE.md
@@ -1,0 +1,204 @@
+# The Completed Scope
+
+**What a redesigned UI system has to solve — the gathering, finished. 2026-07-19.**
+
+This is the capstone of the research phase. It presents the full problem space and stops there:
+**nothing in this repository proposes a UI direction, a component system, a layout, or a spec.**
+Per the owner's instruction, design starts only when the owner says so.
+
+---
+
+## The corpus
+
+| Body of evidence | Findings | Verification |
+|---|---|---|
+| Five persona-driven desktop audits (`01-inventory/`) | 171 (64R / 70O / 37Y, 80 systemic) | adversarial passes in the original audits; 36 claims retracted |
+| Job taxonomy + re-index (`01-inventory/JOB-TAXONOMY.md`, `FINDINGS-BY-JOB.md`) | — (organizes the 171) | checksums tie out to inventory totals |
+| Phone / touch-tablet walk (`07-phone-walk/`) | 17 (P1–P17) | 7 load-bearing claims → 5 CONFIRMED, 2 SCOPED |
+| Unaudited surfaces (`08-unaudited-surfaces/`) | 62 (S1–S62; 11R / 22O / 25Y + 4 confirmatory) | 12 headline claims → 9 CONFIRMED, 2 REFUTED + corrected, 1 SCOPED |
+| Cross-card traces (`09-cross-card-traces/`) | 19 numbered + 15 orphaned arrows | 10 load-bearing claims → 10 CONFIRMED |
+| Detail-view audits (`contrib/*-detail/`, `01-inventory/DETAIL-FINDINGS-BY-JOB.md`) | 130 (40R / 66O / 24Y) | per-card adversarial verify + a v2 persona-seat pass; 3 corpus retractions/re-files |
+
+**≈399 cited findings total.** Every load-bearing claim was handed to an independent refutation
+agent; every refutation and scoping is folded into its document in place, marked with its verdict.
+The original inventory's 36 retractions remain in force, plus the detail wave's corrections
+(`01-inventory/CORPUS-CORRECTIONS.md`) — nothing refuted was resurrected.
+
+**The detail-view wave** deep-audited the standard (detail) view of each of the four cards — the
+dense surfaces the list audits only grazed (Unit detail absorbed the retired Shop card; Customer
+detail absorbed the retired Invoices card). Its v2 passes closed the corpus's biggest fidelity
+gap by walking each card **from the persona's real low-tier seat** (`#local` + `setRole` on pinned
+production bytes) rather than as admin — converting dozens of role/money-gate claims from CODE-READ
+to VERIFIED-LIVE. One residual gap is accepted, not closed: click-time admin gates fail open under
+`#local`, so verifying them at a real low tier would need a staff-tier *production* login — judged
+not worth a round three (render-time gating, the part the UI-system question needs, is verified).
+
+## The backbone: 25 jobs
+
+The primary axis is **the work** — `01-inventory/JOB-TAXONOMY.md` defines 15 business jobs and
+10 table-stakes jobs, phrased as the person doing them would say them, with all 171 original
+findings re-indexed one-job-each and damage-ranked. Every later body arrived pre-tagged against
+the same vocabulary. **All 130 detail-view findings mapped cleanly to the 25 jobs with zero
+off-vocabulary — in a wave that never touched the taxonomy authors.** Across ~399 findings and four
+independent audit waves, nothing required a 26th job. That is the strongest available evidence the
+backbone is right.
+
+**The detail view re-orders the damage.** The list wave was led by `spot-the-fire`; the detail wave
+is led by **`trust-the-screen` (54)**, then `whats-next-to-wrench` (36) — the detail is the dense,
+authoritative surface where two systems' answers to one number render inches apart, and it is where
+the ex-Shop service/repair mass lives. The two axes are complementary, not contradictory: the list
+is where you fail to *notice*, the detail is where you fail to *trust*.
+
+**From the original 171:** the table-stakes layer carries 51% of all damage; the top jobs are
+`spot-the-fire` (29), `get-told` (24), `keep-my-place` (24), `get-to-it` (24); the worst business
+job is `get-it-back` (17); the rental's back half (return · triage · repair · field) outweighs
+its front half (quote · stock · attach · dispatch), 72 to 56.
+
+**What the new evidence moved** (qualitatively — the new bodies use the same tags but their own
+numbering):
+
+- **`get-told` is now provably the deepest hole, not just the widest.** The desktop audits saw
+  the absence; the traces and surfaces proved the *whole stack* is inert by construction: the
+  staff-notification system (driver-assigned, WO-assigned, schedule-change) and the customer
+  reminder engines are fully built Settings panes wired to nothing (T14, T10, S-findings; ≥13
+  individually-inert Settings controls confirmed), and `assignStopDriver` notifies no one. Every
+  dispatcher→driver and dispatcher→mechanic handoff is 100% manual behind a UI that promises
+  otherwise.
+- **`hook-it-to-the-rental` got its worst finding on touch.** On a phone, drag-to-link is retired
+  (P4), the replacement long-press menu self-destructs ~200ms after opening — closed by the
+  browser's own touch-compat mouse event that nothing guards (P5, CONFIRMED with a dedicated
+  refutation hunt) — and the hint toast still says "Drag" (P6). Phone users currently have no
+  reliably working, instructed way to link records. On the touch tablet, the drag works but the
+  unit pill's chat-tag stamp hijacks it (P17-corrected).
+- **`get-it-back` gained a critical:** no code path connects a delinquent/blacklisted account to
+  physically recovering the machine — "recall" is collections paperwork only (T9). Combined with
+  the original findings (overdue invisible to every count; the return captures no hours, no
+  condition, no damage; the $1,000 protection cap enforced nowhere — T4/T5), the end of the
+  rental is the single most damaged stretch of the business.
+- **`keep-the-keys` / `no-fat-fingers` sharpened into one statement: guards are improvised
+  per-gate.** The everyday Quote→Reserved path writes status directly and bypasses the entire
+  gate battery (T13); five gates in one function carry three different override styles (S5
+  corrected); no gate anywhere reads machine fitness (T1: a Failed/Field-Call unit can be
+  attached, reserved and delivered with zero block); Rental Rules is structurally incapable of
+  expressing a machine rule (S6/S11); an Admin can silence any safety flag with an audit trail
+  no surface displays (S-findings).
+- **`works-in-gloves` expanded from a density complaint to a device-class fact.** The tooltip
+  layer, hover previews, and hover-revealed controls are categorically absent on every
+  touch-primary device — including the 641–1024px yard-tablet band, which gets the desktop build
+  with `.r-actions` hidden and `.c-actions`/close-X invisible-but-clickable (P14–P16). The band
+  the yard actually holds is owned by no code branch.
+- **`get-our-money` gained the ACH class:** a returned ACH debit leaves no trail, sets no
+  account block (unlike a card decline), and an in-flight ACH renders identically to
+  stone-cold-overdue everywhere except one popup (T8, S13/S14 scoped).
+- **`clean-records` gained proof the sync hazard is avoidable:** rentals/WOs/units/customers get
+  whole-record last-write-wins while Trips and Invoices in the same file get real conflict-safe
+  handling (T22).
+
+## The six root problems, after the gathering
+
+The inventory's six roots all stand. Three got materially heavier:
+
+- **R1 — the app has no addressee** → now proven end-to-end: not one notification engine behind
+  the Settings toggles exists; nothing addresses anyone, anywhere, on any card.
+- **R4 — guards per-widget, not per-consequence** → now includes: the everyday booking path
+  bypassing the battery entirely; gates that never consult the machine; per-gate override
+  improvisation; `flashOr` swallowing all six failure reasons depending on what an unrelated
+  column happens to display (28 call sites).
+- **R5 — capability without a door** → now includes the sharpest example in the corpus: the
+  built, manager-gated, auto-blacklisting collections flow is reachable *only* through a click
+  inside a hover preview (S15 corrected) — a door that is undiscoverable, is itself the known
+  misclick-trap surface, and does not exist on touch.
+
+Two cross-cutting facts the desktop-only gathering structurally could not see, now on record:
+
+1. **Touch is a second-class citizen categorically, not incrementally.** Every hover-dependent
+   finding class re-graded *worse* on touch except attach-by-drag (P-walk re-grade table), and
+   the linking grammar — the app's core connective gesture — is broken outright on phones.
+2. **The app is weakest at the ends of its own workflows.** Intake has no surface (both traces
+   start at "no intake form exists"); closure has no capture (return), no enforcement (damage
+   cap, billing on terminal jumps), and no recovery path (delinquency). The middles are dense;
+   the ends leak.
+
+Two more the detail wave added:
+
+3. **`keep-the-keys` is now the corpus's strongest security thread, and it is a fail-*open*, not a
+   fail-closed.** The `canMoney()` gate is *computed correctly* and then *never consulted*: the
+   Unit-detail Investment block shows a mechanic the same `Profit / true cost / paid` an owner
+   sees; only 2 of 6 category money figures are gated at all; card-remove (a live Stripe detach) is
+   ungated while card-*add* is gated. And the gate itself fails open on a blank role — reachable by
+   a real signed-in user when a role-aware backend's `auth` RPC throws anything but `unauthorized`,
+   silently degrading a fully-authenticated session to money-tier-everything with nothing on screen
+   to say so (verified live on three surfaces; held at orange because two of its three blank-role
+   paths are documented intent; a second, code-read fail-open at `app.js:8637/8920` is a money-
+   *write* path). The redesign's authority model has to gate *data*, not *widgets* — the audits
+   proved the tier table is sound and the consultation is missing.
+4. **The instrument is not the app — a corpus-quality lesson the sessions taught themselves.**
+   Three sessions independently retracted a finding after mistaking a measurement artifact for
+   behavior: two "% below the fold" densities were a short-viewport tool artifact (re-measured
+   away), and a "card-detach is clickable" claim died when the button proved 0px wide. DOM-present
+   ≠ user-visible; rulebook-registered ≠ rendered. `01-inventory/CORPUS-CORRECTIONS.md` carries the
+   full log and the standing warning to re-measure any Chrome-extension density number.
+
+## What was closed
+
+- The **job axis** exists: 25 jobs, every original finding indexed, new findings pre-tagged.
+- The **phone build has now been walked** — the project's largest evidence gap — plus the
+  unowned tablet band, with screenshots and live-traced mechanisms.
+- The **surfaces no audit touched** are audited: Settings' 11 panes, Rental Rules, the money/ACH
+  layer, the six back-office boards, agreements/signing, print targets, the Wrangler write path,
+  public pages, login/identity/day-one, offline.
+- **Work now crosses card boundaries on paper**: five end-to-end traces, every arrow graded on
+  who carries the baton, 15 orphaned arrows ranked by business consequence.
+- **The detail views are audited** — the dense standard views of all four cards, from the
+  persona's real low-tier seat, with the corpus's known-wrong claims (finding #130; the two
+  density artifacts) retired and #27/#32/#18 re-filed to their true surface.
+
+## What remains unknown — read before treating this scope as complete
+
+1. **No real user has ever been observed.** The personas are constructed. The single best piece
+   of field evidence remains the name-field ledger (staff typing balances and do-not-rent flags
+   into customer names) — found by accident. More workarounds like it certainly exist, unfound.
+2. **No physical device has been touched.** The phone walk is headless Chromium with real CDP
+   touch events. P5's mechanism is standard-spec browser behavior and survived a dedicated
+   refutation hunt, but it has not been reproduced on actual hardware — that is the
+   highest-priority real-world check in the corpus. Gloves, sunlight, OS gestures: untested.
+3. **Production Settings state is unknown.** Every finding was measured against shipped
+   defaults; ten live panes can rewrite statuses, flags, fields, checklists and gates at
+   runtime. What Jac's yard has actually configured — and what breaks when the panes are used as
+   intended — is unexamined.
+4. **The backend is out of scope entirely.** Whether a Stripe webhook resolves ACH, what the
+   sync endpoint does under conflict, the reminder sweep's server half — all gitignored, all
+   unverified from this repo.
+5. **Concurrency was traced, never watched.** Last-write-wins is proven in code (T22); no one
+   has had two sessions edit one record and observed the screens.
+6. **The RENTALS list audit remains reconstructed**, not re-run at full fidelity. The detail-view
+   wave *did* run RENTALS live and found `DETAIL.rentals` role-invariant, but the list-level
+   reconstruction stands. If the original list artifact surfaces, fold it in.
+7. **The Wrangler dock's write path was read, not driven** — `startRental`'s zero-confirm
+   auto-apply is confirmed in code (S-findings) but has never been exercised against a live
+   backend.
+8. **Coverage of the phone walk was representative, not exhaustive** — comms decks, the
+   invoices funnel deck, and WO photo capture were not walked; the SMS login flow cannot be
+   driven headlessly at all. The **phone detail views were not walked either** — the detail wave
+   was desktop, so its findings inherit the corpus's touch caveats.
+9. **Click-time admin gates at a real low tier — accepted CODE-READ, not closed.** The detail
+   wave's `#local` seat faithfully shows what a role *sees* (render-time gating) but structurally
+   fails click-time gates open (`requireAdmin` short-circuits with no backend password). Verifying
+   them at a real low tier needs a staff-tier *production* login; the owner judged this not worth a
+   round three. Also still code-read: the category `salePriceSuggest` money-write fail-open (N-03,
+   the seed generates no drift) and the RENTALS multi-unit `isPrimaryUnit` fallback (RD-08, the one
+   multi-unit fixture had addresses on both units).
+10. **The `#local` demo seed is NOT PII-free** — it carries authentic customer names/phones/
+   addresses (confirmed by four sessions; the same name appears in seed and production). Some
+   already-committed round-one screenshots may contain real PII. The owner has reviewed this and
+   chosen to leave it as-is on the private repo; a future reader taking this corpus wider must
+   re-decide.
+11. **The 36 original retractions plus every later correction** — S15, S5/S12, S13, P10, P17, the
+   account-block correction, **and the detail wave's `01-inventory/CORPUS-CORRECTIONS.md`** (finding
+   #130 FALSE; #27/#32/#18 re-filed; F-14 + the density-artifact class) — are part of the scope. A
+   future reader who quotes a refuted absolute is re-introducing a known error.
+
+---
+
+*The gathering is finished. The next step — deciding what the UI system should be — is
+deliberately not taken here.*


### PR DESCRIPTION
Rescues the design authority from the ephemeral session scratchpad into the repo, so Codex (and future sessions) can study it — closing the `CODEX-ONBOARDING.md` §9 gap where the mockups/artifacts lived only in chat / on claude.ai.

## What lands
- **`docs/design/reference/`** — 14 settled feature mockups (detail-views, list-views, text-links-flags, Trips ledger/schedule/card, Inbox/compose-dock/get-told, Dashboard, funnel, inspection, yard-journey, intake) + `decision-notes.md`, with a README mapping each to its spec section and restating the sourcing rule.
- **`docs/research/`** — the distilled UX research corpus (the ~171-finding inventory, job taxonomy, patterns, corrections, SCOPE) that drove the redesign.
- **`docs/WIP.md`** — the dual-agent work ledger (`CODEX-HANDOFF.md` §8a), seeded with the in-flight dv2 work.

## Notes
- **Docs-only**, non-served files → no cache-bust, no staging deploy needed; `smoke` should pass clean.
- Curated: dropped ~20 iteration-experiment mockups and the raw finding `.output` dumps.
- Secret-scanned before commit — clean.
- Not recoverable: Jac's hand-drawn sketches were chat images, not files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1EAY3d3fehnTBqoCQbjhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1EAY3d3fehnTBqoCQbjhc)_