### PR TITLE
skills: fold the locked atom decisions into style + wrangler-style

### DIFF
--- a/.claude/skills/style/SKILL.md
+++ b/.claude/skills/style/SKILL.md
@@ -1,34 +1,41 @@
 ---
 name: style
 description: >-
-  The MEASURABLE rulebook for Rental Wrangler's UI — numerical rules and
-  guidelines that any control, chip, section, form row, or layout must satisfy,
-  so elements read as one family. It does NOT pick fonts or hex values (those are
-  design decisions that live in the app tokens / style.css and can change) — it
-  gives the numbers those decisions must hit: one control height, one baseline,
-  the size ladder, two radii, weight-with-a-reason, WCAG contrast floors, the
+  The MEASURABLE rulebook for UI — project-agnostic numerical rules and guidelines
+  that any control, chip, section, form row, or layout must satisfy, so elements
+  read as one family. It does NOT pick fonts or hex values (those are design
+  decisions that live in a project's tokens and can change) — it gives the numbers
+  those decisions must hit: one control height, one baseline, the size ladder,
+  one shape per control family, weight-with-a-reason, WCAG contrast floors, the
   colour-blind separation threshold, the 60-30-10 accent budget, and the two
   state functions (colour = state, fill = today). Reach for it on "line these up",
   "is this readable", "which two colours are too close", "make this a proper
   chip/gate/stamp", "why does this look unaligned". The brand *decisions* (the
-  specific typefaces, the accent hex, any signature) live in style.css tokens and
-  are free to change; this skill only enforces the measurable constraints on them.
+  specific typefaces, the accent hex, any signature) live in the project's tokens
+  and are free to change; this skill only enforces the measurable constraints on
+  them. For Rental Wrangler, pair it with `wrangler-style`, which holds those
+  decisions.
 ---
 
 # Style — numerical rules & guidelines
 
 This skill is a **rulebook, not a decision-maker.** It never says "use this font"
-or "use this orange" — those are design decisions that live in `style.css` tokens,
+or "use this orange" — those are design decisions that live in a project's tokens,
 and they're allowed to change. This skill
 says **what numbers any such decision has to satisfy** so the result reads as one
 intentional system instead of chaos. Every rule below is checkable — with a ruler,
 a ratio function, or a simulation — not by eye.
 
+**It is deliberately project-agnostic.** Nothing here names a hex, a typeface, or a
+product. The rules are guidelines that any UI can be held to; a project supplies the
+values and its own component vocabulary.
+
 **Division of labour:** the **brand decisions** — which typefaces, the palette, the
-component looks, any signature, the voice — live in the **`wrangler-style`** skill
-(with the app's `style.css` / `app.js` as the implementation). **This skill** holds
-the measurable *constraints* those decisions must pass. Run **both** on any UI; when
-a decision and a rule conflict, the decision moves — not the rule.
+component looks, any signature, the voice — live in a project's decisions skill (for
+Rental Wrangler that's **`wrangler-style`**, with `style.css` / `app.js` as the
+implementation). **This skill** holds the measurable *constraints* those decisions
+must pass. Run **both** on any UI; when a decision and a rule conflict, the decision
+moves — not the rule.
 
 ---
 
@@ -42,8 +49,25 @@ a decision and a rule conflict, the decision moves — not the rule.
 - **One size ladder.** Text sizes come from a fixed set only — e.g.
   **28 · 15 · 13 · 12 · 11 · 10 · 9.5 px** (value · title · content · field · label
   & every chip · small · finest). **No value off the ladder.** A badge is 11, always.
