### PR TITLE
skill: /paint — the master-copy workflow and the layering doctrine

### DIFF
--- a/.claude/skills/paint/SKILL.md
+++ b/.claude/skills/paint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paint
-description: Pixel-for-pixel recreation of a design mockup/screenshot in clean HTML/CSS, then a gridded multi-agent refinement pass — invoke with /paint when Jac supplies a mockup image and wants it recreated faithfully, wants a "pixel pass" on an existing recreation, or says a build "looks nothing like" his mockup. Recreate FROM SCRATCH first, grid-compare per element with agents, and only then port the proven recipes into the real codebase as construction swaps. NOT for building new UI from a text spec (that is wrangler-style + style) and NOT for triaging a functional bug (that is wrangler-fix).
+description: Pixel-for-pixel recreation of a design mockup/screenshot in clean HTML/CSS, built the way a master copy is built — relationships before objects, and every effect (shading, etching, bevels, gradients, grain) achieved by STACKING thin translucent layers rather than asking one element to carry the accuracy. Then a gridded multi-agent refinement pass. Invoke with /paint when Jac supplies a mockup image and wants it recreated faithfully, wants a "pixel pass" on an existing recreation, or says a build "looks nothing like" his mockup. Recreate FROM SCRATCH first, grid-compare per element with agents, and only then port the proven recipes into the real codebase as construction swaps. NOT for building new UI from a text spec (that is wrangler-style + style) and NOT for triaging a functional bug (that is wrangler-fix).
 ---
 
 # /paint — recreate the pixels, then borrow from what you built
@@ -12,6 +12,13 @@ method:
 > "I think your issue is editing, you're bad at that. You need to create from
 > scratch and then apply/merge into the mockup." … "Break the screenshot into
 > grids. use agents. See how close you can get per element in each grid."
+
+Extended 2026-08-02 with the **master-copy workflow** (Jac) — the copyist's
+discipline, translated to HTML/CSS. Two sentences carry the whole update:
+
+> "Copy the artwork's **relationships** — not its individual objects."
+> "A single one-layer element does not need to bear the weight of accuracy —
+> using opacity and stacking elements can achieve it."
 
 ## The iron rules (each one paid for)
 
@@ -39,52 +46,151 @@ method:
    box-shadows), applied deliberately, one commit, with the recreation as the
    reference artifact. Get Jac's call on the port list first (popup,
    multiSelect).
+7. **Relationships, not objects.** A perfectly rendered eye in the wrong
+   location is still wrong. Match the *intervals, proportions and value gaps*
+   between elements before you perfect any single element. Same aspect ratio
+   as the mockup, always — a `#stage` of the wrong ratio drifts the whole
+   composition and no amount of per-element work recovers it.
+8. **No single element bears the accuracy — stack it.** Shading, etching,
+   bevels, gradients, grain, temperature: each is a *pile* of thin, low-alpha
+   layers, not one clever declaration. When a detail won't come out right,
+   the answer is almost always "add another layer at 8% alpha", not "tune
+   this one value harder." → `references/layering.md`.
+
+## Order of importance — the diagnostic ranking
+
+When the recreation is wrong, fix in **this order**, largest discrepancy
+first. A misplaced highlight never outranks a misplaced plate.
+
+| # | Layer | What "wrong" looks like |
+|---|---|---|
+| 1 | Composition & placement | element in the wrong x/y, wrong `#stage` ratio |
+| 2 | Proportion & drawing | right place, wrong width/height/angle/radius |
+| 3 | Value structure | right shape, wrong lightness — the squint test fails |
+| 4 | Edge hierarchy | everything equally sharp (or equally soft) |
+| 5 | Color temperature & saturation | correct value, but too warm/cool or too chromatic |
+| 6 | Surface handling | gradient/grain/texture reads flat or plastic |
+| 7 | Fine detail | glyphs, ticks, hairlines, micro-labels |
+
+This ranking governs **both** your own passes and the grid pass: an analyst
+reporting a 1px hairline shift while a plate sits 6px off is reporting the
+wrong thing. Cell reports carry the rank so the applier fixes top-down.
+
+## The layering doctrine (short form)
+
+Build every surface as a stack, cheapest layer first. A typical plate:
+
+```
+1. base fill            solid, the local color at correct VALUE
+2. form modeling        1-3 linear/radial gradients, transparent-to-alpha
+3. edge construction    clipped solid rings (light TL / dark BR) — not inset shadows
+4. etching / incised    paired 1px lines: dark line + light line offset 1px
+5. texture / grain      tiled noise or repeating-gradient at 3-6% alpha
+6. temperature wash     one low-alpha warm or cool overlay, blend soft-light
+7. accents              the few hard, opaque marks — last, fewest
+```
+
+Every layer has **one job**. Never re-cover the whole element to fix one
+thing. Two hard constraints from the house language: **matte — no glow**
+(colored blur shadows are banned; build a hairline + a wash instead), and
+**never lighten with white** — white cools *and* desaturates; reach for the
+lighter neighboring hue. Full recipes, blend modes, and the edge-hierarchy
+table: `references/layering.md`.
 
 ## The method
 
+### Phase 0 — define the target and prep the reference
+
+Decide, out loud, before touching anything: is this an **exact reproduction**
+or an **observational study**? Exact ⇒ native pixel size, native aspect ratio,
+sight-size comparison. Then generate the reference set with
+`scripts/refs.py` — full-color, grayscale, 3-value posterized (notan), and a
+focal-area crop. You will judge value against the grayscale copy, not the
+color one; hue is the loudest liar in a value dispute.
+
 ### Phase 1 — solo recreation (2-3 rounds)
 
