### PR TITLE
docs(design): third audit — the section model was reversed twice, not once

### DIFF
--- a/docs/design/LABS-PIPELINE.md
+++ b/docs/design/LABS-PIPELINE.md
@@ -46,6 +46,25 @@ Watch especially for decisions marked **`⚠ NEW — captured here`** in the led
 exist in the ledger and **nowhere else** — not in a skill, not in a spec — so they are exactly the
 ones a from-scratch prompt will miss.
 
+### ⏱ And check the DATE — some decisions reversed more than once
+
+The ledger is dated **2026-07-20**. Several decisions were revisited on **07-21** (in the spec) and
+again on **07-25** (in `prompts/`). **The ledger is not automatically the newest thing.** Grepping it
+and stopping is how you end up confidently citing a superseded decision — which happened on 2026-07-26.
+
+**Known reversal chains — settle these by the newest entry, not the first one you find:**
+
+| Question | 07-20 (ledger) | 07-21 (spec) | **07-25 (prompts) — CURRENT** |
+|---|---|---|---|
+| Section model | paging via chips (#53) | accordion plate stack on desktop, page on mobile (§2.0) | **paging via a section rail, "no accordion stack"** (`prompt-01-detail-views.md`) |
+
+The accordion lost on the second reversal for a concrete reason worth keeping: stacking every section
+open made a Customer record run **~5 phone-screens**. Paging costs nothing in awareness **because**
+every rail chip shows its rolled-up Signal at rest — which was the accordion's whole argument.
+
+**If you reverse one of these, add a row here with the date and the reason.** Two flips already
+happened without a written trail, which is why an audit had to reconstruct it from file dates.
+
 **One screen = one Labs session = one artifact.** Consistency comes from the synced design system +
 the Inherit list, NOT from session continuity. Start a fresh Labs session per screen.
 
@@ -57,8 +76,8 @@ the Inherit list, NOT from session continuity. Start a fresh Labs session per sc
   Run them in this order, each its own Labs session:
   1. `prompts/prompt-03-container-card.md` — **card frame · header · list row.** The most
      load-bearing prompt in the build order: twelve surfaces share this anatomy.
-  2. `prompts/prompt-04-container-section.md` — **section / plate.** A detail view is a stack of
-     these, so it must lock before Tier 1 can.
+  2. `prompts/prompt-04-container-section.md` — **section.** A detail view is a rail of these paged
+     one at a time, so it must lock before Tier 1 can.
   3. `prompts/prompt-05-container-overlay.md` — **panel · popup · ⋯ action menu.**
 - **Tier 0.2 — App shell** — 3-column yard grid, top bar, footer rail; decides how a row-expansion
   relates to the columns. *A first draft exists (parked) — it revealed the real tension: the detail
@@ -67,8 +86,9 @@ the Inherit list, NOT from session continuity. Start a fresh Labs session per sc
 - **Tier 1 — Detail view** — bounded height + section rail that pages one section at a time, each rail
   chip carrying its rolled-up Signal + primary Door, History pinned. *A first draft exists (parked)
   and PROVED the model works; it locks once it sits inside the approved shell.*
-- **Tier 2 — Per-card content** — the twelve surfaces: Units · Rentals (calendar-anchored) ·
-  Customers · Invoices · Categories · Trips · the six back-office boards.
+- **Tier 2 — Per-card content** — the twelve surfaces: the base five (Units · Rentals
+  calendar-anchored · Customers · Trips · Categories), the role Dashboard, and the six back-office
+  boards (Invoices now among them — see Settled + carried).
 - **Tier 3 — Cross-cutting** — item/comms tabs · footer-rail open chats · notifications/toasts ·
   settings boards · creation flows/wizards · empty+loading+login+mobile reflow.
 
@@ -129,6 +149,11 @@ the Inherit list, NOT from session continuity. Start a fresh Labs session per sc
    registry in `labs-build-order.md`.
 
 ## Settled + carried
+- **The base five are Units · Rentals · Customers · Trips · Categories** (Jac, 2026-07-26, confirming
+  ledger #44 over the shipped code). **Invoices is NOT a base card** — it moves to a back-office
+  board. The shipped `config.js` → `GRID_CARDS` still has Invoices in and Trips out, so **`config.js`
+  needs updating in Tier 2** — that is queued app work, not a design task. Plus the role **Dashboard**
+  as a 6th, role-dependent card.
 - **Trips IS a card** (Jac, 2026-07-25). The card anatomy serves **twelve** surfaces: 5 grid cards +
   6 back-office boards + Trips. Trips has no `GRID_CARDS` / `BACKOFFICE_BOARDS` entry yet — only its
   three reference mockups — so **adding the registry row is queued app work for Tier 2**, not part

--- a/docs/design/prompts/prompt-04-container-section.md
+++ b/docs/design/prompts/prompt-04-container-section.md
@@ -1,23 +1,24 @@
-# Labs — Prompt 0.1b · The Section (plate · stack · rail chip)
+# Labs — Prompt 0.1b · The Section (rail chip · paged pane)
 
-**Tier 0.1 — containers, part two.** The section is the container *inside* a record: the plate that
-groups a handful of facts under one labelled, colour-stated header. A detail view is a **stack of
-these**, and the Tier 1 section rail is built from their rolled-up states — so the section has to be
-right before the detail view can lock.
+**Tier 0.1 — containers, part two.** The section is the container *inside* a record: a labelled,
+colour-stated group of facts. A detail view is a **rail of these, paged one at a time** — the rail is
+built from their rolled-up states — so the section has to be right before the detail view can lock.
 
 **Attach from the `rw-design-system` folder:** `components/section-plate.html` (the existing plate
 grammar — the thing being refined) · `elements/signal.html` · `elements/gate.html` ·
 `elements/stamp.html` · `elements/ref.html` · `elements/pin.html` · `elements/door.html` ·
 `foundations/spacing.html`.
 
-**Reference (context, not canon):** `docs/design/reference/detail-views.html` — the plate-stack as
-it was drafted for Units / Rentals / Customers.
+**Reference (context, not canon — and note what's stale):** `docs/design/reference/detail-views.html`
+shows Units / Rentals / Customers as a **plate stack with every section open at once**. That is the
+**superseded** model — it is the very mockup that proved records get far too tall. Mine it for the
+plate's *look* (stripe, stamped label, body grammar); do **not** copy its stacked structure.
 
 ---
 
 ## ⭐ North Star — the one thing this pass decides
-**What a section IS** — one labelled, state-coloured plate that groups related facts, reports its own
-worst state, and carries its own primary action — so a record's detail is nothing but a stack of them.
+**What a section IS** — one labelled, state-coloured group of facts that reports its own worst state
+and carries its own primary action — so a record's detail is nothing but a rail of them, paged.
 
 ## 🚫 Out of scope (anti-objectives — do NOT critique or redesign here)
 - **The atoms.** LOCKED 2026-07-25. Reuse verbatim.
@@ -37,23 +38,44 @@ worst state, and carries its own primary action — so a record's detail is noth
 - **The card frame, header and list row** from prompt 0.1a — a section may *contain* rows, and when
   it does it uses that exact row, not a variant.
 - **The four control shapes** and **`--radius: 14px`** for container corners.
-- **Rollup precedence** `red > yellow > blue > green > gray` — a collapsed section header shows the
-  worst state inside it.
+- **Rollup precedence** `red > yellow > blue > green > gray` — a section's rail chip shows the worst
+  state inside it, whether or not that section is the one currently open.
 - **The `--*-bg` tint tokens.** Outline chips gave up their tints in the atom pass, but **plates kept
   them** — the tinted header band is now the plate's own signature and nothing else uses it.
 
 ## The ask — one artifact, four questions
 
-### 1. The plate, collapsed and expanded
-The existing grammar is: colour stripe · stamped label · a one-line **summary** of what is inside ·
-a chevron. Judge it hard. The summary line is the whole bet — it is what lets someone skim eight
-sections without opening any of them. Decide what belongs in it, how it truncates, and what it says
-when the section is empty.
+### 1. The plate's two forms — rail chip and open pane
+
+**⚠️ Read this before designing: the section model is PAGED, not an accordion.** A section does *not*
+sit in a stack of collapsible plates. It has exactly two presentations:
+
+1. **Its rail chip** — the at-a-glance form, always visible on the rail whether or not the section is
+   open: stamped label + its **rolled-up Signal** (the worst state inside) + its **primary Door**.
+2. **Its open pane** — the body, shown **one section at a time** in the single content pane below the
+   rail. Clicking a chip pages that section in.
+
+There is **no collapsed-plate-in-a-stack state**, and no chevron doing accordion duty. The old
+plate-stack grammar (colour stripe · label · summary · chevron → body) is the **superseded** model —
+see the precedence note below.
+
+So the "summary" question moves onto the **rail chip**: it is what lets someone see all eight sections'
+states at once without opening any. Decide what the chip carries, how the label truncates, what it
+shows when the section is empty, and how chip and pane stay visibly the same object.
+
+> **⏱ Precedence — why paging, and don't flip it back.** This reversed twice, so the chain matters:
+> ledger **#53** (2026-07-20) paging → spec **§2.0** (2026-07-21) accordion plate stack on desktop →
+> **`prompts/prompt-01-detail-views.md`** (2026-07-25) **back to paging, and it is the newest**:
+> *"The settled answer is a bounded, paging detail view driven by a section rail… no long scroll, no
+> accordion stack."* The accordion lost because stacking every section open made records **far too
+> tall** (the Customer ran ~5 phone-screens). Paging hides nothing **because** every rail chip shows
+> its rolled-up Signal at rest — which is exactly what the accordion was chosen for in the first
+> place. If you find yourself designing a collapsible stack, you have reverted to the 07-21 model.
 
 ### 2. The section's own state
-A section reports the worst state of its contents in its header band. Decide **how loud that is
-allowed to be.** Eight sections stacked, three of them red, is a wall of alarm that reports nothing.
-Design the calm case as carefully as the on-fire case — most sections, most of the time, are gray.
+A section reports the worst state of its contents on its rail chip. Decide **how loud that is allowed
+to be.** Eight chips on one rail, three of them red, is a wall of alarm that reports nothing. Design
+the calm case as carefully as the on-fire case — most sections, most of the time, are gray.
 
 ### 3. The body
 What goes inside: a **key/value grid** for facts, a **row list** for contained records, and a
@@ -70,8 +92,8 @@ one level down.
 ### 4. The section's actions — a Door **and** a graph button
 Each section owns at most one **primary Door** ("Add Part", "Collect Payment", "Start Inspection")
 plus optional secondary actions. Decide where it lives — in the header band or the body footer —
-and what happens to it when the section is collapsed. This choice directly feeds the Tier 1 rail
-chip, which carries the section's Signal *and* its primary Door.
+and what happens to it on the rail chip when that section is *not* the open one — the chip carries
+the Door whether or not its pane is showing, which is what lets a dispatcher act without paging in.
 
 **⚠️ Every section also carries a GRAPH BUTTON — this is locked, not optional**
 (`docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md` §5.2). Clicking it pops that
@@ -91,8 +113,8 @@ Both are Tier 1's to design, but they bound this one — so know they exist:
 
 - **The landing section is the Signal summary, and it is labelled "To Do"** (ledger #54). Internally we
   call it Signal; **the user never sees that word** — component names are our vocabulary, never
-  user-facing. So one section in every stack is *the summary of the others*. Make sure the plate
-  grammar can carry that without needing a special case.
+  user-facing. So one chip on every rail is *the summary of the others*, and it is where the user
+  lands on open. Make sure the chip grammar can carry that without needing a special case.
 - **A persistent History-search footer sits under every expanded item, on all sections** (ledger #56)
   — it is **never paged away** when you move between sections. That footer is not yours, but it eats
   the bottom edge: **don't design a section footer that competes with it.** This is the main reason
@@ -100,12 +122,12 @@ Both are Tier 1's to design, but they bound this one — so know they exist:
 
 Also inherited: **role sets the default landing section and the section order**, and a user's
 **drag-resort persists per record-type** (ledger #55). So section order is data — never hard-code a
-sequence into the design, and make sure a plate looks right in any position in the stack.
+sequence into the design, and make sure a chip looks right in any position on the rail.
 
 ## The test the artifact has to pass
-Stack **eight** sections — two red, one yellow, five gray — and scroll it. Can you find the two that
-matter without reading a word? And with everything collapsed, does the stack read as a **table of
-contents** for the record, or as a pile of closed drawers?
+Put **eight** section chips on one rail — two red, one yellow, five gray — with one pane open. Can
+you find the two that matter without reading a word? And does the rail read as a **table of contents**
+for the record, or as a row of tabs you have to click through to learn anything?
 
 ## After you lock
 The plate becomes an Inherit item for the detail view (Tier 1) and every per-card content prompt


### PR DESCRIPTION
## The finding

Jac asked me to hunt for decisions that flipped, and named the section model: *"we switched a couple of times between section paging and accordion collapsing. Most recently we decided to page."*

**He was right. I was initially wrong.** Docs only — no app code, no served files.

## Two reversals, no written trail

| Date | Where | Decision |
|---|---|---|
| 2026-07-20 | ledger #53 | paging via section chips |
| 2026-07-21 | spec §2.0 | **accordion plate stack** on desktop, page on mobile — *"supersedes the paging language below"* |
| **2026-07-25** | **`prompts/prompt-01-detail-views.md`** | **back to paging** — *"The settled answer is a bounded, **paging** detail view driven by a section rail… no long scroll, **no accordion stack**."* |

My first answer cited §2.0 as current, because it was the newest thing I had **found** — not the newest thing that **exists**. The decision was exactly where Jac said it would be: the last session's own prompt. `decision-notes.md:169` independently confirms it ("validated the need for one-section-at-a-time paging… Landing section must be a SIGNAL summary").

Worth keeping the *reason* the accordion lost: stacking every section open made a Customer record run **~5 phone-screens**. And paging costs nothing in awareness **because** every rail chip shows its rolled-up Signal at rest — which was the accordion's own argument for existing.

## `prompt-04` was written to the superseded model throughout

Not one line — the whole frame. Title, intro, North Star, the "collapsed and expanded" ask, the rollup bullet, the section-state question, and the closing test all assumed a stack of collapsible plates.

Reframed to the paged model. A section now has exactly **two forms**:
1. **Its rail chip** — label + rolled-up Signal + primary Door, visible at rest whether or not the section is open. This is where the "summary" question actually lives.
2. **Its paged pane** — the body, one at a time.

No collapsed-plate state, no chevron doing accordion duty. The precedence chain is written into the prompt itself so a future pass can't silently flip it back. Also flags `reference/detail-views.html` as showing the **superseded** structure — mine it for the plate's look, not its stacking, since it's the very mockup that proved records get too tall.

## The durable fix

`LABS-PIPELINE.md` now carries a **dated reversal-chain table** and the rule that **the ledger is not automatically the newest thing** — it's dated 07-20, and things moved on 07-21 and again on 07-25. Plus an instruction to append a row when reversing something, since two flips already happened without a trail and an audit had to reconstruct them from file dates.

## Jac's other call, recorded

**The base five are Units · Rentals · Customers · Trips · Categories** (ledger #44 over the shipped code), plus the role Dashboard. **Invoices is not a base card** — it becomes a back-office board, so `config.js` → `GRID_CARDS` needs updating in Tier 2. Queued as app work, not a design task.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_