-- **Two radii.** **Actions = pill (999).** **Statuses = chip (one small value,
-  ~5–8).** Exactly two families of radius; shape signals action-vs-state pre-read.
+- **One shape per control family — and never shared.** Give each *family* of inline
+  control its own radius, so a control's **silhouette** answers "what kind of thing is
+  this?" before colour or text does. The rule is the **partition**, not the numbers:
+  every family owns exactly one radius, no family borrows another's, and the count stays
+  **small (3–5)** — past that, shape stops being a signal and becomes noise.
+  A working set, by what the control *does*:
+  | Family | Shape | Reads as |
+  |---|---|---|
+  | **State** you read | squared (~0–3) | a flat plate of information |
+  | **Opener** that reveals something | top corners rounded, bottom square (~5 5 0 0) | the top half of an already-open panel |
+  | **Record** you can open | rounded (~6–10) | an object with an identity |
+  | **Action** you fire | pill (999) | a button, unmistakably |
+  Which family takes which radius — and whether a project needs the opener at all — is a
+  **decision**, not a rule. Two constraints bind it: the **container** radius (cards,
+  panels, sheets) is a *separate* value that must not collide with any control radius, and
+  a shape only earns a slot if it maps to a distinct **behaviour** — not a distinct look.
+  *(Supersedes the earlier "exactly two radii — pill for actions, chip for statuses" line;
+  that partition was too coarse once triggers and records both needed to be distinguishable
+  from plain state.)*
 - **Weight has a reason — cap the weights.** At most **three** used: **bold** = a
   name or a value you read · one **stamped** weight = labels · **regular** = the
   rest. If something's bold, it's because it carries meaning. Never "bold for feel."
@@ -78,8 +102,8 @@ colour-vision deficiency (≈8% of men). Test it, don't trust normal-vision eyes
 - Simulate **deuteranopia + protanopia** (Machado-2009 severity-1.0 matrices,
   applied to sRGB) and require **Euclidean RGB distance ≥ 90** between the pair,
   under **both** simulations.
-- Data point that set the line: our amber-yellow vs orange scored **77** (too
-  close — reported as confusable) and the fix landed at **103**. So: **77 fails,
+- Data point that set the line: a real amber-yellow vs orange pair scored **77** — reported
+  as confusable by a colour-blind user — and the fix landed at **103**. So: **77 fails,
   ≥90 is the floor, ~100+ is comfortable.**
 - Prefer separating by **lightness** as well as hue — lightness survives CVD; hue
   often doesn't.
@@ -113,23 +137,24 @@ protan = [[0.152,1.053,-0.205],[0.115,0.786,0.099],[-0.004,-0.048,1.052]]
   hoc per renderer: **red > yellow > blue > green > grey.**
 - The bucket→colour mapping and trigger list are **guidelines** (adjust per app);
   the **"one function, no drift"** structure is the rule.
-- **Time-derived state — the schedule/ETA formula** (Trips ETA-Tracker, generalises to any
-  deadline-vs-estimate signal). Two measurable rules so a countdown can't be hand-tuned:
+- **Time-derived state — the schedule/ETA formula.** Applies to any **deadline-vs-estimate**
+  signal: an ordered run of steps, each with a duration, measured against a promised time.
+  Two measurable rules so a countdown can't be hand-tuned:
   - **Cumulative cascade.** For an ordered run of stops: `departure₀ = tripStart`;
     `ETAᵢ = departureᵢ + driveᵢ`; `departureᵢ₊₁ = ETAᵢ + loadᵢ` with **load = 20 min/stop**
     default. Every estimate sums **all** prior drive + load — one slip re-times everything
     below it. (Not a per-row constant.)
   - **Departure clock.** The active row's ETA cell reads the **scheduled departure time until
     `now ≥ departure`**; after that it **counts up** `now − departure` until the go-action
-    (Start) fires. **Miss threshold:** `now > departure` with no Start = an **escalation**
-    event, not a quiet colour flip — the notify audience widens beyond the operator (e.g.
-    manager + sales), because a missed departure is a business problem. (The widened audience
-    is a decision; the `now > departure ⇒ escalate` trigger is the rule.)
+    (the go-action) fires. **Miss threshold:** `now > departure` with no go-action = an
+    **escalation** event, not a quiet colour flip — the notify audience widens beyond the
+    operator, because a missed start is a business problem, not a display state. (Who gets
+    notified is a decision; the `now > departure ⇒ escalate` trigger is the rule.)
   - **One ladder, two clocks.** The SAME state ladder colours **two** facts against **two**
