### PR TITLE
docs: mark the first Tier 0.1a run as a draft, not a lock

### DIFF
--- a/docs/design/LABS-PIPELINE.md
+++ b/docs/design/LABS-PIPELINE.md
@@ -88,6 +88,13 @@ static state grid cannot. Both are deliberate, both are accepted as slower (ledg
   Run them in this order, each its own Labs session:
   1. `prompts/prompt-03-container-card.md` — **card frame · header · list row.** The most
      load-bearing prompt in the build order: twelve surfaces share this anatomy.
+     > ⚠️ **The FIRST 0.1a run is a DRAFT, not a lock (Jac, 2026-07-26).** It was run against the
+     > prompt *before* the canon corrections (#770–#772), so its header lacks **"Your Work"**,
+     > **"Done"**, the left-aligned **Ref** title and the description line, and its row lacks the
+     > click contract and the group taxonomy. Jac deliberately chose not to restart that session —
+     > the corrections land on the **next** run. **Do not treat that artifact as the locked card
+     > container, and do not build Tier 0.2 on it.** Its frame, list row and Trips stress-test work
+     > are sound and carry forward.
   2. `prompts/prompt-04-container-section.md` — **section.** A detail view is a rail of these paged
      one at a time, so it must lock before Tier 1 can.
   3. `prompts/prompt-05-container-overlay.md` — **panel · popup · ⋯ action menu.**


### PR DESCRIPTION
## Why

Jac chose not to restart the in-flight Labs session for `prompt-03` — the canon corrections (#770–#772) land on the **next** run instead. Sensible call; no reason to throw away work in progress.

But it leaves an artifact that **looks finished and isn't**. Two lines to stop that becoming the next regression.

## What's missing from that draft

Run against the pre-fix prompt, so:

- **Header** — no "Your Work", no "Done", title not left-aligned and not a Ref, no description line
- **Row** — no click contract (single = expand / double = anchor, 220ms), no group taxonomy (Attention vs Lifecycle)

## The risk this prevents

A later session finds an approved-looking card artifact, reads it as **the locked card container**, and builds **Tier 0.2 on top of a design missing four locked decisions**. That's the same failure shape as the section model flipping twice with no written trail — an understanding that lived in a conversation instead of a file.

## What carries forward

The **frame**, the **list row** structure, and the **Trips stress test** are sound work and explicitly noted as carrying over — so the next run isn't starting from zero, it's redoing the header and the row's interaction spec.

Docs only; one note in the build order.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_