### PR TITLE
refactor: split app.js into modules

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@
  * ============================================================================
  */
 
+import { ERR_LOG, logErr, wranglerIssueUrl } from './src/glitch-capture.js';   // installed first thing, same as before the module split
 import { DATA } from './data.js';
 import { createCascade } from './cascade.js';
 import { serviceOrdersForUnit, completeService, SERVICE_TASKS } from './service-countdown.js';
@@ -40,37 +41,12 @@ import {
 const flagOn = (k) => !!(FEATURES && FEATURES[k] === true);
 
 /* ════════════════════════════════════════════════════════════════════════
-   APP-01 · §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you
-   hand a glitch to Mr. Wrangler the repro packet carries what actually broke
-   (the single most useful clue for the auto-fixer). Installed first thing so it
-   catches boot-time errors too. Kept tiny + best-effort — never throws itself.
+   APP-01 · §0.7 GLITCH CAPTURE — moved to src/glitch-capture.js (2026-07-24 module split)
    ════════════════════════════════════════════════════════════════════════ */
-const ERR_LOG = [];
-function logErr(kind, msg) {
-  try {
-    const t = new Date().toTimeString().slice(0, 8);
-    ERR_LOG.push(`[${t}] ${kind}: ${String(msg).replace(/\s+/g, ' ').slice(0, 300)}`);
-    if (ERR_LOG.length > 30) ERR_LOG.shift();
-  } catch (_) {}
-}
-window.addEventListener('error', (e) => logErr('error', (e.message || 'error') + (e.filename ? ` @ ${String(e.filename).split('/').pop()}:${e.lineno || '?'}` : '')));
-window.addEventListener('unhandledrejection', (e) => logErr('promise', (e.reason && (e.reason.message || e.reason)) || 'unhandled rejection'));
-{ const _ce = console.error; console.error = function (...a) { try { logErr('console', a.map((x) => (x && x.message) || x).join(' ')); } catch (_) {} return _ce.apply(this, a); }; }
-
-/* The public repo this app fixes itself through (Track B — see docs/wrangler-pipeline.md).
-   A glitch handed to Mr. Wrangler becomes a `wrangler-fix` GitHub issue that the
-   Action engine reproduces, patches, gate-checks, and auto-merges to live. The
-   browser can't hold a token, so we open a PRE-FILLED issue (one Submit tap). */
-const WRANGLER_REPO = 'operations-jacrentals/rental-wrangler';
-// label 'wrangler-fix' → the auto-fix Action runs (glitches). 'wrangler-request'
-// → filed for Jac's OK, NOT auto-implemented (he can add the fix label to greenlight).
-function wranglerIssueUrl(title, body, label = 'wrangler-fix') {
-  const u = new URL(`https://github.com/${WRANGLER_REPO}/issues/new`);
-  u.searchParams.set('title', String(title || 'Reported glitch').slice(0, 120));
-  u.searchParams.set('labels', label);
-  u.searchParams.set('body', String(body || '').slice(0, 6000));   // GitHub URL body cap headroom
-  return u.toString();
-}
+/* ERR_LOG, logErr, wranglerIssueUrl all now live in src/glitch-capture.js —
+   imported above (and installed immediately, same as before: side-effecting
+   window.addEventListener + console.error hooks run at module-eval time).
+   Kept this banner (no code) so the APP-NN numbering below never shifts. */
 
 /* ════════════════════════════════════════════════════════════════════════
    APP-02 · §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split)

--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ import { ico, I, CARD_ICON, RING_ICON, CATEGORY_ICON } from './icons.js';
 import { CATEGORY_ANIM } from './icons-anim.js';
 import { CATEGORY_FRAMES } from './icons-frames.js';
 import { $, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR } from './src/format.js';
+import { GV_WIN_OPTS, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets } from './src/card-graph-view.js';
 import {
   getStatus, STATUS, ROLES, ROLE_TIERS, tierRank, BUILTIN_ROLE_TIERS, GRID_CARDS, BACKOFFICE_BOARDS, SORT_FIELDS,
   SHOP_TYPES, COLUMNS, COLUMN_OF,
@@ -12164,48 +12165,13 @@ function tabBadge(card, rec) {
 }
 
 /* ════════════════════════════════════════════════════════════════════════
-   APP-23 · §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile
-   dashboard (pieSVG/gvBars tiles + unit roster) was replaced by the §13.6
-   Round-Up reporting board; the chapter number is kept so later APP-NN
-   banners keep their ids. See PR #460–#464 + the removal PR for history.
+   APP-23 · §13.3 CARD GRAPH VIEW — moved to src/card-graph-view.js (2026-07-24
+   module split). RETIRED (2026-07-03): the per-card tile dashboard itself was
+   replaced by the §13.6 Round-Up reporting board, but the time-window/bucket
+   helpers (GV_WIN_OPTS, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff,
+   gvBuckets) survive — imported above, the §13.4 Graph Carousel below still
+   calls into them. Chapter number kept so later APP-NN banners keep their ids.
    ════════════════════════════════════════════════════════════════════════ */
-
-/* §13.4 — TIMELINE SELECTOR (Jac 2026-06-23). Per-source (per card / shop segment) the
-   graph carousel's TIME-BASED views can be scoped to a recent window: 7/10/30/90/180/360
-   days, or All (default = today's all-time/6-month behavior). Snapshot views ignore it and
-   read "Current". The active window is stamped ON the chart head, never hover-only. */
-const GV_WIN_OPTS = [7, 10, 30, 90, 180, 360];
-const GV_WIN_KEY = (src) => `jactec.gvWin.${src}`;
-const GV_WIN = Object.create(null);
-function loadGvWin(src) {
-  if (src in GV_WIN) return GV_WIN[src];
-  let v = 0; try { v = Number(localStorage.getItem(GV_WIN_KEY(src))) || 0; } catch (e) { v = 0; }
-  GV_WIN[src] = GV_WIN_OPTS.includes(v) ? v : 0;   // 0 = All time
-  return GV_WIN[src];
-}
-function saveGvWin(src, days) {
-  const d = GV_WIN_OPTS.includes(days) ? days : 0;
-  GV_WIN[src] = d;
-  try { if (d) localStorage.setItem(GV_WIN_KEY(src), String(d)); else localStorage.removeItem(GV_WIN_KEY(src)); } catch (e) { /* private mode */ }
-}
-const gvWinLabel = (d) => d ? `${d}D` : 'All';
-// ISO (yyyy-mm-dd) cutoff: the oldest day still IN a `days`-long window ending today (inclusive). null = all.
-function gvWinCutoff(days) { if (!days) return null; const d = new Date(TODAY); d.setDate(d.getDate() - days + 1); return d.toISOString().slice(0, 10); }
-// Time buckets spanning the window for the "/period" bar charts. Each = {key:"a|b", label, a, b}
-// with a<=date<b (ISO). Granularity adapts: ≤14d daily · ≤90d weekly · else monthly (All = 6 months).
-function gvBuckets(days) {
-  const out = [], iso = (d) => d.toISOString().slice(0, 10), base = new Date(TODAY);
-  if (!days || days > 90) {
-    const n = !days ? 6 : Math.min(12, Math.max(1, Math.round(days / 30)));
-    for (let i = n - 1; i >= 0; i--) { const a = new Date(base.getFullYear(), base.getMonth() - i, 1), b = new Date(base.getFullYear(), base.getMonth() - i + 1, 1); out.push({ key: iso(a) + '|' + iso(b), label: a.toLocaleString('en-US', { month: 'short' }), a: iso(a), b: iso(b) }); }
-  } else if (days > 14) {
-    const weeks = Math.ceil(days / 7);
-    for (let i = weeks - 1; i >= 0; i--) { const b = new Date(base); b.setDate(b.getDate() - i * 7 + 1); const a = new Date(b); a.setDate(a.getDate() - 7); out.push({ key: iso(a) + '|' + iso(b), label: `${a.getMonth() + 1}/${a.getDate()}`, a: iso(a), b: iso(b) }); }
-  } else {
-    for (let i = days - 1; i >= 0; i--) { const a = new Date(base); a.setDate(a.getDate() - i); const b = new Date(a); b.setDate(b.getDate() + 1); out.push({ key: iso(a) + '|' + iso(b), label: `${a.getMonth() + 1}/${a.getDate()}`, a: iso(a), b: iso(b) }); }
-  }
-  return out;
-}
 /* ════════════════════════════════════════════════════════════════════════
    APP-24 · §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of
    INTERACTIVE views stacked ABOVE the list. Chevrons cycle the view; clicking a

--- a/app.js
+++ b/app.js
@@ -28,6 +28,8 @@ import { CATEGORY_ANIM } from './icons-anim.js';
 import { CATEGORY_FRAMES } from './icons-frames.js';
 import { $, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR } from './src/format.js';
 import { GV_WIN_OPTS, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets } from './src/card-graph-view.js';
+import { APP as APP_INTERNALS } from './src/internals.js';   // late-binding registry — see src/internals.js for why
+import { RB_FOUNDATION, RB_TABS, ruleOf, refPath, onInspectMove } from './src/rulebook.js';
 import {
   getStatus, STATUS, ROLES, ROLE_TIERS, tierRank, BUILTIN_ROLE_TIERS, GRID_CARDS, BACKOFFICE_BOARDS, SORT_FIELDS,
   SHOP_TYPES, COLUMNS, COLUMN_OF,
@@ -6586,173 +6588,11 @@ const RULE_META = {
   R35: ['Dated-action funnel', 'datedFunnelHtml / .dfunnel', 'the customer-detail funnel as a two-tab (Rental | Equipment Sales) stack of clickable LAYERS, narrowing like a real funnel — everyone sits in both tabs (a fresh customer at Lead). Each layer is a SLOT for a dated next-action ("notes = actions"): arm any layer with an action (note + date) and it glows red/yellow/green by that date’s urgency (naUrgency) — several can be armed at once. A reached-but-unarmed layer is quiet steel history (a check + when it happened); the terminal Signed/Paid, once reached, is SOLID BLUE (closed won). Clicking a layer opens its action editor (arm/edit/complete, or Advance the customer here). The armed actions are the same scheduled entries as the date-sorted queue below. Rental Reserved/Rented history-dates derive from live rentals. Bespoke — layers are NOT .pill, the .dfunnel container carries the stamp.'],
   R36: ['Swipe-toggle deck', 'swipeSeg / swipeTrack / .swipe-track', 'the PHONE-ONLY carousel that turns a VIEW-SWITCH toggle section (the customer funnel · invoices · comms Text/Email) into a swipeable deck: both panes sit side-by-side in a nested horizontal scroll-snap track, and the toggle’s ONE-orange fill (R3) becomes a .deck-thumb that RIDES the scroll (deckPaint). The active tab commits on SNAP with NO render (deckCommit) — both panes are already in the DOM — a haptic ticks per change, and a tab tap smooth-scrolls the track. Nests inside the 5-card .grid rail without stealing its swipe (each scroll listener is class-filtered to its own track). Desktop is byte-identical to before — single pane + the R14 tap toggle. Attaches ONLY to view-switch toggles, never a value/action segCtl (a swipe must never set inspection Fail or a transport leg).'],
 };
-/* ════════════ APP-12 · DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) ════
-   The Rulebook grew from "stamped element rules" (R0–R24 above) into the WHOLE
-   design system. RB_FOUNDATION = the primitives the rules are built FROM (type,
-   color, form, surfaces, motion…) — NOT data-r stamped, they're the tokens &
-   guidelines. RB_TABS = the IA that groups every rule + foundation into tabs.
-   Foundation row = [tag, name, spec/token, when/why, exampleHTML]. ── */
-const rbSw = (bg, name, note, ink = '#fff') =>
-  `<span class="rb-sw" style="background:${bg};color:${ink}">${name ? `<b>${name}</b>` : ''}${note ? `<i>${note}</i>` : ''}</span>`;
-const RB_FOUNDATION = {
-  // ── TYPE ──
-  'type-display': ['Aa', 'Display · stamped', "'Saira Condensed' · 600–800 · UPPERCASE · +1–2px tracking",
-    'The yard “stamped-steel” voice: wordmark, column tabs, KPI labels, section headers, ignition buttons.',
-    `<span style="font-family:'Saira Condensed',sans-serif;text-transform:uppercase;letter-spacing:1.6px;font-weight:800;font-size:1.3529rem;color:var(--txt)">Clock In · Wrangle</span>`],
-  'type-body': ['Aa', 'Body', "'Geist' (var(--font)) · 400–700",
-    'Everything you read: row text, field values, descriptions. Quiet, legible, never stamped.',
-    `<span style="font-size:0.8235rem;color:var(--txt)">Rugged equipment, rented right — the body face carries the content.</span>`],
-  'type-mono': ['‹›', 'Mono', 'ui-monospace · 10–12px · txt-3',
-    'Code + debug references only: the Inspector tag and rulebook builder names.',
-    `<code style="font-family:ui-monospace,monospace;font-size:0.7059rem;color:var(--txt-3)">UNITS › INSPECTION › “Passed”</code>`],
-  'type-scale': ['#', 'Size scale', '28 · 15 · 13 · 12 · 11 · 10 · 9.5px',
-    'Bigger = identity/value (28 KPI · 15 popup title). 12–13 = content. ≤11 = stamped micro-labels & counters. ONE size (11px) for every status badge.',
-    `<span style="display:flex;align-items:baseline;gap:13px;flex-wrap:wrap;color:var(--txt)"><span style="font-size:1.6471rem;font-weight:800">28</span><span style="font-size:0.8824rem;font-weight:700">15</span><span style="font-size:0.7647rem">13</span><span style="font-size:0.7059rem">12</span><span style="font-family:'Saira Condensed';text-transform:uppercase;letter-spacing:1px;font-size:0.6471rem;font-weight:700">11 label</span><span style="font-size:0.5588rem;color:var(--txt-3)">9.5</span></span>`],
-  'type-weight': ['B', 'Weight', '800 · 700 · 600 · 400',
-    '800 stamped identity · 700 titles & labels · 600 strong body · 400 body.',
-    `<span style="display:flex;gap:16px;align-items:baseline;color:var(--txt)"><span style="font-weight:800">800</span><span style="font-weight:700">700</span><span style="font-weight:600">600</span><span style="font-weight:400">400</span></span>`],
-  // ── COLOR ──
-  'color-accent': ['●', 'Accent · safety orange', '--accent #ff7a1a (+ --on-orange ink)',
-    'ONE orange, ONE meaning: the selected tab · ignition · primary action. Never decorative.',
-    rbSw('var(--accent)', 'Accent', 'selected · ignition', 'var(--on-orange)')],
-  'color-status': ['◐', 'Status palette', '--green / --yellow / --red / --blue / --navy / --purple / --gray',
-    'Registry status colors — each carries a fixed meaning on every card (Passed · caution · danger · link…).',
-    ['var(--green)', 'var(--yellow)', 'var(--red)', 'var(--blue)', 'var(--navy)', 'var(--purple)', 'var(--gray)'].map((c) => `<span class="rb-sw" style="background:${c}"></span>`).join('')],
-  'color-semantic': ['▣', 'Action-color law', 'commit = blue · money = green · danger = red',
-    'Action INTENT, not status: blue commits/saves · green takes money · solid red confirms destructive.',
-    rbSw('var(--blue)', 'Commit') + rbSw('var(--green)', 'Money') + rbSw('var(--red)', 'Danger')],
-  'color-neutral': ['▤', 'Neutrals', '--txt / --txt-2 / --txt-3 · --line',
-    '3-step text hierarchy on steel; lines separate without shouting.',
-    `<span class="rb-sw" style="background:var(--txt);color:#000"><b>Txt</b></span><span class="rb-sw" style="background:var(--txt-2);color:#000"><b>Txt-2</b></span><span class="rb-sw" style="background:var(--txt-3)"><b>Txt-3</b></span><span class="rb-sw" style="background:var(--line)"><b>Line</b></span>`],
-  'color-tan': ['✶', 'Wrangler tan', '--tan #c2925a / --tan-deep (yard theme)',
-    'The light ranch seasoning — worn leather for saddle-stitch dividers & tiny touches. Restrained.',
-    rbSw('var(--tan,#c2925a)', 'Tan', 'saddle-stitch', '#1a1205')],
-  'color-ec-red': ['⚠', 'ec-red · flagging glow', 'fill: color-mix(--red 65%, white) · shadow: 0 0 3px --red, 0 0 7px (--red 60%+transparent)',
-    'Official treatment for EVERY flagging-red signal — text names/pills/flags/headers, borders, dots/bars. Three knobs in style.css .ec-red group: fill % (65), inner glow (3px), outer halo (7px / 60%). Never use pure --red alone on flagging text.',
-    `<span style="-webkit-text-fill-color:color-mix(in srgb,var(--red) 65%,white);text-shadow:0 0 3px var(--red),0 0 7px color-mix(in srgb,var(--red) 60%,transparent);font-weight:700;font-size:0.7647rem;letter-spacing:.5px">TUCKER FONTENOT · No Card · $0.30 overdue</span>`],
-  // ── FORM ──
-  'radius': ['◳', 'Radius', '--radius 14–16 · --chip-radius 11–12 · 8–10 controls · 999 pills',
-    'Cards/popups softest · chips medium · controls tight · pills & counters full-round · rings/avatars circles.',
-    `<span style="display:flex;gap:8px;align-items:center"><span class="rb-surf" style="border-radius:16px">16</span><span class="rb-surf" style="border-radius:12px">12</span><span class="rb-surf" style="border-radius:8px">8</span><span class="rb-surf" style="border-radius:999px">999</span></span>`],
-  'elevation': ['☁', 'Elevation', '--shadow (float) · --chip-shadow · accent glow',
-    'Two depths: cards/popups float deep; chips/rows lift gently. Pop-ups & menus add the orange halo ring.',
-    `<span style="display:flex;gap:12px"><span class="rb-surf" style="box-shadow:var(--shadow)">float</span><span class="rb-surf" style="box-shadow:var(--chip-shadow)">chip</span><span class="rb-surf" style="box-shadow:0 0 0 2px var(--accent-line),0 0 22px -8px var(--accent)">glow</span></span>`],
-  'spacing': ['▦', 'Spacing', 'grid 12 · list 7 · section pad 12 · row pad 9–11',
-    'Tight, dense yard data — generous enough to scan, never airy.',
-    `<span style="display:flex;align-items:center;color:var(--txt-3);font-size:0.6471rem;gap:8px"><span style="display:flex;gap:12px"><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span></span>12px gap</span>`],
-  'motion': ['↻', 'Motion', '.12s controls · .15s surfaces · .5s rings/timeline',
-    'Fast, functional. Keyframes: attnGlow (flash) · plateIn (login) · flagPulse · rwLint. prefers-reduced-motion respected everywhere.',
-    `<span class="pill c-blue" style="animation:attnGlow 1.1s ease-in-out infinite;border-radius:10px"><span class="t">flash</span></span>`],
-  // ── SURFACES ──
-  'surface-bg': ['▢', 'App background', '--bg · yard: orange dawn-glow + mill texture',
-    'The yard floor everything floats on; the header & bottom bar sit transparent over it.',
-    `<span class="rb-surf" style="background:var(--bg);width:100%;height:34px"></span>`],
-  'surface-panel': ['▢', 'Panel', '--panel / --panel-2',
-    'Sub-surfaces: search bars, chips, dashboard stats, the action chip-trays.',
-    `<span class="rb-surf" style="background:var(--panel);width:100%;height:34px"></span>`],
-  'surface-card': ['▢', 'Card / plate', '--card · radius · --shadow',
-    'The column plate. Yard theme = steel gradient + hazard-stripe top + corner rivets.',
-    `<span class="rb-surf" style="background:var(--card);width:100%;height:38px;position:relative;overflow:hidden;justify-content:flex-start;padding-left:14px"><span style="position:absolute;top:0;left:0;right:0;height:5px;background:repeating-linear-gradient(135deg,var(--yellow,#f5c542) 0 13px,#14181d 13px 26px)"></span>card</span>`],
-  'surface-section': ['▢', 'Section', '.section · --panel · centered header · status-tinted',
-    'Sub-cards inside a record; the header + border follow the live status (sec-green/yellow/red).',
-    `<span class="rb-surf" style="background:var(--panel);border-color:color-mix(in srgb,var(--green) 45%,transparent);width:100%;height:34px"></span>`],
-  'surface-anchored': ['▢', 'Anchored ring', '#18b6ff neon ring',
-    'An opened record glows neon blue — the “you are here” signal (distinct from orange selection).',
-    `<span class="rb-surf" style="background:var(--card);width:100%;height:34px;border-color:#18b6ff;box-shadow:0 0 0 2px rgba(24,182,255,.55)"></span>`],
-  'surface-row': ['▢', 'Row chip', '.row · --panel · row-bg viz',
-    'List items are chips; a faint full-bleed visualization can tint a row by its data.',
-    `<span class="rb-surf" style="background:var(--panel);width:100%;height:30px"></span>`],
-  // ── UPLOAD / CAPTURE ──
-  'upload-capture': ['⌖', 'Capture drop', '.cap-drop · dashed · camera / site',
-    'Photo/selfie/site captures (inspections, deliveries). When transport is set the popup tops with the address + map pin.',
-    `<span class="cap-drop" style="min-height:46px">${I.camera || ''}<span>Capture photo</span></span>`],
-  // ── HEADERS / CONTAINERS ──
-  'header-section': ['▭', 'Section header', '.section>h4 · centered · 11px UPPER',
-    'Centered stamped label; right-side flags pin absolutely so the title stays true-center.',
-    `<span style="display:block;text-align:center;font-size:0.6471rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--txt-3)">Inspection</span>`],
-  'header-popup': ['▭', 'Popup header', '.popup-head · icon + h3(15) + ✕',
-    'Every overlay leads with an accent icon, a 15px title, and the close on the right.',
-    `<span style="display:flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:9px;padding:7px 10px;background:var(--panel)"><span style="color:var(--accent);display:inline-flex">${I.doc || ''}</span><b style="font-size:0.8235rem">Popup title</b></span>`],
-  'overlay-popup': ['◳', 'Pop-up / overlay', '.overlay scrim + .popup',
-    'Centered modal: 50%-black scrim · panel with the orange border + glow halo · max 92vw/86vh · internal scroll.',
-    `<span class="rb-surf" style="background:var(--panel);border:1px solid var(--accent);box-shadow:0 0 0 2px var(--accent-line),0 0 20px -6px var(--accent);width:130px;height:42px;border-radius:12px">modal</span>`],
-  'menu-dropdown': ['▾', 'Menu', '.dropdown-menu / .ctx-menu',
-    'Floating orange-ringed lists: the sort/filter dropdowns and the R20 right-click menu.',
-    `<span style="display:inline-block;background:var(--panel);border:1px solid var(--accent);border-radius:11px;box-shadow:0 0 0 2px var(--accent-line);padding:5px;min-width:128px"><span style="display:block;padding:5px 9px;border-radius:8px;font-size:0.7059rem;color:var(--txt-2)">Sort · Name</span><span style="display:block;padding:5px 9px;border-radius:8px;font-size:0.7059rem;color:var(--accent);background:var(--panel-2)">Sort · Status</span></span>`],
-  'grid': ['▥', 'Yard grid', '.grid · 3 equal cols · 12px gap',
-    'The fixed 3-column layout (Units · Rentals · Customers). Reflows 3→2→1 by width on phones (M0–M3); never squishes below the desktop floor.',
-    `<span style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px;width:150px"><span class="rb-surf" style="height:30px"></span><span class="rb-surf" style="height:30px"></span><span class="rb-surf" style="height:30px"></span></span>`],
-  // ── DATA VIZ ──
-  'data-kpi': ['◎', 'KPI rings', '.kpi-ring · concentric progress',
-    'The header rings: Apple-style progress, each colored by its value band, number + stamped role label below.',
-    `<span style="display:inline-grid;place-items:center;width:38px;height:38px;border-radius:50%;background:conic-gradient(var(--green) 72%,var(--track) 0)"><span style="display:grid;place-items:center;width:27px;height:27px;border-radius:50%;background:var(--bg);font-size:0.5882rem;font-weight:800;color:var(--txt)">9</span></span>`],
-  'data-gauge': ['▰', 'Activity gauge', '.active-bar.bipolar · steel data-plate',
-    'A bipolar −100…+100 track (customer health); a hazard overlay marks the deep-danger end.',
-    `<span style="display:inline-block;width:140px;height:14px;border-radius:7px;overflow:hidden;background:var(--track)"><span style="display:block;height:100%;width:64%;background:linear-gradient(90deg,var(--red),var(--orange),var(--yellow),var(--green))"></span></span>`],
-  // ── BEHAVIORS ──
-  'behavior-preview': ['◉', 'Hover previews', 'the eye system · per-device toggle',
-    'Hovering most elements shows a rich preview; a row eye + bottom-bar eye toggle it. Off = every eye runs red.',
-    `<span class="pill c-gray"><span class="t">${I.eye || ''} preview</span></span>`],
-};
-/* The tabbed IA — every rule (R…) + foundation (f…) lands in exactly one tab. */
-const RB_TABS = [
-  { id: 'foundation', label: 'Foundations', intro: 'The primitives every rule is built from — type, color, form, motion. Change these and the whole yard shifts.',
-    items: [{ f: 'type-display' }, { f: 'type-body' }, { f: 'type-mono' }, { f: 'type-scale' }, { f: 'type-weight' },
-            { f: 'color-accent' }, { f: 'color-status' }, { f: 'color-semantic' }, { f: 'color-neutral' }, { f: 'color-tan' },
-            { f: 'radius' }, { f: 'elevation' }, { f: 'spacing' }, { f: 'motion' }] },
-  { id: 'surfaces', label: 'Surfaces', intro: 'Backgrounds & containers — the steel everything is bolted to.',
-    items: [{ f: 'surface-bg' }, { f: 'surface-panel' }, { f: 'surface-card' }, { f: 'surface-section' }, { f: 'surface-anchored' }, { f: 'surface-row' }] },
-  { id: 'containers', label: 'Containers', intro: 'Title chips, sections, headers, pop-ups, menus and the layout grid.',
-    items: [{ r: 'R10' }, { r: 'R11' }, { r: 'R12' }, { f: 'header-section' }, { f: 'header-popup' }, { f: 'overlay-popup' }, { f: 'menu-dropdown' }, { f: 'grid' }] },
-  { id: 'pills', label: 'Pills & Flags', intro: 'The status vocabulary — every colored chip and exactly what it’s allowed to mean.',
-    items: [{ r: 'R1' }, { r: 'R2' }, { r: 'R3' }, { r: 'R3b' }, { r: 'R4' }, { r: 'R4b' }, { r: 'R9' }, { r: 'R9b' }] },
-  { id: 'fields', label: 'Fields & Adds', intro: 'Where you type, link, and add.',
-    items: [{ r: 'R5' }, { r: 'R5b' }, { r: 'R5c' }, { r: 'R6' }, { r: 'R7' }, { r: 'R8' }, { r: 'R14' }, { r: 'R22' }, { r: 'R31' }, { r: 'R33' }] },
-  { id: 'actions', label: 'Actions', intro: 'Buttons that DO something — colored by intent.',
-    items: [{ r: 'R17' }, { r: 'R18' }, { r: 'R24' }, { r: 'R26' }, { r: 'R28' }, { r: 'R29' }, { r: 'R32' }] },
-  { id: 'upload', label: 'Upload & Capture', intro: 'Add-file zones and photo/site captures.',
-    items: [{ r: 'R21' }, { f: 'upload-capture' }] },
-  { id: 'data', label: 'Data & Behaviors', intro: 'Visualizations, plus the app’s behaviors — it flashes instead of erroring, right-clicks, tooltips, and self-lints.',
-    items: [{ r: 'R16' }, { r: 'R15' }, { r: 'R35' }, { r: 'R36' }, { r: 'R13' }, { f: 'data-kpi' }, { f: 'data-gauge' }, { r: 'R19' }, { r: 'R25' }, { r: 'R20' }, { r: 'R23' }, { f: 'behavior-preview' }, { r: 'R0' }] },
-
-  { id: 'windows', label: 'Windows', intro: 'Every pop-up window in the app, by kind. Expand one for a live preview, its fields, and a copy-paste edit reference — your map to wrangle any screen.', items: [] },
-];
-/* structural fallbacks so hovering containers also names their rule */
-const CLASS_RULE = [
-  ['.c-titlecard', 'R10'], ['.nsec', 'R12'], ['.hvals', 'R13'], ['.history', 'R13'],
-  ['.timeline', 'R16'], ['.jnode', 'R15'], ['.jseg', 'R15'], ['.journey', 'R15'],
-  ['.seg', 'R14'], ['.kv.derived', 'R8'], ['.derived', 'R8'], ['.file-drop', 'R21'], ['.datefield', 'R22'], ['.dfunnel', 'R35'], ['.swipe-track', 'R36'], ['.section', 'R11'],
-];
-function ruleOf(target) {
-  if (!target || !target.closest) return null;
-  const stamped = target.closest('[data-r]');
-  if (stamped) return { r: stamped.dataset.r, el: stamped };
-  for (const [sel, r] of CLASS_RULE) { const m = target.closest(sel); if (m) return { r, el: m }; }
-  const fam = target.closest('.pill, .add-field, .flag, .linkname, .inv-line-link, .req');
-  if (fam) return { r: null, el: fam };            // lint family, unstamped = violation
-  return null;
-}
-/* human-readable reference: CARD › SECTION › "text" — what Jac pastes to debug */
-function refPath(el) {
-  const card = el.closest('[data-card]')?.dataset.card;
-  const sec = el.closest('.section')?.querySelector('h4')?.textContent.replace(/\s+/g, ' ').trim().slice(0, 26);
-  const txt = (el.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 28);
-  return [card ? card.toUpperCase() : null, sec || null, txt ? `“${txt}”` : null].filter(Boolean).join(' › ');
-}
-function onInspectMove(e) {
-  if (!state.inspect) return;
-  let t = document.getElementById('rw-tip');
-  if (!t) { t = document.createElement('div'); t.id = 'rw-tip'; document.body.appendChild(t); }
-  const hit = ruleOf(e.target);
-  if (!hit || e.target.closest('#rw-tip, .overlay')) { t.style.display = 'none'; return; }
-  const meta = hit.r ? RULE_META[hit.r] : null;
-  t.innerHTML = hit.r
-    ? `<b>${esc(hit.r)}</b> ${esc(meta ? meta[0] : '')}<span class="rt-b">${esc(meta ? meta[1] : '')}</span>`
-    : `<b class="bad">⚠ NO RULE</b> bypassed the builders (R0)`;
-  t.style.display = 'block';
-  t.style.left = Math.min(e.clientX + 14, window.innerWidth - 250) + 'px';
-  t.style.top = Math.min(e.clientY + 18, window.innerHeight - 56) + 'px';
-}
+/* ════════════════════════════════════════════════════════════════════════
+   APP-12 · DESIGN-SYSTEM CATALOG — moved to src/rulebook.js (2026-07-24
+   module split). RB_FOUNDATION, RB_TABS, ruleOf, refPath, onInspectMove
+   all now live there — imported above.
+   ════════════════════════════════════════════════════════════════════════ */
 
 /* ════════════════════════════════════════════════════════════════════════
    APP-13 · §6 LIST ROWS — row meta + the universal row template
@@ -27722,6 +27562,12 @@ function commsCustSectionHtml(c) {
   return rows ? `<div class="section comms-sec"><h4>Comms</h4><div class="fieldstack">${rows}</div></div>` : '';
 }
 
+
+// Populate the late-binding registry (src/internals.js) with whatever this file's
+// own chapters still own that an extracted src/*.js module needs read back — done
+// here, after every app.js top-level chapter above has run, so nothing reads a
+// not-yet-initialized value. Extend this object as more chapters extract.
+Object.assign(APP_INTERNALS, { RULE_META, state });
 
 boot();
 

--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ import { AGREEMENTS, AGREEMENT_VERSIONS, AGREEMENT_CURRENT } from './agreements.
 import { ico, I, CARD_ICON, RING_ICON, CATEGORY_ICON } from './icons.js';
 import { CATEGORY_ANIM } from './icons-anim.js';
 import { CATEGORY_FRAMES } from './icons-frames.js';
+import { $, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR } from './src/format.js';
 import {
   getStatus, STATUS, ROLES, ROLE_TIERS, tierRank, BUILTIN_ROLE_TIERS, GRID_CARDS, BACKOFFICE_BOARDS, SORT_FIELDS,
   SHOP_TYPES, COLUMNS, COLUMN_OF,
@@ -72,27 +73,12 @@ function wranglerIssueUrl(title, body, label = 'wrangler-fix') {
 }
 
 /* ════════════════════════════════════════════════════════════════════════
-   APP-02 · §1 UTILITIES & FORMATTING — $, el, esc, money, num, dates
+   APP-02 · §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split)
    ════════════════════════════════════════════════════════════════════════ */
-const $  = (sel, root = document) => root.querySelector(sel);
-const el = (tag, cls, html) => { const n = document.createElement(tag); if (cls) n.className = cls; if (html != null) n.innerHTML = html; return n; };
-const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-const money = (n) => { if (n == null) return '—'; const v = Math.round(Number(n) * 100) / 100; return '$' + v.toLocaleString('en-US', { minimumFractionDigits: Number.isInteger(v) ? 0 : 2, maximumFractionDigits: 2 }); };   // cents shown only when present, so exact tax ($53.75) reads true while whole-dollar figures stay clean
-// money2 — always-two-decimal money for the invoice ledger + payment flow (#109): a
-// printed/paid figure reads what's actually owed, to the cent, even on whole dollars.
-const money2 = (n) => (n == null ? '—' : '$' + Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }));
-const num = (n) => (n == null ? '—' : Number(n).toLocaleString('en-US', { maximumFractionDigits: 1 }));
-let TODAY = parseISO(TODAY_ISO);   // live: refreshToday() rolls it over so an all-day-open tab never stamps yesterday
-const dayDiff = (a, b) => Math.round((b - a) / 86400000);
-// Keep "today" current on a long-lived tab. TODAY_ISO is an ESM live binding, so
-// every call-time reader picks up the new day for free; TODAY (a Date) is re-derived here.
-function refreshToday() { if (refreshTodayISO()) { TODAY = parseISO(TODAY_ISO); } }
-/* Trailing debounce: returns a scheduler you call with a thunk each time — it cancels
-   any pending thunk and reschedules, so only the LAST call in a burst actually runs.
-   Used to keep typing snappy on inputs whose reaction is expensive (a full render()). */
-function debounce(ms) { let t; return (fn) => { clearTimeout(t); t = setTimeout(fn, ms); }; }
-
-const SINGULAR = { customers: 'customer', rentals: 'rental', units: 'unit', invoices: 'invoice', categories: 'category', workOrders: 'workOrder', inspections: 'inspection', serviceOrders: 'unit', models: 'model' };
+/* $, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR
+   all now live in src/format.js — imported above. Kept this banner (no code) so the
+   APP-NN chapter numbering below never shifts (see APP-08's icons.js pointer for the
+   established precedent). */
 
 /* ════════════════════════════════════════════════════════════════════════
    APP-03 · §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke)

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,51 +4,51 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27799 lines, 41 chapters
+## app.js — 27775 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
-| APP-01 | 42–74 | §0.7 | §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you | ERR_LOG, logErr, WRANGLER_REPO, wranglerIssueUrl |
-| APP-02 | 75–82 | §1 | §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split) | — |
-| APP-03 | 83–1048 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
-| APP-04 | 1049–1155 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 1156–1576 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
-| APP-06 | 1577–2339 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
-| APP-07 | 2340–3281 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
-| APP-08 | 3282–3289 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 3290–5778 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
-| APP-10 | 5779–5799 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 5800–6611 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
-| APP-12 | 6612–6779 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 6780–7019 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
-| APP-14 | 7020–7463 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
-| APP-15 | 7464–7663 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 7664–9257 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
-| APP-17 | 9258–9517 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 9518–9972 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
-| APP-19 | 9973–10097 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 10098–10269 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 10270–10605 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
-| APP-22 | 10606–12189 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
-| APP-23 | 12190–12232 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 12233–13075 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 13076–14810 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
-| APP-26 | 14811–15155 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
-| APP-27 | 15156–15640 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 15641–16899 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
-| APP-29 | 16900–17249 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
-| APP-30 | 17250–17625 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
-| APP-31 | 17626–17629 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17630–20134 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 20135–21438 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21439–22975 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22976–23458 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23459–23461 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23462–24687 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
-| APP-38 | 24688–25827 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25828–25834 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25835–26171 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26172–27799 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-01 | 43–50 | §0.7 | §0.7 GLITCH CAPTURE — moved to src/glitch-capture.js (2026-07-24 module split) | — |
+| APP-02 | 51–58 | §1 | §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split) | — |
+| APP-03 | 59–1024 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
+| APP-04 | 1025–1131 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
+| APP-05 | 1132–1552 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
+| APP-06 | 1553–2315 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
+| APP-07 | 2316–3257 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
+| APP-08 | 3258–3265 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 3266–5754 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
+| APP-10 | 5755–5775 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 5776–6587 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
+| APP-12 | 6588–6755 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 6756–6995 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
+| APP-14 | 6996–7439 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
+| APP-15 | 7440–7639 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 7640–9233 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
+| APP-17 | 9234–9493 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 9494–9948 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
+| APP-19 | 9949–10073 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 10074–10245 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 10246–10581 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
+| APP-22 | 10582–12165 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
+| APP-23 | 12166–12208 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 12209–13051 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 13052–14786 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
+| APP-26 | 14787–15131 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
+| APP-27 | 15132–15616 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 15617–16875 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
+| APP-29 | 16876–17225 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
+| APP-30 | 17226–17601 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
+| APP-31 | 17602–17605 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 17606–20110 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 20111–21414 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21415–22951 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22952–23434 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23435–23437 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23438–24663 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
+| APP-38 | 24664–25803 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25804–25810 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25811–26147 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26148–27775 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 703 lines, 0 chapters
 
@@ -78,6 +78,10 @@ Chapter **ICON** — no internal banners, the whole file is one chapter.
 
 Chapter **FMT** — no internal banners, the whole file is one chapter.
 
+## src/glitch-capture.js — 37 lines, 0 chapters
+
+Chapter **GLC** — no internal banners, the whole file is one chapter.
+
 ---
 
-_Total: 48 chapters across 8 files._
+_Total: 49 chapters across 9 files._

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,51 +4,51 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27741 lines, 41 chapters
+## app.js — 27587 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
-| APP-01 | 44–51 | §0.7 | §0.7 GLITCH CAPTURE — moved to src/glitch-capture.js (2026-07-24 module split) | — |
-| APP-02 | 52–59 | §1 | §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split) | — |
-| APP-03 | 60–1025 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
-| APP-04 | 1026–1132 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 1133–1553 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
-| APP-06 | 1554–2316 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
-| APP-07 | 2317–3258 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
-| APP-08 | 3259–3266 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 3267–5755 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
-| APP-10 | 5756–5776 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 5777–6588 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
-| APP-12 | 6589–6756 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 6757–6996 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
-| APP-14 | 6997–7440 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
-| APP-15 | 7441–7640 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 7641–9234 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
-| APP-17 | 9235–9494 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 9495–9949 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
-| APP-19 | 9950–10074 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 10075–10246 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 10247–10582 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
-| APP-22 | 10583–12166 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
-| APP-23 | 12167–12174 | §13.3 | §13.3 CARD GRAPH VIEW — moved to src/card-graph-view.js (2026-07-24 | — |
-| APP-24 | 12175–13017 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 13018–14752 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
-| APP-26 | 14753–15097 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
-| APP-27 | 15098–15582 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 15583–16841 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
-| APP-29 | 16842–17191 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
-| APP-30 | 17192–17567 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
-| APP-31 | 17568–17571 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17572–20076 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 20077–21380 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21381–22917 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22918–23400 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23401–23403 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23404–24629 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
-| APP-38 | 24630–25769 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25770–25776 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25777–26113 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26114–27741 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-01 | 46–53 | §0.7 | §0.7 GLITCH CAPTURE — moved to src/glitch-capture.js (2026-07-24 module split) | — |
+| APP-02 | 54–61 | §1 | §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split) | — |
+| APP-03 | 62–1027 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
+| APP-04 | 1028–1134 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
+| APP-05 | 1135–1555 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
+| APP-06 | 1556–2318 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
+| APP-07 | 2319–3260 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
+| APP-08 | 3261–3268 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 3269–5757 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
+| APP-10 | 5758–5778 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 5779–6590 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
+| APP-12 | 6591–6596 | — | DESIGN-SYSTEM CATALOG — moved to src/rulebook.js (2026-07-24 | — |
+| APP-13 | 6597–6836 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
+| APP-14 | 6837–7280 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
+| APP-15 | 7281–7480 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 7481–9074 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
+| APP-17 | 9075–9334 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 9335–9789 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
+| APP-19 | 9790–9914 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 9915–10086 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 10087–10422 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
+| APP-22 | 10423–12006 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
+| APP-23 | 12007–12014 | §13.3 | §13.3 CARD GRAPH VIEW — moved to src/card-graph-view.js (2026-07-24 | — |
+| APP-24 | 12015–12857 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 12858–14592 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
+| APP-26 | 14593–14937 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
+| APP-27 | 14938–15422 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 15423–16681 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
+| APP-29 | 16682–17031 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
+| APP-30 | 17032–17407 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
+| APP-31 | 17408–17411 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 17412–19916 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 19917–21220 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21221–22757 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22758–23240 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23241–23243 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23244–24469 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
+| APP-38 | 24470–25609 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25610–25616 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25617–25953 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 25954–27587 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 703 lines, 0 chapters
 
@@ -86,6 +86,14 @@ Chapter **GLC** — no internal banners, the whole file is one chapter.
 
 Chapter **GVW** — no internal banners, the whole file is one chapter.
 
+## src/internals.js — 26 lines, 0 chapters
+
+Chapter **INT** — no internal banners, the whole file is one chapter.
+
+## src/rulebook.js — 184 lines, 0 chapters
+
+Chapter **RBK** — no internal banners, the whole file is one chapter.
+
 ---
 
-_Total: 50 chapters across 10 files._
+_Total: 52 chapters across 12 files._

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,51 +4,51 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27775 lines, 41 chapters
+## app.js — 27741 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
-| APP-01 | 43–50 | §0.7 | §0.7 GLITCH CAPTURE — moved to src/glitch-capture.js (2026-07-24 module split) | — |
-| APP-02 | 51–58 | §1 | §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split) | — |
-| APP-03 | 59–1024 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
-| APP-04 | 1025–1131 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 1132–1552 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
-| APP-06 | 1553–2315 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
-| APP-07 | 2316–3257 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
-| APP-08 | 3258–3265 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 3266–5754 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
-| APP-10 | 5755–5775 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 5776–6587 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
-| APP-12 | 6588–6755 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 6756–6995 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
-| APP-14 | 6996–7439 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
-| APP-15 | 7440–7639 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 7640–9233 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
-| APP-17 | 9234–9493 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 9494–9948 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
-| APP-19 | 9949–10073 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 10074–10245 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 10246–10581 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
-| APP-22 | 10582–12165 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
-| APP-23 | 12166–12208 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 12209–13051 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 13052–14786 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
-| APP-26 | 14787–15131 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
-| APP-27 | 15132–15616 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 15617–16875 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
-| APP-29 | 16876–17225 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
-| APP-30 | 17226–17601 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
-| APP-31 | 17602–17605 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17606–20110 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 20111–21414 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21415–22951 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22952–23434 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23435–23437 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23438–24663 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
-| APP-38 | 24664–25803 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25804–25810 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25811–26147 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26148–27775 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-01 | 44–51 | §0.7 | §0.7 GLITCH CAPTURE — moved to src/glitch-capture.js (2026-07-24 module split) | — |
+| APP-02 | 52–59 | §1 | §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split) | — |
+| APP-03 | 60–1025 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
+| APP-04 | 1026–1132 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
+| APP-05 | 1133–1553 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
+| APP-06 | 1554–2316 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
+| APP-07 | 2317–3258 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
+| APP-08 | 3259–3266 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 3267–5755 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
+| APP-10 | 5756–5776 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 5777–6588 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
+| APP-12 | 6589–6756 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 6757–6996 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
+| APP-14 | 6997–7440 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
+| APP-15 | 7441–7640 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 7641–9234 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
+| APP-17 | 9235–9494 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 9495–9949 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
+| APP-19 | 9950–10074 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 10075–10246 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 10247–10582 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
+| APP-22 | 10583–12166 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
+| APP-23 | 12167–12174 | §13.3 | §13.3 CARD GRAPH VIEW — moved to src/card-graph-view.js (2026-07-24 | — |
+| APP-24 | 12175–13017 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 13018–14752 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
+| APP-26 | 14753–15097 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
+| APP-27 | 15098–15582 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 15583–16841 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
+| APP-29 | 16842–17191 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
+| APP-30 | 17192–17567 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
+| APP-31 | 17568–17571 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 17572–20076 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 20077–21380 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21381–22917 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22918–23400 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23401–23403 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23404–24629 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
+| APP-38 | 24630–25769 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25770–25776 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25777–26113 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26114–27741 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 703 lines, 0 chapters
 
@@ -82,6 +82,10 @@ Chapter **FMT** — no internal banners, the whole file is one chapter.
 
 Chapter **GLC** — no internal banners, the whole file is one chapter.
 
+## src/card-graph-view.js — 49 lines, 0 chapters
+
+Chapter **GVW** — no internal banners, the whole file is one chapter.
+
 ---
 
-_Total: 49 chapters across 9 files._
+_Total: 50 chapters across 10 files._

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,51 +4,51 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27813 lines, 41 chapters
+## app.js — 27799 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
-| APP-01 | 41–73 | §0.7 | §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you | ERR_LOG, logErr, WRANGLER_REPO, wranglerIssueUrl |
-| APP-02 | 74–96 | §1 | §1 UTILITIES & FORMATTING — $, el, esc, money, num, dates | $, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR |
-| APP-03 | 97–1062 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
-| APP-04 | 1063–1169 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
-| APP-05 | 1170–1590 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
-| APP-06 | 1591–2353 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
-| APP-07 | 2354–3295 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
-| APP-08 | 3296–3303 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
-| APP-09 | 3304–5792 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
-| APP-10 | 5793–5813 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
-| APP-11 | 5814–6625 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
-| APP-12 | 6626–6793 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
-| APP-13 | 6794–7033 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
-| APP-14 | 7034–7477 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
-| APP-15 | 7478–7677 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
-| APP-16 | 7678–9271 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
-| APP-17 | 9272–9531 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
-| APP-18 | 9532–9986 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
-| APP-19 | 9987–10111 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
-| APP-20 | 10112–10283 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
-| APP-21 | 10284–10619 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
-| APP-22 | 10620–12203 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
-| APP-23 | 12204–12246 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
-| APP-24 | 12247–13089 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
-| APP-25 | 13090–14824 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
-| APP-26 | 14825–15169 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
-| APP-27 | 15170–15654 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
-| APP-28 | 15655–16913 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
-| APP-29 | 16914–17263 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
-| APP-30 | 17264–17639 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
-| APP-31 | 17640–17643 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
-| APP-32 | 17644–20148 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
-| APP-33 | 20149–21452 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
-| APP-34 | 21453–22989 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
-| APP-35 | 22990–23472 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
-| APP-36 | 23473–23475 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23476–24701 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
-| APP-38 | 24702–25841 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25842–25848 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25849–26185 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26186–27813 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-01 | 42–74 | §0.7 | §0.7 GLITCH CAPTURE — a small ring buffer of recent JS errors, so when you | ERR_LOG, logErr, WRANGLER_REPO, wranglerIssueUrl |
+| APP-02 | 75–82 | §1 | §1 UTILITIES & FORMATTING — moved to src/format.js (2026-07-24 module split) | — |
+| APP-03 | 83–1048 | §2 §3 | §2 INDEXES & SEARCH — built once on load (SPEC §3: never scan per keystroke) | IDX, parseCustomerName, fullName, blankFunnels, ensureFunnels, RENTAL_OUT, customerRentals, hasRentalActivity, inRental, rentalFunnelStage, funnelStageOf, inFunnel, …(+108) |
+| APP-04 | 1049–1155 | §3 §10 | §3 DERIVATIONS (SPEC §10) — money, availability, statuses, countdowns | RATE_LABELS, rentalPrice, catRatesUnset, unitRentalPrice, rentalLineItems, unitFueled, transportCost, rentalTransport, unitTransport, transportLineItems |
+| APP-05 | 1156–1576 | — | RENTAL EXTENSIONS (Jac 2026-06-25) | retroPricingOn, unitBilledRental, unitExtensionDelta, INV_CAP_DAYS, rentalInvoices, rentalActiveInvoice, invCovStart, invCovEnd, invCoveredDays, minISO, maxISO, isWindowExtension, …(+16) |
+| APP-06 | 1577–2339 | — | INLINE TRANSPORT EDITOR + GOOGLE MAPS (Jac 2026-06-15) | _mapsKey, ensureMapsKey, loadGoogleMaps, afterMapsLoad, mapsReady, YARD_CENTER, _teMap, openTransportEdit, closeTransportEdit, transportEditorHtml, mountTransportEditor, teQuery, …(+63) |
+| APP-07 | 2340–3281 | §4 §0.1 | §4 STATE & SESSIONS — one normalized object + the session model (SPEC §0.1) | freshSession, columnOfMember, SORT_LS_KEY, loadSort, saveSort, entityCardOf, unitOfShopRec, COMMS_LS_KEY, COMMS_CATS, commsFreshSessions, loadCommsRail, saveCommsRail, …(+85) |
+| APP-08 | 3282–3289 | §5a | §5a ICONS — inline SVG (stroke-based, currentColor) | — |
+| APP-09 | 3290–5778 | — | SETTINGS BOARD — admin customization (config.settings). | STATUS_ICONS, SETTINGS_STATUS_SETS, STATUS_DEFAULTS, ovIcon, loadAdminSettings, applyStatusOverrides, settingsReverted, applySettings, persistAdminSettings, hasSettingsBackup, pageDefaultSlice, resetPageSettings, …(+163) |
+| APP-10 | 5779–5799 | §5 | §5 UI BUILDERS — ONE function per design rule (the SPEC v8 rulebook). | SET_CARD, dataAttrs |
+| APP-11 | 5800–6611 | — | FLAG-DRIVEN COLOR ENGINE — SPEC docs/specs/flag-color-system.md | openWOsForRental, rentalUnitRecords, woHasEta, insuranceTypeCatalog, unitCoverage, INS_OUT, fleetInsuredValue, fleetPremiumMonthly, FLAG_COND, getEntityFlags, entityArchived, getEntityColor, …(+56) |
+| APP-12 | 6612–6779 | — | DESIGN-SYSTEM CATALOG — the tabbed Rulebook (Jac 2026-06-14) | rbSw, RB_FOUNDATION, RB_TABS, CLASS_RULE, ruleOf, refPath, onInspectMove |
+| APP-13 | 6780–7019 | §6 | §6 LIST ROWS — row meta + the universal row template | ROW_META, isSoldInactive, unitsVisible, rentalsVisible, INV_METHOD_OPTS, INV_METHOD_LABEL, invMethodClass, rowViz, customerSpectrumViz, CATEGORY_MOTION, categoryIconFor, catFramesSvg, …(+7) |
+| APP-14 | 7020–7463 | §6b | §6b PER-CARD ROWS | INLINE_EXPAND_CARDS, dv2On, inlineExpandActive, rowEl, genericRow, ROWS |
+| APP-15 | 7464–7663 | §7 | §7 COLUMN REGISTRY & FOOTER TOTALS — one source of truth per card | pillS, C, CARD_COLUMNS, cardColumns, boardSegmentFor, aggColumn, AGG_CALCS, AGG_LABEL, fmtAggValue, LIST_LAYOUT_KEY, LIST_LAYOUTS, DEFAULT_LAYOUT, …(+11) |
+| APP-16 | 7664–9257 | §8 | §8 DETAIL RENDERERS — kv/efld/notes · v2 helpers (yard tool, WO sections, | kv, kvPills, efld, notesSection, openWOsForUnit, latestInspForUnit, WO_SEV, woBottleneck, unitWorstBottleneck, unitCondLock, newInspectionForUnit, yardToolHtml, …(+46) |
+| APP-17 | 9258–9517 | §9 | §9 CARDS & GRID — cardEl, listView, the 3-column shell | listFor, collection, sortRows, VIRT_CAP, SHOW_MORE_BATCH, appendWindowed, UNIT_SECTIONS, unitStageKey, GROUP_DEFS, COLLAPSED_GROUPS, groupDefaultCollapsed, groupCollapsed, …(+8) |
+| APP-18 | 9518–9972 | — | 3-COLUMN LAYOUT (display-only shell over the existing cards). | GRID_CARD_BY_ID, MEMBER_TITLE, memberIcon, memberCount, unitsAlertCount, wave2ListOverride, columnEl, mobileRailPanelEl, inertRailClone, colTabsEl, mobileNavEl, colTabButtonsHtml, …(+9) |
+| APP-19 | 9973–10097 | §11 | §11 HEADER, KPI & BOTTOM BAR | bandColor, ring3SVG, ringsSVG, pctOf, fleetInsp, legacyKpiPct, KPI_HELP |
+| APP-20 | 10098–10269 | §11b | §11b KPI METRIC ENGINE — admin-definable KPIs (Settings → KPIs & Rings). | KPI_ENTITY, KPI_DERIVED, KPI_TOKENS, kpiField, kpiVal, kpiCond, kpiRows, kpiAgg, kpiBand, kpiTarget, kpiEval, KPI_DEFAULTS, …(+11) |
+| APP-21 | 10270–10605 | — | COMING 2026 — the roadmap morale plate (Jac 2026-06-23) | ROADMAP_ITEMS, ROADMAP_AREAS, headerEl, bottomBarInner, toolsMenuRows, openToolsMenu, toolsBtn, commsBellCount, commsMenuRows, openCommsMenu, commsBellBtn, bottomBarEl, …(+13) |
+| APP-22 | 10606–12189 | §17 | §17 INTERNAL TEAM DOCK (Jac, Phase 7) — a bottom-bar chat built on the Phase-6 | chatComments, chatUnreadCount, chatById, activeChat, chatsTagging, chatMarkSeen, chatUnseenForRec, newChat, myRosterId, chatIsAdmin, chatAmMember, chatVisibleToMe, …(+136) |
+| APP-23 | 12190–12232 | §13.3 | §13.3 CARD GRAPH VIEW — RETIRED (2026-07-03). The per-card tile | GV_WIN_OPTS, GV_WIN_KEY, GV_WIN, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets |
+| APP-24 | 12233–13075 | §13.4 | §13.4 GRAPH CAROUSEL (Jac 2026-06-16) — the per-card Graph is a deck of | gvClampIdx, gvKey, gvSegOn, gvSmallest, graphViewsFor, gvSaveCurrent, gvStripTerms, gvRestore, gvOpen, gvChevron, gvSyncClosed, toggleGraphSeg, …(+71) |
+| APP-25 | 13076–14810 | §12 | §12 OVERLAYS & BOARDS — renderOverlay kinds + back-office board popups | _ovScroll, _popDrag, wirePopupDrag, backGuard, swipeFired, anyDismissable, dismissTopSheet, syncBackGuard, closePhoneSheet, _pg, PULL_MIN, _sheetScroller, …(+4) |
+| APP-26 | 14811–15155 | — | RB-WINDOWS catalog (Jac 2026-06-22) — the admin Rulebook's index of | WINDOW_CATALOG, previewOverlayFor, STANDALONE_SURFACES, feedbackContext, sendFeedback, CB_BLOCK_LABEL, CB_REASON_LABEL, crewBroadcastEmps, RR_STAR_TIP, rrBand, RR_BAND_LABEL, notifRatingTemplate, …(+12) |
+| APP-27 | 15156–15640 | §18 | §18 MR. WRANGLER — the in-app AI (Claude via the Apps Script backend). | WRANGLER_SYSTEM, wranglerDigest, wrIssueIndex, wranglerContext, WR_DEDUP_NOTE, wranglerAttachAny, wranglerAttachFile, parseCsvFile, wranglerAttachTextFile, wranglerImageBlock, wranglerErrMsg, WR_TOOL_LIMIT, …(+11) |
+| APP-28 | 15641–16899 | — | Mr. Wrangler ACTS on your data (Jac 2026-06-16) | WR_FUNNEL, wrFunnel, WR_ACCT, wrAccount, WR_EDITABLE, WR_REQUIRED, WR_NUMERIC, WR_MONEY_FIELDS, wrPlanNeedsApply, WR_IDX, wrGet, wrNorm, …(+116) |
+| APP-29 | 16900–17249 | §13 | §13 DROPDOWNS — openDropdown + status/fleet/funnel/sort menus | GTI, GATE_ICON, GATE_TL, GTCHK, gateTimeline, openDropdown, openStatusDropdown, openFleetDropdown, setUnitFleet, openReconcileDropdown, setExpenseReconcile, funnelMenuChip, …(+23) |
+| APP-30 | 17250–17625 | §14 | §14 RENDER PIPELINE + toast | renderCount, scrollMemo, scrollHostOf, render, renderResults, scheduleCardListRender, renderCardList, mirrorGlobeBars, _titlesRaf, applyTitles, HOVER_CAPABLE, initTooltip, …(+9) |
+| APP-31 | 17626–17629 | §15 | §15 EVENT HANDLERS — onClick/onInput/onChange (single listener tree) | — |
+| APP-32 | 17630–20134 | §15c | §15c DRAG & DROP LINK ENGINE (DRAGDROP-DESIGN.md) — custom pointer engine. | DRAG, DRAG_SOURCES, INV_LINEABLE, dragLayer, DROP_MATRIX, woDroppableToInvoice, invoiceUnitIds, LINK_TARGET_LABEL, linkRoleAllows, linkActionPossible, linkActionsFor, enterLinking, …(+63) |
+| APP-33 | 20135–21438 | §16 | §16 ACTIONS / MUTATIONS — every state change funnels through here | setUnitCondition, openInspectionRecord, pendingInspForUnit, openChecklist, completeChecklist, washBtn, cycleUnitWash, uncompleteWash, setUnitWash, sellUnit, captureUnit, setUnitCapture, …(+52) |
+| APP-34 | 21439–22975 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
+| APP-35 | 22976–23458 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
+| APP-36 | 23459–23461 | §18 | §18 PERSISTENCE & BOOT | — |
+| APP-37 | 23462–24687 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, devPwMode, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+86) |
+| APP-38 | 24688–25827 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25828–25834 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25835–26171 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26172–27799 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 703 lines, 0 chapters
 
@@ -74,6 +74,10 @@ Chapter **AGR** — no internal banners, the whole file is one chapter.
 
 Chapter **ICON** — no internal banners, the whole file is one chapter.
 
+## src/format.js — 29 lines, 0 chapters
+
+Chapter **FMT** — no internal banners, the whole file is one chapter.
+
 ---
 
-_Total: 47 chapters across 7 files._
+_Total: 48 chapters across 8 files._

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260721a" />
+  <link rel="stylesheet" href="style.css?v=20260724a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260721a"></script>
-  <script type="module" src="app.js?v=20260721a"></script>
+  <script src="rule-usage.js?v=20260724a"></script>
+  <script type="module" src="app.js?v=20260724a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->

--- a/src/card-graph-view.js
+++ b/src/card-graph-view.js
@@ -1,0 +1,48 @@
+/**
+ * card-graph-view.js — Rental Wrangler graph time-window helpers (moved from
+ * app.js APP-23 · §13.3 CARD GRAPH VIEW, 2026-07-24 module split).
+ * ----------------------------------------------------------------------------
+ * RETIRED (2026-07-03). The per-card tile dashboard (pieSVG/gvBars tiles +
+ * unit roster) was replaced by the §13.6 Round-Up reporting board, but the
+ * time-window + bucket helpers below survive — the §13.4 Graph Carousel
+ * (src still in app.js) calls into these. Pure relocation: same functions,
+ * same behavior, just callable via import.
+ */
+import { TODAY } from './format.js';
+
+/* §13.4 — TIMELINE SELECTOR (Jac 2026-06-23). Per-source (per card / shop segment) the
+   graph carousel's TIME-BASED views can be scoped to a recent window: 7/10/30/90/180/360
+   days, or All (default = today's all-time/6-month behavior). Snapshot views ignore it and
+   read "Current". The active window is stamped ON the chart head, never hover-only. */
+export const GV_WIN_OPTS = [7, 10, 30, 90, 180, 360];
+const GV_WIN_KEY = (src) => `jactec.gvWin.${src}`;
+const GV_WIN = Object.create(null);
+export function loadGvWin(src) {
+  if (src in GV_WIN) return GV_WIN[src];
+  let v = 0; try { v = Number(localStorage.getItem(GV_WIN_KEY(src))) || 0; } catch (e) { v = 0; }
+  GV_WIN[src] = GV_WIN_OPTS.includes(v) ? v : 0;   // 0 = All time
+  return GV_WIN[src];
+}
+export function saveGvWin(src, days) {
+  const d = GV_WIN_OPTS.includes(days) ? days : 0;
+  GV_WIN[src] = d;
+  try { if (d) localStorage.setItem(GV_WIN_KEY(src), String(d)); else localStorage.removeItem(GV_WIN_KEY(src)); } catch (e) { /* private mode */ }
+}
+export const gvWinLabel = (d) => d ? `${d}D` : 'All';
+// ISO (yyyy-mm-dd) cutoff: the oldest day still IN a `days`-long window ending today (inclusive). null = all.
+export function gvWinCutoff(days) { if (!days) return null; const d = new Date(TODAY); d.setDate(d.getDate() - days + 1); return d.toISOString().slice(0, 10); }
+// Time buckets spanning the window for the "/period" bar charts. Each = {key:"a|b", label, a, b}
+// with a<=date<b (ISO). Granularity adapts: ≤14d daily · ≤90d weekly · else monthly (All = 6 months).
+export function gvBuckets(days) {
+  const out = [], iso = (d) => d.toISOString().slice(0, 10), base = new Date(TODAY);
+  if (!days || days > 90) {
+    const n = !days ? 6 : Math.min(12, Math.max(1, Math.round(days / 30)));
+    for (let i = n - 1; i >= 0; i--) { const a = new Date(base.getFullYear(), base.getMonth() - i, 1), b = new Date(base.getFullYear(), base.getMonth() - i + 1, 1); out.push({ key: iso(a) + '|' + iso(b), label: a.toLocaleString('en-US', { month: 'short' }), a: iso(a), b: iso(b) }); }
+  } else if (days > 14) {
+    const weeks = Math.ceil(days / 7);
+    for (let i = weeks - 1; i >= 0; i--) { const b = new Date(base); b.setDate(b.getDate() - i * 7 + 1); const a = new Date(b); a.setDate(a.getDate() - 7); out.push({ key: iso(a) + '|' + iso(b), label: `${a.getMonth() + 1}/${a.getDate()}`, a: iso(a), b: iso(b) }); }
+  } else {
+    for (let i = days - 1; i >= 0; i--) { const a = new Date(base); a.setDate(a.getDate() - i); const b = new Date(a); b.setDate(b.getDate() + 1); out.push({ key: iso(a) + '|' + iso(b), label: `${a.getMonth() + 1}/${a.getDate()}`, a: iso(a), b: iso(b) }); }
+  }
+  return out;
+}

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,28 @@
+/**
+ * format.js — Rental Wrangler shared utilities & formatting (moved from app.js
+ * APP-02 · §1 UTILITIES & FORMATTING, 2026-07-24 module split).
+ * ----------------------------------------------------------------------------
+ * $, el, esc, money, num, dates — the atoms every other module reaches for.
+ * Pure relocation: same functions, same behavior, just callable via import.
+ */
+import { parseISO, TODAY_ISO, refreshTodayISO } from '../config.js';
+
+export const $  = (sel, root = document) => root.querySelector(sel);
+export const el = (tag, cls, html) => { const n = document.createElement(tag); if (cls) n.className = cls; if (html != null) n.innerHTML = html; return n; };
+export const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+export const money = (n) => { if (n == null) return '—'; const v = Math.round(Number(n) * 100) / 100; return '$' + v.toLocaleString('en-US', { minimumFractionDigits: Number.isInteger(v) ? 0 : 2, maximumFractionDigits: 2 }); };   // cents shown only when present, so exact tax ($53.75) reads true while whole-dollar figures stay clean
+// money2 — always-two-decimal money for the invoice ledger + payment flow (#109): a
+// printed/paid figure reads what's actually owed, to the cent, even on whole dollars.
+export const money2 = (n) => (n == null ? '—' : '$' + Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }));
+export const num = (n) => (n == null ? '—' : Number(n).toLocaleString('en-US', { maximumFractionDigits: 1 }));
+export let TODAY = parseISO(TODAY_ISO);   // live: refreshToday() rolls it over so an all-day-open tab never stamps yesterday
+export const dayDiff = (a, b) => Math.round((b - a) / 86400000);
+// Keep "today" current on a long-lived tab. TODAY_ISO is an ESM live binding, so
+// every call-time reader picks up the new day for free; TODAY (a Date) is re-derived here.
+export function refreshToday() { if (refreshTodayISO()) { TODAY = parseISO(TODAY_ISO); } }
+/* Trailing debounce: returns a scheduler you call with a thunk each time — it cancels
+   any pending thunk and reschedules, so only the LAST call in a burst actually runs.
+   Used to keep typing snappy on inputs whose reaction is expensive (a full render()). */
+export function debounce(ms) { let t; return (fn) => { clearTimeout(t); t = setTimeout(fn, ms); }; }
+
+export const SINGULAR = { customers: 'customer', rentals: 'rental', units: 'unit', invoices: 'invoice', categories: 'category', workOrders: 'workOrder', inspections: 'inspection', serviceOrders: 'unit', models: 'model' };

