### PR TITLE
skills: teach /start to read the decisions ledger, and record why

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -99,6 +99,22 @@ The app uses **trunk-based development**: one trunk (`trunk`), short-lived **fea
 - **Any new or reshaped UI → `/jactec-ui`** — the single design skill and quality gate for every visual change. It's the yard data-plate design language enforcer (dark steel, ONE safety-orange accent, hazard-stripe, Saira Condensed, rivets, R0–R24 rulebook) and governs every screen, card, column, pill, button, field, popup, menu, date picker, KPI ring. It now also carries the four folded sub-capabilities — **aesthetic direction / typography** (former `/frontend`), **mobile** reflow/viewport/touch (former `mobile-*`), **DESIGN.md** scaffold/lint (former `/design-md`), and the **`/role` audit** — each behind its own reference + section. Backend (`Code.gs`) changes, CI scripts, and pure logic are exempt.
 - **R-Rulebook — stamp UI + keep `rule-usage.js` current.** Every new UI element gets a `data-r="Rxx"` attribute matching the rulebook. When rule usage changes, regenerate: `node ci/gen-rule-usage.mjs` (no `--check`). The `--check` flag is the CI gate — run `node ci/gen-rule-usage.mjs --check` before pushing; it fails on drift or duplicate rules. **Any new or reshaped UI keeps the R-Rulebook current — a hard rule (see CLAUDE.md → R-rulebook).** New popup windows also need a `WINDOW_CATALOG` entry, enforced by `node ci/check-window-catalog.mjs`.
 