-    targets: the **departure time** (slack vs *leave-time* → "should I leave?") and the
-    **deadline chip** (slack vs *deadline* → "will it make it?"). Same colours, same meanings,
+    targets: the **start time** (slack vs *leave-time* → "should I go?") and the
+    **deadline** (slack vs *deadline* → "will it make it?"). Same colours, same meanings,
     different targets = not double-encoding. Restraint rule: at most **one "next" (blue)** per
-    trip — everything ahead is grey (not-yet), everything behind green (done).
+    run — everything ahead is grey (not-yet), everything behind green (done).
   - **Deadline slack → colour** — the **standard state buckets**, no reassignment, from
     `slack = deadline − ETA` (live, recomputed on every change): **Done** (gate closed) →
     green (overrides all) · `slack < 0` → red (late/overdue) · `0 ≤ slack ≤ 2h` → yellow
@@ -138,7 +163,14 @@ protan = [[0.152,1.053,-0.205],[0.115,0.786,0.099],[-0.004,-0.048,1.052]]
     only**, an on-time pending stop is blue, never green. Still one function; rolls up
     `red > yellow > blue > green`.
 
-## 7. The five named parts — definitions (structural vocabulary)
+## 7. Control archetypes — structural definitions, not a naming mandate
+
+These are the **roles** an inline control can play. A project names them and decides how
+each one *looks* (for Rental Wrangler, in `wrangler-style`); what's structural — and what
+this skill holds you to — is that **each role is exactly one thing and never does two jobs.**
+That single-responsibility split is what lets shape, colour, and fill each stay a reliable
+signal. The set below is a proven partition, not the only possible one.
+
 
 - **Signal** — coloured chip, **read-only** state (colour=state, fill=today) + a
   verbalising word + parent-card icon. Click → teleport to source.
@@ -156,7 +188,8 @@ protan = [[0.152,1.053,-0.205],[0.115,0.786,0.099],[-0.004,-0.048,1.052]]
 ## 8. Pre-ship checklist — every item measurable
 
 - [ ] Every inline control the **same height**; baseline deviation **0**.
-- [ ] All sizes on the **ladder**; **≤3** weights; radii are only **999** or the chip value.
+- [ ] All sizes on the **ladder**; **≤3** weights; every control's radius is **its family's**
+      — no family borrows another's, and the container radius collides with none of them.
 - [ ] **Two** type families (+mono for the one tag); names bold, sentence-case.
 - [ ] Every text/fill pair **≥4.5** (or ≥3 large/UI), computed — in dark **and** light.
 - [ ] Co-occurring status colours **≥90** apart under deuter+protan sim.

--- a/.claude/skills/wrangler-style/SKILL.md
+++ b/.claude/skills/wrangler-style/SKILL.md
@@ -4,11 +4,14 @@ description: >-
   The DECISIONS home for Rental Wrangler's UI — the hard brand/design picks that
   the `style` skill's numbers constrain. This is the true replacement for the old
   jactec-ui skill. Holds the locked steel palette (exact hexes, dark + light), the
-  two type voices, the button taxonomy, the Signal · Gate · Stamp · Ref · Door
-  component vocabulary, the kept-structure layout rules, and the restrained
-  wrangler/ranch voice. Reach for it whenever you build or restyle ANY UI to look
-  up "which colour / which font / how does a chip/gate/stamp/ref/door look / what's
-  our voice". ALWAYS pair it with `style` (the measurable rulebook): every UI
+  two type voices (Archivo body · mono stamped), the FOUR control shapes (squared
+  state · opener · rounded record · pill action), the button taxonomy, the
+  Signal · Gate · Stamp · Ref · Door · Pin · Field component vocabulary, the
+  uniform hover/focus/press rules, the kept-structure layout rules, and the
+  restrained wrangler/ranch voice. Reach for it whenever you build or restyle ANY
+  UI to look up "which colour / which font / which radius / how does a
+  chip/gate/stamp/ref/door/pin look / what's our voice". ALWAYS pair it with
+  `style` (the measurable rulebook): every UI
   decision here must also pass style's numbers, and when a decision and a rule
   conflict, the decision moves — not the rule.
 ---