--- a/src/glitch-capture.js
+++ b/src/glitch-capture.js
@@ -1,0 +1,36 @@
+/**
+ * glitch-capture.js — Rental Wrangler glitch capture (moved from app.js APP-01
+ * · §0.7 GLITCH CAPTURE, 2026-07-24 module split).
+ * ----------------------------------------------------------------------------
+ * A small ring buffer of recent JS errors, so when you hand a glitch to Mr.
+ * Wrangler the repro packet carries what actually broke (the single most
+ * useful clue for the auto-fixer). Installed first thing so it catches
+ * boot-time errors too. Kept tiny + best-effort — never throws itself.
+ * Pure relocation: same functions, same behavior, just callable via import.
+ */
+export const ERR_LOG = [];
+export function logErr(kind, msg) {
+  try {
+    const t = new Date().toTimeString().slice(0, 8);
+    ERR_LOG.push(`[${t}] ${kind}: ${String(msg).replace(/\s+/g, ' ').slice(0, 300)}`);
+    if (ERR_LOG.length > 30) ERR_LOG.shift();
+  } catch (_) {}
+}
+window.addEventListener('error', (e) => logErr('error', (e.message || 'error') + (e.filename ? ` @ ${String(e.filename).split('/').pop()}:${e.lineno || '?'}` : '')));
+window.addEventListener('unhandledrejection', (e) => logErr('promise', (e.reason && (e.reason.message || e.reason)) || 'unhandled rejection'));
+{ const _ce = console.error; console.error = function (...a) { try { logErr('console', a.map((x) => (x && x.message) || x).join(' ')); } catch (_) {} return _ce.apply(this, a); }; }
+
+/* The public repo this app fixes itself through (Track B — see docs/wrangler-pipeline.md).
+   A glitch handed to Mr. Wrangler becomes a `wrangler-fix` GitHub issue that the
+   Action engine reproduces, patches, gate-checks, and auto-merges to live. The
+   browser can't hold a token, so we open a PRE-FILLED issue (one Submit tap). */
+const WRANGLER_REPO = 'operations-jacrentals/rental-wrangler';
+// label 'wrangler-fix' → the auto-fix Action runs (glitches). 'wrangler-request'
+// → filed for Jac's OK, NOT auto-implemented (he can add the fix label to greenlight).
+export function wranglerIssueUrl(title, body, label = 'wrangler-fix') {
+  const u = new URL(`https://github.com/${WRANGLER_REPO}/issues/new`);
+  u.searchParams.set('title', String(title || 'Reported glitch').slice(0, 120));
+  u.searchParams.set('labels', label);
+  u.searchParams.set('body', String(body || '').slice(0, 6000));   // GitHub URL body cap headroom
+  return u.toString();
+}

