### PR TITLE
docs: handoff for the stale-design-language sweep + where the rescued skills belong

### DIFF
--- a/docs/design/reference/legacy-jactec-ui/README.md
+++ b/docs/design/reference/legacy-jactec-ui/README.md
@@ -36,10 +36,27 @@ verified, not assumed:
 These files are **not a skill** — nothing loads them automatically. They are readable canon for the
 capabilities above until someone gives them a proper one.
 
-**Open follow-up for Jac:** the **`/role` audit** and **mobile** guidance deserve to be their own
-skills so they trigger automatically again. Right now they only work if someone remembers to open
-this folder — which is exactly the "lives in the wrong place" failure that cost three audits on
-2026-07-26. Filed rather than invented: creating two new skills is a decision, not cleanup.
+## Where these should actually live — the recommendation
+
+**The lesson from `jactec-ui` is that one skill doing four jobs rots**, because the parts get
+superseded at different rates and nobody notices the stale ones. So the answer is *not* "make a new
+combined design skill." It is to put each capability where its own kind of content already lives:
+
+| Capability | Recommended home | Why |
+|---|---|---|
+| **mobile** | **split across the existing two** — measurable bits (≥44px touch floor, safe-area/dvh sizing, gesture timing thresholds) into `style`; decisions (bottom sheets, the 3-column phone reflow, which gesture does what, haptics) into `wrangler-style` | Matches the established rules-vs-decisions architecture. **No new skill** — mobile isn't a separate discipline, it's the same design system at another width. |
+| **`/role` audit** | **its own skill** (`.claude/skills/role/`) | It is a **review gate**, not design language — explicitly invoked, its own triggers, its own output. Critically it is the **PII / margin-leak** check, and burying a security gate inside a styling skill is how it gets skipped by a design-focused session. |
+| **anti-slop** | **`wrangler-style`** | "Don't look generic" is a voice/decision concern, and it's short. |
+| **DESIGN.md guides** | **decide first** | Ask Jac whether `DESIGN.md` is still a live artifact. If it's being retired, these go with it; if it's live, they belong wherever it's owned. Don't build a skill for a file that may be on the way out. |
+
+⚠️ **One thing to check before creating the `/role` skill:** it overlaps the existing **`lazy-audit`**
+skill, which is also role-lens auditing. They are *probably* distinct — `lazy-audit` walks a **running
+surface** as one persona; `/role` reviews a **spec** against 15 lenses plus the authority /
+data-sensitivity / gate checklist — different inputs, different outputs. But confirm that before
+standing up a second, overlapping skill rather than extending `lazy-audit`.
+
+**All of this is filed, not done.** Creating skills and moving canon between them is a decision, not
+cleanup — and doing it silently is what produced the mess this folder documents.
 
 Anything else from the old skill (tokens, signature recipes, checklists, frontend-design,
 jactec.design.md) was **dropped deliberately** — it taught the superseded design language, and it

