### PR TITLE
docs: lock the accent≠status agency law; log the two atom gaps

### DIFF
--- a/.claude/skills/wrangler-style/SKILL.md
+++ b/.claude/skills/wrangler-style/SKILL.md
@@ -120,6 +120,13 @@ that needs a Signal/Stamp/icon distinction instead — solve it in the component
 = *touchable* · deep-blue `--commit` = *commit* · everything else = plain honest text.
 Nothing ever does two jobs — that's the whole reason Signal, Ref, and Door don't collide.
 
+**ACCENT ≠ STATUS — the agency law (locked 2026-07-26, ledger #137).** Accent means **user agency**;
+status hues mean **the world.** Anything that says *"you did this"* — the selected row, an active
+filter, the hover ring, the focus ring — is `--accent`. A status hue (red · yellow · blue · green ·
+gray) always describes the **record's** condition, never the user's choice. This sharpens
+"orange = touchable" above: *touchable* is the affordance, *agency* is the state of having acted.
+Without it, a selected row and an on-fire row compete for the same meaning — and the fire loses.
+
 ### 3.0 The four control shapes (locked 2026-07-25 — this is our answer to `style` §1)
 
 Shape carries the **family**, so a control's silhouette says what kind of thing it is before

--- a/docs/superpowers/specs/2026-07-20-decisions-ledger.md
+++ b/docs/superpowers/specs/2026-07-20-decisions-ledger.md
@@ -558,8 +558,17 @@ history is what lets a future reader tell "settled" from "settled twice."
 | 134 | **Every Labs prompt must inherit this ledger, never re-derive from scratch.** Labs is blind to the repo, so anything absent from a prompt does not exist to it — a prompt that re-derives settled ground silently undoes it | [LABS-PIPELINE] |
 | 135 | **A decision is not made until it has a row in this table.** The 07-20 snapshot going un-extended for six days is what let a superseded decision be cited as current | [this section] |
 | 136 | **A Labs prompt MAY ask for several artifacts in one session, and container mockups STAY interactive** — both deliberate, both accepted as slower. Reviewed 2026-07-26 after Jac asked why one artifact takes so long: prompt-03 asks a single session for frame + header + row across ~17 rendered states, with live JS. Kept because designing the three **against each other** stops them drifting, and because clicking a row and watching it expand catches what a static state grid cannot. **Cost accepted:** slower builds, and a wrong part means re-running the whole prompt. **Do not "fix" the apparent conflict with "one screen = one Labs session = one artifact" by splitting these prompts** — the rule is about *scope of subject*, not count of rendered pieces | ✅ **CURRENT** [Jac] |
+| 137 | **ACCENT ≠ STATUS — accent means USER AGENCY, status hues mean THE WORLD.** Selected row, active filter, hover ring, focus ring — anything that says *"you did this"* — is `--accent`. A status hue (red/yellow/blue/green/gray) always describes the **record's** condition, never the user's choice. Raised by the Tier 0.1a card artifact, which needed a colour for "you did this" that could not be mistaken for the world being on fire. **Accepted as a law** (Jac, 2026-07-26). Sharpens the existing "orange = touchable" line in `wrangler-style` §3: touchable is the affordance, agency is the *state* of having acted | ✅ **CURRENT** [Jac] |
+| 138 | **Two atom gaps found by the 0.1a card artifact — real, not workarounds to keep.** (a) The kit has **no real text input** — Search is currently faked with a `.field`, which is an *opener* (it opens something) and therefore the wrong shape for free typing. (b) The **Pin's ring colour is hard-coded** to `--panel`, so a Pin breaks on any surface that isn't a panel. Both need fixing in the kit and re-syncing | ⏳ **OPEN — queued for the kit** |
 
 ## Still open after 07-20 (do not treat as locked)
+
+- **The card header's seating — 1a / 1b / 1c** (Tier 0.1a artifact §2.2). Two bands (identity over
+  controls, the artifact's recommendation), one band, or identity-cap + filter rail in the body.
+  **Jac has not chosen.** Do not treat 1a as settled just because it is marked RECOMMENDED.
+- **The drop order under narrowing** — the artifact proposes *glance frequency*
+  (sort → search → description → chip words, with title Ref / rollup / Door never dropping).
+  **Jac has not ruled.** Undecided.
 
 - **The Detail-view structural reshape** (#119) — deferred pending its own reviewed pass.
 - **Invoice line-item IDs as Ref vs Stamp** (#116) — shipped as Ref, explicitly flagged as revertible.


### PR DESCRIPTION
From the Tier 0.1a card artifact — which turned out to have been built against the **corrected** prompt after all. #778 is closed; its premise that the run was pre-fix was wrong.

## #137 — ACCENT ≠ STATUS, accepted as a law

**Accent means user agency; status hues mean the world.**

Anything that says *"you did this"* — selected row, active filter, hover ring, focus ring — is `--accent`. A status hue (red · yellow · blue · green · gray) always describes the **record's** condition, never the user's choice.

It sharpens the existing *"orange = touchable"* line rather than replacing it: **touchable is the affordance, agency is the state of having acted.** Without the distinction, a selected row and an on-fire row compete for the same meaning — **and the fire loses**, which is the one thing this whole design language exists to prevent.

Written into both the ledger and `wrangler-style` §3, right next to the rule it refines.

## #138 — two real atom gaps, logged as open

The artifact **reported these instead of silently working around them**, which is what the prompt asked for:

| Gap | Why it matters |
|---|---|
| **No real text input in the kit** — Search is faked with a `.field` | A `.field` is an **opener** (it opens something). Free typing is not opening. Wrong shape, wrong affordance. |
| **The Pin's ring colour is hard-coded** to `--panel` | A Pin breaks on any surface that isn't a panel — and the Pin is explicitly the *universal* corner marker. |

Both are queued for the kit and need a re-sync once fixed.

## What Jac has NOT decided — recorded so it can't drift into "settled"

- **The header seating, 1a / 1b / 1c.** 1a (two bands) is the **artifact's recommendation**, not a ruling. Anyone reading "RECOMMENDED" should not treat it as locked.
- **The drop order under narrowing** (glance frequency: sort → search → description → chip words, with title Ref / rollup / Door never dropping). Proposed, not ruled.

Docs + one skill file; no app code, no served files.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yb5VkKeHdNJG8W8wK2vHQ)_