--- a/src/internals.js
+++ b/src/internals.js
@@ -1,0 +1,25 @@
+/**
+ * internals.js — shared late-binding registry (2026-07-24 module split).
+ * ----------------------------------------------------------------------------
+ * WHY THIS EXISTS: index.html loads the app as `app.js?v=<token>` (a
+ * cache-busting query string — see CLAUDE.md "Cache-bust every deploy").
+ * ES modules cache/dedupe by exact resolved URL, so if an extracted
+ * src/*.js module did `import {...} from '../app.js'` (no query string),
+ * that resolves to a DIFFERENT URL than the one the browser already loaded
+ * — the module loader silently evaluates a SECOND, fully independent copy
+ * of the entire app.js body (its own IDX, its own state, its own boot()
+ * call…) instead of sharing the real one. Confirmed empirically while
+ * splitting app.js: a chapter that imported IDX/state back from '../app.js'
+ * read from that phantom second copy, which the real app never touches —
+ * so tests silently got undefined/stale data instead of a hard error.
+ *
+ * The fix: nothing imports FROM app.js. Instead app.js writes the internals
+ * an extracted chapter still needs onto this ONE shared, non-circular
+ * object (APP), and the extracted module reads APP.<name> at CALL TIME
+ * (inside a function body — never at module-eval time, since app.js
+ * populates APP only after its own top-level chapters have run). Every
+ * OTHER module (including app.js) reaches this same file via an ordinary
+ * relative specifier, so there is exactly one instance of it — no
+ * duplication trap, because it is never anyone's <script> entry point.
+ */
+export const APP = {};

