### PR TITLE
docs(design): second ledger audit — nine more dropped decisions restored

### DIFF
--- a/docs/design/prompts/prompt-03-container-card.md
+++ b/docs/design/prompts/prompt-03-container-card.md
@@ -98,9 +98,31 @@ selected, expanded-parent, and the row that is on fire. Decide:
   should be readable as a fixed set of positions, not an improvised flex soup.
 - **Density.** How tall, how much breathing room, how many rows before the eye loses the column.
 - **The group header** — the divider that separates "Overdue" from "Due today" from "Later". It is a
-  different object from the card header; decide how different.
-- **The expansion affordance.** How the row says "there is more inside me," and what it looks like
-  the instant before the detail opens.
+  different object from the card header; decide how different. **⚠️ Groups come in two locked kinds**
+  (ledger #31/#34/#35) and the header must serve both:
+  - **Attention groups** (Field Calls, Failed) exist *only* because something is wrong — they are
+    **hidden entirely when empty** and carry colour natively.
+  - **Lifecycle groups** (On Rent, Reserved, Available) are **always present, gray by default**, and
+    take colour **only** when a member inside triggers it. No group ever carries a fixed colour.
+  - **Never named after status** ("Bad", "To-Do") — a group name says *where in the workflow*, colour
+    says *how much it needs you*. Double-encoding those is the error to design against.
+  - The same group **set** is **reordered per role** — so group order is data, not layout. Don't bake
+    an order into the design.
+- **The expansion affordance — and the click contract behind it** (ledger #50/#62/#63/#67):
+  - **Single click = inline-expand in place. No cascade.** The row opens where it sits; siblings
+    **push down**. There is a **220ms discriminator**, so single and double click are different verbs.
+  - **Double click = anchor** — that one fires the cascade and opens a tab. The row needs to make
+    both reachable without advertising two buttons.
+  - **An expanded row carries an anchor icon, top-right.** If something is *already* anchored, that
+    icon becomes a **"+"** on every other expanded row. Design both states.
+  - The expand animates with the **mobile-swipe easing and timing**, to a **fixed target size**.
+  - The old **hover-eye preview is retired** — inline-expand *is* the peek. Don't reintroduce a
+    preview affordance.
+- **The hover-jump accelerator** (ledger #58/#59/#60). On hover, a **popover emerges from the row's
+  top edge** with a tail/notch, **one chip-line tall**, flipping below when the row is near the top of
+  the list. It is **instant — no dwell timer** — and made mis-click-safe by **geometry** (a right-lane
+  or whole-row hover target), never by a delay. Here, decide only **what the row owes it**: where it
+  emerges from and what must stay clear. The popover itself is designed in prompt 0.1c.
 - **Overflow.** What a row does when the name is too long, when there are six chips and room for
   three, and when a value is missing entirely.
 
@@ -118,6 +140,21 @@ time-anchored (a schedule and an ETA ledger, not a static roster), so its rows c
 prominently as *what*. **If the row grammar can seat a departure time and an ETA without a special
 case, it will seat anything the other eleven throw at it.** Check the row design against
 `trips-ledger.html` before calling it done — but design the general row, not a Trips row.
+
+**Plus a thirteenth, different one: the Dashboard card** (ledger #44/#45/#86–#89). Every role gets the
+base cards **plus a role-dependent Dashboard** as a 6th. It is a **landing, never a lockout** — the
+base cards stay reachable. Its content is charts rather than rows, and **chart marks are links**
+(a wedge fires the same cascade a text link would), under **one colour law shared by chip and chart**:
+a graph wedge is the same colour as the Signal chip it lands on. Field roles get a live timeline
+(Yard Journey / route) instead of graphs — one pattern, two forms.
+**You are not designing the Dashboard here** — that is Tier 2. What matters now is that the card
+**frame and header must not assume a row list inside them**, because one of the thirteen isn't one.
+
+> **⚠️ Flag for Jac — a canon/code mismatch worth settling before Tier 2.** Ledger #44 names the five
+> base cards as **Units · Rentals · Customers · Trips · Categories** (+ Dashboard). The shipped
+> registry (`config.js` → `GRID_CARDS`) has **Units · Categories · Rentals · Invoices · Customers** —
+> it includes **Invoices** and omits **Trips**. Both can't be the base five. This doesn't block the
+> container work (the frame serves all of them either way), but it decides Tier 2's scope.
 
 > The build order used to say "all 7 cards." That number was stale: the Shop card was retired
 > 2026-07-07 (Work Orders / Service Orders / Inspections moved inside each Unit's detail view).

--- a/docs/design/prompts/prompt-04-container-section.md
+++ b/docs/design/prompts/prompt-04-container-section.md
@@ -28,8 +28,8 @@ worst state, and carries its own primary action — so a record's detail is noth
 - **The section rail itself** — the horizontal strip of chips that pages between sections one at a
   time. That is **Tier 1, the detail view**, and it depends on the shell. Here you only decide what
   a single section *contributes* to a rail chip: its label, its rolled-up Signal, its primary Door.
-- **Bounded height and paging behaviour.** Tier 1. Design the section as if it will be given
-  whatever height it needs.
+- **The expanded item's bounded height and section paging.** Tier 1. ⚠️ But **not** the section's own
+  overflow — see the locked rule below; a section does *not* get "whatever height it needs."
 - **Popups and the ⋯ menu.** The next prompt.
 
 ## ♻️ Inherit (locked — reuse verbatim)
@@ -61,6 +61,12 @@ What goes inside: a **key/value grid** for facts, a **row list** for contained r
 label/value alignment, what a missing value looks like, and how a long value wraps without breaking
 the 24px control band.
 
+**⚠️ A tall section scrolls INTERNALLY — it never blows out the card** (ledger #57; the worked example
+is Customers' Invoices, which can hold hundreds of rows). So the section owns a max height and its own
+scroll. Decide what that scroll looks like, where the boundary reads, and how a scrolled section still
+shows that there is more below — the same anti-silent-cutoff problem the card frame solves at its hem,
+one level down.
+
 ### 4. The section's actions — a Door **and** a graph button
 Each section owns at most one **primary Door** ("Add Part", "Collect Payment", "Start Inspection")
 plus optional secondary actions. Decide where it lives — in the header band or the body footer —
@@ -78,6 +84,23 @@ So a section header carries **two** affordances of different kinds: a **Door** (
 this record) and a **graph button** (a verb that changes *the user's dashboard*). Decide how they sit
 together without reading as a row of equal buttons — they are not equals, and the graph button is the
 quieter of the two. Decide what it looks like once the graph is already on the Dashboard.
+
+## Two neighbours the section must not collide with
+
+Both are Tier 1's to design, but they bound this one — so know they exist:
+
+- **The landing section is the Signal summary, and it is labelled "To Do"** (ledger #54). Internally we
+  call it Signal; **the user never sees that word** — component names are our vocabulary, never
+  user-facing. So one section in every stack is *the summary of the others*. Make sure the plate
+  grammar can carry that without needing a special case.
+- **A persistent History-search footer sits under every expanded item, on all sections** (ledger #56)
+  — it is **never paged away** when you move between sections. That footer is not yours, but it eats
+  the bottom edge: **don't design a section footer that competes with it.** This is the main reason
+  the section's primary Door may want to live in the header band rather than at the bottom.
+
+Also inherited: **role sets the default landing section and the section order**, and a user's
+**drag-resort persists per record-type** (ledger #55). So section order is data — never hard-code a
+sequence into the design, and make sure a plate looks right in any position in the stack.
 
 ## The test the artifact has to pass
 Stack **eight** sections — two red, one yellow, five gray — and scroll it. Can you find the two that

--- a/docs/design/prompts/prompt-05-container-overlay.md
+++ b/docs/design/prompts/prompt-05-container-overlay.md
@@ -37,12 +37,36 @@ nothing floating above a screen is ever invented on the spot.
 - **Door taxonomy** — commit · +Add · money · destroy · ghost. A popup's footer is built from these
   and nothing else, and the pill silhouette stays Doors-only.
 
-## The ask — three artifacts
+## The ask — four artifacts
+
+### 0. The popover-above — a locked family, not a free design
+Before the panel and the popup: there is a **third overlay shape already decided**, and it recurs
+app-wide (ledger #58/#59/#60/#77). Design it once, here.
+
+- **The hover-jump accelerator.** On hovering a list row, a popover **emerges from the row's top
+  edge** with a **tail/notch**, exactly **one chip-line tall**, and **flips below** when the row sits
+  near the top of the list. It is **instant — no dwell timer.** It is made mis-click-safe by
+  **geometry** (a right-lane or whole-row hover target), *never* by a delay. A fallback was also
+  approved if "above" proves too tight: a **left-stack** variant anchored on the item name.
+- **The recent-search history popup** uses the **same principle** — it opens **ABOVE the search bar,
+  app-wide** (#77), not below it as a normal dropdown would.
+
+So this is a family: **things that open upward from their trigger, with a tail, and flip when
+cornered.** Decide the tail geometry, the flip threshold, and how it differs on sight from the Field's
+*downward* opener dropdown — because a user must never confuse "this opened up to help me jump" with
+"this opened down to let me choose."
 
 ### 1. The panel
 A persistent surface anchored to an edge or a record — it stays while you work in it. Decide: where
 it attaches, how wide, whether the app behind it dims or stays live, how it is dismissed, and
 whether it can be open alongside another panel. Design its header and its footer.
+
+**⚠️ One panel is already specified: the compose dock** (ledger #78, spec §7.3). It **docks at the
+footer on desktop and is minimizable**; on mobile it goes **full-screen**. It **never follows the
+pointer and never pops mid-screen** — even when triggered by a right-click. Treat it as the worked
+example your panel design has to accommodate: a footer-docked, minimizable, multi-instance surface.
+Related context (not yours to design): comms live at **three altitudes** — the bell for alerts, this
+footer dock for quick replies, and the Inbox card as the full workspace (#71).
 
 ### 2. The popup
 A modal moment: it takes focus, asks one thing, and leaves. Design **three sizes** — a confirm, a


### PR DESCRIPTION
## Why this exists

Jac didn't trust the first fix and asked for a full audit. He was right not to. The first pass **grepped** the ledger for what he'd already spotted; this one **read all 485 lines** and cross-checked every decision against all three prompts. That turned up **nine more misses of the same class**.

Docs only — no app code, no served files.

## The worst one wasn't an omission

`prompt-04` told Labs: *"design the section as if it will be given whatever height it needs."*

Ledger **#57** says a tall section **scrolls internally and never blows out the card** — the worked example is Customers' Invoices, which can run to hundreds of rows. That wasn't a gap in my prompt; it was an instruction to build the wrong thing. Fixed, and turned into the more useful framing: it's the same anti-silent-cutoff problem the card frame solves at its hem, one level down.

## `prompt-03` — card / header / row

| Restored | Ledger |
|---|---|
| **Group taxonomy is locked.** *Attention* groups (hidden entirely when empty, colour native) vs *Lifecycle* groups (always present, gray until a member triggers). Never named after status. The set is **reordered per role**, so group order is data, not layout. | #31/#34/#35 |
| **The click contract.** Single = inline-expand in place, siblings push down, **no cascade**. Double = anchor + tab. Separated by a **220ms discriminator**. | #50/#62 |
| Expand animates on the **mobile-swipe easing/timing** to a **fixed target size**. | #51 |
| An expanded row carries an **anchor icon top-right** — which becomes a **"+"** on every other expanded row once something is anchored. | #63 |
| The **hover-eye preview is retired**; inline-expand *is* the peek. Don't reintroduce it. | #67 |
| What the row owes the **hover-jump popover** (where it emerges, what stays clear). | #58/#59/#60 |
| **The Dashboard is a 13th card and isn't a list.** Chart marks are links; one colour law shared by chip and chart; field roles get a live timeline instead of graphs. So the frame and header **must not assume rows inside them**. | #44/#45/#86–89 |

## `prompt-04` — section

- **Tall sections scroll internally** (#57 — see above).
- The **landing section is the Signal summary, shown to users as "To Do"** (#54). Component names are internal vocabulary and never user-facing, so one section in every stack is *the summary of the others*.
- A **persistent History-search footer** sits under every expanded item across all sections and is **never paged away** (#56) — so a section footer must not compete with it. This is the strongest argument for putting the section's primary Door in the header band.
- **Role sets the default landing and section order**, and a user's drag-resort **persists per record-type** (#55) — so a plate must look right in any position in the stack.

## `prompt-05` — overlays

- **A fourth artifact: the popover-above family.** The hover-jump's tail/notch, one-chip-line height, flip-when-near-the-top, **instant with no dwell timer**, mis-click-safe **by geometry not delay** — plus the recent-search popup that opens **above** the bar app-wide on the same principle (#58/#59/#60/#77). The prompt now asks how this reads differently from the Field's *downward* opener, since a user must never confuse "opened up to help me jump" with "opened down to let me choose."
- **The compose dock** as the worked panel example: footer-docked and minimizable on desktop, full-screen on mobile, and it **never follows the pointer or pops mid-screen** — even from a right-click (#78). Three comms altitudes given as context (#71).

## One thing for Jac to settle

**Ledger #44 and the shipped code disagree on the base cards.** The ledger names **Units · Rentals · Customers · Trips · Categories**; `config.js` → `GRID_CARDS` has **Units · Categories · Rentals · Invoices · Customers** — it includes Invoices and omits Trips. Both can't be the base five. It doesn't block the container work (the frame serves all of them regardless), but it decides Tier 2's scope. Flagged in the prompt rather than guessed at.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_