-1. Copy `scripts/shot.mjs` and `scripts/compare.py` into the scratchpad;
-   point them at your recreation file and the mockup path.
-2. Sample the mockup's key geometry with PIL (see `scripts/probe-example.py`).
-3. Build `recreation.html` at the mockup's native size. Render, stack-compare
-   (mockup on top, recreation below), fix the big reads yourself: layout,
-   proportions, palette, silhouettes. Stop when only fine detail differs.
+1. Copy `scripts/` into the scratchpad; point `shot.mjs` and `compare.py` at
+   your recreation file and the mockup path. `pip3 install Pillow` if PIL is
+   missing (it usually is on a fresh cloud container).
+2. Sample the mockup's key geometry with PIL (see `scripts/probe-example.py`):
+   outer envelope, major axes, extreme points, big negative shapes.
+3. **Envelope first.** Lay in `#stage` at native size on a *toned ground*
+   (mid-steel, not white or black — a brilliant ground misreads every value),
+   then block only the major masses as flat rectangles. No text, no ticks, no
+   icons, no gradients. Check the block-in with `scripts/diag.py --overlay`
+   before adding anything.
+4. **Value map before color.** Take the whole recreation monochrome
+   (`#stage { filter: grayscale(1) }`) and match it against the grayscale
+   mockup at 3-5 values. It must read correctly at 25% scale
+   (`scripts/diag.py --squint`) before any color goes down.
+5. **First color pass, thin and simple.** Background, big shadow masses, big
+   light masses, local colors, broad temperature shifts. Do not chase small
+   variations yet — establish the color climate.
+6. **Model with successive layers** (§ layering doctrine) — then rebuild the
+   edge hierarchy deliberately: sharpen at the focal point, soften turning
+   forms, *lose* edges where adjacent values merge. Do not outline everything.
+7. Render, stack-compare (mockup on top, recreation below), fix the big reads
+   yourself in the order-of-importance ranking. Stop when only fine detail
+   differs.
 
 ### Phase 2 — the grid pass (agents; needs Jac's multi-agent opt-in unless ultracode is on)
 
-4. Cut BOTH images into **element-aligned** cells — one cell per meaningful
+8. Cut BOTH images into **element-aligned** cells — one cell per meaningful
    element cluster (a rack, a board, a plate, a frame corner), not blind
    squares. 3x nearest-neighbor upscale per cell. `scripts/cut.py` template.