--- a/src/rulebook.js
+++ b/src/rulebook.js
@@ -1,0 +1,183 @@
+/**
+ * rulebook.js — Rental Wrangler Design-System Catalog (moved from app.js
+ * APP-12 · DESIGN-SYSTEM CATALOG, 2026-07-24 module split).
+ * ----------------------------------------------------------------------------
+ * The tabbed Rulebook: RB_FOUNDATION = the primitives the rules are built
+ * FROM (type, color, form, surfaces, motion…); RB_TABS = the IA that groups
+ * every rule + foundation into tabs. Pure relocation: same functions, same
+ * behavior, just callable via import.
+ *
+ * RULE_META and state still live in app.js — read via the APP registry
+ * (see src/internals.js for why a direct `import ... from '../app.js'`
+ * would be unsafe here).
+ */
+import { esc } from './format.js';
+import { I } from '../icons.js';
+import { APP } from './internals.js';
+
+/* The Rulebook grew from "stamped element rules" (R0–R24) into the WHOLE
+   design system. RB_FOUNDATION = the primitives the rules are built FROM (type,
+   color, form, surfaces, motion…) — NOT data-r stamped, they're the tokens &
+   guidelines. RB_TABS = the IA that groups every rule + foundation into tabs.
+   Foundation row = [tag, name, spec/token, when/why, exampleHTML]. */
+const rbSw = (bg, name, note, ink = '#fff') =>
+  `<span class="rb-sw" style="background:${bg};color:${ink}">${name ? `<b>${name}</b>` : ''}${note ? `<i>${note}</i>` : ''}</span>`;
+export const RB_FOUNDATION = {
+  // ── TYPE ──
+  'type-display': ['Aa', 'Display · stamped', "'Saira Condensed' · 600–800 · UPPERCASE · +1–2px tracking",
+    'The yard “stamped-steel” voice: wordmark, column tabs, KPI labels, section headers, ignition buttons.',
+    `<span style="font-family:'Saira Condensed',sans-serif;text-transform:uppercase;letter-spacing:1.6px;font-weight:800;font-size:1.3529rem;color:var(--txt)">Clock In · Wrangle</span>`],
+  'type-body': ['Aa', 'Body', "'Geist' (var(--font)) · 400–700",
+    'Everything you read: row text, field values, descriptions. Quiet, legible, never stamped.',
+    `<span style="font-size:0.8235rem;color:var(--txt)">Rugged equipment, rented right — the body face carries the content.</span>`],
+  'type-mono': ['‹›', 'Mono', 'ui-monospace · 10–12px · txt-3',
+    'Code + debug references only: the Inspector tag and rulebook builder names.',
+    `<code style="font-family:ui-monospace,monospace;font-size:0.7059rem;color:var(--txt-3)">UNITS › INSPECTION › “Passed”</code>`],
+  'type-scale': ['#', 'Size scale', '28 · 15 · 13 · 12 · 11 · 10 · 9.5px',
+    'Bigger = identity/value (28 KPI · 15 popup title). 12–13 = content. ≤11 = stamped micro-labels & counters. ONE size (11px) for every status badge.',
+    `<span style="display:flex;align-items:baseline;gap:13px;flex-wrap:wrap;color:var(--txt)"><span style="font-size:1.6471rem;font-weight:800">28</span><span style="font-size:0.8824rem;font-weight:700">15</span><span style="font-size:0.7647rem">13</span><span style="font-size:0.7059rem">12</span><span style="font-family:'Saira Condensed';text-transform:uppercase;letter-spacing:1px;font-size:0.6471rem;font-weight:700">11 label</span><span style="font-size:0.5588rem;color:var(--txt-3)">9.5</span></span>`],
+  'type-weight': ['B', 'Weight', '800 · 700 · 600 · 400',
+    '800 stamped identity · 700 titles & labels · 600 strong body · 400 body.',
+    `<span style="display:flex;gap:16px;align-items:baseline;color:var(--txt)"><span style="font-weight:800">800</span><span style="font-weight:700">700</span><span style="font-weight:600">600</span><span style="font-weight:400">400</span></span>`],
+  // ── COLOR ──
+  'color-accent': ['●', 'Accent · safety orange', '--accent #ff7a1a (+ --on-orange ink)',
+    'ONE orange, ONE meaning: the selected tab · ignition · primary action. Never decorative.',
+    rbSw('var(--accent)', 'Accent', 'selected · ignition', 'var(--on-orange)')],
+  'color-status': ['◐', 'Status palette', '--green / --yellow / --red / --blue / --navy / --purple / --gray',
+    'Registry status colors — each carries a fixed meaning on every card (Passed · caution · danger · link…).',
+    ['var(--green)', 'var(--yellow)', 'var(--red)', 'var(--blue)', 'var(--navy)', 'var(--purple)', 'var(--gray)'].map((c) => `<span class="rb-sw" style="background:${c}"></span>`).join('')],
+  'color-semantic': ['▣', 'Action-color law', 'commit = blue · money = green · danger = red',
+    'Action INTENT, not status: blue commits/saves · green takes money · solid red confirms destructive.',
+    rbSw('var(--blue)', 'Commit') + rbSw('var(--green)', 'Money') + rbSw('var(--red)', 'Danger')],
+  'color-neutral': ['▤', 'Neutrals', '--txt / --txt-2 / --txt-3 · --line',
+    '3-step text hierarchy on steel; lines separate without shouting.',
+    `<span class="rb-sw" style="background:var(--txt);color:#000"><b>Txt</b></span><span class="rb-sw" style="background:var(--txt-2);color:#000"><b>Txt-2</b></span><span class="rb-sw" style="background:var(--txt-3)"><b>Txt-3</b></span><span class="rb-sw" style="background:var(--line)"><b>Line</b></span>`],
+  'color-tan': ['✶', 'Wrangler tan', '--tan #c2925a / --tan-deep (yard theme)',
+    'The light ranch seasoning — worn leather for saddle-stitch dividers & tiny touches. Restrained.',
+    rbSw('var(--tan,#c2925a)', 'Tan', 'saddle-stitch', '#1a1205')],
+  'color-ec-red': ['⚠', 'ec-red · flagging glow', 'fill: color-mix(--red 65%, white) · shadow: 0 0 3px --red, 0 0 7px (--red 60%+transparent)',
+    'Official treatment for EVERY flagging-red signal — text names/pills/flags/headers, borders, dots/bars. Three knobs in style.css .ec-red group: fill % (65), inner glow (3px), outer halo (7px / 60%). Never use pure --red alone on flagging text.',
+    `<span style="-webkit-text-fill-color:color-mix(in srgb,var(--red) 65%,white);text-shadow:0 0 3px var(--red),0 0 7px color-mix(in srgb,var(--red) 60%,transparent);font-weight:700;font-size:0.7647rem;letter-spacing:.5px">TUCKER FONTENOT · No Card · $0.30 overdue</span>`],
+  // ── FORM ──
+  'radius': ['◳', 'Radius', '--radius 14–16 · --chip-radius 11–12 · 8–10 controls · 999 pills',
+    'Cards/popups softest · chips medium · controls tight · pills & counters full-round · rings/avatars circles.',
+    `<span style="display:flex;gap:8px;align-items:center"><span class="rb-surf" style="border-radius:16px">16</span><span class="rb-surf" style="border-radius:12px">12</span><span class="rb-surf" style="border-radius:8px">8</span><span class="rb-surf" style="border-radius:999px">999</span></span>`],
+  'elevation': ['☁', 'Elevation', '--shadow (float) · --chip-shadow · accent glow',
+    'Two depths: cards/popups float deep; chips/rows lift gently. Pop-ups & menus add the orange halo ring.',
+    `<span style="display:flex;gap:12px"><span class="rb-surf" style="box-shadow:var(--shadow)">float</span><span class="rb-surf" style="box-shadow:var(--chip-shadow)">chip</span><span class="rb-surf" style="box-shadow:0 0 0 2px var(--accent-line),0 0 22px -8px var(--accent)">glow</span></span>`],
+  'spacing': ['▦', 'Spacing', 'grid 12 · list 7 · section pad 12 · row pad 9–11',
+    'Tight, dense yard data — generous enough to scan, never airy.',
+    `<span style="display:flex;align-items:center;color:var(--txt-3);font-size:0.6471rem;gap:8px"><span style="display:flex;gap:12px"><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span><span style="width:14px;height:14px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:3px"></span></span>12px gap</span>`],
+  'motion': ['↻', 'Motion', '.12s controls · .15s surfaces · .5s rings/timeline',
+    'Fast, functional. Keyframes: attnGlow (flash) · plateIn (login) · flagPulse · rwLint. prefers-reduced-motion respected everywhere.',
+    `<span class="pill c-blue" style="animation:attnGlow 1.1s ease-in-out infinite;border-radius:10px"><span class="t">flash</span></span>`],
+  // ── SURFACES ──
+  'surface-bg': ['▢', 'App background', '--bg · yard: orange dawn-glow + mill texture',
+    'The yard floor everything floats on; the header & bottom bar sit transparent over it.',
+    `<span class="rb-surf" style="background:var(--bg);width:100%;height:34px"></span>`],
+  'surface-panel': ['▢', 'Panel', '--panel / --panel-2',
+    'Sub-surfaces: search bars, chips, dashboard stats, the action chip-trays.',
+    `<span class="rb-surf" style="background:var(--panel);width:100%;height:34px"></span>`],
+  'surface-card': ['▢', 'Card / plate', '--card · radius · --shadow',
+    'The column plate. Yard theme = steel gradient + hazard-stripe top + corner rivets.',
+    `<span class="rb-surf" style="background:var(--card);width:100%;height:38px;position:relative;overflow:hidden;justify-content:flex-start;padding-left:14px"><span style="position:absolute;top:0;left:0;right:0;height:5px;background:repeating-linear-gradient(135deg,var(--yellow,#f5c542) 0 13px,#14181d 13px 26px)"></span>card</span>`],
+  'surface-section': ['▢', 'Section', '.section · --panel · centered header · status-tinted',
+    'Sub-cards inside a record; the header + border follow the live status (sec-green/yellow/red).',
+    `<span class="rb-surf" style="background:var(--panel);border-color:color-mix(in srgb,var(--green) 45%,transparent);width:100%;height:34px"></span>`],
+  'surface-anchored': ['▢', 'Anchored ring', '#18b6ff neon ring',
+    'An opened record glows neon blue — the “you are here” signal (distinct from orange selection).',
+    `<span class="rb-surf" style="background:var(--card);width:100%;height:34px;border-color:#18b6ff;box-shadow:0 0 0 2px rgba(24,182,255,.55)"></span>`],
+  'surface-row': ['▢', 'Row chip', '.row · --panel · row-bg viz',
+    'List items are chips; a faint full-bleed visualization can tint a row by its data.',
+    `<span class="rb-surf" style="background:var(--panel);width:100%;height:30px"></span>`],
+  // ── UPLOAD / CAPTURE ──
+  'upload-capture': ['⌖', 'Capture drop', '.cap-drop · dashed · camera / site',
+    'Photo/selfie/site captures (inspections, deliveries). When transport is set the popup tops with the address + map pin.',
+    `<span class="cap-drop" style="min-height:46px">${I.camera || ''}<span>Capture photo</span></span>`],
+  // ── HEADERS / CONTAINERS ──
+  'header-section': ['▭', 'Section header', '.section>h4 · centered · 11px UPPER',
+    'Centered stamped label; right-side flags pin absolutely so the title stays true-center.',
+    `<span style="display:block;text-align:center;font-size:0.6471rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--txt-3)">Inspection</span>`],
+  'header-popup': ['▭', 'Popup header', '.popup-head · icon + h3(15) + ✕',
+    'Every overlay leads with an accent icon, a 15px title, and the close on the right.',
+    `<span style="display:flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:9px;padding:7px 10px;background:var(--panel)"><span style="color:var(--accent);display:inline-flex">${I.doc || ''}</span><b style="font-size:0.8235rem">Popup title</b></span>`],
+  'overlay-popup': ['◳', 'Pop-up / overlay', '.overlay scrim + .popup',
+    'Centered modal: 50%-black scrim · panel with the orange border + glow halo · max 92vw/86vh · internal scroll.',
+    `<span class="rb-surf" style="background:var(--panel);border:1px solid var(--accent);box-shadow:0 0 0 2px var(--accent-line),0 0 20px -6px var(--accent);width:130px;height:42px;border-radius:12px">modal</span>`],
+  'menu-dropdown': ['▾', 'Menu', '.dropdown-menu / .ctx-menu',
+    'Floating orange-ringed lists: the sort/filter dropdowns and the R20 right-click menu.',
+    `<span style="display:inline-block;background:var(--panel);border:1px solid var(--accent);border-radius:11px;box-shadow:0 0 0 2px var(--accent-line);padding:5px;min-width:128px"><span style="display:block;padding:5px 9px;border-radius:8px;font-size:0.7059rem;color:var(--txt-2)">Sort · Name</span><span style="display:block;padding:5px 9px;border-radius:8px;font-size:0.7059rem;color:var(--accent);background:var(--panel-2)">Sort · Status</span></span>`],
+  'grid': ['▥', 'Yard grid', '.grid · 3 equal cols · 12px gap',
+    'The fixed 3-column layout (Units · Rentals · Customers). Reflows 3→2→1 by width on phones (M0–M3); never squishes below the desktop floor.',
+    `<span style="display:grid;grid-template-columns:repeat(3,1fr);gap:6px;width:150px"><span class="rb-surf" style="height:30px"></span><span class="rb-surf" style="height:30px"></span><span class="rb-surf" style="height:30px"></span></span>`],
+  // ── DATA VIZ ──
+  'data-kpi': ['◎', 'KPI rings', '.kpi-ring · concentric progress',
+    'The header rings: Apple-style progress, each colored by its value band, number + stamped role label below.',
+    `<span style="display:inline-grid;place-items:center;width:38px;height:38px;border-radius:50%;background:conic-gradient(var(--green) 72%,var(--track) 0)"><span style="display:grid;place-items:center;width:27px;height:27px;border-radius:50%;background:var(--bg);font-size:0.5882rem;font-weight:800;color:var(--txt)">9</span></span>`],
+  'data-gauge': ['▰', 'Activity gauge', '.active-bar.bipolar · steel data-plate',
+    'A bipolar −100…+100 track (customer health); a hazard overlay marks the deep-danger end.',
+    `<span style="display:inline-block;width:140px;height:14px;border-radius:7px;overflow:hidden;background:var(--track)"><span style="display:block;height:100%;width:64%;background:linear-gradient(90deg,var(--red),var(--orange),var(--yellow),var(--green))"></span></span>`],
+  // ── BEHAVIORS ──
+  'behavior-preview': ['◉', 'Hover previews', 'the eye system · per-device toggle',
+    'Hovering most elements shows a rich preview; a row eye + bottom-bar eye toggle it. Off = every eye runs red.',
+    `<span class="pill c-gray"><span class="t">${I.eye || ''} preview</span></span>`],
+};
+/* The tabbed IA — every rule (R…) + foundation (f…) lands in exactly one tab. */
+export const RB_TABS = [
+  { id: 'foundation', label: 'Foundations', intro: 'The primitives every rule is built from — type, color, form, motion. Change these and the whole yard shifts.',
+    items: [{ f: 'type-display' }, { f: 'type-body' }, { f: 'type-mono' }, { f: 'type-scale' }, { f: 'type-weight' },
+            { f: 'color-accent' }, { f: 'color-status' }, { f: 'color-semantic' }, { f: 'color-neutral' }, { f: 'color-tan' },
+            { f: 'radius' }, { f: 'elevation' }, { f: 'spacing' }, { f: 'motion' }] },
+  { id: 'surfaces', label: 'Surfaces', intro: 'Backgrounds & containers — the steel everything is bolted to.',
+    items: [{ f: 'surface-bg' }, { f: 'surface-panel' }, { f: 'surface-card' }, { f: 'surface-section' }, { f: 'surface-anchored' }, { f: 'surface-row' }] },
+  { id: 'containers', label: 'Containers', intro: 'Title chips, sections, headers, pop-ups, menus and the layout grid.',
+    items: [{ r: 'R10' }, { r: 'R11' }, { r: 'R12' }, { f: 'header-section' }, { f: 'header-popup' }, { f: 'overlay-popup' }, { f: 'menu-dropdown' }, { f: 'grid' }] },
+  { id: 'pills', label: 'Pills & Flags', intro: 'The status vocabulary — every colored chip and exactly what it’s allowed to mean.',
+    items: [{ r: 'R1' }, { r: 'R2' }, { r: 'R3' }, { r: 'R3b' }, { r: 'R4' }, { r: 'R4b' }, { r: 'R9' }, { r: 'R9b' }] },
+  { id: 'fields', label: 'Fields & Adds', intro: 'Where you type, link, and add.',
+    items: [{ r: 'R5' }, { r: 'R5b' }, { r: 'R5c' }, { r: 'R6' }, { r: 'R7' }, { r: 'R8' }, { r: 'R14' }, { r: 'R22' }, { r: 'R31' }, { r: 'R33' }] },
+  { id: 'actions', label: 'Actions', intro: 'Buttons that DO something — colored by intent.',
+    items: [{ r: 'R17' }, { r: 'R18' }, { r: 'R24' }, { r: 'R26' }, { r: 'R28' }, { r: 'R29' }, { r: 'R32' }] },
+  { id: 'upload', label: 'Upload & Capture', intro: 'Add-file zones and photo/site captures.',
+    items: [{ r: 'R21' }, { f: 'upload-capture' }] },
+  { id: 'data', label: 'Data & Behaviors', intro: 'Visualizations, plus the app’s behaviors — it flashes instead of erroring, right-clicks, tooltips, and self-lints.',
+    items: [{ r: 'R16' }, { r: 'R15' }, { r: 'R35' }, { r: 'R36' }, { r: 'R13' }, { f: 'data-kpi' }, { f: 'data-gauge' }, { r: 'R19' }, { r: 'R25' }, { r: 'R20' }, { r: 'R23' }, { f: 'behavior-preview' }, { r: 'R0' }] },
+
+  { id: 'windows', label: 'Windows', intro: 'Every pop-up window in the app, by kind. Expand one for a live preview, its fields, and a copy-paste edit reference — your map to wrangle any screen.', items: [] },
+];
+/* structural fallbacks so hovering containers also names their rule */
+const CLASS_RULE = [
+  ['.c-titlecard', 'R10'], ['.nsec', 'R12'], ['.hvals', 'R13'], ['.history', 'R13'],
+  ['.timeline', 'R16'], ['.jnode', 'R15'], ['.jseg', 'R15'], ['.journey', 'R15'],
+  ['.seg', 'R14'], ['.kv.derived', 'R8'], ['.derived', 'R8'], ['.file-drop', 'R21'], ['.datefield', 'R22'], ['.dfunnel', 'R35'], ['.swipe-track', 'R36'], ['.section', 'R11'],
+];
+export function ruleOf(target) {
+  if (!target || !target.closest) return null;
+  const stamped = target.closest('[data-r]');
+  if (stamped) return { r: stamped.dataset.r, el: stamped };
+  for (const [sel, r] of CLASS_RULE) { const m = target.closest(sel); if (m) return { r, el: m }; }
+  const fam = target.closest('.pill, .add-field, .flag, .linkname, .inv-line-link, .req');
+  if (fam) return { r: null, el: fam };            // lint family, unstamped = violation
+  return null;
+}
+/* human-readable reference: CARD › SECTION › "text" — what Jac pastes to debug */
+export function refPath(el) {
+  const card = el.closest('[data-card]')?.dataset.card;
+  const sec = el.closest('.section')?.querySelector('h4')?.textContent.replace(/\s+/g, ' ').trim().slice(0, 26);
+  const txt = (el.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 28);
+  return [card ? card.toUpperCase() : null, sec || null, txt ? `“${txt}”` : null].filter(Boolean).join(' › ');
+}
+export function onInspectMove(e) {
+  if (!APP.state.inspect) return;
+  let t = document.getElementById('rw-tip');
+  if (!t) { t = document.createElement('div'); t.id = 'rw-tip'; document.body.appendChild(t); }
+  const hit = ruleOf(e.target);
+  if (!hit || e.target.closest('#rw-tip, .overlay')) { t.style.display = 'none'; return; }
+  const meta = hit.r ? APP.RULE_META[hit.r] : null;
+  t.innerHTML = hit.r
+    ? `<b>${esc(hit.r)}</b> ${esc(meta ? meta[0] : '')}<span class="rt-b">${esc(meta ? meta[1] : '')}</span>`
+    : `<b class="bad">⚠ NO RULE</b> bypassed the builders (R0)`;
+  t.style.display = 'block';
+  t.style.left = Math.min(e.clientX + 14, window.innerWidth - 250) + 'px';
+  t.style.top = Math.min(e.clientY + 18, window.innerHeight - 56) + 'px';
+}

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@ const TOKEN = (self.location.search.match(/v=([\w-]+)/) || [])[1] || 'dev';
 const CACHE = 'rw-shell-' + TOKEN;
 const SHELL = ['./', './index.html', './app.js', './style.css', './config.js', './data.js',
   './cascade.js', './icons.js', './icons-anim.js', './agreements.js', './service-countdown.js',
-  './src/format.js', './src/glitch-capture.js', './src/card-graph-view.js',
+  './src/format.js', './src/glitch-capture.js', './src/card-graph-view.js', './src/internals.js', './src/rulebook.js',
   './rule-usage.js', './manifest.webmanifest'];
 const SHELL_SET = new Set(SHELL.map((p) => new URL(p, self.location.href).pathname));
 /* Standalone PUBLIC pages (SMS-compliance + business info) are their OWN documents, NOT the SPA

--- a/sw.js
+++ b/sw.js
@@ -12,6 +12,7 @@ const TOKEN = (self.location.search.match(/v=([\w-]+)/) || [])[1] || 'dev';
 const CACHE = 'rw-shell-' + TOKEN;
 const SHELL = ['./', './index.html', './app.js', './style.css', './config.js', './data.js',
   './cascade.js', './icons.js', './icons-anim.js', './agreements.js', './service-countdown.js',
+  './src/format.js',
   './rule-usage.js', './manifest.webmanifest'];
 const SHELL_SET = new Set(SHELL.map((p) => new URL(p, self.location.href).pathname));
 /* Standalone PUBLIC pages (SMS-compliance + business info) are their OWN documents, NOT the SPA

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@ const TOKEN = (self.location.search.match(/v=([\w-]+)/) || [])[1] || 'dev';
 const CACHE = 'rw-shell-' + TOKEN;
 const SHELL = ['./', './index.html', './app.js', './style.css', './config.js', './data.js',
   './cascade.js', './icons.js', './icons-anim.js', './agreements.js', './service-countdown.js',
-  './src/format.js',
+  './src/format.js', './src/glitch-capture.js',
   './rule-usage.js', './manifest.webmanifest'];
 const SHELL_SET = new Set(SHELL.map((p) => new URL(p, self.location.href).pathname));
 /* Standalone PUBLIC pages (SMS-compliance + business info) are their OWN documents, NOT the SPA

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@ const TOKEN = (self.location.search.match(/v=([\w-]+)/) || [])[1] || 'dev';
 const CACHE = 'rw-shell-' + TOKEN;
 const SHELL = ['./', './index.html', './app.js', './style.css', './config.js', './data.js',
   './cascade.js', './icons.js', './icons-anim.js', './agreements.js', './service-countdown.js',
-  './src/format.js', './src/glitch-capture.js',
+  './src/format.js', './src/glitch-capture.js', './src/card-graph-view.js',
   './rule-usage.js', './manifest.webmanifest'];
 const SHELL_SET = new Set(SHELL.map((p) => new URL(p, self.location.href).pathname));
 /* Standalone PUBLIC pages (SMS-compliance + business info) are their OWN documents, NOT the SPA

--- a/tools/gen-code-map.mjs
+++ b/tools/gen-code-map.mjs
@@ -36,6 +36,10 @@ const FILES = [
   { rel: 'service-countdown.js', key: 'SVC' },
   { rel: 'agreements.js', key: 'AGR' },
   { rel: 'icons.js', key: 'ICON' },
+  // src/*.js — chapters extracted out of app.js (module split, 2026-07-24). Each currently
+  // carries no internal ═══ banner of its own (avoids re-stamping collisions with the
+  // APP-NN id it was moved from); add a { rel, key } entry here for every new file.
+  { rel: 'src/format.js', key: 'FMT' },
 ];
 
 const RULE = /═{6,}/;                 // a full-width ═══ banner rule line

--- a/tools/gen-code-map.mjs
+++ b/tools/gen-code-map.mjs
@@ -42,6 +42,8 @@ const FILES = [
   { rel: 'src/format.js', key: 'FMT' },
   { rel: 'src/glitch-capture.js', key: 'GLC' },
   { rel: 'src/card-graph-view.js', key: 'GVW' },
+  { rel: 'src/internals.js', key: 'INT' },
+  { rel: 'src/rulebook.js', key: 'RBK' },
 ];
 
 const RULE = /═{6,}/;                 // a full-width ═══ banner rule line

--- a/tools/gen-code-map.mjs
+++ b/tools/gen-code-map.mjs
@@ -40,6 +40,7 @@ const FILES = [
   // carries no internal ═══ banner of its own (avoids re-stamping collisions with the
   // APP-NN id it was moved from); add a { rel, key } entry here for every new file.
   { rel: 'src/format.js', key: 'FMT' },
+  { rel: 'src/glitch-capture.js', key: 'GLC' },
 ];
 
 const RULE = /═{6,}/;                 // a full-width ═══ banner rule line

--- a/tools/gen-code-map.mjs
+++ b/tools/gen-code-map.mjs
@@ -41,6 +41,7 @@ const FILES = [
   // APP-NN id it was moved from); add a { rel, key } entry here for every new file.
   { rel: 'src/format.js', key: 'FMT' },
   { rel: 'src/glitch-capture.js', key: 'GLC' },
+  { rel: 'src/card-graph-view.js', key: 'GVW' },
 ];
 
 const RULE = /═{6,}/;                 // a full-width ═══ banner rule line


### PR DESCRIPTION
## Summary

Pure mechanical refactor — no behavior, feature, or design changes. Extracts 4 of app.js's 41 chapters (`docs/CODE-MAP.md`/`docs/code-map.generated.md`) into standalone ES modules under `src/`, gate-green after every single extraction. **Not merged — for review.**

| Chapter | Moved to | Lines | Notes |
|---|---|---|---|
| APP-02 §1 Utilities & Formatting | `src/format.js` | ~23 | `$, el, esc, money, money2, num, TODAY, dayDiff, refreshToday, debounce, SINGULAR`. Zero app.js dependencies. |
| APP-01 §0.7 Glitch Capture | `src/glitch-capture.js` | ~33 | `ERR_LOG, logErr, wranglerIssueUrl` + the `window.addEventListener`/`console.error` install (still runs first thing). Zero app.js dependencies. |
| APP-23 §13.3 Card Graph View (retired) | `src/card-graph-view.js` | ~43 | Time-window helpers (`GV_WIN_OPTS, loadGvWin, saveGvWin, gvWinLabel, gvWinCutoff, gvBuckets`) that survive under the chapter's own "RETIRED" banner — still used by the Graph Carousel. Only depends on `format.js`. |
| APP-12 Design-System Catalog | `src/rulebook.js` + `src/internals.js` | ~168 | `RB_FOUNDATION, RB_TABS, ruleOf, refPath, onInspectMove`. First extraction needing something app.js still owns (`state`, `RULE_META`) — see architectural note below. |

Each extraction is its own commit, gate-green (full suite) before moving to the next. A pointer banner (no code) is left at each old chapter location — same pattern already established by `APP-08`'s `icons.js` pointer — so every other chapter's `APP-NN` id keeps its position in `tools/gen-code-map.mjs`'s positional numbering (removing a banner outright shifts everyone after it, which fails `gen-code-map --check`).

## Important architectural discovery: circular imports back to app.js are unsafe here

`index.html` loads the app as `app.js?v=<cachebust-token>` (the shared `?v=` token CLAUDE.md requires). **ES modules cache/dedupe by exact resolved URL** — so a sibling module doing `import {...} from '../app.js'` (no query string) resolves to a **different URL** than the one already loaded, and the browser silently evaluates a **second, fully independent copy of the entire app** (its own `IDX`, its own `state`, its own `boot()` call) instead of sharing the real one.

I hit this for real: an initial attempt to extract APP-04 (Derivations/money engine) into `src/derivations.js` imported `IDX`/`rentalUnits`/`isActiveMember`/etc. back from `'../app.js'`. `node ci/smoke.mjs` passed clean (nothing throws — the phantom copy boots fine too), but `node ci/logic-test.mjs` failed: `IDX.unit.get(...)` inside the moved function silently read the **phantom copy's empty indexes** instead of the real, live one, so rental prices computed as `null`/`$0`. No error, just wrong data — exactly the kind of thing a "boots clean" check can't catch. I reverted that extraction (`git checkout` before it was ever committed) and instrumented a one-line proof (`console.log` counter in app.js's own top-level body) that confirmed **two separate module evaluations** — see commit `1c7cf7c`'s message for the full trace.

**Fix used for APP-12** (validated, gate-green): `src/internals.js` exports one shared object, `APP = {}`. app.js does `Object.assign(APP, { RULE_META, state })` right before its own `boot()` call (i.e. after every one of its own chapters has already run). `src/rulebook.js` reads `APP.state` / `APP.RULE_META` **inside its function bodies** (never at module-eval time). Every module reaches `internals.js` via an ordinary relative specifier — it's never anyone's `<script>` entry point, so there's exactly one instance, no duplication trap. This pattern is documented in `src/internals.js` and is ready to reuse for further extractions.

## Skipped chapters (and why)

- **APP-27 Mr. Wrangler / APP-28 Wrangler Acts / APP-34 Stripe** — CLAUDE.md and the code-map both flag these "security/auth-sensitive — keep edits on the main session." A pure relocation still touches every line of money/AI-action code; left alone per that instruction.
- **APP-26 RB-Windows catalog / APP-25 Overlays & Boards** — `ci/check-window-catalog.mjs` greps `app.js` specifically for `buildPopupEl`/`WINDOW_CATALOG`; moving either breaks that gate unless the checker script itself is also updated. Left as a follow-up decision rather than quietly widening this PR's blast radius.
- **APP-13 List Rows / APP-30 Render Pipeline / APP-32 Drag & Drop / APP-33 Actions-Mutations** (and similar builder-call-heavy chapters) — `ci/gen-rule-usage.mjs` also greps `app.js` only, for `data-r` builder call sites (`actionPill(`, `statusPill(`, etc.); several of these chapters are full of exactly those calls. Same category as above — extractable, but needs a coordinated checker-script update first.
- **Everything else** (APP-03 Indexes, APP-07 State, APP-09 Settings Board, APP-16 Detail Renderers, APP-19/20 Header+KPI, APP-22 Team Dock, APP-37 Backend Sync, APP-38+ Instant Cache/Phone-Identity/Scan-to-Log, etc.) — all depend on symbols still resident in app.js and would need the `src/internals.js` registry pattern (more `Object.assign` entries + `APP.` prefixing at each call site). Mechanically straightforward now that the pattern is proven, but each one adds real review surface (a missed export/typo is a silent wrong-answer bug, not a crash — see the discovery above), so I stopped at a clean, fully-verified subset rather than rushing a long tail of these in one pass.

## Gate status (every extraction, individually)

`node ci/smoke.mjs` (boots clean) · `node ci/logic-test.mjs` (**706/706**) · `node ci/lease-test.mjs` · `node ci/lease-deploy-test.mjs` · `node ci/promote-test.mjs` · `node ci/cachebust-test.mjs` · `node ci/gen-rule-usage.mjs --check` · `node ci/check-window-catalog.mjs` · `node tools/gen-code-map.mjs --check` · `node ci/check-cachebust.mjs` (after `node tools/bump-cachebust.mjs` bumped `?v=` `20260721a` → `20260724a`, since `app.js` is a served/versioned file).

`tools/gen-code-map.mjs`'s `FILES` list and `sw.js`'s offline-shell `SHELL` precache list were both updated to include every new `src/*.js` file.

## Test plan

- [x] All CI gates green locally, after every commit (see above)
- [ ] Human review of the `src/internals.js` registry pattern before it's reused further
- [ ] Decide (outside this PR) whether `ci/gen-rule-usage.mjs` / `ci/check-window-catalog.mjs` should scan `src/*.js` too, to unblock the remaining builder-heavy chapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1EAY3d3fehnTBqoCQbjhc


---
_Generated by [Claude Code](https://claude.ai/code/session_01A1EAY3d3fehnTBqoCQbjhc)_