--- a/docs/handoffs/STALE-DESIGN-LANGUAGE-SWEEP.md
+++ b/docs/handoffs/STALE-DESIGN-LANGUAGE-SWEEP.md
@@ -1,0 +1,105 @@
+# Handoff — sweep the superseded design language out of the specs
+
+**Created 2026-07-26.** Self-contained: everything needed is below. Est. one focused session.
+
+## The job in one line
+
+**~30 documents still describe the OLD design language** — `#ff7a1a`, Saira Condensed, the
+hazard-stripe, rivets — and/or still tell the reader to run UI through **`jactec-ui`, a skill that
+no longer exists** (deleted 2026-07-26, PR #775). Bring them to current canon.
+
+## Why it matters
+
+These are **live product specs**, not history. Anyone building from one today gets pointed at a
+deleted skill and a retired palette. The current canon is:
+
+| | superseded (what the specs still say) | **current** |
+|---|---|---|
+| Accent | `--accent #ff7a1a` | **`#ff7e1f`** |
+| Body voice | **Saira Condensed** | **Archivo** (mono voice unchanged) |
+| Control shapes | one 7px chip radius | **four** — squared `2px` state · opener `5px 5px 0 0` (Gate/Field) · rounded `8px` records · pill (Doors only) |
+| Signature | hazard-stripe + rivets, ignition buttons | **not re-adopted** — matte, **no glow** |
+| Design skill | `jactec-ui` | **`style` + `wrangler-style`, both, always** |
+
+Sources of truth: `.claude/skills/wrangler-style/SKILL.md` (decisions),
+`.claude/skills/style/SKILL.md` (measurable rules), and
+`docs/superpowers/specs/2026-07-20-decisions-ledger.md` (the index — **read to the end**, rows #101+
+supersede some of #1–100).
+
+## The worklist
+
+### Class B — describes the old language (26 files, the real work)
+
+Each is phrased differently — **this is not a find-and-replace.** Expect a bespoke edit per file.
+
+**Start with the two heavyweights** (they're the canonical design descriptions others echo):
+
+| File | old-language hits |
+|---|---|
+| `DESIGN.md` | 13 |
+| `docs/specs/design-system.md` | 10 |
+
+Then, by weight: `mobile-remote.md` (9) · `hr-compliance.md` (9) · `customers-crm.md` (9) ·
+`automated-pricing.md` (7) · `security-cameras.md` (6) · `marketing.md` (5) · then the remainder:
+`accounting.md` · `backend-data.md` · `collections.md` · `comms-notifications.md` ·
+`customer-portal.md` · `equipment-insurance.md` · `financials-kpi.md` · `flag-color-system.md` ·
+`fleet-spread.md` · `gps-tracking.md` · `maintenance-shop.md` · `maps-location.md` ·
+`market-research.md` · `memberships.md` · `rentals-dispatch.md` · `sales-growth.md` ·
+`search-views.md` · `units-fleet.md`.
+
+Find them with:
+```
+grep -rln 'ff7a1a\|Saira\|hazard.stripe\|rivets' docs/specs/ DESIGN.md
+```
+
+### Class A — only names the dead skill (4 files, quick)
+
+`AGENTS.md` · `backlog.md` · `docs/specs/AREAS-ROADMAP.md` · `docs/specs/wrangler-ai.md` —
+just reroute the pointer to `style` + `wrangler-style`.
+
+### Leave alone
+
+- **`docs/superpowers/plans/` (~17 dated plans)** — historical records of builds that really did run
+  through `jactec-ui`. **Rewriting them falsifies the record.** Don't.
+- The one prose mention in an `app.js` comment (~line 25616). Harmless.
+
+## Two judgement calls to make, not guess
+
+1. **`DESIGN.md` may be being retired, not fixed.** It's the portable YAML-tokens file (a Google Labs
+   spec) and its scaffolding guides now sit unowned in
+   `docs/design/reference/legacy-jactec-ui/designmd-*.md`. **Ask Jac whether DESIGN.md is still a
+   live artifact** before investing in rewriting 13 references inside it.
+2. **`docs/specs/design-system.md` may substantially duplicate `wrangler-style`.** If so, the right
+   fix is to make it a pointer rather than a second, drifting copy — that duplication is exactly how
+   today's mess started. Check before rewriting it in place.
+
+## What "done" looks like
+
+- `grep -rn 'ff7a1a\|Saira\|hazard.stripe\|rivets' docs/specs/ DESIGN.md` returns nothing, **or**
+  only clearly-labelled "superseded, kept for history" notes.
+- `grep -rn 'jactec-ui' docs/specs/ AGENTS.md backlog.md DESIGN.md` returns nothing.
+- `docs/superpowers/plans/` is **untouched**.
+- Gates pass: `node ci/smoke.mjs`, `node ci/gen-rule-usage.mjs --check`,
+  `node ci/check-window-catalog.mjs`, `node tools/gen-code-map.mjs --check`,
+  `node ci/check-cachebust.mjs`. (Port 8000 is reserved — `sed -i 's/8000/9147/g' ci/smoke.mjs
+  ci/logic-test.mjs`, run, then `git checkout -- ci/`. Playwright is global here:
+  `ln -sfn /opt/node22/lib/node_modules/playwright node_modules/playwright`.)
+- Docs-only, so no cache-bust bump — `check-cachebust` confirms.
+
+## Traps
+
+- **Don't restyle the app.** This is a documentation sweep. No `style.css`, no `app.js`.
+- **Don't invent canon.** If a spec describes something the current skills don't cover, that's a
+  finding to report, not a licence to decide. Add it to the ledger only with Jac's say-so — a
+  decision isn't made until it has a row (#135).
+- **Read the ledger to the END.** Rows #1–100 are a 2026-07-20 snapshot; #101+ supersede several of
+  them. Grepping and stopping at the first hit is how a superseded decision got cited as canon on
+  2026-07-26 — it cost three audits and six PRs.
+
+## Background
+
+`jactec-ui` was deleted in PR #775, executing ledger #26/#91 (recorded 07-20, never carried out).
+Four capabilities lived only in it and were preserved as reference in
+`docs/design/reference/legacy-jactec-ui/` — the `/role` audit, mobile, anti-slop, and the DESIGN.md
+guides. See that folder's README; it also carries the recommendation for where those should
+eventually live as skills.


### PR DESCRIPTION
Two deliverables, both docs-only.

## 1 · `docs/handoffs/STALE-DESIGN-LANGUAGE-SWEEP.md`

Jac is running the spec sweep in its own session, so it gets a self-contained handoff instead of a bullet in a chat log.

**The job:** ~30 documents still describe the retired language (`#ff7a1a`, Saira Condensed, hazard-stripe, rivets) and/or route UI through `jactec-ui`, which no longer exists.

**The finding that shapes the work:** it is **not** a find-and-replace. I checked whether the stale paragraph was repeated boilerplate — it isn't. Each spec phrases it differently:

```
"dark steel panels, ONE safety-orange #ff7a1a accent reserved for chrome/ignition…"
"exactly one safety-orange accent (--accent #ff7a1a) on the primary/ignition action, the…"
"| Accent | `--accent #ff7a1a`, `--accent-soft`, `--accent-line`…"
```

So the handoff splits the worklist into **class B** (26 files that actually describe the old language — bespoke edits) and **class A** (4 that only name the dead skill — quick pointer fixes), ordered by weight, starting with the two heavyweights: `DESIGN.md` (13 hits) and `docs/specs/design-system.md` (10).

Also includes the superseded-vs-current table, what "done" looks like with the exact gate commands and the port-9147 swap, and the traps — don't restyle the app, don't invent canon, **read the ledger to the end**.

**Two judgement calls flagged rather than pre-decided:**
1. Whether `DESIGN.md` is still a live artifact at all — its scaffolding guides are now unowned, and it'd be daft to rewrite 13 references inside a file that's on the way out.
2. Whether `docs/specs/design-system.md` duplicates `wrangler-style` badly enough that it should become a **pointer** rather than a second drifting copy — that duplication is exactly how today's mess started.

Explicitly out of scope: the ~17 dated plans under `docs/superpowers/plans/`. They're historical records, and rewriting them would falsify the record.

## 2 · Where the rescued capabilities should live

Recorded in `docs/design/reference/legacy-jactec-ui/README.md`, where whoever picks this up will actually look.

**The recommendation follows the lesson from jactec-ui itself: one skill doing four jobs rots, because the parts go stale at different rates and nobody notices the dead ones.** So the answer is *not* a new combined design skill:

| Capability | Home | Why |
|---|---|---|
| **mobile** | **split across the existing pair** — measurable (≥44px touch floor, safe-area/dvh, gesture timing) → `style`; decisions (bottom sheets, phone reflow, gesture meanings, haptics) → `wrangler-style` | Mobile isn't a separate discipline — it's the same design system at another width. **No new skill.** |
| **`/role` audit** | **its own skill** | It's a review **gate**, not design language. Critically it's the **PII / margin-leak** check, and burying a security gate inside a styling skill is how it gets skipped by a design-focused session. |
| **anti-slop** | `wrangler-style` | "Don't look generic" is a voice concern, and it's short. |
| **DESIGN.md guides** | **decide first** | Don't build a skill for a file that may be retired. |

⚠️ Flagged: `/role` overlaps the existing **`lazy-audit`** skill. They're *probably* distinct — `lazy-audit` walks a **running surface** as one persona; `/role` reviews a **spec** against 15 lenses plus the authority/data-sensitivity/gate checklist — but that should be confirmed before standing up a second, overlapping skill rather than extending `lazy-audit`.

All of it filed, not done — creating skills and moving canon between them is a decision, not cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_