### PR TITLE
docs(design): restore the locked header canon the container prompts dropped

### DIFF
--- a/docs/design/LABS-PIPELINE.md
+++ b/docs/design/LABS-PIPELINE.md
@@ -29,6 +29,23 @@ to emit the approved markup. (Codex is NOT in use.)
 3. **♻️ Inherit** — the already-locked components this mockup must reuse **verbatim**. Once a thing is
    locked it rides onto every later screen unchanged.
 
+### ⛔ Before writing ANY prompt: mine the decisions ledger
+
+**`docs/superpowers/specs/2026-07-20-decisions-ledger.md` is the index of every locked decision** —
+grep it for the surface you are about to prompt, and put what you find in the **Inherit** list.
+Its companion `2026-07-20-list-views-inline-expand-design.md` carries the same session's spec.
+
+This is not optional politeness — **it is the step that was skipped once and caused a real
+regression** (2026-07-26): the card-header prompt derived its own slot list (name · count · rollup ·
+filter · verb) instead of inheriting the ledger's, and Labs faithfully designed a header with **no
+"Your Work" chip, no "Done" chip, a centred title, and no description line** — all four of which
+were decided months earlier. Labs is blind to our repo; **anything not in the prompt does not exist
+to it.** A prompt that re-derives what was already settled *will* silently undo it.
+
+Watch especially for decisions marked **`⚠ NEW — captured here`** in the ledger's index table: those
+exist in the ledger and **nowhere else** — not in a skill, not in a spec — so they are exactly the
+ones a from-scratch prompt will miss.
+
 **One screen = one Labs session = one artifact.** Consistency comes from the synced design system +
 the Inherit list, NOT from session continuity. Start a fresh Labs session per screen.
 

--- a/docs/design/prompts/prompt-03-container-card.md
+++ b/docs/design/prompts/prompt-03-container-card.md
@@ -54,11 +54,42 @@ scroll, and what the bottom edge does when there is more below the fold — a ca
 off is the failure mode to design against.
 
 ### 2. The card header
-The cap that says what this card is and what is wrong inside it. It has to carry, in one 
-constant-height band: the card's **name**, a **count**, the **rolled-up worst state** of everything
-inside, a **filter/segment control**, and a **primary action**. Decide the order, what survives when
+The cap that says what this card is and what is wrong inside it. Decide the order, what survives when
 the card is narrow, and what happens to the header when the body is scrolled. This header appears on
 all twelve surfaces below — design it as a system, not a one-off.
