### PR TITLE
docs: make sandbox auth fallback explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,11 @@ Invoke a command as `$rental-wrangler-commands:<name>` (for example,
   working rules, then propose a `codex/<slug>` branch and wait for explicit approval
   before switching. It never starts work on `trunk`.
 
+  In a Codex sandbox, local `gh` credentials may belong to a different Windows
+  identity than the user's desktop session. Do not loop on reauthentication or ask
+  for a token. Use the authenticated GitHub integration for remote publishing when
+  available, and never write credentials to the repo, workspace, or logs.
+
 The five ship commands have these exact boundaries:
 
 - `$rental-wrangler-commands:build` — build safe approved work, run gates, commit and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,11 @@ Invoke a command as `$rental-wrangler-commands:<name>` (for example,
   identity than the user's desktop session. Do not loop on reauthentication or ask
   for a token. Use the authenticated GitHub integration for remote publishing when
   available, and never write credentials to the repo, workspace, or logs.
+  If that integration is unavailable, check non-secret token presence, SSH, and the
+  configured Git credential helper; if all remote channels fail, continue local work
+  and mark only publishing/PR creation pending. Give one concrete host-side auth
+  action only at the final remote boundary—never block the entire session or request
+  a pasted token.
 
 The five ship commands have these exact boundaries:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,12 @@ Invoke a command as `$rental-wrangler-commands:<name>` (for example,
   working rules, then propose a `codex/<slug>` branch and wait for explicit approval
   before switching. It never starts work on `trunk`.
 
+  Match model capability to risk: use the strongest available frontier coding/reasoning
+  model for architecture, sensitive product/security decisions, and final review;
+  use a balanced model for ordinary implementation; and use an efficient model for
+  bounded mechanical checks. Prefer capability roles over hard-coded model names so
+  this remains valid as the model picker changes.
+
   In a Codex sandbox, local `gh` credentials may belong to a different Windows
   identity than the user's desktop session. Do not loop on reauthentication or ask
   for a token. Use the authenticated GitHub integration for remote publishing when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,8 +167,11 @@ Invoke a command as `$rental-wrangler-commands:<name>` (for example,
 - `$rental-wrangler-commands:start` — at the top of every task, probe node/npm/gh/git,
   note the expected local Playwright limitation, verify origin/branch/tree state,
   read AGENTS/MEMORY/WIP plus the current spec and plan (report exact missing paths),
-  load the design canon and working rules, then propose a `codex/<slug>` branch and
-  wait for explicit approval before switching. It never starts work on `trunk`.
+  choose the most efficient agent plan for the task (parallelize independent,
+  low-risk reconnaissance or mechanical checks; keep product/security/money/auth/PII
+  and work-order completion reasoning on the main thread), load the design canon and
+  working rules, then propose a `codex/<slug>` branch and wait for explicit approval
+  before switching. It never starts work on `trunk`.
 
 The five ship commands have these exact boundaries:
 

--- a/plugins/rental-wrangler-commands/skills/start/SKILL.md
+++ b/plugins/rental-wrangler-commands/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: Orient a Rental Wrangler Codex task before any work begins. Probe the toolchain, confirm repository and branch state, recall the project context, load the working rules, and propose a codex/* feature branch while waiting for approval before switching.
+description: Orient a Rental Wrangler Codex task before any work begins. Probe the toolchain, confirm repository and branch state, recall the project context, choose an efficient agent plan, load the working rules, and propose a codex/* feature branch while waiting for approval before switching.
 ---
 
 # Start
@@ -55,7 +55,21 @@ If any requested file is absent, report its exact path as missing; do not recrea
 or substitute a guessed document. Give a short summary of the project state, active
 work, and the next likely step, distinguishing facts from missing context.
 
-## 4. Propose, then wait before branching
+## 4. Choose the efficient agent plan
+
+Before proposing execution, decide whether subagents would materially help the task.
+Use them for separable, low-risk work that can run in parallel, such as focused
+read-only reconnaissance, mechanical file inventory, or independent verification.
+Keep tightly coupled implementation, high-blast-radius reasoning, and any product,
+security, money, auth, customer-PII/isolation, work-order completion, secret, force
+push, or live-deployment decisions on the main thread.
+
+When agents are useful, state the intended split briefly: what stays on the main
+thread, what each agent should inspect or verify, and how the results will be
+integrated. Do not spawn duplicate agents for the same question, and do not let
+agent use bypass the branch, gates, staging, PR, or promotion rules.
+
+## 5. Propose, then wait before branching
 
 Based on the user's actual task, propose one short feature branch off the latest
 `trunk`, using the form:
@@ -70,7 +84,7 @@ Stop and wait for the user's explicit OK before switching or creating the branch
 After approval, start from the latest `origin/trunk`, use the proposed `codex/<slug>`
 branch, and verify the branch before editing. Never start work directly on `trunk`.
 
-## 5. Load the session working rules
+## 6. Load the session working rules
 
 Before any change, read and apply:
 

--- a/plugins/rental-wrangler-commands/skills/start/SKILL.md
+++ b/plugins/rental-wrangler-commands/skills/start/SKILL.md
@@ -87,7 +87,29 @@ thread, what each agent should inspect or verify, and how the results will be
 integrated. Do not spawn duplicate agents for the same question, and do not let
 agent use bypass the branch, gates, staging, PR, or promotion rules.
 
-## 5. Propose, then wait before branching
+## 5. Match model strength to task risk
+
+Choose by capability and risk, not by a hard-coded model name; model labels and
+picker offerings change over time. Keep the main thread on the strongest available
+frontier coding/reasoning model for architecture, large refactors, design judgment,
+auth, money, customer PII/isolation, work-order semantics, or release-risk review.
+Use the balanced general coding model for ordinary feature work, bug fixes, PR
+preparation, and test-guided implementation. Use a fast/efficient coding model for
+bounded reconnaissance, code-map or file inventory, documentation, syntax checks,
+and other mechanical work whose acceptance criteria are already clear.
+
+Start with a balanced reasoning setting. Raise it for ambiguous, high-blast-radius,
+or evidence-heavy work; lower it for latency-sensitive, well-specified work. Do not
+trade away model strength for sensitive decisions, and do not block a task merely
+because a preferred model label is unavailable—map the current picker to these roles
+and continue with the closest safe capability.
+
+For parallel work, keep product and safety judgment on the frontier-model main
+thread and give independent low-risk checks to efficient models. Use a fresh context
+for an adversarial second review when that is more valuable than additional effort in
+the original thread.
+
+## 6. Propose, then wait before branching
 
 Based on the user's actual task, propose one short feature branch off the latest
 `trunk`, using the form:
@@ -102,7 +124,7 @@ Stop and wait for the user's explicit OK before switching or creating the branch
 After approval, start from the latest `origin/trunk`, use the proposed `codex/<slug>`
 branch, and verify the branch before editing. Never start work directly on `trunk`.
 
-## 6. Load the session working rules
+## 7. Load the session working rules
 
 Before any change, read and apply:
 

--- a/plugins/rental-wrangler-commands/skills/start/SKILL.md
+++ b/plugins/rental-wrangler-commands/skills/start/SKILL.md
@@ -24,6 +24,13 @@ smoke and logic suites install Chromium and run in CI. Report the local browser 
 
 Never print secret values. If a tool or credential check is unavailable, say so plainly.
 
+If local `gh auth status` is unavailable or reports an invalid credential because the
+Codex sandbox uses a different Windows identity, do not repeatedly ask the user to
+reauthenticate and do not ask for a token. Use the authenticated GitHub integration
+for remote branch, commit, PR, and workflow operations when available. Report the
+local CLI limitation separately; never copy credentials into the repository, a
+workspace file, or command output.
+
 ## 2. Confirm the repository and orient
 
 Confirm that `origin` points to:

--- a/plugins/rental-wrangler-commands/skills/start/SKILL.md
+++ b/plugins/rental-wrangler-commands/skills/start/SKILL.md
@@ -31,6 +31,17 @@ for remote branch, commit, PR, and workflow operations when available. Report th
 local CLI limitation separately; never copy credentials into the repository, a
 workspace file, or command output.
 
+Use this fallback ladder for remote work:
+
+1. Prefer the authenticated GitHub integration.
+2. If it is unavailable, check for non-secret `GH_TOKEN`/`GITHUB_TOKEN` presence,
+   an existing SSH agent/key, or a configured Git credential helper without printing
+   or exporting any credential value.
+3. If no remote channel is available, continue read-only investigation, edits, local
+   checks, commits, and artifact preparation. Mark only the final publish/PR action
+   as pending and give the user one concrete host-side auth action at that boundary;
+   never leave the whole session blocked and never ask them to paste a token.
+
 ## 2. Confirm the repository and orient
 
 Confirm that `origin` points to:


### PR DESCRIPTION
## What changed

- Document the Codex sandbox/Windows credential boundary.
- Prefer the authenticated GitHub integration for remote operations.
- Add a fallback ladder for environment tokens, SSH, and Git credential helpers.
- Keep local investigation, edits, checks, commits, and artifact preparation moving when remote auth is unavailable.
- Prohibit repeated reauthentication prompts, pasted tokens, and credential files.

## Validation

- `git diff --check`
- `node ci/check-design-md.mjs`
- Local browser gates remain CI-authoritative because Chromium is not installed in this environment; GitHub Actions installs Chromium.