@@ -36,6 +39,8 @@ Text      --txt #eef2f7 · --txt-2 #aab4c1 · --txt-3 #838e9c
 Accent    --accent #ff7e1f · --on-orange #1a1205   (safety orange; dark ink ALWAYS)
 Status    --green #34d399 · --yellow #eed44b · --red #ff4242 · --red-fill #d63636
           --blue #6394cc · --gray #8b94a3 · --on-red-fill #fdfdfd
+          --red-line  = color-mix(in oklch, var(--red) 78%, var(--txt))
+                        (oklch(from --red .74 .215 h) where supported)
 Action    --commit #2f6fd0 · --on-commit #fdfdfd   (deep blue: Save / +Add / write)
 Leather   --tan #c2925a      (wrangler seasoning — tiny touches only)
 ```
@@ -60,6 +65,12 @@ blocks + pure `#fff` inside them — **strip them on build.**
   separation; softening more breaks green — `#eed44b` is the floor. (Amber `#e0b13a` = 77,
   failed. Jac is colour-blind — this is a gate, don't dim past it.)
 - **`--blue #6394cc`** — muted so it stops fighting the orange (soften-complements).
+- **`--red-line`** (added 2026-07-25 with the atom pass) — the red for **outline** chips.
+  When outline chips lost their tinted backfill (§3), bright `--red #ff4242` on bare
+  `--panel` sat too low to read comfortably; `--red-line` lifts lightness at full chroma to
+  clear ~6:1. **This is not a new colour** under the frozen-palette rule — it is `--red`
+  *derived* (a `color-mix`, refined to `oklch` where supported), so it adds no new hue to
+  the vocabulary and cascades automatically if `--red` ever changes.
 
 **Neutral-text floor (`--txt-3`):** nudged `#717b89` → **`#838e9c`** — the old value read
 only **3.78–4.20** against `--card`/`--card-head` as body text, failing the 4.5 floor. The
@@ -91,9 +102,15 @@ that needs a Signal/Stamp/icon distinction instead — solve it in the component
   "SF Mono", Menlo, Consolas, monospace`), UPPERCASE, ~0.03–0.06em tracking, 700–800.
   Used for: section/field **labels**, **chips** (Signal/Gate/Stamp), KPI micro-labels,
   the eyebrow. (This is the crisp "data-plate stamp" look Jac keeps — not Saira.)
-- **Body voice** — a clean **system sans** (`-apple-system, "Segoe UI", Roboto,
-  system-ui, sans-serif`). Record **names** are body-voice **bold, sentence-case**
-  (not caps). Values / prose are body-voice regular.
+- **Body voice — `Archivo`** (locked 2026-07-25, atom pass): `"Archivo", "Helvetica Neue",
+  -apple-system, "Segoe UI", sans-serif`. A grotesque with a taller x-height and squarer
+  terminals than the system stack or the earlier `Geist` — it holds up better at 12–13px on
+  the dark panels, and sits closer to the stamped mono voice than a humanist face does.
+  Record **names** are body-voice **bold, sentence-case** (not caps); values / prose are
+  body-voice regular.
+  **Fonts are CDN-loaded, never bundled** — shipping this is one line in the Google Fonts
+  `<link>` in `index.html` (weights 400;500;600;700;800). *(Not yet in the shipped app —
+  it lands with the redesign; the design-system kit already loads it.)*
 - **Numbers / IDs / timestamps** — monospace, tabular (`font-variant-numeric:tabular-nums`).
 - Never a third family.
 
@@ -103,18 +120,65 @@ that needs a Signal/Stamp/icon distinction instead — solve it in the component
 = *touchable* · deep-blue `--commit` = *commit* · everything else = plain honest text.
 Nothing ever does two jobs — that's the whole reason Signal, Ref, and Door don't collide.
 
+### 3.0 The four control shapes (locked 2026-07-25 — this is our answer to `style` §1)
+
+Shape carries the **family**, so a control's silhouette says what kind of thing it is before
+colour or text does. **This supersedes the old "two radii / one 7px chip radius" line** —
+that partition couldn't tell a trigger from a record from plain state.
+
+| Token | Value | Family | Who takes it |
+|---|---|---|---|
+| `--chip-radius` | **2px** — squared | **state you read** | Signal · Seg |
+| *(the opener)* | **5px 5px 0 0** | **trigger that opens** | Gate · Field |
+| `--item-radius` | **8px** — rounded | **record you open** | Ref · `+Add` |
+| `--pill-radius` | **999px** — pill | **verb you fire** | **Door, and nothing else** |
+| `--radius` | **14px** | *container, not a control* | cards · panels · plates |
+
+- **The opener** — top corners rounded, bottom square — reads as the *top half of an
+  already-open menu*, so the panel it drops lands flush against a flat edge. The stacked
+  status picker is capped by `.seg--stack__cap`, which wears the same shape.
+- **Considered and rejected for the opener, on purpose:** `.plate` / `.plate__head` (it
+  collapses, but it is a **container** on `--radius` — giving it a control shape would put
+  container and control in one language) · `.door` (actions never *open*) · `.seg`
+  (a toggle **switches**, it does not open).
+- **Nothing but a Door may take `--pill-radius`.** The one Door that isn't a pill is
+  **`+Add`**: it *creates a record*, so it rides the Ref pattern instead — `--item-radius`,
+  with the plus in the same square icon holder a Ref uses, keeping its dashed `--commit` border.
+
 - **Signal** — coloured chip, read-only state; **colour = state, fill = today**;
-  radius 7 (the ONE chip radius — see note); dark ink on fill (filled red = `--red-fill`
+  **squared** (`--chip-radius` 2px, §3.0); dark ink on fill (filled red = `--red-fill`
   + `--on-red-fill` ink). Three-tier read: **(1) colour + fill** = the instant
   at-a-glance state, **(2) the word on the chip** = what it is, **(3) hover / Tab-focus /
   long-press** = *why* and *what it stops*. Click → teleport to source.
+  **Outline = a TRUE outline** (2026-07-25): transparent background + a 1px border in the
+  status hue — **no tint backfill**. The old `--*-bg` tints read as a third, muddier fill
+  state instead of an honest "same state, not today"; the tokens stay (plates still use
+  them), they just no longer back a chip. Outlined red uses **`--red-line`**, not `--red`.
+  **Green is filled-only** for live status: green is a *completion*, only ever true today —
+  tomorrow the thing isn't "less green," it's done and ages to **gray**. An outlined green
+  chip would name a state the app doesn't have.
 - **Gate** — a Signal + a **leading, optically-centred SVG chevron that hugs the text**
-  (≤2px gap). **No orange dot.** Opens a status picker.
+  (≤2px gap). **No orange dot.** Takes the **opener** shape (§3.0) — that silhouette, plus
+  the chevron, is what tells a Gate from a Signal at a glance: same colour, same height,
+  same word, but a Gate's shape says it opens.
+  **Its picker is `.seg--stack`, not a menu** (2026-07-25): the segmented toggle stacked
+  vertically, capped by a filled-accent header cell. A menu of *unrelated verbs*
+  (⋯ → Duplicate · Export · Archive · Delete) is a different job and is a **container**,
+  not an atom — see the Tier 0.1 container prompts.
+- **Pin** — the universal **corner marker** (new atom, 2026-07-25). Colour = state, fill =
+  today, exactly like a Signal, but it rides the **top-right corner of another control**
+  instead of taking a slot in the row. **13px — deliberately off the 24px control ladder**,
+  because it is not a control; it is a marker *on* one. **Zero layout footprint**:
+  absolutely positioned, no margin, no reserved space — nothing moves when it appears or
+  disappears. Content is a count, a countdown, a day/date, or a type icon. Hover explains,
+  click teleports. **One host, one pin** — two pins means the host is doing two jobs.
+  If a marker needs its own slot in a row, it's a **Signal**, not a Pin.
 - **Stamp** — a plain fact: **chip text, no box, no colour** (`--txt-3`), stamped
   voice. Sits beside a Signal as its quiet sibling. Budget overflow → `+N` (accent).
 - **Ref** — a linked record: square **accent-tinted backing holding the parent's
-  Lucide icon** + the name (body voice); radius 7 (its square shape + accent tint carry
-  its distinction, not a different radius — chips use ONE radius); orange-marked = touchable. Not a
+  Lucide icon** + the name (body voice); **rounded** (`--item-radius` 8px, §3.0 — a Ref is
+  the only atom that links to another record, so it owns the record shape, shared only with
+  `+Add`, which creates one); orange-marked = touchable. Not a
   status chip. Walks across cards. **EVERY linked record is a Ref, everywhere its name/ID
   appears** — unit · customer · rental · invoice · category — including a card's **own
   title/header**, not just inline body references; **never plain text**. The icon is that
@@ -122,8 +186,12 @@ Nothing ever does two jobs — that's the whole reason Signal, Ref, and Door don
   generic user icon for all** (a shared `ref()` that hardcodes the user glyph is the bug).
   *(Confirmed drift 2026-07-21: card titles + unit/invoice sub-rows rendered as plain text
   on list-views/detail-views — the same miss caught on Trips.)*
-- **Door** — a verb action, **radii = pill (999)**:
-  - **Commit / create** → deep blue `--commit` (Save = solid; `+Add` = dashed outline).
+- **Field** — a select-style input. Takes the **opener** shape (§3.0) because it *opens*
+  something; its dropdown lands flush against the flat bottom edge. Shares that shape with
+  the Gate and nothing else.
+- **Door** — a verb action, **pill (999) — the only atom allowed on `--pill-radius`**:
+  - **Commit / create** → deep blue `--commit` (Save = solid; `+Add` = dashed outline —
+    and `+Add` is the one Door **not** on the pill: it rides the Ref pattern, §3.0).
   - **Takes money** → green. **Destructive-confirm** → red.
   - **The one quiet Cancel/Close** → **ghost** (transparent, `--line` border).
   - **Toggle active segment** → the **filled Signal chip** of the selected option's status
@@ -135,6 +203,25 @@ Nothing ever does two jobs — that's the whole reason Signal, Ref, and Door don
 - **Contact** — show the **phone number itself** as the `tel:` link (readable on
   desktop, tappable on mobile); email likewise. Honest-affordance: tappable ⇒ looks
   it; not ⇒ plain text. No fake hover-underlines.
+
+### 3.1 Interaction — one behaviour for every atom (locked 2026-07-25)
+
+- **One hover: an accent ring drawn OUTSIDE the element** (`outline` + `outline-offset`), so
+  no atom's own border, fill or size changes and **nothing in the layout moves**. On a
+  segmented toggle the ring goes around the **track**, never a single cell.
+- **One focus ring** — `--accent-line`, same geometry, for every tappable atom.
+- **Press dips the fill** (`brightness(.94)`) on filled tappables only.
+- **Hover *ink*** is reserved for atoms that **navigate or switch** (Ref, Contact, an unselected
+  segment) — never for atoms that merely report.
+- **Every tappable atom is a real `<button type="button">`** (or an `<a>` when it genuinely
+  navigates). Read-only atoms — Signal, Stamp, dead text — carry `cursor: default` so they
+  admit it.
+- **No atom shrinks or wraps inside a flex row** (`flex: none; white-space: nowrap`) — that
+  is what keeps a mixed row on one 24px band instead of collapsing into a ransom note.
+- **State-pair toggle → `.seg--state`**: the live side is the **filled Signal chip of its
+  status**, the other side is the **secondary outline in ITS OWN hue** (e.g. Insured green /
+  Uninsured red). Neutral pairs (do-now / later) and no-status pairs (details / activity,
+  orange) stay plain.
 - **Ledger** (Trips ETA-Tracker; Jac 2026-07-21) — a trip renders as a **dispatch-book
   ledger**, not a card: a list of stop rows joined by a connector spine. Borrows the
   **register / carbon-dispatch-ticket** look **as a LAYOUT only** — it is built from the
@@ -215,6 +302,11 @@ Nothing ever does two jobs — that's the whole reason Signal, Ref, and Door don
 - **Signature motif** — we did **not** re-adopt jactec-ui's hazard-stripe + rivets by
   default. If we want one bold signature beat, decide it here fresh. (Current builds
   are clean matte plates.)
+- **Containers (Tier 0.1) are being designed now, not decided yet** — card frame · header ·
+  list row · section plate · panel · popup · the ⋯ action menu. Prompts are written
+  (`docs/design/prompts/prompt-03/04/05-container-*.md`); each locks on Jac's approval in
+  Design Labs and gets recorded here. **Until then, don't improvise a container** — if a
+  build needs one before it's locked, ask.
 - **Commit-blue exact** — `#2f6fd0` chosen (near-white ink `--on-commit #fdfdfd` clears
   AA **4.80**); revisit if it reads too close to `--blue`.
 - Any new colour/font/component decision gets **added here**, then re-checked against