+
+**⚠️ The header's CONTENTS are already decided — do not re-derive them.** These are locked
+(`docs/superpowers/specs/2026-07-20-decisions-ledger.md` §5 + decisions 36/37, and
+`2026-07-20-list-views-inline-expand-design.md` §5.2). Your job is the **grammar** — order, spacing,
+priority, responsive behaviour — **not** which controls exist:
+
+- **The card's name, LEFT-aligned.** It moved from centre to left *specifically* to free header room
+  for the filter chips (ledger #37). Do not centre it. It renders as a **Ref**, not plain text — a
+  card title is a linked record like any other (critique log: "Ref drift").
+- **A short description line** under the name — mono, uppercase, muted, ellipsised
+  (e.g. "3-up tiles · staff priority order"). Present in the reference mockup as `col-desc`.
+- **"Your Work"** — the quick-filter chip. Hides any group holding **only** green/gray; shows only
+  groups containing red/yellow/blue. It does **not** re-bucket items, only hides/shows whole groups,
+  and it **carries a rolled-up count**. Accent-filled when on. This was deliberately chosen over four
+  time-based chips (Today/Tomorrow/Week/Done) because those are Rentals-specific words that don't fit
+  Units or Customers — a per-card filter set would have broken "same builder everywhere."
+- **"Done"** — its sibling and opposite: shows only items in the green "done today" state, so a user
+  can re-find and re-touch what they just did. A **filter**, explicitly *not* a group.
+- **Search** and **sort**. (Sort is flagged weak and parked for a future all-cards redesign, ledger
+  #85 — give it a slot, don't over-invest in it.)
+- **The rolled-up worst state** and a **primary action** (one verb per card).
+- **NOT the graph button.** It used to live in the card subheader; it **moved onto each section**
+  (spec §5.2), where clicking it pops that graph onto the user's Dashboard. Do not put it back here.
+
+So the real question this artifact answers is: **how do a left-aligned Ref title, a description line,
+two filter chips (one carrying a count), search, sort, a rollup, and one Door share one band** — and
+what drops first as the card narrows. That is a harder packing problem than a generic six-slot header,
+and it is the actual problem.
+
+**A note on what already exists:** a prior Labs pass produced a clean six-slot header
+(stripe · name · count · rollup · filter-seg · verb) that is good grammar but was built without the
+list above — its `ALL / OPEN / PAID` segment is not the locked Your Work / Done model. Treat that
+pass's **frame, row and overflow work as sound**; the header is the part to redo against this canon.
 
 ### 3. The list row
 The unit that repeats. Design the **collapsed** row and its **states**: default, hover, focused,

--- a/docs/design/prompts/prompt-04-container-section.md
+++ b/docs/design/prompts/prompt-04-container-section.md
@@ -61,11 +61,23 @@ What goes inside: a **key/value grid** for facts, a **row list** for contained r
 label/value alignment, what a missing value looks like, and how a long value wraps without breaking
 the 24px control band.
 
-### 4. The section's action
+### 4. The section's actions — a Door **and** a graph button
 Each section owns at most one **primary Door** ("Add Part", "Collect Payment", "Start Inspection")
 plus optional secondary actions. Decide where it lives — in the header band or the body footer —
 and what happens to it when the section is collapsed. This choice directly feeds the Tier 1 rail
 chip, which carries the section's Signal *and* its primary Door.
+
+**⚠️ Every section also carries a GRAPH BUTTON — this is locked, not optional**
+(`docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md` §5.2). Clicking it pops that
+section's graph **onto the user's role Dashboard** — *not* inline, which is the whole point: the graph
+never eats the card's vertical budget. This is the **composition mechanism** for the role Dashboard —
+users curate it section by section (open a unit's Investment / Services / GPS section → click its
+graph → it lands on their Dashboard).
+
+So a section header carries **two** affordances of different kinds: a **Door** (a verb that changes
+this record) and a **graph button** (a verb that changes *the user's dashboard*). Decide how they sit
+together without reading as a row of equal buttons — they are not equals, and the graph button is the
+quieter of the two. Decide what it looks like once the graph is already on the Dashboard.
 
 ## The test the artifact has to pass
 Stack **eight** sections — two red, one yellow, five gray — and scroll it. Can you find the two that

--- a/docs/design/prompts/prompt-05-container-overlay.md
+++ b/docs/design/prompts/prompt-05-container-overlay.md
@@ -54,7 +54,22 @@ and what a **destructive** confirm looks like when it must not be clicked throug
 ### 3. The ⋯ action menu — the one this tier added
 The atom pass **dropped `.menu`** as a status picker (that job now belongs to `.seg--stack`, a
 stacked segmented toggle). What is left is a genuinely different container: a short list of
-**unrelated verbs** hanging off a ⋯ trigger — Duplicate · Export · Archive · Delete.
+**unrelated verbs** hanging off a ⋯ trigger.
+
+**⚠️ This menu is already half-decided — read before designing**
+(`docs/superpowers/specs/2026-07-20-decisions-ledger.md` #79/#83,
+`2026-07-20-list-views-inline-expand-design.md` §7.3–7.4):
+
+- **It is the same surface as the R20 right-click menu.** Right-clicking a row and tapping its ⋯ must
+  open **one menu**, not two designs of one. Design it once.
+- **It carries a user-CUSTOMIZABLE quick-action set** — Hide · Mark unread/read · Star · Snooze ·
+  Archive — surfaced **identically** as row actions (hover-reveal on desktop, **swipe** on mobile) and
+  in this menu. *"One set, learned once, available everywhere."* So the menu is not a fixed list you
+  get to author: design it to hold a **configurable** set, and decide what a user-ordered menu looks
+  like and where a customize entry point lives.
+- **Comms items stay in place.** "Text {name}…" / "Email {name}…" open compose **with the record
+  pre-attached**, docked — they must **never teleport to the Inbox card**, and never pop mid-screen.
+  A comms verb in this menu is a different animal from Duplicate/Delete; decide how it reads.
 
 Design it as a container, and settle the questions that make it a menu rather than a list of chips:
 - **The trigger.** What ⋯ looks like at rest, on hover, and while open — and where it sits on a row


### PR DESCRIPTION
## The report

Jac spotted it: the Tier 0.1 card artifact has **no "Your Work" button** in the card header. He was right, and it wasn't one miss — tracing it turned up **three of the same class**. Docs only; no app code, no served files.

## Root cause

The container prompts derived their contents **from my own reasoning** instead of inheriting `docs/superpowers/specs/2026-07-20-decisions-ledger.md`. Labs is blind to the repo — anything absent from a prompt does not exist to it — so a prompt that re-derives settled ground **silently undoes it**. Labs did nothing wrong; it faithfully built what the prompt asked for.

The compounding factor: every dropped decision is marked **`⚠ NEW — captured here`** in the ledger's index, meaning it lives in the ledger and **nowhere else** — not in a skill, not in a spec. Those are precisely the ones a from-scratch prompt cannot accidentally get right. And that ledger had never reached `trunk` until this week's rescue, so it was invisible to every prior session too.

## What was dropped, with citations

**`prompt-03` — the card header.** Contents are locked (ledger §5, decisions **#36/#37**; spec §5.2):

| Decision | What the artifact did |
|---|---|
| Title **left-aligned** — moved from centre *specifically* to free room for the filter chips (#37) | header built without it |
| Title renders as a **Ref**, not plain text (critique log: "Ref drift") | plain text |
| A muted mono **description line** (`col-desc` in `list-views.html`) | absent |
| **"Your Work"** — hides groups holding only green/gray, shows only groups with red/yellow/blue; never re-buckets; **carries a rolled-up count**; accent-filled when on | absent |
| **"Done"** — its opposite: only green done-today items, so you can re-find what you just did. A filter, explicitly *not* a group | absent |
| **Search** + **sort** (sort parked as weak, #85) | absent |
| Graph button **NOT** in the header — it moved onto sections (§5.2) | correctly absent |

Worth recording *why* Your Work exists in that exact shape: four time-based chips (Today/Tomorrow/Week/Done) were **considered and rejected**, because those are Rentals-specific words that don't fit Units (service language) or Customers (money/lead language) — a per-card filter set would have broken "same builder everywhere."

**`prompt-04` — the section.** Every section carries a **graph button** that pops its graph onto the role Dashboard, never inline (§5.2). That is the *composition mechanism* for the Dashboard — users curate it section by section. So a section header has **two affordances of different weight**, not one Door.

**`prompt-05` — the ⋯ menu.** It **is** the R20 right-click menu (#79/#83) — one surface, not two designs of one. It holds a user-**customizable** quick-action set (Hide · Mark unread/read · Star · Snooze · Archive) shared identically with row actions and mobile swipe — *"one set, learned once, available everywhere"* — so it can't be authored as a fixed list. Comms items compose **in place** with the record attached and must never teleport to the Inbox card.

## The fix for the cause, not just the symptom

`LABS-PIPELINE.md` now carries a standing **"mine the decisions ledger before writing any prompt"** step, with this regression recorded as the reason and a pointer to the `⚠ NEW — captured here` marker as the highest-risk category.

## What Labs needs to redo

**Only the header.** The prior pass's **frame, list row, overflow handling and Trips stress test are sound work** and should be kept — `prompt-03` now says so explicitly, so a re-run doesn't throw out the good parts.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_