### PR TITLE
skill: /paint — pixel-for-pixel mockup recreation + gridded agent pass

### DIFF
--- a/.claude/skills/paint/SKILL.md
+++ b/.claude/skills/paint/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: paint
+description: Pixel-for-pixel recreation of a design mockup/screenshot in clean HTML/CSS, then a gridded multi-agent refinement pass — invoke with /paint when Jac supplies a mockup image and wants it recreated faithfully, wants a "pixel pass" on an existing recreation, or says a build "looks nothing like" his mockup. Recreate FROM SCRATCH first, grid-compare per element with agents, and only then port the proven recipes into the real codebase as construction swaps. NOT for building new UI from a text spec (that is wrangler-style + style) and NOT for triaging a functional bug (that is wrangler-fix).
+---
+
+# /paint — recreate the pixels, then borrow from what you built
+
+Born 2026-08-02, after two failed attempts to edit the Tier-0.1 card toward
+Jac's mockups from memory. Jac's diagnosis, verbatim, is the core of the
+method:
+
+> "I think your issue is editing, you're bad at that. You need to create from
+> scratch and then apply/merge into the mockup." … "Break the screenshot into
+> grids. use agents. See how close you can get per element in each grid."
+
+## The iron rules (each one paid for)
+
+1. **The target image lives ON DISK and you have OPENED it.** Never work from
+   a remembered description of an image — two full rebuild passes were wasted
+   that way while the mockup sat unopened in the uploads folder. Check
+   `/root/.claude/uploads/<session>/` by *opening files*, not by filename.
+   If the image only exists in conversation, ask Jac to re-attach it.
+2. **Recreate from scratch, never edit toward.** A big cascade fights every
+   move; a clean standalone file has the mockup as its only constraint.
+   One `#stage` div at the image's native pixel size, absolute-positioned
+   elements, zero project CSS.
+3. **Measure before building.** PIL-sample colors and geometry (bboxes, stroke
+   widths, corner cuts, lean directions) — the eye misreads gloss as lean and
+   hue as shape.
+4. **Disputes are settled by sampling, not by confidence.** When an agent's
+   reading disagrees with yours, sample the pixels. (The tick-lean incident:
+   my eyes said `/`, three analysts said `\`, the pixels said `\`.)
+5. **Appliers introduce cross-cell regressions.** After any multi-agent apply
+   round, put YOUR OWN eyes on the full-frame comparison — cell analysts
+   can't see neighboring-cell damage (the chevron plate, the wrong-way
+   slash).
+6. **Port = construction swap, not nudge.** What moves into the real codebase
+   is the *recipe* (e.g. two-layer clipped-solid rings instead of inset
+   box-shadows), applied deliberately, one commit, with the recreation as the
+   reference artifact. Get Jac's call on the port list first (popup,
+   multiSelect).
+
+## The method
+
+### Phase 1 — solo recreation (2-3 rounds)
+
+1. Copy `scripts/shot.mjs` and `scripts/compare.py` into the scratchpad;
+   point them at your recreation file and the mockup path.
+2. Sample the mockup's key geometry with PIL (see `scripts/probe-example.py`).
+3. Build `recreation.html` at the mockup's native size. Render, stack-compare
+   (mockup on top, recreation below), fix the big reads yourself: layout,
+   proportions, palette, silhouettes. Stop when only fine detail differs.
+
+### Phase 2 — the grid pass (agents; needs Jac's multi-agent opt-in unless ultracode is on)
+
+4. Cut BOTH images into **element-aligned** cells — one cell per meaningful
+   element cluster (a rack, a board, a plate, a frame corner), not blind
+   squares. 3x nearest-neighbor upscale per cell. `scripts/cut.py` template.
+5. Workflow: `parallel` one **analyst per cell** (read-only!), each returns
+   `{score 1-10, deltas:[{element, issue, fix}]}` with original-scale px
+   coordinates and sampled hex pairs. Then ONE **applier** (opus) merges all
+   cells' deltas into the file — cells own their shared styles (the tick cell
+   rules tick styles), re-renders, re-cuts. Loop analyze→apply until every
+   cell ≥9 or 3 rounds.
+6. **Your final pass:** full-frame compare with your own eyes; hand-apply the
+   analysts' last coordinates and fix any applier regressions. Republish the
+   recreation artifact (its own URL, never the app artifact's).
+
+### Phase 3 — the port (separate, gated)
+
+7. Name what the recreation taught — as recipes, with the false findings
+   retracted explicitly. Popup Jac the port list (multiSelect). Only then
+   touch the real codebase, and through its own gates (backtick audit, sweep,
+   ledger rows).
+
+## Scripts
+
+Templates in `scripts/` (copy to scratchpad and adjust paths):
+- `cut.py` — cell definitions + 3x crops for both images
+- `shot.mjs` — playwright render of the recreation at native size
+- `compare.py` — stacked mockup/recreation comparison image
+- `probe-example.py` — PIL sampling patterns (blob columns, stroke runs,
+  lean-direction settlement)
+
+## Score honestly
+
+Cell scores of 6-7 with a strong visual match are normal — analysts at 3x
+zoom see texture gaps a viewer never will. The stop condition is Jac's read
+("not terrible" → another pass; silence → ship the comparison and ask), not
+a perfect 10.

--- a/.claude/skills/paint/scripts/compare.py
+++ b/.claude/skills/paint/scripts/compare.py
@@ -1,0 +1,5 @@
+# stack mockup over recreation: python3 compare.py <mockup> <recreation> <out>
+from PIL import Image; import sys
+a = Image.open(sys.argv[1]).convert('RGB'); b = Image.open(sys.argv[2]).convert('RGB')
+c = Image.new('RGB',(max(a.width,b.width), a.height+b.height+8),(10,10,10))
+c.paste(a,(0,0)); c.paste(b,(0,a.height+8)); c.save(sys.argv[3])

--- a/.claude/skills/paint/scripts/cut.py
+++ b/.claude/skills/paint/scripts/cut.py
@@ -1,0 +1,16 @@
+from PIL import Image
+import sys
+CELLS = {
+ 'c1': (0,0,350,100),    # header-left: frame corner, ticks, etched circuit
+ 'c2': (330,5,895,100),  # header board
+ 'c3': (880,0,1098,100), # FAILED plate + frame right end
+ 'c4': (20,95,340,217),  # row-left: frame corner, hex icon, name, facts start
+ 'c5': (300,100,710,217),# facts tail + row ticks
+ 'c6': (680,95,1098,217),# row board + right frame + bottom rails
+}
+src, prefix = sys.argv[1], sys.argv[2]
+im = Image.open(src).convert('RGB')
+for k,(x0,y0,x1,y1) in CELLS.items():
+    c = im.crop((x0,y0,x1,y1))
+    c.resize((c.width*3, c.height*3), Image.NEAREST).save(f'grid/{prefix}-{k}.png')
+print('cut', prefix)

--- a/.claude/skills/paint/scripts/probe-example.py
+++ b/.claude/skills/paint/scripts/probe-example.py
@@ -1,0 +1,17 @@
+# PIL sampling patterns proven on 2026-08-02. Adjust predicates/regions per image.
+from PIL import Image
+im = Image.open('MOCKUP.png').convert('RGB'); px = im.load()
+def isred(c): r,g,b=c; return r>150 and g<90 and b<90
+
+# 1) element bbox: scan a bounded region for a color family
+# 2) stroke width: count consecutive hits walking inward from an edge
+# 3) LEAN DIRECTION (settles skew disputes): x-centers of blobs at two heights;
+#    centers shifting RIGHT at larger y == bottom-right lean == CSS skewX(+deg)
+def centers(y, x0, x1):
+    runs=[]; s=None
+    for x in range(x0,x1):
+        h=isred(px[x,y])
+        if h and s is None: s=x
+        if not h and s is not None: runs.append(((s+x-1)//2, x-1-s)); s=None
+    return [c for c,w in runs if w>6]
+print(centers(30,105,340), centers(60,105,340))

--- a/.claude/skills/paint/scripts/shot.mjs
+++ b/.claude/skills/paint/scripts/shot.mjs
@@ -1,0 +1,9 @@
+import pw from '/opt/node22/lib/node_modules/playwright/index.js';
+const { chromium } = pw;
+const OUT='/tmp/claude-0/-home-user-rental-wrangler/10a973a8-b1b9-5794-8775-4aaf37a97dd9/scratchpad';
+const b = await chromium.launch();
+const p = await b.newPage({ viewport:{width:1098,height:217} });
+await p.goto('file://'+OUT+'/dump-recreation.html');
+await p.waitForTimeout(400);
+await p.screenshot({ path: OUT+'/recreation.png', clip:{x:0,y:0,width:1098,height:217} });
+await b.close();


### PR DESCRIPTION
## Why this PR exists separately

The `/paint` skill was authored on `claude/read-prompt-ls8uj8` (commit `aab66d1`, inside PR #789). That branch isn't merged, so **no other session can see the skill** — a fresh session clones from `trunk`, finds no `.claude/skills/paint/`, and reports `/paint` isn't a skill. This cherry-picks just that one commit onto `trunk` so the skill registers everywhere, without waiting on the much larger card PR.

## What it is

A method skill, locked after two failed attempts to edit the Tier-0.1 card toward Jac's mockups from memory. Jac's own diagnosis is the core of it: *"You need to create from scratch and then apply/merge into the mockup"* and *"Break the screenshot into grids. use agents."*

The three phases:
1. **Solo recreation** — confirm the mockup is on disk and OPEN it, measure with PIL, rebuild it from scratch in a clean standalone stage (never edit a large cascade toward a picture).
2. **Grid pass** — element-aligned cells, one read-only analyst agent per cell plus one applier per round, disputes settled by pixel sampling rather than confidence, human eyes on the full frame after every apply round.
3. **The port** — proven recipes into the real codebase as deliberate construction swaps, gated on Jac's approval and the file's normal checks.

Ships four script templates (`cut.py`, `shot.mjs`, `compare.py`, `probe-example.py`).

## Scope

Tooling only — `.claude/skills/paint/**`. No served-site file changes, so no cache-bust is due. Identical content to `aab66d1`; nothing else from PR #789 rides along.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UMwbpjLHH4Am2vSAd7DRh)_