### PR TITLE
skills: add /paint — the master-copy workflow

### DIFF
--- a/.claude/skills/paint/SKILL.md
+++ b/.claude/skills/paint/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: paint
+description: >-
+  How to copy a painting, drawing, or any reference image faithfully — the master-copy
+  workflow. Copy the artwork's RELATIONSHIPS, not its individual objects: proportion first,
+  then value, edges, colour, and only then detail. Covers defining the target (study vs exact
+  reproduction, sight-size vs grid vs projection), analysing the original as abstract shapes
+  (composition, drawing structure, value, colour, edges), preparing reference and surface,
+  blocking in the composition, the pencil drawing, the value map, the monochrome
+  underpainting, palette strings, the first colour pass, layered form modelling, the edge
+  hierarchy, selective detail, the final comparison, and unifying. Also carries the
+  ORDER OF IMPORTANCE used to diagnose a copy that "looks off". Reach for this whenever the
+  task is reproducing, studying, or master-copying an existing artwork or photo in any medium
+  — oil, acrylic, gouache, watercolour, graphite, digital — or when a copy already in progress
+  needs diagnosing ("why doesn't this look like the original?", "what's wrong with my copy?").
+  NOT for original composition from imagination, and NOT for the Rental Wrangler UI design
+  language (that's `style` + `wrangler-style`).
+---
+
+# /paint — the master-copy workflow
+
+**The central rule: copy the artwork's *relationships*, not its individual objects.**
+Proportion comes first, then value, edges, colour, and finally detail. *A perfectly rendered
+eye in the wrong location is still wrong.*
+
+Full step-by-step method: **`references/master-copy-workflow.md`** — read it before starting a
+copy, and again at step 13 when comparing.
+
+## The diagnostic hierarchy (use this first, always)
+
+When something looks wrong — in your copy or in one you're critiquing — walk this order and
+**correct the largest discrepancy first.** A small highlight never takes priority over a
+misplaced head, a wrong shadow mass, or an over-bright background.
+
+1. Composition and placement
+2. Proportion and drawing
+3. Value structure
+4. Edge hierarchy
+5. Colour temperature and saturation
+6. Surface handling
+7. Fine detail
+
+**If the first four are strong, the copy will often feel convincing even before it is highly
+finished.** Conversely, no amount of rendering at levels 5–7 will rescue an error at 1–3.
+
+## The spine — 14 steps
+
+| # | Step | The one thing it must settle |
+|---|---|---|
+| 1 | Define the target | Study or exact reproduction? Which transfer method? Same aspect ratio as the original — differing canvas proportions drift the whole composition. |
+| 2 | Analyse the original | See it as abstract shapes: composition, drawing structure, value, colour, edges. Reduce to a three-value notan. |
+| 3 | Prepare reference + workspace | Highest-resolution reference; grayscale, posterised, and cropped-detail versions; neutral consistent light; a lightly toned ground. |
+| 4 | Establish the composition | Transfer only major structure — boundaries, alignments, diagonals, large negative spaces, centres of forms. Light, correctable lines. |
+| 5 | Construct the pencil drawing | Large forms → small. Envelope, masses, axes, landmarks, negative spaces, contours, shadow shapes. **Never start with features, fingers, ornament, or foliage.** |
+| 6 | Make a clean value map | Three or five values, light and shadow families clearly separated. It should read correctly from across the room. |
+| 7 | Build the monochrome underpainting | Grisaille solves proportion, volume, lighting, value, and major edges. Don't over-polish it. |
+| 8 | Plan the palette | Mix organised strings before painting. Judge **value first**, then temperature, then saturation. White also cools and desaturates — it isn't just "lighter". |
+| 9 | Lay in the first colour pass | Largest colour families, thin and simple. Establish the colour *climate*; don't chase small variations. |
+| 10 | Model form with successive layers | Glaze / scumble / wet-into-wet / opaque / broken colour — match the original's handling. Each layer needs a specific job. Fat over lean. |
+| 11 | Reconstruct the edge hierarchy | Hard · firm · soft · lost. Sharpen at the focal point, lose edges where values merge, never outline everything. Edges are composition, not boundaries. |
+| 12 | Add selective details | Late, because they depend on everything beneath. Describe texture through value, edge, direction, and rhythm — not by drawing every particle. |
+| 13 | Perform a final comparison | Walk the diagnostic hierarchy above, in order. |
+| 14 | Finish and unify | A few accents, restored highlights, softened over-active passages, repeated colours, removed detail. Stop when marks no longer improve the larger relationships. |
+
+## Checking your own work (step 5 and step 13)
+
+Errors hide from the eye that made them. Break the habituation:
+
+- Step several feet away
+- View it in a mirror
+- Turn **both** reference and copy upside down
+- Compare vertical and horizontal alignments
+- Photograph and overlay the images
+
+**An overlay should reveal errors; it should not replace understanding them.** Fix the cause
+in the drawing, don't trace over the symptom.
+
+## Standing cautions
+
+- **Detail too early is a trap.** Features, fingers, ornament, foliage, and texture make an
+  inaccurate drawing feel temporarily convincing — and therefore much harder to correct.
+- **Edge hierarchy is the most frequently missed quality in copies.** Not every boundary
+  should be equally sharp.
+- **A colour can have the correct hue and still be wrong** — too light, too dark, too
+  saturated, or too cool. Value first.
+- **Reflected light inside a shadow stays darker than halftones in the light.** Keep the
+  families separate or the form flattens.
+- **Aspect ratio is not a detail.** Get it wrong at step 1 and every measurement downstream
+  inherits the error.

--- a/.claude/skills/paint/references/master-copy-workflow.md
+++ b/.claude/skills/paint/references/master-copy-workflow.md
@@ -1,0 +1,321 @@
+# A Reliable Master-Copy Workflow
+
+The central rule is simple: copy the artwork's relationships—not its individual objects.
+Proportion comes first, then value, edges, color, and finally detail. A perfectly rendered eye
+in the wrong location is still wrong.
+
+## 1. Define the target
+
+Before touching the surface, decide:
+
+- Is this an observational study or an extremely accurate reproduction?
+- Will you use sight-size, comparative measurement, a grid, projection, or tracing?
+- Are you reproducing the original dimensions and medium?
+- Which qualities matter most: composition, likeness, color, texture, or brushwork?
+
+For an exact copy, use the same aspect ratio as the original. If the proportions of the canvas
+differ, the entire composition will drift.
+
+## 2. Analyze the original
+
+Study the artwork as an arrangement of abstract shapes.
+
+### Composition
+
+Identify:
+
+- The dominant directional lines
+- Large light and dark masses
+- The focal point
+- Repeated angles, curves, and intervals
+- Areas of visual rest
+- The balance of positive and negative space
+
+Try reducing the artwork to three values: light, middle, and dark. This simplified "notan"
+often reveals its underlying design more clearly than the subject matter does.
+
+### Drawing structure
+
+Locate:
+
+- The outer envelope of the whole subject
+- Centerlines and major axes
+- Highest, lowest, leftmost, and rightmost points
+- Major intersections and alignments
+- Important negative shapes
+- Relative widths, heights, and distances
+
+### Value structure
+
+Determine:
+
+- Lightest light
+- Darkest dark
+- Shadow family
+- Light family
+- Halftones
+- Reflected light
+- Cast shadows
+- Where contrast is strongest and weakest
+
+### Color structure
+
+Analyze color by:
+
+- Hue
+- Value
+- Chroma or saturation
+- Warmth versus coolness
+- Local color versus light-influenced color
+
+A color can have the correct hue but still look wrong because it is too light, too dark, too
+saturated, or too cool.
+
+### Edge structure
+
+Classify major edges as:
+
+- Hard
+- Firm
+- Soft
+- Lost
+
+Edge hierarchy is one of the most frequently missed qualities in copies. Not every boundary
+should be equally sharp.
+
+## 3. Prepare the reference and workspace
+
+Use the highest-resolution reference available. Ideally, obtain:
+
+- A full-color image
+- A grayscale version
+- A cropped detail of the focal area
+- A three-value or posterized version
+- Information about the original size and medium
+
+Work under neutral, consistent lighting. Avoid direct sunlight or strongly warm household
+bulbs when matching color.
+
+Prepare the surface according to the medium. For painting, a lightly toned ground is often
+easier to judge than a brilliant white surface.
+
+## 4. Establish the composition
+
+Transfer only the major structure at first.
+
+Suitable methods include:
+
+- **Sight-size:** Place the copy and reference so they appear the same visual size.
+- **Comparative measurement:** Compare every measurement to one chosen unit.
+- **Grid:** Best for controlled enlargement or reduction.
+- **Proportional divider:** Useful for transferring accurate ratios.
+- **Tracing or projection:** Appropriate when the objective is surface and color study rather
+  than drawing practice.
+
+Mark:
+
+1. The outer boundaries
+2. Major vertical and horizontal alignments
+3. Primary diagonals
+4. Large negative spaces
+5. Centers of major forms
+
+Keep the lines light and easy to correct.
+
+## 5. Construct the pencil drawing
+
+Work from large forms toward smaller ones:
+
+1. Draw the overall envelope.
+2. Divide it into major masses.
+3. Establish axes and gesture.
+4. Place large internal landmarks.
+5. Compare negative spaces.
+6. Refine contours.
+7. Map the principal shadow shapes.
+
+Do not begin with facial features, fingers, ornament, foliage, or texture. These details can
+make an inaccurate drawing feel temporarily convincing and therefore harder to correct.
+
+Check the drawing by:
+
+- Stepping several feet away
+- Viewing it in a mirror
+- Turning both reference and copy upside down
+- Comparing vertical and horizontal alignments
+- Photographing and overlaying the images for diagnosis
+
+An overlay should reveal errors; it should not replace understanding them.
+
+## 6. Make a clean value map
+
+Before full rendering, establish a simple three- or five-value design.
+
+A useful sequence is:
+
+1. Paper or ground
+2. Light halftone
+3. Dark halftone
+4. General shadow
+5. Dark accent
+
+Keep the light and shadow families clearly separated. Reflected light inside a shadow should
+generally remain darker than halftones in the illuminated area.
+
+At this stage, the work should already read correctly from across the room.
+
+## 7. Build the monochrome underpainting
+
+For oil or acrylic, this is commonly called a grisaille, brunaille, or monochromatic
+underpainting.
+
+A reliable order is:
+
+1. Apply a thin overall tone.
+2. Draw the major forms with diluted paint.
+3. Mass in the shadow family.
+4. Wipe or paint out the largest lights.
+5. Model the major planes with middle values.
+6. Add only a few dark accents.
+7. Refine transitions and edges.
+
+The underpainting should solve:
+
+- Proportion
+- Volume
+- Lighting
+- Value relationships
+- Major edges
+
+Avoid polishing it into a finished black-and-white painting unless the intended color layers
+will remain very transparent. Excessive monochrome detail can become buried or make the final
+color appear lifeless.
+
+## 8. Plan the palette
+
+Mix several organized color strings before painting:
+
+- Shadow mixtures
+- Dark halftones
+- Middle halftones
+- Light-facing planes
+- Highlights
+- Warm and cool variations
+
+Compare mixtures against the reference with a viewing aperture or small neutral-gray card.
+Judge value first, then temperature, then saturation.
+
+Avoid using white merely to make every color lighter. White also cools and reduces saturation.
+Sometimes a lighter neighboring pigment produces a cleaner result.
+
+## 9. Lay in the first color pass
+
+Place the largest color families first:
+
+1. Background
+2. Large shadow masses
+3. Large light masses
+4. Major local colors
+5. Broad temperature shifts
+
+Keep this pass thin and relatively simple. Preserve the value structure established underneath.
+
+Do not chase small color variations yet. The purpose is to establish the painting's overall
+color climate.
+
+## 10. Model form with successive layers
+
+Now refine the major planes and transitions.
+
+Use the technique that resembles the original:
+
+- **Glazing:** Transparent dark or saturated color over a dry layer
+- **Scumbling:** Thin, lighter opaque paint dragged over darker paint
+- **Wet-into-wet:** Soft transitions and blended passages
+- **Opaque placement:** Solid lights and decisive shape corrections
+- **Broken color:** Separate strokes that mix optically at a distance
+
+Each layer should have a specific job. Avoid repeatedly covering the entire painting without a
+clear reason.
+
+For oils, follow the principle of leaner, thinner layers underneath and more oil-rich or
+thicker layers above.
+
+## 11. Reconstruct the edge hierarchy
+
+Once the forms are established, deliberately organize the edges.
+
+- Sharpen edges near the focal point.
+- Soften turning forms.
+- Lose edges where adjacent values merge.
+- Keep secondary areas quieter.
+- Avoid outlining every object.
+
+Edges should guide the eye through the painting. They are part of the composition, not just
+boundaries around objects.
+
+## 12. Add selective details
+
+Details come late because they depend on everything beneath them.
+
+Add:
+
+- Essential facial features
+- Material-specific texture
+- Small reflected lights
+- Accents in hair, fabric, metal, foliage, or architecture
+- Distinctive marks that establish likeness or character
+
+Describe texture through changes in value, edge, direction, and rhythm—not by drawing every
+visible particle.
+
+The focal area can support the greatest detail. Peripheral areas should usually remain broader
+and quieter.
+
+## 13. Perform a final comparison
+
+Compare the works in this order:
+
+1. Overall silhouette
+2. Placement and proportion
+3. Large value masses
+4. Focal contrast
+5. Color temperature
+6. Saturation
+7. Edge hierarchy
+8. Detail
+
+Correct the largest discrepancy first. A small highlight should never take priority over a
+misplaced head, incorrect shadow mass, or overly bright background.
+
+## 14. Finish and unify
+
+The final pass may include:
+
+- Deepening a few dark accents
+- Restoring selected highlights
+- Softening overactive passages
+- Glazing an area to adjust temperature
+- Scumbling to create atmosphere
+- Repeating key colors across the composition
+- Removing unnecessary detail
+
+Stop when additional marks no longer improve the larger relationships.
+
+Allow the work to dry or cure appropriately before applying a final varnish suitable for the
+medium.
+
+## Order of Importance
+
+When diagnosing a copy, use this hierarchy:
+
+1. Composition and placement
+2. Proportion and drawing
+3. Value structure
+4. Edge hierarchy
+5. Color temperature and saturation
+6. Surface handling
+7. Fine detail
+
+If the first four are strong, the copy will often feel convincing even before it is highly
+finished.


### PR DESCRIPTION
Adds a new `/paint` skill holding the master-copy workflow — how to copy a painting, drawing, or reference image faithfully.

There was no `paint` skill in the repo, in its history, or in the user-level skill directory, so this creates it rather than extending an existing one.

## What's in it

**`.claude/skills/paint/SKILL.md`** — the operating spine:
- The central rule: copy the artwork's *relationships*, not its individual objects. Proportion → value → edges → colour → detail.
- The **diagnostic order-of-importance hierarchy** (composition/placement → proportion/drawing → value structure → edge hierarchy → colour temp & saturation → surface handling → fine detail), used to decide what to fix first when a copy looks off.
- The **14-step spine** as a table, one line per step, each naming the single thing that step must settle.
- The self-checking methods for steps 5 and 13 (step back, mirror, invert both, compare alignments, photograph and overlay).
- Standing cautions: detail-too-early, edge hierarchy as the most-missed quality, value-before-hue, reflected light staying below the light family's halftones, and aspect ratio as a step-1 decision every later measurement inherits.

**`.claude/skills/paint/references/master-copy-workflow.md`** — the full step-by-step method, from defining the target and analysing the original through the underpainting, palette strings, colour passes, edge reconstruction, final comparison, and unifying.

## Scope

Skill files only — no app source, no served files, no UI. Nothing to cache-bust, no R-Rulebook or window-catalog impact, no staging deploy needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxJDyDRxkHA37EifyZWtnB)_