### PR TITLE
[parked] p1-verification-harness

### DIFF
--- a/docs/design/tier-01-card/verify/README.md
+++ b/docs/design/tier-01-card/verify/README.md
@@ -1,0 +1,44 @@
+# P1 verification harness (parked)
+
+Deferred from `claude/tier-01-card-audit-crnxj3` on 2026-07-31 (PR #785).
+
+These scripts built and verified the Tier-0.1 **P1** block that now ships inside
+`docs/design/tier-01-card/index.html`. They are parked because they only ever lived in an
+ephemeral session scratchpad, and because they regression-test **six real bugs a fresh-context
+review found after the block had already been landed and declared verified** (ledger #179).
+
+| File | What it is |
+|---|---|
+| `p1.mjs` | The source of truth for the R2→R7 + P1 **CSS**. Injects it against a served prototype and screenshots. |
+| `land.mjs` | **Generates the landed block** in `index.html` from `p1.mjs`'s CSS, so what ships is byte-identical to what was measured. Idempotent — replaces a previously-landed block. |
+| `verify2.mjs` | Clean-load verification of all six #179 findings, each independently. |
+| `regress.mjs` | The chained-interaction version (filter → search → open → remount). |
+| `glow.mjs` | The **#146 audit**: proves nothing on the housing emits — an outer `0 0 Npx` shadow is light, an inset or hard-offset shadow is paint. |
+
+## Running them
+
+Serve the prototype from **inside** `docs/design/tier-01-card/` on port **9147** (8000 is
+reserved): `python3 -m http.server 9147 --bind 127.0.0.1`. Kill a stuck one with
+`fuser -k 9147/tcp`.
+
+Playwright **must** launch with
+`executablePath: '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell'` —
+the plain chromium binary errors *"Old Headless mode has been removed"*. Wait ~3000ms after
+`networkidle`; the component mounts asynchronously.
+
+## What they exist to stop coming back
+
+1. **`getComputedStyle` on a `display:none` element returns `transform: none`** — reading state off
+   an element your own CSS hides pins that state forever. This killed the whole housing open/shut
+   mechanic while a "measured proof" said it worked.
+2. **dc-runtime RECYCLES row/head nodes positionally.** A presence-based "already built?" guard
+   leaves an injected layer describing a *different record*.
+3. The jump band being permanently swept on a row that unmounts while open.
+4. `.rw-noframe` over-matching and taking chassis steel with the laser.
+5. Head counts falling back to member **state** text, so an empty lifecycle group read "N OPEN".
+6. `+N` specified by #170 but never emitted, so excess ticks clipped silently.
+
+## Needs
+
+Nothing to finish — they pass as of `d196df4`. Re-point the paths if the prototype moves, and
+re-run `verify2.mjs` + `glow.mjs` after any change to the landed block.

--- a/docs/design/tier-01-card/verify/glow.mjs
+++ b/docs/design/tier-01-card/verify/glow.mjs
@@ -1,0 +1,30 @@
+// #146 audit: nothing on the HOUSING may emit. An emissive shadow is an outer
+// "0 0 Npx" blur; an inset shadow or a hard offset is shading/paint, not light.
+import { chromium } from 'playwright';
+const EXEC='/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell';
+const b=await chromium.launch({executablePath:EXEC});
+const pg=await b.newPage({viewport:{width:440,height:1700}});
+await pg.goto('http://127.0.0.1:9147/index.html',{waitUntil:'networkidle'});
+await pg.waitForTimeout(3000);
+console.log(JSON.stringify(await pg.evaluate(`(()=>{
+  const emissive = bs => {
+    if(!bs||bs==='none') return false;
+    // split top-level commas
+    const parts=bs.split(/,(?![^(]*\\))/);
+    return parts.some(p=>{ const t=p.trim(); if(/^inset/.test(t)) return false;
+      // outer shadow with zero offsets and a real blur = glow
+      const m=t.match(/(-?[\\d.]+)px\\s+(-?[\\d.]+)px\\s+([\\d.]+)px/);
+      return !!m && Math.abs(+m[1])<0.5 && Math.abs(+m[2])<0.5 && +m[3]>0.5; });
+  };
+  const out={housingGlow:[], litRowGlow:null};
+  document.querySelectorAll('.scp1').forEach(s=>{
+    const grp=s.parentElement;
+    // the head band and every non-row element inside the group container
+    [s, ...s.querySelectorAll('*'), ...[...grp.children].filter(c=>!c.hasAttribute('data-row'))]
+      .forEach(e=>{ if(e.closest && e.closest('[data-row]')) return;
+        const bs=getComputedStyle(e).boxShadow;
+        if(emissive(bs)) out.housingGlow.push({cls:String(e.className).slice(0,24)||e.tagName, bs:bs.slice(0,70)}); });
+  });
+  return {housingEmissiveCount: out.housingGlow.length, sample: out.housingGlow.slice(0,4)};
+})()`),null,2));
+await b.close();

--- a/docs/design/tier-01-card/verify/land.mjs
+++ b/docs/design/tier-01-card/verify/land.mjs
@@ -1,0 +1,289 @@
+// Land R2->P1 into the prototype, taking the CSS verbatim from the verified p1.mjs
+// so what ships is byte-identical to what was measured.
+import fs from 'node:fs';
+const SCR = '/tmp/claude-0/-home-user-rental-wrangler/0ae968fe-28c8-53d0-84a6-9fc8848ba315/scratchpad/p1/p1.mjs';
+const TGT = '/home/user/rental-wrangler/docs/design/tier-01-card/index.html';
+
+const src = fs.readFileSync(SCR, 'utf8');
+const CSS_R7 = src.split('const CSS_R7 = `')[1].split('`;')[0];
+const CSS_P1 = src.split('const CSS_P1 = `')[1].split('`;')[0];
+const CSS = (CSS_R7 + '\n' + CSS_P1).trim();
+
+const BLOCK = `
+<!-- ============================================================================
+     Tier-0.1 head/row build — revert points R2-R7 plus P1, landed 2026-07-31.
+     Trail: docs/superpowers/specs/2026-07-31-tier-01-head-row-design-log.md
+     Rulings: decisions ledger #165-#173.
+
+       R2-R4  the group head: a 26px deep milled pocket, raised letter faces in
+              an etched-away field, hue on the faces, open/shut on the floor.
+       R5-R7  pins retired for slots (skewed ticks); the row's message board;
+              row order = message board . button . slots . facts . name.
+       P1     TWO LEVELS, TWO PHYSICS (#168):
+                GROUP = housing,   opens by MOVING    steel . mechanical . no light
+                ROW   = cartridge, opens by LIGHTING  glass . terminal . emission
+              Invariant at both levels: the name is right-aligned.
+
+     WHY THIS IS A RUNTIME BLOCK AND NOT A STATIC <style>: the card ships its own
+     runtime-INJECTED stylesheet, which lands after anything static, so an
+     equal-specificity rule loses on source order (design log section 3.3). The
+     style element is appended from JS so it is guaranteed to come last, and the
+     DOM work has to wait for the component to mount anyway.
+
+     WHY IT HOOKS THE CARD'S OWN OPEN STATE: ledger #173 keeps the existing 220ms
+     single/double click discriminator (#67/#164) exactly as it is. The card marks
+     an open row by writing an inline color-mix wash (#156's group-hue-at-16%);
+     this block detects that and re-skins it as a lit cartridge, per #172. It does
+     NOT add a competing click handler.
+     ============================================================================ -->
+<script>
+(function () {
+  var CSS = ${JSON.stringify(CSS)};
+
+  var HUE = function (l) { var s = (l || '').toLowerCase();
+    if (/overdue|failed|fail|damage|breakdown/.test(s)) return ['#ff4242', 'red'];
+    if (/service due|needs wash|open|promised|due/.test(s)) return ['#eed44b', 'yellow'];
+    if (/transport|truck|pickup|reserved/.test(s)) return ['#6394cc', 'blue'];
+    if (/available|complete|passed|paid/.test(s)) return ['#34d399', 'green'];
+    return ['#8a94a2', 'gray']; };
+  var RANK = { red: 0, yellow: 1, blue: 2, green: 3, gray: 4 };   // style section 6 rollup
+
+  // A row's issues live in the .pin's data-hint: one per line, "Source, State, Date".
+  // (data-tip does not exist in this build — see design log section 5.7.)
+  // Slots are ISSUES, so this is pin-derived ONLY: a row with nothing open gets no
+  // ticks, rather than a filler tick made from its own state text.
+  function rowIssues(row) {
+    var pin = row.querySelector('.pin[data-hint]');
+    if (!pin) return [];
+    return (pin.getAttribute('data-hint') || '').split(/\\n+/).map(function (l) {
+      var p = l.split(',').map(function (s) { return s.trim(); });
+      return p.length >= 2 ? p[1] : p[0];
+    }).filter(Boolean);
+  }
+  function rowState(row) {
+    var sg = row.querySelector('.signal'); return sg ? (sg.textContent || '').trim() : '';
+  }
+  // THE STALENESS GUARD. dc-runtime RECYCLES row/head nodes positionally instead of
+  // replacing them, so "a rack already exists here" does NOT mean "this node is still
+  // about the same record". Without this, filtering or searching leaves a rack, board
+  // and data-tone describing a DIFFERENT unit — and a wrong data-tone mis-colours the
+  // laser frame, which #172 makes the sole carrier of the state hue.
+  function rowSig(row) {
+    var pin = row.querySelector('.pin[data-hint]');
+    return (pin ? pin.getAttribute('data-hint') : '') + '\\u0001' +
+           (((row.querySelector('.rmq') || {}).textContent) || '') + '\\u0001' + rowState(row);
+  }
+  function headSig(gate, grp) {
+    var s = ((gate.querySelector('.sc-interp') || {}).textContent) || '';
+    if (grp) { var rs = grp.querySelectorAll('[data-row]');
+      for (var i = 0; i < rs.length; i++) s += '\\u0002' + rowSig(rs[i]); }
+    return s;
+  }
+  // #170 — "+N appears only when real width runs out". The rack clips at overflow:hidden,
+  // so without this the excess ticks vanish silently instead of being counted.
+  function fitRack(rk) {
+    if (!rk) return;
+    var old = rk.querySelector('.rw-more'); if (old) old.parentNode.removeChild(old);
+    var ticks = [].slice.call(rk.querySelectorAll('.rw-tick'));
+    ticks.forEach(function (t) { t.style.display = ''; });
+    if (!ticks.length || rk.clientWidth <= 0) return;
+    var n = ticks.length, more = null;
+    while (n > 0 && rk.scrollWidth > rk.clientWidth + 1) {
+      n--; ticks[n].style.display = 'none';
+      if (!more) { more = document.createElement('span'); more.className = 'rw-more'; rk.appendChild(more); }
+      more.textContent = '+' + (ticks.length - n);
+    }
+  }
+  // children[0] is the absolutely-positioned accent caret span, NOT the content div.
+  function rowInner(row) {
+    for (var i = 0; i < row.children.length; i++) if (row.children[i].tagName === 'DIV') return row.children[i];
+    return null;
+  }
+  function rack(list) {
+    var r = document.createElement('div'); r.className = 'rw-rack';
+    list.forEach(function (t) {
+      var k = document.createElement('i'); k.className = 'rw-tick';
+      k.style.background = HUE(t)[0]; k.dataset.label = t; r.appendChild(k);
+    });
+    return r;
+  }
+  function board(txt) {
+    var b = document.createElement('div'); b.className = 'rw-board';
+    var s = document.createElement('span'); s.textContent = txt; s.style.color = '#6a7684';
+    b.appendChild(s); return b;
+  }
+  function wire(ticks, b, rest) {
+    ticks.forEach(function (k) {
+      k.addEventListener('mouseenter', function () {
+        var s = b.querySelector('span'); s.textContent = k.dataset.label.toUpperCase();
+        s.style.color = HUE(k.dataset.label)[0]; k.classList.add('hot');
+      });
+      k.addEventListener('mouseleave', function () {
+        var s = b.querySelector('span'); s.textContent = rest; s.style.color = '#6a7684';
+        k.classList.remove('hot');
+      });
+    });
+  }
+
+  function build() {
+    // #169 takes the LASER off the housing — and ONLY the laser. The frame is the one
+    // element carrying an inline transform-origin (the browser normalises the authored
+    // "top" to "center top", so match the PROPERTY, not a value); there are exactly ten,
+    // one per group. It is NOT a direct child of the group, which is why a grp.children
+    // scan missed it entirely. The earlier blanket "hide every absolute div in the group"
+    // did find it, but took the side rails, U-groove, uBeam and both tongues with it —
+    // and those are chassis steel, which #168 defines the housing as keeping.
+    [].forEach.call(document.querySelectorAll('div[style*="transform-origin"]'), function (c) {
+      c.classList.add('rw-noframe');
+    });
+
+    // --- open/shut, read off the chevron's INLINE transform ---
+    // NOT getComputedStyle: this block's own CSS sets .gate__chev{display:none},
+    // and a display:none element computes transform as "none" no matter what the
+    // inline value says — which pinned every gate to data-open="1" and left the
+    // whole housing open/shut mechanic dead. The inline value survives hiding.
+    [].forEach.call(document.querySelectorAll('.gate'), function (g) {
+      var c = g.querySelector('.gate__chev');
+      var t = c ? (c.style.transform || 'none') : 'none';
+      g.setAttribute('data-open', (t && t !== 'none') ? '0' : '1');
+    });
+
+    // --- LEVEL 2 · cartridges (rows). REPLACE, don't ADD: the 380px budget is
+    //     already spent, and the bare spans are the date/facts column, which
+    //     R7/#162 drop first anyway. ---
+    [].forEach.call(document.querySelectorAll('[data-row]'), function (row) {
+      var inner = rowInner(row); if (!inner) return;
+      var sig = rowSig(row);
+      if (row.getAttribute('data-rwsig') !== sig) {
+        // the node was recycled onto a different record — tear the old layer out
+        var ob = inner.querySelector('.rw-board'); if (ob) ob.parentNode.removeChild(ob);
+        var ork = inner.querySelector('.rw-rack'); if (ork) ork.parentNode.removeChild(ork);
+
+        [].forEach.call(inner.children, function (c) {
+          // NEVER sweep the jump band: it only exists while the row is open, and
+          // hiding it once is permanent because the sweep does not re-run for it.
+          if (c.hasAttribute('data-jump-band')) return;
+          if (!c.classList.contains('pin-wrap') && !c.classList.contains('ref')) c.classList.add('rw-off');
+        });
+        var list = rowIssues(row);
+        var worst = list.slice().sort(function (a, b) { return RANK[HUE(a)[1]] - RANK[HUE(b)[1]]; })[0];
+        // no open issues -> the row's own state still gives the lit frame its hue
+        row.setAttribute('data-tone', HUE(worst || rowState(row))[1]);
+        var rest = list[0] ? list[0].toUpperCase() : '\\u2014';
+        var bd = board(rest);
+        inner.insertBefore(bd, inner.firstChild);
+        var rk = rack(list);                     // empty list -> no ticks, not a filler tick
+        inner.insertBefore(rk, bd.nextSibling);
+        wire([].slice.call(rk.querySelectorAll('.rw-tick')), bd, rest);
+        fitRack(rk);
+        row.setAttribute('data-rwsig', sig);
+      }
+
+      // The card signals "this row is open" by writing an inline color-mix wash
+      // (#156). #172 re-skins that as a lit cartridge; #173 leaves the click alone.
+      var open = /color-mix/.test((inner.getAttribute('style') || ''));
+
+      // The card renders its own detail panel as a LATER div child — that panel
+      // is the cartridge's drawer slot and it carries the #63 anchor icon, so
+      // the terminal lines go INSIDE it rather than becoming a second drawer.
+      var drawer = null;
+      for (var j = row.children.length - 1; j >= 0; j--) {
+        var ch = row.children[j];
+        if (ch.tagName === 'DIV' && ch !== inner) { drawer = ch; break; }
+      }
+
+      if (open) {
+        row.setAttribute('data-lit', '1');
+        if (drawer && !drawer.querySelector('.rw-cartlines')) {
+          drawer.classList.add('rw-drawer');
+          var nm = ((row.querySelector('.rmq') || {}).textContent || 'UNIT').trim();
+          var li = rowIssues(row);
+          var lines = document.createElement('div'); lines.className = 'rw-cartlines';
+          lines.innerHTML = '<div class="l">&gt; <b>' + nm + '</b> ONLINE</div>' +
+            (li.length ? li.map(function (t) { return '<div class="l">&nbsp;&nbsp;\\u00b7 ' + t.toUpperCase() + '</div>'; }).join('')
+                       : '<div class="l dim">&nbsp;&nbsp;\\u00b7 NO OPEN ISSUES</div>') +
+            '<div class="l dim">&nbsp;&nbsp;READY</div>';
+          drawer.appendChild(lines);
+        }
+      } else if (row.getAttribute('data-lit') === '1') {
+        row.removeAttribute('data-lit');
+        if (drawer) {
+          drawer.classList.remove('rw-drawer');
+          var old = drawer.querySelector('.rw-cartlines');
+          if (old) old.parentNode.removeChild(old);
+        }
+      }
+    });
+
+    // --- LEVEL 1 · housings (group heads), right-condensed at .scp1:
+    //     [ slots ...residual... ][ board ][ NAME ]. The head's own board/stamp/
+    //     spacers are retired so the rack inherits the width they held (#170). ---
+    [].forEach.call(document.querySelectorAll('.gate'), function (g) {
+      var scp = g.closest('.scp1'); if (!scp) return;
+      var grp = scp.parentElement;
+      var sig = headSig(g, grp);
+      if (scp.getAttribute('data-rwsig') === sig) return;   // same record, still valid
+
+      var ob = scp.querySelector('.rw-board'); if (ob) ob.parentNode.removeChild(ob);
+      var ork = scp.querySelector('.rw-rack'); if (ork) ork.parentNode.removeChild(ork);
+
+      [].forEach.call(scp.children, function (c) {
+        if (c.classList.contains('pin-wrap')) return;
+        if (getComputedStyle(c).position === 'absolute') return;
+        c.classList.add('rw-off');
+      });
+      var rows = grp ? [].slice.call(grp.querySelectorAll('[data-row]')) : [];
+      var list = [];
+      rows.forEach(function (r) { list = list.concat(rowIssues(r)); });   // pin-derived only
+      list.sort(function (a, b) { return RANK[HUE(a)[1]] - RANK[HUE(b)[1]]; });   // hottest first
+      // a lifecycle group with nothing open reads NOMINAL and shows no ticks, instead
+      // of counting its own members' states as if they were open issues
+      var rest = list.length ? (list.length + ' OPEN') : 'NOMINAL';
+      var bd = board(rest);
+      var rk = rack(list);
+      scp.insertBefore(bd, scp.firstChild);
+      scp.insertBefore(rk, bd);
+      wire([].slice.call(rk.querySelectorAll('.rw-tick')), bd, rest);
+      fitRack(rk);
+      scp.setAttribute('data-rwsig', sig);
+    });
+  }
+
+  var obs = null, queued = false;
+  function rebuild() {
+    if (obs) obs.disconnect();
+    try { build(); } catch (e) { if (window.console) console.warn('[rw-p1]', e); }
+    if (obs) obs.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['style'] });
+    queued = false;
+  }
+  function schedule() { if (!queued) { queued = true; requestAnimationFrame(rebuild); } }
+
+  function start() {
+    var st = document.createElement('style');
+    st.id = 'rw-p1'; st.textContent = CSS;
+    document.head.appendChild(st);          // appended last, so it wins source order
+    rebuild();
+    obs = new MutationObserver(schedule);
+    obs.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['style'] });
+  }
+
+  // the component mounts asynchronously — wait for it, then bail out politely
+  var tries = 0;
+  var t = setInterval(function () {
+    if (document.querySelector('.gate')) { clearInterval(t); start(); }
+    else if (++tries > 150) { clearInterval(t); }   // ~12s, then give up silently
+  }, 80);
+})();
+</script>
+`;
+
+let html = fs.readFileSync(TGT, 'utf8');
+const marker = '</body></html>';
+if (html.indexOf(marker) === -1) { console.error('marker not found'); process.exit(1); }
+// idempotent: strip any previously-landed block, then re-insert the current one
+const START = '<!-- ============================================================================\n     Tier-0.1 head/row build';
+const i = html.indexOf(START);
+if (i !== -1) { html = html.slice(0, i) + html.slice(html.indexOf(marker)); console.log('replaced previous block'); }
+html = html.replace(marker, BLOCK + '\n' + marker);
+fs.writeFileSync(TGT, html);
+console.log('landed, bytes now', html.length);

--- a/docs/design/tier-01-card/verify/p1.mjs
+++ b/docs/design/tier-01-card/verify/p1.mjs
@@ -1,0 +1,461 @@
+// P1 — the two-level architecture, built by injection (ledger #168-#171).
+//   GROUP = housing,   opens by MOVING    (steel · mechanical · NO light)
+//   ROW   = cartridge, opens by LIGHTING  (glass · terminal · emission)
+// Layers on the R2->R7 stack from design-log section 5. Harness per section 4.
+//
+// DOM facts established by probe (they differ from the log's section 2.7 shorthand):
+//   * the group container is  gate.closest('.scp1').parentElement
+//   * a row's issue list is the .pin's data-hint, newline-separated "Source, State, Date"
+//   * a row's content div is the DIV child (children[0] is the accent caret SPAN)
+//   * that div carries INLINE background/height -> stylesheet rules need !important
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+
+const OUT = '/tmp/claude-0/-home-user-rental-wrangler/0ae968fe-28c8-53d0-84a6-9fc8848ba315/scratchpad/p1';
+fs.mkdirSync(OUT, { recursive: true });
+const EXEC = '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell';
+
+/* ---------- section 5 preamble + R2..R7, verbatim from the design log ---------- */
+const CSS_R7 = `
+.ref{background:none!important;background-color:transparent!important;background-image:none!important;
+     box-shadow:none!important;border:0!important;clip-path:none!important;width:auto!important;
+     flex:1 1 auto!important;min-width:0!important;padding-left:0!important;}
+.ref__icon{width:12px!important;height:12px!important;background:transparent!important;opacity:.45!important;}
+.rmq{font-family:'Archivo',sans-serif!important;font-weight:700!important;font-size:15px!important;
+     letter-spacing:-.005em!important;color:#eef2f7!important;}
+
+/* R3 — deep milled pocket */
+.scp1{padding-right:2px!important;}
+.scp1 .pin{display:none!important;}
+.gate{height:26px!important;padding:0 11px!important;margin-right:0!important;
+  background:linear-gradient(#080d14 0%, #0b111a 62%, #0d141d 100%)!important;
+  background-color:#0a0f16!important;
+  clip-path:polygon(8px 0,100% 0,100% calc(100% - 8px),calc(100% - 8px) 100%,0 100%,0 8px)!important;
+  box-shadow:
+    inset 0 6px 7px -1px rgba(0,0,6,.96), inset 0 2px 0 rgba(0,0,8,.9),
+    inset -3px 0 0 rgba(0,0,8,.72), inset -8px 0 9px -4px rgba(0,0,6,.85),
+    inset 0 -8px 9px -5px rgba(0,0,6,.5), inset 0 -2px 0 rgba(198,218,248,.22),
+    inset -3px -2px 0 rgba(198,218,248,.10)!important;
+  border:0!important;display:inline-flex!important;align-items:center!important;overflow:hidden!important;}
+.gate__chev{display:none!important;}
+.gate .sc-interp{font-family:ui-monospace,'Cascadia Code',Menlo,Consolas,monospace!important;
+  font-size:12.5px!important;font-weight:800!important;letter-spacing:.04em!important;
+  text-transform:uppercase!important;overflow:hidden!important;
+  text-overflow:ellipsis!important;white-space:nowrap!important;}
+
+/* R4 — hue faces + floor tint (the settled head) */
+.gate--red    .sc-interp{color:#ff8080!important;text-shadow:0 -1px 0 rgba(255,196,196,.30), 0 1px 2px rgba(0,0,4,.95)!important;}
+.gate--yellow .sc-interp{color:#f2dc6a!important;text-shadow:0 -1px 0 rgba(255,244,190,.30), 0 1px 2px rgba(0,0,4,.95)!important;}
+.gate--blue   .sc-interp{color:#9dbfe4!important;text-shadow:0 -1px 0 rgba(206,228,250,.30), 0 1px 2px rgba(0,0,4,.95)!important;}
+.gate--green  .sc-interp{color:#5ee0ab!important;text-shadow:0 -1px 0 rgba(186,246,220,.30), 0 1px 2px rgba(0,0,4,.95)!important;}
+.gate--gray   .sc-interp{color:#c2ccd8!important;text-shadow:0 -1px 0 rgba(226,236,248,.28), 0 1px 2px rgba(0,0,4,.95)!important;}
+.gate--red[data-open="0"]    .sc-interp{color:#c26161!important;}
+.gate--yellow[data-open="0"] .sc-interp{color:#b8a751!important;}
+.gate--blue[data-open="0"]   .sc-interp{color:#7791ad!important;}
+.gate--green[data-open="0"]  .sc-interp{color:#47aa82!important;}
+.gate--gray[data-open="0"]   .sc-interp{color:#939ba4!important;}
+.gate--red[data-open="1"]   {background:linear-gradient(rgba(255,66,66,.26),rgba(255,66,66,.09))!important;}
+.gate--yellow[data-open="1"]{background:linear-gradient(rgba(238,212,75,.24),rgba(238,212,75,.08))!important;}
+.gate--blue[data-open="1"]  {background:linear-gradient(rgba(99,148,204,.28),rgba(99,148,204,.10))!important;}
+.gate--green[data-open="1"] {background:linear-gradient(rgba(52,211,153,.24),rgba(52,211,153,.09))!important;}
+.gate--gray[data-open="1"]  {background:linear-gradient(rgba(170,180,193,.20),rgba(170,180,193,.07))!important;}
+
+/* R5 — slots */
+.seg,.seg__opt,[data-row],[data-row]>div{overflow:visible!important;}
+.rw-tick{flex:0 0 auto;width:6px;height:12px;transform:skewX(19deg);border-radius:1.5px;cursor:pointer;
+  background-image:linear-gradient(rgba(255,255,255,.20), rgba(255,255,255,.04) 42%, rgba(0,0,0,.28));
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.24), inset 0 -1.5px 2px rgba(0,0,0,.45),
+             0 1px 2px rgba(0,0,0,.6);}
+.rw-rack{flex:0 0 auto;display:flex;align-items:center;gap:2.5px;margin-left:2px;}
+.rw-more{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:9px;color:#838e9c;margin-left:1px;}
+
+/* R6 — row message board (needs steel under it, section 2.3) */
+[data-row] > div{background:linear-gradient(rgba(185,205,235,.085),rgba(185,205,235,.02) 45%,rgba(0,0,12,.16)),
+           #171F2A !important;
+  box-shadow:inset 0 1px 0 rgba(185,205,235,.13)!important;}
+.rw-board{background:#050A10;display:flex;align-items:center;padding:0 7px;
+  clip-path:polygon(5px 0,100% 0,100% calc(100% - 5px),calc(100% - 5px) 100%,0 100%,0 5px);
+  box-shadow:inset 0 1px 2px rgba(0,0,6,.8), inset 0 -1px 0 rgba(190,210,240,.10);}
+.rw-board span{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:8.5px;font-weight:700;
+  letter-spacing:.03em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.rw-tick.hot{filter:brightness(1.5);}
+
+/* R7 — row order: message board · button · slots · facts · name */
+[data-row]>div{height:34px!important;display:flex!important;align-items:center!important;
+  gap:6px!important;position:relative!important;padding-left:8px!important;padding-right:8px!important;}
+[data-row] .pin{display:none!important;}
+.rw-board          {order:1!important;flex:0 0 auto!important;width:76px!important;height:19px!important;}
+[data-row] .pin-wrap{order:2!important;flex:0 0 auto!important;width:auto!important;margin-left:0!important;}
+[data-row] .rw-rack{order:3!important;flex:0 0 auto!important;margin-left:0!important;}
+[data-row] > div > span.rw-facts{order:4!important;flex:0 0 auto!important;width:52px!important;
+  text-align:right!important;font-size:9.5px!important;display:none!important;}
+[data-row] .ref    {order:5!important;flex:1 1 0!important;min-width:0!important;width:auto!important;
+  display:flex!important;align-items:center!important;gap:5px!important;
+  justify-content:flex-end!important;height:auto!important;
+  background:none!important;box-shadow:none!important;border:0!important;clip-path:none!important;}
+[data-row] .rmq    {overflow:hidden!important;text-overflow:ellipsis!important;
+  white-space:nowrap!important;min-width:0!important;}
+`;
+
+/* ---------------------------- P1 ---------------------------- */
+const CSS_P1 = `
+/* ============================================================================
+   P1 · TWO LEVELS, TWO PHYSICS   (ledger #168)
+     GROUP = housing   — opens by MOVING    steel · mechanical · NO light
+     ROW   = cartridge — opens by LIGHTING  glass · terminal · emission
+   Invariant held at BOTH levels: the NAME is right-aligned.
+   ============================================================================ */
+
+/* #169 — the laser drop/frame comes OFF the group. A housing never emits. */
+.rw-noframe{display:none!important;}
+
+/* ---------------------------------------------------------------------------
+   LEVEL 1 · THE HOUSING (group head), right-condensed at the .scp1 level:
+   [ slots ....residual.... ][ board ][ NAME ]
+   #170 — board and name are edge-anchored, so the rack takes what is LEFT.
+   The head's ORIGINAL board / stamp / spacers are retired (.rw-off), not
+   added alongside — that is what kept the 380px budget honest.
+   --------------------------------------------------------------------------- */
+.rw-off{display:none!important;}
+.scp1 .rw-rack {order:1!important;flex:1 1 auto!important;min-width:0!important;
+  margin-left:0!important;overflow:hidden!important;justify-content:flex-start!important;}
+.scp1 .rw-board{order:2!important;flex:0 0 auto!important;width:auto!important;max-width:118px!important;
+  height:17px!important;}
+.scp1 .pin-wrap{order:3!important;flex:0 1 auto!important;min-width:0!important;
+  margin-left:auto!important;overflow:hidden!important;}
+.gate{max-width:100%!important;
+  transition:transform .26s cubic-bezier(.32,.72,0,1), box-shadow .26s cubic-bezier(.32,.72,0,1)!important;}
+
+/* the housing's OPEN state is MOTION. Nothing here emits light: the only
+   changes are WHERE the steel sits and WHICH WAY its shadow falls.          */
+.gate[data-open="1"]{
+  transform:translateY(-1.5px)!important;
+  box-shadow:
+    inset 0 3px 5px -1px rgba(0,0,6,.80),
+    inset 0 1px 0 rgba(0,0,8,.7),
+    inset -3px 0 0 rgba(0,0,8,.72),
+    inset -8px 0 9px -4px rgba(0,0,6,.62),
+    inset 0 -1px 0 rgba(198,218,248,.30),
+    inset -3px -1px 0 rgba(198,218,248,.14),
+    0 3px 0 -1px rgba(0,0,5,.92),      /* the bay mouth it lifted out of */
+    0 5px 7px -3px rgba(0,0,4,.75)!important;
+}
+.gate[data-open="0"]{transform:translateY(0)!important;}
+
+/* ---------------------------------------------------------------------------
+   LEVEL 2 · THE CARTRIDGE (row)
+   Seated shut = steel, matte, exactly as R7 left it.
+   Opened = the face POWERS ON (#161, #139/#140 relocated here by #168/#169).
+   The inner div carries an INLINE background, so these need !important.
+   --------------------------------------------------------------------------- */
+[data-row][data-lit="1"] > div{
+  background:
+    radial-gradient(120% 180% at 50% 0%, rgba(120,190,255,.11), transparent 62%),
+    linear-gradient(#04080e 0%, #061019 62%, #040a11 100%)!important;
+  box-shadow:inset 0 1px 2px rgba(0,0,6,.9), inset 0 -1px 0 rgba(190,215,245,.13)!important;}
+
+/* the laser frame — now a ROW event, and drawn on the ROW so it wraps the WHOLE
+   cartridge (face + drawer) as one object. Drawing it on `> div` framed each
+   child separately, which read as two stacked panels.                        */
+[data-row][data-lit="1"]::before{
+  content:'';position:absolute;inset:0;pointer-events:none;z-index:3;
+  transform-origin:top;animation:rwLaserDrop .24s cubic-bezier(.32,.72,0,1) both;}
+[data-row][data-lit="1"][data-tone="red"]::before   {box-shadow:inset 2px 0 0 #ff4242, inset -2px 0 0 #ff4242, inset 0 -2px 0 #ff4242, 0 0 9px rgba(255,66,66,.30);}
+[data-row][data-lit="1"][data-tone="yellow"]::before{box-shadow:inset 2px 0 0 #eed44b, inset -2px 0 0 #eed44b, inset 0 -2px 0 #eed44b, 0 0 9px rgba(238,212,75,.30);}
+[data-row][data-lit="1"][data-tone="blue"]::before  {box-shadow:inset 2px 0 0 #6394cc, inset -2px 0 0 #6394cc, inset 0 -2px 0 #6394cc, 0 0 9px rgba(99,148,204,.30);}
+[data-row][data-lit="1"][data-tone="green"]::before {box-shadow:inset 2px 0 0 #34d399, inset -2px 0 0 #34d399, inset 0 -2px 0 #34d399, 0 0 9px rgba(52,211,153,.30);}
+[data-row][data-lit="1"][data-tone="gray"]::before  {box-shadow:inset 2px 0 0 #8b94a3, inset -2px 0 0 #8b94a3, inset 0 -2px 0 #8b94a3, 0 0 9px rgba(139,148,163,.26);}
+
+/* THE DRAWER IS THE CARD'S OWN PANEL, not a new element. The card already
+   renders a "Tier 1 · detail view (parked)" panel as the row's third child —
+   that is the cartridge's drawer slot, and it carries the #63 anchor icon, so
+   it is decorated rather than replaced. Its label stays: Tier 1 IS still parked;
+   the terminal lines are what P1 puts in the slot now.                        */
+[data-row][data-lit="1"] .rw-drawer{height:auto!important;display:block!important;
+  padding:0 0 5px 0!important;}
+.rw-cartlines{padding-top:2px;}
+
+/* the lit face emits; the name stays right-aligned (the invariant) */
+[data-row][data-lit="1"] .rmq{color:#dcecff!important;text-shadow:0 0 7px rgba(150,205,255,.42)!important;}
+[data-row][data-lit="1"] .rw-board{background:#02060b!important;
+  box-shadow:inset 0 1px 3px rgba(0,0,6,.92), inset 0 -1px 0 rgba(190,215,245,.16)!important;}
+[data-row][data-lit="1"] .rw-board span{color:#8fd8ff!important;text-shadow:0 0 6px rgba(80,190,255,.45)!important;}
+
+/* CRT flicker on power-on (#161, relocated to row-open) */
+@keyframes rwCrtOn{
+  0%{opacity:.16;filter:brightness(2.6) saturate(.4)} 12%{opacity:1;filter:brightness(1.5)}
+  22%{opacity:.55;filter:brightness(.8)} 34%{opacity:1;filter:brightness(1.28)}
+  52%{opacity:.86;filter:brightness(.97)} 100%{opacity:1;filter:brightness(1)}}
+[data-row][data-lit="1"] > div > *{animation:rwCrtOn .34s steps(16,end) both;}
+
+/* ---------------------------------------------------------------------------
+   ROW ORDER, RULED (ledger #176) — supersedes R7's order for the P1 era.
+   Jac: "From right to left: Name, Message board, slots. Then aligned to the
+   left is the button."  That is the HEAD's own grammar (name, board, slots
+   right-to-left) plus a left-anchored button — the row-only element, which is
+   exactly what P1 means by "middles may differ (heads have no button)".
+   Slots take the residual at BOTH levels now, so #170's law is universal.
+   R7's block in the design log is left untouched: it is a revert point.
+   --------------------------------------------------------------------------- */
+[data-row] .pin-wrap{order:1!important;flex:0 0 auto!important;
+  margin-left:0!important;margin-right:0!important;}
+[data-row] .rw-rack {order:2!important;flex:1 1 auto!important;min-width:0!important;
+  overflow:hidden!important;justify-content:flex-start!important;margin-left:0!important;}
+[data-row] .rw-board{order:3!important;flex:0 0 auto!important;}
+[data-row] .ref     {order:4!important;flex:0 1 auto!important;min-width:0!important;
+  justify-content:flex-end!important;margin-left:0!important;}
+
+/* the drawer the cartridge drops — the terminal body */
+.rw-cart{overflow:hidden;background:linear-gradient(#04080e,#03070c);
+  box-shadow:inset 0 1px 0 rgba(150,200,255,.14), inset 0 -1px 0 rgba(0,0,6,.9);
+  animation:rwCartDrop .26s cubic-bezier(.32,.72,0,1) both;}
+@keyframes rwCartDrop{from{height:0}to{height:var(--cart-h,58px)}}
+.rw-cart .l,.rw-cartlines .l{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:9px;
+  letter-spacing:.05em;color:#7fd0ff;text-shadow:0 0 6px rgba(80,190,255,.40);padding:3px 10px;
+  white-space:nowrap;overflow:hidden;}
+.rw-cart .l b,.rw-cartlines .l b{color:#cfe9ff;font-weight:800;}
+.rw-cart .l.dim,.rw-cartlines .l.dim{color:#4d6d86;text-shadow:none;}
+`;
+
+const BUILD = `
+(() => {
+  const HUE = l => { const s=(l||'').toLowerCase();
+    if(/overdue|failed|fail|damage|breakdown/.test(s)) return ['#ff4242','red'];
+    if(/service due|needs wash|open|promised|due/.test(s)) return ['#eed44b','yellow'];
+    if(/transport|truck|pickup|reserved/.test(s)) return ['#6394cc','blue'];
+    if(/available|complete|passed|paid/.test(s)) return ['#34d399','green'];
+    return ['#8a94a2','gray']; };
+  const RANK = {red:0,yellow:1,blue:2,green:3,gray:4};   // style section 6 rollup precedence
+
+  // section 4 — derive open/shut from the chevron BEFORE hiding it
+  document.querySelectorAll('.gate').forEach(g => {
+    const c = g.querySelector('.gate__chev');
+    const t = c ? getComputedStyle(c).transform : 'none';
+    g.setAttribute('data-open', (t !== 'none' && !/^matrix\\(1,\\s*0,\\s*0,\\s*1/.test(t)) ? '0' : '1');
+  });
+
+  // a row's issues live in the .pin's data-hint: "Source, State, Date" per line (section 2.7)
+  const rowIssues = row => {
+    const pin = row.querySelector('.pin[data-hint]');
+    if (!pin) {
+      const sg = row.querySelector('.signal');
+      return sg ? [(sg.textContent||'').trim()] : [];
+    }
+    return (pin.getAttribute('data-hint')||'').split(/\\n+/).map(l => {
+      const p = l.split(',').map(s=>s.trim());
+      return p.length >= 2 ? p[1] : p[0];
+    }).filter(Boolean);
+  };
+  const rowInner = row => [...row.children].find(c => c.tagName === 'DIV');
+
+  const rack = list => {
+    const r = document.createElement('div'); r.className='rw-rack';
+    list.forEach(t => { const k=document.createElement('i'); k.className='rw-tick';
+      k.style.background=HUE(t)[0]; k.dataset.label=t; r.appendChild(k); });
+    return r;
+  };
+  const board = txt => {
+    const b=document.createElement('div'); b.className='rw-board';
+    const s=document.createElement('span'); s.textContent=txt; s.style.color='#6a7684';
+    b.appendChild(s); return b;
+  };
+  const wire = (ticks, b, rest) => {
+    ticks.forEach(k => {
+      k.addEventListener('mouseenter', () => {
+        const s=b.querySelector('span'); s.textContent=k.dataset.label.toUpperCase();
+        s.style.color=HUE(k.dataset.label)[0]; k.classList.add('hot'); });
+      k.addEventListener('mouseleave', () => {
+        const s=b.querySelector('span'); s.textContent=rest; s.style.color='#6a7684';
+        k.classList.remove('hot'); });
+    });
+  };
+
+  /* ---------- LEVEL 2 · cartridges (rows) ----------
+     REPLACE, don't add: the row's 380px budget is already spent (section 2.4).
+     The bare unclassed spans are the date/facts column + a spacer — facts drop
+     first, which is exactly what R7/#162 already specify.                     */
+  document.querySelectorAll('[data-row]').forEach(row => {
+    const inner = rowInner(row); if (!inner || inner.querySelector('.rw-rack')) return;
+    [...inner.children].forEach(c => {
+      if (!c.classList.contains('pin-wrap') && !c.classList.contains('ref')) c.classList.add('rw-off');
+    });
+    const list = rowIssues(row);
+    const worst = list.slice().sort((a,b)=>RANK[HUE(a)[1]]-RANK[HUE(b)[1]])[0] || '';
+    row.setAttribute('data-tone', HUE(worst)[1]);
+    const rest = list[0] ? list[0].toUpperCase() : '\\u2014';
+    const b = board(rest);
+    inner.insertBefore(b, inner.firstChild);
+    const rk = rack(list.length ? list : ['available']);
+    inner.insertBefore(rk, b.nextSibling);
+    wire([...rk.querySelectorAll('.rw-tick')], b, rest);
+  });
+
+  /* ---------- LEVEL 1 · housings (group heads) ----------
+     Right-condensed at .scp1: [ slots ...residual... ][ board ][ NAME ].
+     The head's own board/stamp/spacers are RETIRED so the rack inherits the
+     width they were holding — that is #170 made visible: no cap, the rack
+     simply runs until the real width is gone.                                */
+  document.querySelectorAll('.gate').forEach(g => {
+    const scp = g.closest('.scp1'); if (!scp || scp.querySelector('.rw-rack')) return;
+    const grp = scp.parentElement;
+
+    // retire every head child except the gate's wrapper and absolute overlays
+    [...scp.children].forEach(c => {
+      if (c.classList.contains('pin-wrap')) return;
+      if (getComputedStyle(c).position === 'absolute') return;
+      c.classList.add('rw-off');
+    });
+    // #169/#168 — the group's laser frame is an absolute overlay; it moves to rows
+    if (grp) [...grp.children].forEach(c => {
+      const s = getComputedStyle(c);
+      if (s.position === 'absolute' && s.transformOrigin.startsWith('0px') === false
+          && c.tagName === 'DIV' && !c.classList.contains('rw-cart')) c.classList.add('rw-noframe');
+    });
+
+    const rows = grp ? [...grp.querySelectorAll('[data-row]')] : [];
+    let list = []; rows.forEach(r => { list = list.concat(rowIssues(r)); });
+    list.sort((a,b)=>RANK[HUE(a)[1]]-RANK[HUE(b)[1]]);           // hottest first
+    const rest = list.length ? (list.length + ' OPEN') : 'NOMINAL';
+    const b = board(rest);
+    const rk = rack(list.length ? list : ['available']);
+    scp.insertBefore(b, scp.firstChild);
+    scp.insertBefore(rk, b);
+    wire([...rk.querySelectorAll('.rw-tick')], b, rest);
+  });
+
+  /* power a cartridge on — the row's open IS the light */
+  window.__lit = null;
+  window.rwLight = row => {
+    if (window.__lit) {
+      const prev = window.__lit; prev.removeAttribute('data-lit');
+      const d = prev.nextElementSibling;
+      if (d && d.classList.contains('rw-cart')) d.remove();
+      window.__lit = null;
+      if (prev === row) return;
+    }
+    row.setAttribute('data-lit','1');
+    const name = ((row.querySelector('.rmq')||{}).textContent || 'UNIT').trim();
+    const list = rowIssues(row);
+    const cart = document.createElement('div'); cart.className='rw-cart';
+    cart.innerHTML = '<div class="l">&gt; <b>' + name + '</b> ONLINE</div>' +
+      (list.length ? list.map(t=>'<div class="l">&nbsp;&nbsp;\\u00b7 '+t.toUpperCase()+'</div>').join('')
+                   : '<div class="l dim">&nbsp;&nbsp;\\u00b7 NO OPEN ISSUES</div>') +
+      '<div class="l dim">&nbsp;&nbsp;READY</div>';
+    row.parentNode.insertBefore(cart, row.nextSibling);
+    cart.style.setProperty('--cart-h', (cart.scrollHeight+6)+'px');
+    window.__lit = row;
+  };
+  document.querySelectorAll('[data-row]').forEach(r => {
+    r.addEventListener('click', e => {
+      if (e.target.closest('.rw-tick') || e.target.closest('.signal')) return;
+      window.rwLight(r);
+    });
+  });
+
+  const ticksPerHead = [...document.querySelectorAll('.gate')].map(g=>g.querySelectorAll('.rw-tick').length);
+  return { gates:document.querySelectorAll('.gate').length,
+           rows:document.querySelectorAll('[data-row]').length,
+           headRacks:document.querySelectorAll('.gate .rw-rack').length,
+           rowRacks:document.querySelectorAll('[data-row] .rw-rack').length,
+           ticksPerHead };
+})()
+`;
+
+const b = await chromium.launch({ executablePath: EXEC });
+const errs = [];
+
+async function boot(dsf) {
+  const pg = await b.newPage({ viewport: { width: 440, height: 1700 }, deviceScaleFactor: dsf });
+  pg.on('pageerror', e => errs.push(String(e).slice(0, 200)));
+  await pg.goto('http://127.0.0.1:9147/index.html', { waitUntil: 'networkidle' });
+  await pg.waitForTimeout(2600);
+  return pg;
+}
+
+const pg = await boot(1.5);
+await pg.screenshot({ path: `${OUT}/00-R0-baseline.png`, fullPage: true });
+await pg.addStyleTag({ content: CSS_R7 });
+await pg.waitForTimeout(400);
+await pg.screenshot({ path: `${OUT}/01-R7.png`, fullPage: true });
+await pg.addStyleTag({ content: CSS_P1 });
+const built = await pg.evaluate(BUILD);
+await pg.waitForTimeout(700);
+await pg.screenshot({ path: `${OUT}/02-P1-housings.png`, fullPage: true });
+
+const lit = await pg.evaluate(`(() => {
+  const rows=[...document.querySelectorAll('[data-row]')];
+  const r=rows.find(x=>x.querySelector('.pin[data-hint]')) || rows[0];
+  if(!r) return 'no rows'; window.rwLight(r);
+  return ((r.querySelector('.rmq')||{}).textContent||'row').trim();
+})()`);
+await pg.waitForTimeout(650);
+await pg.screenshot({ path: `${OUT}/03-P1-cartridge-lit.png`, fullPage: true });
+
+/* ---- proof: light lives only on glass; the housing only moved ---- */
+const proof = await pg.evaluate(`(() => {
+  const out={}; const cs=el=>getComputedStyle(el);
+  const g=document.querySelector('.gate[data-open="1"]')||document.querySelector('.gate');
+  if(g){ const s=cs(g);
+    out.housing={ outerGlow:/(^|,)\\s*0 0 \\d/.test(s.boxShadow)?'HAS GLOW (VIOLATION)':'none',
+      transform:s.transform,
+      nameTextShadow:cs(g.querySelector('.sc-interp')).textShadow,
+      nameRightAligned: (()=>{ const n=g.querySelector('.sc-interp').getBoundingClientRect();
+        const gb=g.getBoundingClientRect(); return Math.round(gb.right-n.right); })() }; }
+  const lit=document.querySelector('[data-row][data-lit="1"]');
+  if(lit){ const inner=[...lit.children].find(c=>c.tagName==='DIV'); const s=cs(inner);
+    out.cartridge={ background:s.backgroundImage.slice(0,72),
+      nameGlow:cs(lit.querySelector('.rmq')).textShadow,
+      nameRightAligned: (()=>{ const n=lit.querySelector('.rmq').getBoundingClientRect();
+        const rb=inner.getBoundingClientRect(); return Math.round(rb.right-n.right); })() };
+    out.drawerPresent=!!(lit.nextElementSibling&&lit.nextElementSibling.classList.contains('rw-cart')); }
+  // an UNLIT row must stay matte steel — no emission anywhere
+  const dark=[...document.querySelectorAll('[data-row]')].find(r=>!r.hasAttribute('data-lit'));
+  if(dark){ const inner=[...dark.children].find(c=>c.tagName==='DIV');
+    out.unlitRow={ background:cs(inner).backgroundImage.slice(0,60),
+      nameTextShadow:cs(dark.querySelector('.rmq')||inner).textShadow }; }
+
+  /* --- the 380px budget (section 2.4): nothing may exceed its container --- */
+  const over=[];
+  document.querySelectorAll('.scp1').forEach(s=>{
+    const b=s.getBoundingClientRect();
+    [...s.children].forEach(c=>{ if(cs(c).position==='absolute')return;
+      const r=c.getBoundingClientRect(); if(r.right>b.right+1)
+        over.push({lvl:'head',cls:String(c.className).slice(0,26),by:Math.round(r.right-b.right)}); }); });
+  document.querySelectorAll('[data-row]').forEach(rw=>{
+    const inner=[...rw.children].find(c=>c.tagName==='DIV'); if(!inner)return;
+    const b=inner.getBoundingClientRect();
+    [...inner.children].forEach(c=>{ if(cs(c).position==='absolute')return;
+      const r=c.getBoundingClientRect(); if(r.right>b.right+1)
+        over.push({lvl:'row',cls:String(c.className).slice(0,26),by:Math.round(r.right-b.right)}); }); });
+  out.overflow = over.length ? over.slice(0,8) : 'NONE — everything inside the 380px card';
+  out.docScrollW = document.documentElement.scrollWidth;
+  // widest head rack actually rendered, and its tick count (proves #170's no-cap)
+  const racks=[...document.querySelectorAll('.scp1 .rw-rack')].map(r=>({
+    ticks:r.querySelectorAll('.rw-tick').length, w:Math.round(r.getBoundingClientRect().width)}));
+  out.headRacks=racks;
+  return out;
+})()`);
+
+/* detail crops at 3.4 */
+const pg2 = await boot(3.4);
+await pg2.addStyleTag({ content: CSS_R7 });
+await pg2.addStyleTag({ content: CSS_P1 });
+await pg2.evaluate(BUILD);
+await pg2.waitForTimeout(500);
+const g0 = await pg2.$('.gate');
+if (g0) {
+  const bb = await g0.boundingBox();
+  if (bb) await pg2.screenshot({ path: `${OUT}/04-housing-detail@3.4x.png`,
+    clip:{ x:Math.max(0,bb.x-8), y:Math.max(0,bb.y-10), width:Math.min(440,bb.width+16), height:bb.height+22 } });
+}
+await pg2.evaluate(`(() => { const rows=[...document.querySelectorAll('[data-row]')];
+  const r=rows.find(x=>x.querySelector('.pin[data-hint]'))||rows[0]; if(r) window.rwLight(r); })()`);
+await pg2.waitForTimeout(700);
+const litRow = await pg2.$('[data-row][data-lit="1"]');
+if (litRow) { const bb = await litRow.boundingBox();
+  if (bb) await pg2.screenshot({ path: `${OUT}/05-cartridge-detail@3.4x.png`,
+    clip:{ x:Math.max(0,bb.x-6), y:Math.max(0,bb.y-8), width:Math.min(440,bb.width+12), height:bb.height+104 } }); }
+
+fs.writeFileSync(`${OUT}/proof.json`, JSON.stringify({ built, lit, proof, errs }, null, 2));
+console.log(JSON.stringify({ built, lit, proof, errs: errs.slice(0,4) }, null, 2));
+await b.close();

--- a/docs/design/tier-01-card/verify/regress.mjs
+++ b/docs/design/tier-01-card/verify/regress.mjs
@@ -1,0 +1,102 @@
+// Regression tests for the six review findings. Each reproduces the reviewer's exact repro.
+import { chromium } from 'playwright';
+const EXEC='/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell';
+const b=await chromium.launch({executablePath:EXEC});
+const pg=await b.newPage({viewport:{width:440,height:1700}});
+const errs=[]; pg.on('pageerror',e=>errs.push(String(e).slice(0,160)));
+await pg.goto('http://127.0.0.1:9147/index.html',{waitUntil:'networkidle'});
+await pg.waitForTimeout(3000);
+const out={};
+
+// F2 — data-open must actually vary with collapsed/open
+out.F2_dataOpen = await pg.evaluate(`(()=>{
+  const g=[...document.querySelectorAll('.gate')];
+  const before=g.map(x=>x.getAttribute('data-open'));
+  // collapse the first group by clicking its head
+  document.querySelector('.scp1').click();
+  return {before};
+})()`);
+await pg.waitForTimeout(700);
+out.F2_afterCollapse = await pg.evaluate(`(()=>{
+  const g=document.querySelector('.gate');
+  const chev=g.querySelector('.gate__chev');
+  return { dataOpen:g.getAttribute('data-open'), inlineTransform:chev.style.transform||'none',
+           gateTransform:getComputedStyle(g).transform };
+})()`);
+await pg.evaluate(`document.querySelector('.scp1').click()`); await pg.waitForTimeout(700);
+
+// F1 — staleness: filter to Done, check the surviving row's rack matches ITS record
+out.F1_done = await pg.evaluate(`(()=>{
+  const done=[...document.querySelectorAll('.seg__opt')].find(b=>/done/i.test(b.textContent||''));
+  if(done) done.click(); return !!done;
+})()`);
+await pg.waitForTimeout(900);
+out.F1_doneRows = await pg.evaluate(`(()=>{
+  return [...document.querySelectorAll('[data-row]')].map(r=>{
+    const pin=r.querySelector('.pin[data-hint]');
+    return { name:((r.querySelector('.rmq')||{}).textContent||'').trim(),
+             state:((r.querySelector('.signal')||{}).textContent||'').trim(),
+             board:((r.querySelector('.rw-board span')||{}).textContent||'').trim(),
+             ticks:r.querySelectorAll('.rw-tick').length,
+             tone:r.getAttribute('data-tone'),
+             realIssues: pin?(pin.getAttribute('data-hint')||'').split(/\\n+/).filter(Boolean).length:0 };
+  });
+})()`);
+// reset filter
+await pg.evaluate(`(()=>{const w=[...document.querySelectorAll('.seg__opt')].find(b=>/work/i.test(b.textContent||''));if(w)w.click();})()`);
+await pg.waitForTimeout(600);
+
+// F1b — search staleness
+await pg.evaluate(`(()=>{const i=document.querySelector('input');if(i){i.focus();}})()`);
+await pg.keyboard.type('a'); await pg.waitForTimeout(900);
+out.F1_search = await pg.evaluate(`(()=>{
+  return [...document.querySelectorAll('[data-row]')].slice(0,6).map(r=>{
+    const pin=r.querySelector('.pin[data-hint]');
+    const real=pin?(pin.getAttribute('data-hint')||'').split(/\\n+/).filter(Boolean)
+      .map(l=>{const p=l.split(',').map(s=>s.trim());return p.length>=2?p[1]:p[0];}):[];
+    return { name:((r.querySelector('.rmq')||{}).textContent||'').trim(),
+             board:((r.querySelector('.rw-board span')||{}).textContent||'').trim(),
+             expectBoard: real[0]?real[0].toUpperCase():'—',
+             ticks:r.querySelectorAll('.rw-tick').length, expectTicks:real.length,
+             ok: (real[0]?real[0].toUpperCase():'—')===((r.querySelector('.rw-board span')||{}).textContent||'').trim()
+                 && real.length===r.querySelectorAll('.rw-tick').length };
+  });
+})()`);
+
+// F3 — jump band survives an unmount/remount while open
+await pg.evaluate(`(()=>{const i=document.querySelector('input');i.value='';i.dispatchEvent(new Event('input',{bubbles:true}));})()`);
+await pg.waitForTimeout(700);
+await pg.evaluate(`(()=>{const r=document.querySelector('[data-row]');const bb=r.getBoundingClientRect();
+  r.dispatchEvent(new MouseEvent('click',{bubbles:true,clientX:bb.x+4,clientY:bb.y+bb.height/2}));})()`);
+await pg.waitForTimeout(800);
+await pg.evaluate(`(()=>{const i=document.querySelector('input');i.focus();i.value='zzzz';i.dispatchEvent(new Event('input',{bubbles:true}));})()`);
+await pg.waitForTimeout(800);
+await pg.evaluate(`(()=>{const i=document.querySelector('input');i.value='';i.dispatchEvent(new Event('input',{bubbles:true}));})()`);
+await pg.waitForTimeout(900);
+out.F3_jumpBand = await pg.evaluate(`(()=>{
+  const jb=document.querySelector('[data-jump-band]');
+  if(!jb) return 'no band present (row not open)';
+  return { hasRwOff:jb.classList.contains('rw-off'), display:getComputedStyle(jb).display };
+})()`);
+
+// F4 — only the laser frame is hidden, not the rails/U-groove
+out.F4_noframe = await pg.evaluate(`(()=>{
+  const n=[...document.querySelectorAll('.rw-noframe')];
+  return { count:n.length, allHaveTransformOrigin:n.every(e=>/transform-origin\\s*:\\s*top/.test(e.getAttribute('style')||'')) };
+})()`);
+
+// F5 — a group with nothing open must read NOMINAL, not "N OPEN"
+out.F5_heads = await pg.evaluate(`(()=>{
+  return [...document.querySelectorAll('.scp1')].map(s=>{
+    const grp=s.parentElement;
+    let real=0; grp.querySelectorAll('[data-row]').forEach(r=>{const p=r.querySelector('.pin[data-hint]');
+      if(p) real+=(p.getAttribute('data-hint')||'').split(/\\n+/).filter(Boolean).length;});
+    const board=((s.querySelector('.rw-board span')||{}).textContent||'').trim();
+    return { name:((s.querySelector('.sc-interp')||{}).textContent||'').trim(), board,
+             realIssues:real, ticks:s.querySelectorAll('.rw-tick').length,
+             ok: real===0 ? board==='NOMINAL' : board===real+' OPEN' };
+  });
+})()`);
+out.errs=errs;
+console.log(JSON.stringify(out,null,2));
+await b.close();

--- a/docs/design/tier-01-card/verify/verify2.mjs
+++ b/docs/design/tier-01-card/verify/verify2.mjs
@@ -1,0 +1,86 @@
+// Clean-load verification of all six review findings, each independently.
+import { chromium } from 'playwright';
+const OUT='/tmp/claude-0/-home-user-rental-wrangler/0ae968fe-28c8-53d0-84a6-9fc8848ba315/scratchpad/p1';
+const EXEC='/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell';
+const b=await chromium.launch({executablePath:EXEC});
+const errs=[];
+async function fresh(dsf){ const p=await b.newPage({viewport:{width:440,height:1700},deviceScaleFactor:dsf||1.5});
+  p.on('pageerror',e=>errs.push(String(e).slice(0,150)));
+  p.on('console',m=>{if(m.type()==='error'&&!/p\.icon|c\.icon/.test(m.text()))errs.push('con:'+m.text().slice(0,120));});
+  await p.goto('http://127.0.0.1:9147/index.html',{waitUntil:'networkidle'}); await p.waitForTimeout(3000); return p; }
+const R={};
+
+// F4 — exactly the 10 laser frames hidden, nothing else
+const p1=await fresh();
+R.F4 = await p1.evaluate(`(()=>{const n=[...document.querySelectorAll('.rw-noframe')];
+  return {count:n.length, allAreFrames:n.every(e=>/transform-origin/.test(e.getAttribute('style')||''))};})()`);
+
+// F2 — data-open tracks collapse
+R.F2_open = await p1.evaluate(`[...document.querySelectorAll('.gate')].map(g=>g.getAttribute('data-open'))`);
+await p1.evaluate(`document.querySelector('.scp1').click()`); await p1.waitForTimeout(800);
+R.F2_afterCollapse = await p1.evaluate(`(()=>{const g=document.querySelector('.gate');
+  return {dataOpen:g.getAttribute('data-open'), inline:(g.querySelector('.gate__chev').style.transform||'none'),
+          gateTransform:getComputedStyle(g).transform,
+          faceColor:getComputedStyle(g.querySelector('.sc-interp')).color};})()`);
+await p1.evaluate(`document.querySelector('.scp1').click()`); await p1.waitForTimeout(800);
+R.F2_afterReopen = await p1.evaluate(`(()=>{const g=document.querySelector('.gate');
+  return {dataOpen:g.getAttribute('data-open'), gateTransform:getComputedStyle(g).transform,
+          faceColor:getComputedStyle(g.querySelector('.sc-interp')).color};})()`);
+await p1.close();
+
+// F1 — staleness under the Done filter
+const p2=await fresh();
+await p2.evaluate(`(()=>{const d=[...document.querySelectorAll('.seg__opt')].find(b=>/done/i.test(b.textContent||''));if(d)d.click();})()`);
+await p2.waitForTimeout(1000);
+R.F1_done = await p2.evaluate(`(()=>[...document.querySelectorAll('[data-row]')].map(r=>{
+  const pin=r.querySelector('.pin[data-hint]');
+  const real=pin?(pin.getAttribute('data-hint')||'').split(/\\n+/).filter(Boolean)
+    .map(l=>{const p=l.split(',').map(s=>s.trim());return p.length>=2?p[1]:p[0];}):[];
+  const board=((r.querySelector('.rw-board span')||{}).textContent||'').trim();
+  const ticks=r.querySelectorAll('.rw-tick').length;
+  return {name:((r.querySelector('.rmq')||{}).textContent||'').trim(), board, ticks,
+          expectBoard:real[0]?real[0].toUpperCase():'\\u2014', expectTicks:real.length,
+          tone:r.getAttribute('data-tone'),
+          ok: board===(real[0]?real[0].toUpperCase():'\\u2014') && ticks===real.length};}))()`);
+await p2.close();
+
+// F3 — jump band survives unmount/remount while open
+const p3=await fresh();
+await p3.evaluate(`(()=>{const r=document.querySelector('[data-row]');const bb=r.getBoundingClientRect();
+  r.dispatchEvent(new MouseEvent('click',{bubbles:true,clientX:bb.x+4,clientY:bb.y+bb.height/2}));})()`);
+await p3.waitForTimeout(900);
+R.F3_bandBefore = await p3.evaluate(`(()=>{const j=document.querySelector('[data-jump-band]');
+  return j?{off:j.classList.contains('rw-off'),display:getComputedStyle(j).display}:'none';})()`);
+await p3.evaluate(`(()=>{const i=document.querySelector('input');i.focus();i.value='zzzz';i.dispatchEvent(new Event('input',{bubbles:true}));})()`);
+await p3.waitForTimeout(800);
+await p3.evaluate(`(()=>{const i=document.querySelector('input');i.value='';i.dispatchEvent(new Event('input',{bubbles:true}));})()`);
+await p3.waitForTimeout(1000);
+R.F3_bandAfter = await p3.evaluate(`(()=>{const j=document.querySelector('[data-jump-band]');
+  return j?{off:j.classList.contains('rw-off'),display:getComputedStyle(j).display}:'no band (row closed by remount)';})()`);
+await p3.close();
+
+// F5 + overall: heads read correctly on a clean load; no overflow
+const p4=await fresh();
+R.F5 = await p4.evaluate(`(()=>[...document.querySelectorAll('.scp1')].map(s=>{
+  const grp=s.parentElement; let real=0;
+  grp.querySelectorAll('[data-row]').forEach(r=>{const p=r.querySelector('.pin[data-hint]');
+    if(p) real+=(p.getAttribute('data-hint')||'').split(/\\n+/).filter(Boolean).length;});
+  const gate=s.querySelector('.gate');
+  const board=((s.querySelector('.rw-board span')||{}).textContent||'').trim();
+  return {group:((gate.querySelector('.sc-interp')||{}).textContent||'').trim(), board, realIssues:real,
+          ticks:s.querySelectorAll('.rw-tick').length,
+          ok: real===0 ? board==='NOMINAL' : board===real+' OPEN'};}))()`);
+R.overflow = await p4.evaluate(`(()=>{const over=[];const cs=e=>getComputedStyle(e);
+  document.querySelectorAll('.scp1').forEach(s=>{const bb=s.getBoundingClientRect();
+    [...s.children].forEach(c=>{if(cs(c).position==='absolute')return;const r=c.getBoundingClientRect();
+      if(r.right>bb.right+1)over.push('head+'+Math.round(r.right-bb.right));});});
+  document.querySelectorAll('[data-row]').forEach(rw=>{const i=[...rw.children].find(c=>c.tagName==='DIV');if(!i)return;
+    const bb=i.getBoundingClientRect();
+    [...i.children].forEach(c=>{if(cs(c).position==='absolute')return;const r=c.getBoundingClientRect();
+      if(r.right>bb.right+1)over.push('row+'+Math.round(r.right-bb.right));});});
+  return over.length?over.slice(0,5):'NONE';})()`);
+await p4.screenshot({path:`${OUT}/50-FIXED-rest.png`,fullPage:true});
+await p4.close();
+R.errs=errs;
+console.log(JSON.stringify(R,null,2));
+await b.close();


### PR DESCRIPTION
**Parked, not for merge as-is.** Deferred from `claude/tier-01-card-audit-crnxj3` on 2026-07-31 (PR #785, now merged).

## What it is

The scripts that built and verified the Tier-0.1 **P1** block now shipping inside `docs/design/tier-01-card/index.html`.

| File | What it does |
|---|---|
| `p1.mjs` | Source of truth for the R2→R7 + P1 **CSS** |
| `land.mjs` | **Generates** the landed block from that CSS, so what ships is byte-identical to what was measured. Idempotent — replaces a previously-landed block |
| `verify2.mjs` | Clean-load verification of each review finding, independently |
| `regress.mjs` | The chained-interaction version (filter → search → open → remount) |
| `glow.mjs` | The **#146 audit** — proves nothing on the housing emits. An outer `0 0 Npx` shadow is light; an inset or hard-offset shadow is paint |

## Why it was parked rather than dropped

These only ever lived in an ephemeral session scratchpad, and they regression-test **nine real bugs that two rounds of fresh-context review found *after* the block had already been landed and declared verified** (ledger #179). Two of those are general traps, not one-offs:

- **`getComputedStyle` on a `display:none` element returns `transform: none`** regardless of the inline value — reading state off an element your own CSS hides silently freezes that state. This killed the entire housing open/shut mechanic while a "measured proof" reported it working.
- **dc-runtime RECYCLES row/head nodes positionally** rather than replacing them, so a presence-based "already built?" guard leaves an injected layer describing a *different record*.

## Running them

Serve from **inside** `docs/design/tier-01-card/` on port **9147** (8000 is reserved): `python3 -m http.server 9147 --bind 127.0.0.1`. Kill a stuck one with `fuser -k 9147/tcp`.

Playwright **must** launch with `executablePath: '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell'` — the plain chromium binary errors *"Old Headless mode has been removed"*. Wait ~3000ms after `networkidle`. Note a row's centre point sits on its `.signal` chip, which `stopPropagation`s per #67, so a scripted click on a row's centre does **not** open it — click the row **body**.

## Needs

Nothing to finish — they pass as of the merged head. Re-point the paths if the prototype moves, and re-run `verify2.mjs` + `glow.mjs` after any change to the landed block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJPAEubxBkYvL7Um88s8GV)_