### PR DESCRIPTION
## Summary

The atom consistency pass (#768) superseded canon that both skills still taught — most sharply the **"exactly two radii / one 7px chip radius"** rule, which is now four shapes. A future session reading `style` would have been given instructions that contradict the locked design. **Skill files only: no app code, no served files, no behavior change.**

## `style` — kept project-agnostic

Per Jac's steer that `style` is a set of guidelines, not a Rental Wrangler document:

- **De-branded** the description, intro, the schedule/ETA formula (written around one specific card, though the maths is general), and the CVD calibration example. What's left are three deliberate *"for Rental Wrangler, see `wrangler-style`"* pointers — the rules stay generic, they just say where this project's values live.
- **"Two radii" → one shape per control family.** The rule is now the *partition*, not the numbers: every family owns exactly one radius, none borrows another's, the count stays 3–5, and a shape only earns a slot if it maps to a distinct **behaviour** rather than a distinct look. A table gives what each shape reads as; which family takes which value is explicitly a decision, not a rule. The container radius must not collide with any control radius.
- **The five named parts → control archetypes.** Reframed as *roles*, not a naming mandate, since the vocabulary itself is a project decision. What stays structural is the single-responsibility split — each role is one thing and never does two jobs — because that is what lets shape, colour and fill each remain a reliable signal.
- Checklist updated to match.

## `wrangler-style` — the decisions themselves

- **New §3.0 — the four control shapes**, with exact tokens and owners: squared `--chip-radius: 2px` (state) · opener `5px 5px 0 0` (Gate, Field) · rounded `--item-radius: 8px` (Ref, `+Add`) · pill (Door only) · `--radius: 14px` (containers, not controls). Records **what was rejected for the opener and why** — `.plate` is a container on `--radius`, `.door` never opens, `.seg` switches rather than opens — so it can't be quietly re-litigated.
- **New §3.1 — uniform interaction:** one hover ring drawn *outside* the element (no layout shift), one focus ring, press-dip on filled tappables, hover-ink only for atoms that navigate or switch, a real `<button type="button">` for every tappable atom, no atom shrinks or wraps in a row, and `.seg--state` for state pairs.
- **Body voice is Archivo** — CDN-loaded, with a note that it is not yet in the shipped app.
- **`--red-line` documented**, including why it does **not** violate the frozen-palette rule: it is derived from `--red`, so it adds no new hue and cascades if `--red` ever changes.
- **Component updates:** Signal is squared with a true outline and green stays filled-only (an outlined green would name a state the app doesn't have); Gate takes the opener shape and its picker is `.seg--stack`, not a menu; Ref takes the record radius; **Field** added; `+Add` called out as the one Door off the pill; **Pin** added as the eighth atom.
- **Open decisions** note that Tier 0.1 containers are in flight — don't improvise one before it locks.

## Verification

Frontmatter validated on both files (name + description parse). Grepped for the superseded canon: the only remaining mentions are the two deliberate "this supersedes…" notes.

No served file changed, so there is no cache-bust to bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_