+- **Any DESIGN/UI decision → the decisions ledger is the index, and it is dated.**
+  `docs/superpowers/specs/2026-07-20-decisions-ledger.md` is the flat index of every locked UI
+  decision. Three rules, learned the hard way on 2026-07-26 (one missed lookup → three audits and six
+  PRs):
+  1. **Read it BEFORE writing a spec, a Labs prompt, or any UI.** Don't re-derive what's settled.
+     Anything you don't carry forward gets silently undone — a Design Labs prompt that omits a locked
+     decision produces a mockup without it, because Labs is blind to this repo.
+  2. **Read to the END, and check dates.** Rows #1–100 are a **2026-07-20 snapshot**; #101+ is the
+     extension through 07-26. **A 07-20 row may be superseded further down** — the section model
+     reversed *twice*. Grepping and stopping at the first hit is exactly how a dead decision gets
+     cited as canon.
+  3. **A decision is not made until it has a row in that table** (#135). When Jac settles something,
+     add the row — with the date and, if it reverses something, a pointer both ways.
+  Decisions marked **`⚠ NEW — captured here`** exist in the ledger and *nowhere else* — not in a
+  skill, not in a spec — so they're the ones a from-scratch pass will miss.
+
 ### Working discipline
 - **Token discipline:** terse by default; `Grep`/`Glob` before `Read`; read only the range you need; spawn subagents for large isolated work to protect the main context.
 - **Session title tracks this session's PRs.** When you **open** a PR, append its number to `.claude/.session-prs` (gitignored, one per line) and surface a one-tap **`/rename #<nums> · <branch-label>`** line — the model can't self-`/rename`, so this is how Jac gets an *instant* title update. When a PR **merges/closes**, remove its number and surface the updated `/rename`. A `SessionStart` hook (`.claude/hooks/session-title.mjs`) re-derives the title from that file on every start/resume (respecting a manual rename), so the title auto-heals even without the tap. Best-effort: the file is session-scoped and lost on a fresh-container reclaim.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -258,6 +258,18 @@
   one line through single-column pan mode; the `<480px` query re-enables wrap for the mobile stack.
 
 ## Gotchas
+- **A stale INDEX is worse than a missing one (2026-07-26, PRs #770-773).** The decisions ledger
+  (`docs/superpowers/specs/2026-07-20-decisions-ledger.md`) was a 07-20 snapshot that stopped at #100
+  and indexed nothing after. Six days of decisions accumulated in a spec, a build plan, five prompts
+  and two pipeline docs — so grepping the "canonical" index returned confidently WRONG answers:
+  the section model had reversed **twice** (paging → accordion → paging) and the ledger still showed
+  the first. Cost: one missed lookup → three audits, six PRs. **Rules now:** read the ledger before
+  any UI/design work, **read to the END and check dates** (#101+ is the 07-21→07-26 extension), and
+  **add a row when Jac settles something** — a decision isn't made until it's in that table (#135).
+  Reversed rows are marked in place so a grep surfaces the reversal, not the dead answer.
+- **Design Labs is blind to this repo.** Whatever a Labs prompt omits, the mockup won't have — that's
+  how "Your Work", the group taxonomy, the click contract and the section-paging model all silently
+  vanished from a container design. Prompts must INHERIT canon, never re-derive it.
 - **The Staging Deck (`d/`) shares the slot-1 repo, so a STALE-checkout session wipes it** (2026-07-18,
   #720). The deck folders live at `d/` inside `rental-wrangler-staging` — the SAME repo slot-1 deploys
   wipe. Any session still running the **pre-#720** `deploy-staging.mjs` (whose `syncFiles` doesn't


### PR DESCRIPTION
## Why

`LABS-PIPELINE.md` only helps a session that opens `LABS-PIPELINE.md`. **`/start` runs at the top of every session** — that's where the rule belongs. Jac's suggestion, and it's the better hook.

Skill + memory files only; no app code, no served files.

## `/start` — new hard rule

Any design/UI decision goes through the decisions ledger, with the three rules today's failures earned:

1. **Read it before writing a spec, a Labs prompt, or any UI** — don't re-derive what's settled, because Labs is blind to this repo and silently drops whatever a prompt omits.
2. **Read to the END and check dates.** Rows #1–100 are a 07-20 snapshot; #101+ is the extension through 07-26, and **a 07-20 row may be superseded below** — the section model reversed twice. Grepping and stopping at the first hit is exactly how a dead decision gets cited as canon.
3. **A decision is not made until it has a row** (#135).

Plus a pointer to the **`⚠ NEW — captured here`** marker as the highest-risk category — those exist in the ledger and nowhere else.

## `MEMORY.md` — two gotchas

- **A stale index is worse than a missing one**, with the actual cost recorded: one missed lookup → three audits, six PRs.
- **Design Labs is blind to this repo** — a prompt that omits canon produces a mockup without it. That's how "Your Work", the group taxonomy, the click contract and the paging model all vanished at once.

## ⚠️ Flagged, not fixed — a contradiction in `/start` itself

While in the file I found the same staleness class, and it's Jac's call rather than mine:

| Source | Says |
|---|---|
| Ledger **#26** and **#91** | *"jactec-ui **deleted** at Jac's explicit request; replaced by the `style`/`wrangler-style` split, both mandatory together"* |
| `wrangler-style` intro | *"the **true replacement** for the old jactec-ui skill"* |
| **`/start` lines 99, 127, 147** | still routes **all** UI work to **`/jactec-ui`** — *"the single design skill — mandatory for any UI"* |
| `CLAUDE.md` | same — *"Every new or reshaped UI runs through the `jactec-ui` skill"* |
| Disk | `.claude/skills/jactec-ui/` **still present** |

It matters because the two skills teach **different canon**: `jactec-ui` carries the legacy language (Saira Condensed, `--accent #ff7a1a`, hazard-stripe/rivets, R0–R24), while `wrangler-style` carries the dv2 set (`#ff7e1f`, Archivo, four control shapes, matte-no-glow, and the explicit note that the hazard-stripe signature was **not** re-adopted). A session that follows `/start` today gets routed to the superseded one.

Either jactec-ui should go and `/start` + `CLAUDE.md` should route to `style` + `wrangler-style`, or it was deliberately kept and the ledger rows are wrong. **Not guessing** — retiring a skill and rewriting `CLAUDE.md`'s design routing is a real decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_