### PR TITLE
docs: mark the cascade handoff DONE — the next session read it and carried it out (#788)

### DIFF
--- a/docs/handoffs/2026-07-31-cascade-tier01-decisions.md
+++ b/docs/handoffs/2026-07-31-cascade-tier01-decisions.md
@@ -1,5 +1,29 @@
 # Handoff — cascade the Tier-0.1 decisions + retyping into the rest of the design artifacts
 
+> # ✅ DONE — THIS JOB IS COMPLETE. DO NOT RUN IT.
+>
+> **Superseded 2026-08-01 by PR #788 (`b35e4bb`), which a concurrent session shipped while this
+> brief was being written.** The cascade described below has already happened:
+>
+> - the kit's `elements/pin.html` was **renamed to `slot.html`** (#177) and every element,
+>   component and foundation page rebuilt;
+> - `tier-01-handoff/atom-rebuild.md` now carries *"Retired 2026-07-31 (ledger #170)"* against the
+>   8-tick cap and the fixed 114px board;
+> - all six Labs prompts (`prompt-00`…`prompt-05`) were updated;
+> - `docs/design/audit/prompt-b-tier-01-card.md` was **regenerated** and now indexes #172–#181, so
+>   the "stale at #164" warning below is **no longer true**;
+> - `tokens.css` took the #152 token pass, and `STALE-DESIGN-LANGUAGE-SWEEP.md` was folded in.
+>
+> **Two open items named below are also closed:** ledger **#180** closes **#156** (the laser frame
+> carries the hue alone; the lit cartridge face does *not* also keep the group hue) and **#181**
+> closes **#152**.
+>
+> **Kept, not deleted,** because the "Traps this session paid for" section is still accurate and
+> still worth reading — and because deleting it would erase the record that two sessions worked the
+> same job in parallel (a known failure mode: see `MEMORY.md`'s concurrent-duplicate gotcha).
+> **Everything below is history. Verify against the ledger before acting on any of it.**
+
+
 **Created 2026-07-31.** Self-contained. The prompt for the next session is at the bottom —
 copy from `## THE PROMPT` down.
 

--- a/docs/handoffs/2026-07-31-cascade-tier01-decisions.md
+++ b/docs/handoffs/2026-07-31-cascade-tier01-decisions.md
@@ -2,8 +2,10 @@
 
 > # ✅ DONE — THIS JOB IS COMPLETE. DO NOT RUN IT.
 >
-> **Superseded 2026-08-01 by PR #788 (`b35e4bb`), which a concurrent session shipped while this
-> brief was being written.** The cascade described below has already happened:
+> **Superseded by PR #788 (`b35e4bb`) — which is this brief being CARRIED OUT, exactly as intended.**
+> Timeline: this brief merged to trunk at 19:17 as `57cb296`; the cascade landed 93 minutes later at
+> 20:50, **built directly on top of it** (`b35e4bb`'s parent *is* `57cb296`). A following session read
+> the brief and did the job. The cascade described below has already happened:
 >
 > - the kit's `elements/pin.html` was **renamed to `slot.html`** (#177) and every element,
 >   component and foundation page rebuilt;
@@ -19,8 +21,8 @@
 > closes **#152**.
 >
 > **Kept, not deleted,** because the "Traps this session paid for" section is still accurate and
-> still worth reading — and because deleting it would erase the record that two sessions worked the
-> same job in parallel (a known failure mode: see `MEMORY.md`'s concurrent-duplicate gotcha).
+> still worth reading, and because this file is now evidence that a written handoff **works**: it was
+> picked up and executed by the next session without a conversation.
 > **Everything below is history. Verify against the ledger before acting on any of it.**
 
 


### PR DESCRIPTION
Docs-only. One banner on one file.

## The problem

`docs/handoffs/2026-07-31-cascade-tier01-decisions.md` landed on trunk in #785 telling the next session to cascade the Tier-0.1 decisions into the kit, the Labs prompts and the audit doc.

**That job has since been done** — PR #788 (`b35e4bb`). Left unmarked, the brief would send a fresh session to redo finished work, which is the stale-doc failure mode this repo keeps paying for (ledger #163, and the "a stale INDEX is worse than a missing one" gotcha in `MEMORY.md`).

## This was a handoff working, not a collision

Worth stating precisely, because my first version of this banner got it wrong and filed it under the *concurrent-duplicate* failure mode:

```
57cb296   19:17   this brief merges to trunk        (#785)
b35e4bb   20:50   the cascade lands — parent IS 57cb296   (#788)
```

93 minutes apart, strictly sequential, **built directly on top**. A following session read the merged handoff and carried it out. No work was duplicated and nothing raced.

Filing a success under a failure mode would teach the next reader the wrong lesson about writing handoffs, so the banner now says what actually happened.

## What #788 did

| | |
|---|---|
| `elements/pin.html` | **renamed to `slot.html`** (#177) |
| every element / component / foundation page | rebuilt |
| `tier-01-handoff/atom-rebuild.md` | now carries *"Retired 2026-07-31 (ledger #170)"* against the 8-tick cap and the fixed 114px board |
| all six Labs prompts | updated |
| `docs/design/audit/prompt-b-tier-01-card.md` | **regenerated** — now indexes #172–#181 |
| `tokens.css` | took the #152 token pass |
| `STALE-DESIGN-LANGUAGE-SWEEP.md` | folded in |

Two open items the brief names are also closed: **#180** closes **#156** (the laser frame carries the hue alone; the lit cartridge face does *not* also keep the group hue), and **#181** closes **#152**.

This also retires a warning I put in the brief and repeated to Jac — *"prompt-b is stale at #164."* True when written, **no longer true**: #788 regenerated it.

## Integrity check

The only file both PRs touched was the decisions ledger, and it merged additively. Verified on trunk: rows **#165–#181 all present** (165–179 from #785, 180–181 from #788), the landed P1 block intact (`ownPin`, `data-rwsig`, `rw-noframe`, `fitRack`, `rw-cartlines`), and both the design log and this handoff still in place. **Nothing was lost.**

## Why marked, not deleted

- The **"Traps this session paid for"** section is still accurate and still worth reading (the shallow-clone count trap, `getComputedStyle` on a hidden element, node recycling, the `.signal` centre-point trap).
- The file is now evidence that a written handoff **works** — picked up and executed by the next session with no conversation in between.