-5. Workflow: `parallel` one **analyst per cell** (read-only!), each returns
-   `{score 1-10, deltas:[{element, issue, fix}]}` with original-scale px
-   coordinates and sampled hex pairs. Then ONE **applier** (opus) merges all
-   cells' deltas into the file — cells own their shared styles (the tick cell
-   rules tick styles), re-renders, re-cuts. Loop analyze→apply until every
-   cell ≥9 or 3 rounds.
-6. **Your final pass:** full-frame compare with your own eyes; hand-apply the
-   analysts' last coordinates and fix any applier regressions. Republish the
-   recreation artifact (its own URL, never the app artifact's).
+9. Workflow: `parallel` one **analyst per cell** (read-only!), each returns
+   `{score 1-10, deltas:[{rank 1-7, element, issue, fix}]}` with
+   original-scale px coordinates and sampled hex pairs — `rank` is the
+   order-of-importance row, and fixes are phrased as *layers to add* where a
+   layer is the answer. Then ONE **applier** (opus) merges all cells' deltas
+   **rank-ascending** (placement before proportion before value before edges…)
+   into the file — cells own their shared styles (the tick cell rules tick
+   styles) — re-renders, re-cuts. Loop analyze→apply until every cell ≥9 or
+   3 rounds.
+10. **Your final pass:** full-frame compare with your own eyes, in the
+    order-of-importance sequence — silhouette, placement, value masses, focal
+    contrast, temperature, saturation, edges, detail. Hand-apply the analysts'
+    last coordinates and fix any applier regressions. Then **unify**: deepen a
+    few darks, restore a few highlights, quiet overactive passages, repeat key
+    colors across the frame, and delete detail that isn't earning its place.
+    Republish the recreation artifact (its own URL, never the app artifact's).
 
 ### Phase 3 — the port (separate, gated)
 
-7. Name what the recreation taught — as recipes, with the false findings
-   retracted explicitly. Popup Jac the port list (multiSelect). Only then
-   touch the real codebase, and through its own gates (backtick audit, sweep,
-   ledger rows).
+11. Name what the recreation taught — as recipes, with the false findings
+    retracted explicitly. Popup Jac the port list (multiSelect). Only then
+    touch the real codebase, and through its own gates (backtick audit, sweep,
+    ledger rows).
 
 ## Scripts
 
-Templates in `scripts/` (copy to scratchpad and adjust paths):
+Templates in `scripts/` (copy to scratchpad; each takes paths as argv):
+- `refs.py` — reference set: grayscale, 3-value notan, posterized, focal crop
 - `cut.py` — cell definitions + 3x crops for both images
 - `shot.mjs` — playwright render of the recreation at native size
 - `compare.py` — stacked mockup/recreation comparison image
+- `diag.py` — the diagnostic checks: `--overlay` (difference map + alignment),
+  `--squint` (blur/downscale, the across-the-room read), `--flip` (mirror and
+  180° for drawing errors), `--values` (both images posterized side by side)
 - `probe-example.py` — PIL sampling patterns (blob columns, stroke runs,
   lean-direction settlement)
+
+Bootstrap: `pip3 install Pillow` · playwright lives at
+`/opt/node22/lib/node_modules/playwright`.
+
+## Reference
+
+- `references/layering.md` — the stacking recipes: shading, etching, bevels,
+  gradients, grain, temperature washes, the edge-hierarchy table, blend-mode
+  choices, and how to debug a stack.
+- `references/master-copy.md` — the full master-copy workflow (Jac's brief),
+  each step translated to what it means in HTML/CSS.
 
 ## Score honestly
 
 Cell scores of 6-7 with a strong visual match are normal — analysts at 3x
 zoom see texture gaps a viewer never will. The stop condition is Jac's read
 ("not terrible" → another pass; silence → ship the comparison and ask), not
-a perfect 10.
+a perfect 10. Stop adding layers when another mark no longer improves the
+larger relationships.

--- a/.claude/skills/paint/references/layering.md
+++ b/.claude/skills/paint/references/layering.md
@@ -1,0 +1,241 @@
+# Layering — how a pixel-perfect surface is actually built
+
+> "A single one-layer element does not need to bear the weight of accuracy —
+> using opacity and stacking elements can achieve it." — Jac, 2026-08-02
+
+The failure mode this file exists to kill: staring at one `background:` or one
+`box-shadow:` and tuning its numbers harder and harder, trying to make a single
+declaration do the work of six. It never converges. The mockup's surface was
+*accumulated*, so the recreation has to be accumulated too.
+
+---
+
+## 1. The stack model
+
+Build every non-trivial surface as an ordered pile. Cheapest and broadest at
+the bottom, fewest and hardest at the top.
+
+| # | Layer | Job | Typical alpha |
+|---|---|---|---|
+| 1 | **Base fill** | the local color, at the correct **value** | 1.0 |
+| 2 | **Form modeling** | which way the surface turns toward the light | 0.04 – 0.18 |
+| 3 | **Edge construction** | bevels, plate rings, cut corners | 0.10 – 0.35 |
+| 4 | **Etching / incised marks** | engraved lines, stamps, scribes | 0.12 – 0.30 |
+| 5 | **Texture / grain** | the material's tooth | 0.03 – 0.06 |
+| 6 | **Temperature wash** | warm/cool shift over the whole plate | 0.03 – 0.08 |
+| 7 | **Accents** | the few opaque, hard marks | 0.7 – 1.0 |
+
+Rules of the stack:
+
+- **One job per layer.** If you can't name a layer's single job in four words,
+  split it or delete it.
+- **Never re-cover the whole element to fix one thing.** That is the painting
+  equivalent of a full repaint, and it buries everything underneath.
+- **Lean-to-fat.** Broad, thin, low-alpha layers underneath; small, opaque,
+  decisive marks on top. Reversing this makes the surface read plastic.
+- **Add, don't tune.** When something is 90% right, the last 10% is a new
+  layer at 6–10% alpha, not a bigger number on an existing one.
+- **Layer count is not a cost you're paying.** Six background layers on one
+  element is normal and cheap; six extra DOM nodes is also fine in a
+  recreation. Accuracy first — the *port* is where you decide what's worth
+  carrying into the real codebase.
+
+### Where the layers live
+
+Three carriers, in order of preference:
+
+1. **Multiple `background-image` layers on one element** — comma-separated
+   gradients composite bottom-to-top-of-list = front-to-back. Free, no DOM.
+2. **`::before` / `::after`** — when a layer needs its own blend mode,
+   clipping, transform, or `filter`.
+3. **Extra absolutely-positioned `<span>`/`<i>` children** — when you need
+   more than two extra layers, or independent z-order between siblings.
+
+```css
+/* one element, five layers, no extra DOM */
+.plate {
+  background:
+    /* 6 grain          */ url("data:image/svg+xml,…") ,
+    /* 5 corner falloff */ radial-gradient(120% 100% at 8% 0%, #fff2 0%, #fff0 42%),
+    /* 4 top sheen      */ linear-gradient(#ffffff14, #ffffff00 38%),
+    /* 3 bottom shade   */ linear-gradient(#00000000 62%, #0000001f),
+    /* 1 base fill      */ linear-gradient(#232830, #232830);
+}
+```
+
+---
+
+## 2. Recipes
+
+### Bevel / raised plate edge
+
+Two **clipped solid rings**, not `inset box-shadow`. (This is the recipe the
+origin session proved — inset shadows blur across the corner cut and read
+mushy at 3x.)
+
+```css
+.plate { position: relative; background: #232830; }
+.plate::before,               /* light ring, top-left */
+.plate::after {               /* dark ring, bottom-right */
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  border: 1px solid transparent;
+}
+.plate::before { border-top-color: #ffffff2e; border-left-color: #ffffff1c; }
+.plate::after  { border-bottom-color: #00000059; border-right-color: #0000003d; }
+```
+
+Recessed/engraved plate = swap the two (dark on top-left, light on
+bottom-right). A **thicker** bevel is two rings of *each*, the outer at half
+the alpha of the inner — not one 2px ring.
+
+### Etching / incised line
+
+An incised line is never one line. It is a **dark line plus a light line
+offset by 1px** — the light one on the side the light comes from.
+
+```css
+/* horizontal scribe across a plate, light from top-left */
+.scribe {
+  height: 2px;
+  background:
+    linear-gradient(#00000000 0 1px, #ffffff22 1px 2px),  /* lower lip, lit */
+    linear-gradient(#0000006b 0 1px, #00000000 1px 2px);  /* the cut itself */
+}
+```
+
+Engraved **text** is the same trick with `text-shadow`:
+`text-shadow: 0 -1px 0 #00000080, 0 1px 0 #ffffff1f;` — dark above, light
+below for incised; reverse for embossed. Keep both under 0.35 alpha or it
+reads as a drop shadow.
+
+### Shading / form turning
+
+Layer **transparent-to-alpha gradients**, one per direction the form turns.
+A cylinder is not one gradient — it is a light-side gradient, a core-shadow
+band, and a reflected-light band that must stay **darker than the lightest
+halftone**.
+
+```css
+.barrel {
+  background:
+    linear-gradient(90deg, #00000000 78%, #ffffff12 96%),   /* reflected light */
+    linear-gradient(90deg, #00000000 52%, #00000047 74%),   /* core shadow     */
+    linear-gradient(90deg, #ffffff1a 6%,  #ffffff00 34%),   /* light family    */
+    #2b3038;
+}
+```
+
+The value check that catches 90% of shading errors: **reflected light inside a
+shadow must never be lighter than a halftone in the lit area.** Run
+`diag.py --values` — if the reflected-light band jumps a value bracket, drop
+its alpha.
+
+### Matte — no glow
+
+The house language is matte. A colored blurred `box-shadow` around an accent
+is banned. Build the same "it's lit" read with:
+
+```css
+/* WRONG: box-shadow: 0 0 12px #ff7e1f80; */
+.signal {
+  background: #ff7e1f;
+  box-shadow: 0 0 0 1px #ff7e1f2e;            /* one hard hairline halo */
+}
+.signal-bed { background: #ff7e1f0f; }         /* a low-alpha wash behind */
+```
+
+Hairline + wash, both hard-edged. The perceived brightness comes from the
+*value gap* to its surround, not from a blur.
+
+### Gradients that don't band
+
+Two fixes, both layer-shaped:
+
+1. Add a **third stop** at the midpoint with a slightly off-linear alpha
+   (a 0.5 stop at 0.42 alpha instead of 0.5 reads far smoother).
+2. Put a **3–5% grain layer on top** — noise dithers the banding away. This is
+   the single highest-value cheap layer in the whole stack.
+
+### Grain / texture
+
+```css
+.grain::after {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  opacity: .045; mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml;utf8,\
+<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'>\
+<filter id='n'><feTurbulence baseFrequency='.9' numOctaves='3'/></filter>\
+<rect width='120' height='120' filter='url(%23n)'/></svg>");
+}
+```
+
+Brushed metal = `repeating-linear-gradient(90deg, #fff0 0 2px, #ffffff08 2px 3px)`
+at ~0.05 with `overlay`. Keep grain **under 6% alpha** — above that it stops
+being material and starts being noise. Describe texture through changes in
+value, edge, direction and rhythm — never by drawing every particle.
+
+### Temperature and saturation — without white
+
+White lightens, **but it also cools and desaturates**. Three correct moves:
+
+| Want | Do |
+|---|---|
+| Lighter, same warmth | layer the **lighter neighboring hue** at low alpha, not `#fff` |
+| Warmer | `linear-gradient(#c2925a12, #c2925a00)` over it, `mix-blend-mode: soft-light` |
+| Cooler | same with a steel-blue, e.g. `#7d94ad14` |
+| Less chromatic | a low-alpha **neutral gray** wash at the same value, `soft-light` |
+| More chromatic | repeat the base hue at 8–12% with `mix-blend-mode: color` |
+
+A wash is reversible and composable; editing the base hex is neither. Reach
+for the wash.
+
+---
+
+## 3. Edge hierarchy
+
+Not every boundary is equally sharp. This is the most frequently missed
+quality in a copy — and it is a *composition* tool: edges route the eye.
+
+| Edge | Reads as | CSS |
+|---|---|---|
+| **Hard** | focal point, cut metal, type | `1px solid` at ≥0.45 alpha, or a clipped solid ring |
+| **Firm** | secondary plate boundary | `1px solid` at 0.18–0.30, no gradient |
+| **Soft** | a form turning away | a 2–4px transparent-to-alpha gradient band instead of a border |
+| **Lost** | value merge — deliberate | **no border at all**; the two fills sit within ~4% lightness |
+
+Method: sharpen near the focal point, soften every turning form, and lose the
+edges where adjacent values merge in the mockup. If your recreation looks
+"cut out" or "sticker-like" compared to the mockup, you have too many hard
+edges — that is almost always the diagnosis.
+
+---
+
+## 4. Blend modes — which one, when
+
+| Mode | Use for |
+|---|---|
+| `soft-light` | temperature washes, gentle shading — the default, safest |
+| `overlay` | grain and texture; punchier than soft-light |
+| `multiply` | shadows, cast shadows, dirt in recesses |
+| `screen` | small lights, sheen, specular ticks |
+| `color` | shifting chroma while holding value |
+| `luminosity` | shifting value while holding hue |
+| *(none)* | anything where a plain alpha composite already matches |
+
+Blend modes need a stacking context to behave — if a blended `::after` bleeds
+past its plate, give the parent `isolation: isolate`.
+
+---
+
+## 5. Debugging a stack
+
+- **Toggle one layer at a time.** Comment a single background layer out,
+  re-shoot, diff. If nothing changed, the layer is dead weight — delete it.
+- **Alpha-hunt from below.** When a stack is close but flat, raise the *lowest*
+  suspect layer's alpha until it's visibly wrong, then halve it twice.
+- **Check in grayscale.** `#stage { filter: grayscale(1) }` — most "the color
+  is off" reports are actually value errors and vanish when you fix the value.
+- **Squint before you zoom.** `diag.py --squint`. A stack that fails at 25%
+  scale cannot be rescued by another layer at 100%.
+- **Count your hard edges.** More than a handful per element cluster and the
+  edge hierarchy has collapsed.

--- a/.claude/skills/paint/references/master-copy.md
+++ b/.claude/skills/paint/references/master-copy.md
@@ -1,0 +1,284 @@
+# The master-copy workflow, translated to HTML/CSS
+
+Jac's brief, 2026-08-02. The left-hand discipline is the copyist's; the
+right-hand column is what it means when the "surface" is a `#stage` div and
+the "paint" is stacked CSS layers.
+
+**The central rule: copy the artwork's *relationships*, not its individual
+objects.** Proportion first, then value, edges, color, and finally detail.
+A perfectly rendered eye in the wrong location is still wrong.
+
+---
+
+## 1. Define the target
+
+Before touching the surface, decide:
+
+- Is this an **observational study** or an **extremely accurate reproduction**?
+- Which transfer method: sight-size, comparative measurement, grid, projection,
+  or tracing?
+- Are you reproducing the original dimensions and medium?
+- Which qualities matter most: composition, likeness, color, texture, or
+  brushwork?
+
+> **In CSS:** an exact copy means `#stage` at the mockup's **native pixel size
+> and native aspect ratio**. If the ratio differs, the entire composition
+> drifts and no per-element work recovers it. "Same medium" = build it with the
+> same construction the real codebase would use (real borders, real gradients),
+> not by slicing the mockup into images. Declare the target out loud in the
+> first message so the stop condition is agreed before work starts.
+
+## 2. Analyze the original
+
+Study the artwork as an arrangement of abstract shapes.
+
+**Composition** — the dominant directional lines; the large light and dark
+masses; the focal point; repeated angles, curves and intervals; areas of visual
+rest; the balance of positive and negative space. Reduce the artwork to three
+values (light / middle / dark) — this "notan" reveals the underlying design
+more clearly than the subject matter does.
+
+**Drawing structure** — the outer envelope; centerlines and major axes; the
+highest, lowest, leftmost and rightmost points; major intersections and
+alignments; important negative shapes; relative widths, heights and distances.
+
+**Value structure** — lightest light; darkest dark; the shadow family; the
+light family; halftones; reflected light; cast shadows; where contrast is
+strongest and weakest.
+
+**Color structure** — hue; value; chroma/saturation; warmth vs coolness; local
+color vs light-influenced color. *A color can have the correct hue and still
+look wrong because it is too light, too dark, too saturated, or too cool.*
+
+**Edge structure** — classify major edges as **hard / firm / soft / lost**.
+Edge hierarchy is one of the most frequently missed qualities in copies. Not
+every boundary should be equally sharp.
+
+> **In CSS:** this is the PIL sampling pass (`scripts/probe-example.py`), and
+> it is *measurement*, not looking. Produce, in writing, before any markup:
+> the bbox of every major mass; the x/y of every alignment; a 3-value notan
+> (`scripts/refs.py`); the lightest and darkest sampled hex; and an edge
+> classification per boundary. The edge table drives `references/layering.md`
+> § Edge hierarchy directly.
+
+## 3. Prepare the reference and workspace
+
+Use the highest-resolution reference available. Ideally obtain a full-color
+image, a grayscale version, a cropped detail of the focal area, a three-value
+or posterized version, and information about the original size and medium.
+Work under neutral, consistent lighting. Prepare the surface according to the
+medium — a lightly **toned ground** is easier to judge than brilliant white.
+
+> **In CSS:** `python3 scripts/refs.py <mockup> <outdir>` generates the whole
+> set. "Neutral lighting" = render and compare on a neutral dark backdrop, at
+> 1:1, no browser zoom, no OS scaling — and never judge a color against a
+> screenshot that has been resized. **Toned ground:** give `#stage` a mid-value
+> steel base fill before anything else. A white or pure-black stage makes every
+> value you lay on it read wrong.
+
+## 4. Establish the composition
+
+Transfer only the major structure at first. Methods: sight-size (copy and
+reference at the same visual size), comparative measurement (everything
+compared to one chosen unit), grid (for controlled enlargement/reduction),
+proportional divider, tracing/projection (when the objective is surface and
+color study rather than drawing practice).
+
+Mark, in order: outer boundaries → major vertical and horizontal alignments →
+primary diagonals → large negative spaces → centers of major forms. Keep the
+lines light and easy to correct.
+
+> **In CSS:** sight-size is free — render at native size and stack-compare
+> (`scripts/compare.py`). The **grid** is Phase 2's cell cut. "Light and easy
+> to correct" = flat blocked-in rectangles with a single `background`, no
+> gradients, no text, no borders yet. Resist adding a border to a block-in
+> rectangle: a border reads as a finished edge and hides a placement error.
+
+## 5. Construct the drawing
+
+Work from large forms toward smaller ones: overall envelope → major masses →
+axes and gesture → large internal landmarks → negative-space comparison →
+refined contours → principal shadow shapes.
+
+**Do not begin with facial features, fingers, ornament, foliage, or texture.**
+These details can make an inaccurate drawing feel temporarily convincing and
+therefore harder to correct.
+
+Check the drawing by stepping several feet away; viewing it in a mirror;
+turning both reference and copy upside down; comparing vertical and horizontal
+alignments; and photographing and overlaying the images. *An overlay should
+reveal errors; it should not replace understanding them.*
+
+> **In CSS:** the banned-until-later list is **icons, glyphs, ticks, hairlines,
+> micro-labels, grain, and any `text-shadow`**. Every one of them makes a
+> misplaced plate look plausible.
+> The four checks are `scripts/diag.py`:
+> `--squint` (step back), `--flip` (mirror + 180°), `--overlay` (the difference
+> map), `--values` (posterized pair). Run `--overlay` to *locate* the error,
+> then go read the mockup to *understand* it — a blind nudge-until-the-diff-
+> shrinks loop produces a file nobody can maintain.
+
+## 6. Make a clean value map
+
+Before full rendering, establish a simple three- or five-value design:
+
+1. Paper or ground → 2. light halftone → 3. dark halftone → 4. general shadow
+→ 5. dark accent
+
+Keep the light and shadow families clearly separated. Reflected light inside a
+shadow should generally remain **darker than halftones in the illuminated
+area**. At this stage the work should already read correctly from across the
+room.
+
+> **In CSS:** name five literal hexes — `--v1`…`--v5` — sampled from the
+> mockup's posterized version, and build the entire block-in from *only* those
+> five. Any sixth value has to earn its place. The across-the-room test is
+> `diag.py --squint`; it is a **gate**, not advice — do not proceed to color
+> while it fails.
+
+## 7. Build the monochrome underpainting
+
+The grisaille. A reliable order: thin overall tone → draw major forms with
+diluted paint → mass in the shadow family → wipe/paint out the largest lights
+→ model major planes with middle values → a few dark accents → refine
+transitions and edges.
+
+The underpainting solves **proportion, volume, lighting, value relationships,
+and major edges**. Avoid polishing it into a finished black-and-white
+painting — excessive monochrome detail gets buried, or makes the final color
+look lifeless.
+
+> **In CSS:** set `#stage { filter: grayscale(1) }` and work there until the
+> grayscale recreation matches the grayscale mockup. This is the single
+> highest-leverage step in the whole workflow and the one most often skipped.
+> "Don't over-polish" translates exactly: no grain, no etching, no accents
+> during grisaille — those are layers 4–7 and they go on *after* color.
+
+## 8. Plan the palette
+
+Mix organized color strings before painting: shadow mixtures, dark halftones,
+middle halftones, light-facing planes, highlights, warm and cool variations.
+Compare mixtures against the reference through a viewing aperture or a small
+neutral-gray card. **Judge value first, then temperature, then saturation.**
+
+Avoid using white merely to lighten — white also cools and desaturates.
+Sometimes a lighter neighboring pigment produces a cleaner result.
+
+> **In CSS:** a `:root` token block, authored *before* the color pass and not
+> improvised mid-build — `--shadow`, `--halftone-d`, `--halftone-m`,
+> `--plane-lit`, `--highlight`, plus `--wash-warm` / `--wash-cool` as the two
+> temperature washes. The "viewing aperture" is a PIL point-sample of both
+> images at the same coordinate, compared as hex pairs — never an eyeball
+> judgement across two windows. The no-white rule is a hard one; see
+> `references/layering.md` § Temperature and saturation.
+
+## 9. Lay in the first color pass
+
+Place the largest color families first: background → large shadow masses →
+large light masses → major local colors → broad temperature shifts. Keep this
+pass thin and relatively simple, and preserve the value structure underneath.
+Do not chase small color variations yet — the purpose is to establish the
+painting's overall **color climate**.
+
+> **In CSS:** base fills only (stack layer 1). No gradients, no rings, no
+> etching. Re-run `diag.py --values` after this pass: if any value bracket
+> moved, the color pass broke the value structure and that is fixed *now*,
+> not later.
+
+## 10. Model form with successive layers
+
+Refine the major planes and transitions using the technique that resembles the
+original: **glazing** (transparent dark or saturated color over a dry layer),
+**scumbling** (thin lighter opaque paint dragged over darker), **wet-into-wet**
+(soft transitions), **opaque placement** (solid lights, decisive corrections),
+**broken color** (separate strokes that mix optically at a distance).
+
+Each layer should have a specific job. Avoid repeatedly covering the entire
+painting without a clear reason. Leaner/thinner layers underneath; richer or
+thicker layers above.
+
+> **In CSS — the five techniques have exact analogues:**
+>
+> | Technique | CSS |
+> |---|---|
+> | Glazing | a low-alpha overlay with `mix-blend-mode: multiply` or `color` |
+> | Scumbling | a low-alpha **lighter** overlay, `soft-light` or `screen`, often over grain |
+> | Wet-into-wet | a `transparent → alpha` gradient band instead of a border |
+> | Opaque placement | a full-alpha layer or a hard 1px ring — the accents |
+> | Broken color | a `repeating-linear-gradient` or tiled noise that mixes optically |
+>
+> "Lean to fat" = broad low-alpha layers at the bottom of the stack, small
+> opaque marks at the top. Full recipes: `references/layering.md`.
+
+## 11. Reconstruct the edge hierarchy
+
+Once the forms are established, deliberately organize the edges: sharpen near
+the focal point; soften turning forms; lose edges where adjacent values merge;
+keep secondary areas quieter; **avoid outlining every object**. Edges guide the
+eye — they are part of the composition, not just boundaries around objects.
+
+> **In CSS:** a dedicated pass, not a side effect. Walk the edge table from
+> § 2 and set each boundary to its class per `references/layering.md`
+> § Edge hierarchy. If the recreation reads "cut out" or "sticker-like" next
+> to the mockup, the diagnosis is nearly always *too many hard edges*.
+
+## 12. Add selective details
+
+Details come late because they depend on everything beneath them: essential
+features, material-specific texture, small reflected lights, accents in hair /
+fabric / metal / foliage / architecture, and the distinctive marks that
+establish likeness or character.
+
+Describe texture through changes in **value, edge, direction and rhythm** — not
+by drawing every visible particle. The focal area can support the greatest
+detail; peripheral areas should stay broader and quieter.
+
+> **In CSS:** now — and only now — the glyphs, ticks, hairlines, micro-labels,
+> stamped mono text, grain and `text-shadow` etching. Detail density is a
+> gradient across the frame: full at the focal element, deliberately reduced at
+> the periphery. Matching peripheral detail 1:1 is usually *over*-copying — the
+> mockup is quieter there than you think.
+
+## 13. Perform a final comparison
+
+Compare in this order:
+
+1. Overall silhouette → 2. placement and proportion → 3. large value masses →
+4. focal contrast → 5. color temperature → 6. saturation → 7. edge hierarchy →
+8. detail
+
+**Correct the largest discrepancy first.** A small highlight should never take
+priority over a misplaced head, an incorrect shadow mass, or an overly bright
+background.
+
+> **In CSS:** this is the ordering the Phase-2 analysts report against (the
+> `rank` field) and the order the applier merges in. Full-frame, your own eyes,
+> at 1:1 — cell agents structurally cannot see silhouette or cross-cell
+> placement.
+
+## 14. Finish and unify
+
+The final pass may deepen a few dark accents, restore selected highlights,
+soften overactive passages, glaze an area to adjust temperature, scumble to
+create atmosphere, repeat key colors across the composition, and **remove
+unnecessary detail**.
+
+Stop when additional marks no longer improve the larger relationships.
+
+> **In CSS:** deliberately repeat two or three accent hexes across distant
+> elements — it is what makes a frame cohere — and delete the layers that
+> toggle-testing proved dead. The stop condition is Jac's read, not a score.
+
+---
+
+## Order of importance — the diagnostic hierarchy
+
+When diagnosing a copy:
+
+1. Composition and placement
+2. Proportion and drawing
+3. Value structure
+4. Edge hierarchy
+5. Color temperature and saturation
+6. Surface handling
+7. Fine detail

--- a/.claude/skills/paint/scripts/cut.py
+++ b/.claude/skills/paint/scripts/cut.py
@@ -1,5 +1,11 @@
+# Element-aligned grid cut: python3 cut.py <image> <prefix> [outdir]
+# Cells are ONE PER MEANINGFUL ELEMENT CLUSTER (a rack, a board, a plate, a frame
+# corner) — never blind squares. Redefine CELLS per mockup; the values below are
+# the 2026-08-02 Tier-0.1 card, kept as a shape example.
+# Cut BOTH images with the same CELLS so each analyst compares like for like.
 from PIL import Image
-import sys
+import os, sys
+
 CELLS = {
  'c1': (0,0,350,100),    # header-left: frame corner, ticks, etched circuit
  'c2': (330,5,895,100),  # header board
@@ -8,9 +14,13 @@ CELLS = {
  'c5': (300,100,710,217),# facts tail + row ticks
  'c6': (680,95,1098,217),# row board + right frame + bottom rails
 }
+
 src, prefix = sys.argv[1], sys.argv[2]
+outdir = sys.argv[3] if len(sys.argv) > 3 else 'grid'
+os.makedirs(outdir, exist_ok=True)
 im = Image.open(src).convert('RGB')
-for k,(x0,y0,x1,y1) in CELLS.items():
-    c = im.crop((x0,y0,x1,y1))
-    c.resize((c.width*3, c.height*3), Image.NEAREST).save(f'grid/{prefix}-{k}.png')
-print('cut', prefix)
+for k, (x0, y0, x1, y1) in CELLS.items():
+    c = im.crop((x0, y0, x1, y1))
+    c.resize((c.width*3, c.height*3), Image.NEAREST).save(f'{outdir}/{prefix}-{k}.png')
+    print(f'{prefix}-{k}  origin=({x0},{y0})  3x')  # analysts report ORIGINAL-scale px
+print('cut', prefix, '->', outdir)

--- a/.claude/skills/paint/scripts/diag.py
+++ b/.claude/skills/paint/scripts/diag.py
@@ -23,8 +23,9 @@ def side_by_side(imgs, gap=8, bg=(10, 10, 10)):
 
 
 def posterize(im, n=5):
+    # clamp the bucket index, not the output — see refs.py:posterize
     step = 256 // n
-    lut = [min(255, (v // step) * step + step // 2) for v in range(256)]
+    lut = [min(v // step, n - 1) * step + step // 2 for v in range(256)]
     return im.convert('L').point(lut).convert('RGB')
 
 

--- a/.claude/skills/paint/scripts/diag.py
+++ b/.claude/skills/paint/scripts/diag.py
@@ -1,0 +1,60 @@
+# The four diagnostic checks. python3 diag.py <mode> <mockup> <recreation> <out.png>
+#   --overlay  difference map + red-channel alignment flicker (WHERE the error is)
+#   --squint   both blurred and downscaled to 25% (the across-the-room read; a GATE)
+#   --flip     mirrored and 180-rotated pairs (exposes drawing errors the eye adapts to)
+#   --values   both posterized to 5 values, side by side (value structure only)
+# An overlay REVEALS an error; it does not replace understanding it. Read the
+# mockup after locating a delta — never nudge blindly until the diff shrinks.
+from PIL import Image, ImageChops, ImageFilter
+import sys
+
+mode, a_path, b_path, out = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+a = Image.open(a_path).convert('RGB')
+b = Image.open(b_path).convert('RGB').resize(a.size)
+
+
+def side_by_side(imgs, gap=8, bg=(10, 10, 10)):
+    w = max(i.width for i in imgs)
+    c = Image.new('RGB', (w, sum(i.height for i in imgs) + gap * (len(imgs) - 1)), bg)
+    y = 0
+    for i in imgs:
+        c.paste(i.convert('RGB'), (0, y)); y += i.height + gap
+    return c
+
+
+def posterize(im, n=5):
+    step = 256 // n
+    lut = [min(255, (v // step) * step + step // 2) for v in range(256)]
+    return im.convert('L').point(lut).convert('RGB')
+
+
+if mode == '--overlay':
+    diff = ImageChops.difference(a, b)
+    boosted = diff.point(lambda v: min(255, v * 4))          # 4x so 2-value drifts show
+    # alignment view: mockup in red, recreation in cyan — misregistration fringes
+    r = a.convert('L'); c = b.convert('L')
+    align = Image.merge('RGB', (r, c, c))
+    side_by_side([boosted, align]).save(out)
+    bbox = diff.convert('L').point(lambda v: 255 if v > 24 else 0).getbbox()
+    print('worst-delta bbox', bbox)
+
+elif mode == '--squint':
+    def squint(im):
+        s = im.filter(ImageFilter.GaussianBlur(2)).resize(
+            (max(1, im.width // 4), max(1, im.height // 4)), Image.LANCZOS)
+        return s.resize(im.size, Image.NEAREST)
+    side_by_side([squint(a), squint(b)]).save(out)
+
+elif mode == '--flip':
+    side_by_side([
+        a.transpose(Image.FLIP_LEFT_RIGHT), b.transpose(Image.FLIP_LEFT_RIGHT),
+        a.rotate(180), b.rotate(180),
+    ]).save(out)
+
+elif mode == '--values':
+    side_by_side([posterize(a), posterize(b)]).save(out)
+
+else:
+    sys.exit('mode must be --overlay | --squint | --flip | --values')
+
+print(mode, '->', out)

--- a/.claude/skills/paint/scripts/refs.py
+++ b/.claude/skills/paint/scripts/refs.py
@@ -1,0 +1,35 @@
+# Reference set for a master copy: python3 refs.py <mockup> <outdir> [fx,fy,fw,fh]
+# Produces: -color, -gray, -notan3 (light/mid/dark), -poster5, -focal (3x crop).
+# Judge VALUE against -gray and -notan3. Never judge value from the color image.
+from PIL import Image
+import os, sys
+
+src, out = sys.argv[1], sys.argv[2]
+os.makedirs(out, exist_ok=True)
+base = os.path.join(out, os.path.splitext(os.path.basename(src))[0])
+im = Image.open(src).convert('RGB')
+im.save(base + '-color.png')
+
+g = im.convert('L')
+g.save(base + '-gray.png')
+
+def posterize(gray, n):
+    """Flatten to n evenly-spaced values — the notan."""
+    step = 256 // n
+    lut = [min(255, (v // step) * step + step // 2) for v in range(256)]
+    return gray.point(lut)
+
+posterize(g, 3).save(base + '-notan3.png')
+posterize(g, 5).save(base + '-poster5.png')
+
+if len(sys.argv) > 3:
+    x, y, w, h = (int(v) for v in sys.argv[3].split(','))
+    c = im.crop((x, y, x + w, y + h))
+    c.resize((c.width * 3, c.height * 3), Image.NEAREST).save(base + '-focal.png')
+
+# lightest / darkest, and the five value anchors to author as --v1..--v5
+px = g.load()
+vals = sorted(px[x, y] for y in range(im.height) for x in range(im.width))
+print('size', im.size, 'ratio %.4f' % (im.width / im.height))
+print('darkest', vals[len(vals) // 200], 'lightest', vals[-len(vals) // 200])
+print('v1..v5', [vals[int(len(vals) * f)] for f in (.05, .27, .5, .73, .95)])

--- a/.claude/skills/paint/scripts/refs.py
+++ b/.claude/skills/paint/scripts/refs.py
@@ -14,9 +14,12 @@ g = im.convert('L')
 g.save(base + '-gray.png')
 
 def posterize(gray, n):
-    """Flatten to n evenly-spaced values — the notan."""
+    """Flatten to n evenly-spaced values — the notan.
+    Clamp the BUCKET INDEX, not the output: 256//n truncates, so the top
+    values (255 at n=3) land in a leftover n-th bucket and pure white would
+    read as an extra tone the mockup does not have."""
     step = 256 // n
-    lut = [min(255, (v // step) * step + step // 2) for v in range(256)]
+    lut = [min(v // step, n - 1) * step + step // 2 for v in range(256)]
     return gray.point(lut)
 
 posterize(g, 3).save(base + '-notan3.png')

--- a/.claude/skills/paint/scripts/shot.mjs
+++ b/.claude/skills/paint/scripts/shot.mjs
@@ -1,9 +1,22 @@
+// Render the recreation at the mockup's NATIVE size (never resized — a resized
+// screenshot cannot be used to judge color or edges).
+//   node shot.mjs <recreation.html> <out.png> <width> <height> [grayscale]
+// Pass `grayscale` for the grisaille check (step 7 of the master-copy workflow).
 import pw from '/opt/node22/lib/node_modules/playwright/index.js';
 const { chromium } = pw;
-const OUT='/tmp/claude-0/-home-user-rental-wrangler/10a973a8-b1b9-5794-8775-4aaf37a97dd9/scratchpad';
+
+const [file, out, w, h, gray] = process.argv.slice(2);
+if (!file || !out || !w || !h) {
+  console.error('usage: node shot.mjs <recreation.html> <out.png> <width> <height> [grayscale]');
+  process.exit(1);
+}
+const width = Number(w), height = Number(h);
+
 const b = await chromium.launch();
-const p = await b.newPage({ viewport:{width:1098,height:217} });
-await p.goto('file://'+OUT+'/dump-recreation.html');
+const p = await b.newPage({ viewport: { width, height }, deviceScaleFactor: 1 });
+await p.goto('file://' + (file.startsWith('/') ? file : process.cwd() + '/' + file));
+if (gray === 'grayscale') await p.addStyleTag({ content: 'html{filter:grayscale(1)}' });
 await p.waitForTimeout(400);
-await p.screenshot({ path: OUT+'/recreation.png', clip:{x:0,y:0,width:1098,height:217} });
+await p.screenshot({ path: out, clip: { x: 0, y: 0, width, height } });
 await b.close();
+console.log('shot', out, `${width}x${height}`, gray === 'grayscale' ? '(grayscale)' : '');

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ tmp-*.mjs
 # (each cloud session gets its own clone), best-effort, NEVER committed.
 .claude/.session-prs
 .claude/.session-title-set
+
+# Python bytecode — /paint's scripts are run in place, so a stray __pycache__
+# lands inside the skill dir. Build artifact, never committed.
+__pycache__/
+*.pyc


### PR DESCRIPTION
Two additions to `/paint`, both from Jac's 2026-08-02 brief. Skill files only — nothing served changes.

## Layering doctrine — `references/layering.md` (new)

> "A single one-layer element does not need to bear the weight of accuracy — using opacity and stacking elements can achieve it."

The failure mode this kills: tuning one `background:` or one `box-shadow:` harder and harder, trying to make one declaration do the work of six. It never converges.

- **The stack model** — 7 ordered layers (base fill → form modeling → edge construction → etching → grain → temperature wash → accents) with typical alpha per layer, one job each, lean-to-fat. When something is 90% right, the last 10% is a new layer at 6–10% alpha.
- **Recipes** — clipped solid bevel rings (not inset box-shadows), paired-line etching (dark line + 1px-offset light line), form-turning gradients with the reflected-light value check, matte-no-glow (hairline + wash, blur banned), non-banding gradients, grain under 6%, and temperature/saturation shifts **without white** (white cools *and* desaturates — reach for the lighter neighboring hue).
- **Edge hierarchy table** — hard / firm / soft / lost, each with its CSS. "Looks cut out next to the mockup" ⇒ too many hard edges.
- **Blend-mode selection** and **how to debug a stack** (toggle one layer, alpha-hunt from below, check in grayscale, squint before you zoom).

## Master-copy workflow — `references/master-copy.md` (new)

> "Copy the artwork's relationships — not its individual objects."

Jac's 14-step copyist method, each step translated to what it means when the surface is a `#stage` div: native aspect ratio, toned ground, five named value tokens sampled from the notan, a **grayscale grisaille pass before any color**, palette strings authored up front, then modeling (glazing/scumbling/wet-into-wet/opaque/broken colour → their exact CSS analogues), a deliberate edge pass, and detail last. Includes the banned-until-late list — icons, glyphs, ticks, hairlines, grain, `text-shadow` — because each one makes a misplaced plate look plausible.

## `SKILL.md`

- Two new iron rules: **#7 relationships, not objects** and **#8 no single element bears the accuracy — stack it**.
- **Order-of-importance table** (placement → proportion → value → edges → temperature/saturation → surface → detail). This now also ranks the Phase-2 cell deltas: analysts return a `rank`, and the applier merges **rank-ascending**, so a 1px hairline never gets fixed before a 6px plate offset.
- Phase 0 (define the target, prep the reference set) added ahead of the solo recreation; Phase 1 restructured as envelope → value map → grisaille → thin color pass → layered modeling → edge pass; Phase 2's final step gains the unify pass.

## Scripts

| Script | Change |
|---|---|
| `refs.py` | **new** — grayscale, 3-value notan, poster5, focal crop, plus the `v1..v5` value anchors and the image ratio |
| `diag.py` | **new** — `--overlay` (4x difference map + red/cyan registration view + worst-delta bbox), `--squint` (the across-the-room gate), `--flip`, `--values` |
| `shot.mjs` | argv-driven (was a hardcoded dead scratchpad path from a previous session), plus a `grayscale` mode for the grisaille check |
| `cut.py` | takes an outdir, prints each cell's original-scale origin so analysts report in mockup coordinates |

Bootstrap noted in the skill: `pip3 install Pillow` (PIL is absent on a fresh cloud container — confirmed, and the install works).

## Testing

All scripts smoke-tested end to end against a synthetic mockup/recreation pair; the `--overlay` registration view correctly shows red fringes on the shifted edges.

Gates green locally: `smoke` ✅ · `logic` 706/706 ✅ · `cachebust` 23/23 ✅ · `lease` 77/77 ✅ · `lease-deploy` 42/42 ✅ · `promote` 23/23 ✅ · `rule-usage --check` ✅ · `window-catalog` ✅ · `code-map --check` ✅ · `check-cachebust` ✅ (no versioned served-file change).

No UI change, so no `data-r` stamps, no `WINDOW_CATALOG` entry, no cache-bust bump, and no decisions-ledger row.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Guqvi7rSzE9GgCdBukNzBA)_