### PR TITLE
fix(prune): classify delete failures on stderr, not the echoed command

### DIFF
--- a/docs/cleanup/2026-08-02-work-manifest.md
+++ b/docs/cleanup/2026-08-02-work-manifest.md
@@ -165,9 +165,13 @@ These merge cleanly but are sandbox/branding/doc artifacts. Low risk either way.
   merge base; `reconcile/staging-into-trunk` is 485. That lineage predates the trunk rename and is
   **archive, not backlog**.
 
-**21 branches are provably safe to delete** — verified by content, holding back trunk, production,
+**33 branches are provably safe to delete** — verified by content, holding back trunk, production,
 the current branch, and any open-PR head. Run `node tools/prune-absorbed-branches.mjs` for the dry
 run and `--yes` to execute.
+
+> It was **21** before this cleanup merged. Landing the 12 parked notes on trunk made their branches
+> absorbed too — deleting them can no longer lose anything, which it could have beforehand. Re-run
+> the dry run rather than trusting any number written down here; the tool is the source of truth.
 
 ⚠ **Deletion cannot be done from a cloud session.** The sandboxed git proxy returns **HTTP 403** on
 ref deletion (it permits pushes to the session's own branch, not deletes), and the GitHub MCP server

--- a/tools/prune-absorbed-branches.mjs
+++ b/tools/prune-absorbed-branches.mjs
@@ -192,13 +192,19 @@ for (const { name, sha } of absorbed) {
     console.log(`  deleted ${name}`);
     ok++;
   } catch (e) {
-    const msg = e.message || e.stderr?.toString() || '';
-    if (/stale info|force-with-lease|non-fast-forward|rejected/i.test(msg)) {
+    // Classify on STDERR only. `e.message` starts with "Command failed: git push origin
+    // --force-with-lease=..." — it echoes the command line, so matching it for "force-with-lease"
+    // matches EVERY failure and mislabels unrelated errors (a 403, a network drop) as "moved".
+    const err = (e.stderr ? e.stderr.toString() : '') || '';
+    if (/stale info/i.test(err)) {
       stale++;
       console.error(`  SKIPPED ${name}  (moved since it was classified — re-run to re-evaluate)`);
     } else {
       fail++;
-      console.error(`  FAILED  ${name}${msg.includes('403') ? '  (HTTP 403 — this environment forbids ref deletion; run from a session with real push rights)' : ''}`);
+      const why = /\b403\b/.test(err)
+        ? '  (HTTP 403 — this environment forbids ref deletion; run from a session with real push rights)'
+        : `  (${err.split('\n').find((l) => l.trim()) || 'unknown error'})`;
+      console.error(`  FAILED  ${name}${why}`);
     }
   }
 }


### PR DESCRIPTION
Follow-up to #796. One-line-cause bug in the `--force-with-lease` guard that shipped in it.

**Symptom.** Every failed branch delete reported as `SKIPPED … (moved since it was classified)`, including failures that had nothing to do with the lease.

**Cause.** `execFileSync`'s `error.message` begins:

```
Command failed: git push origin --force-with-lease=refs/heads/<b>:<sha> :refs/heads/<b>
```

It echoes the command line. So a regex matching `/force-with-lease/` against `error.message` matches **every** failure. This environment's HTTP 403 was being reported as a stale-lease skip, which points the reader at exactly the wrong problem — "the branch moved" instead of "this environment can't delete refs".

**Fix.** Classify on `stderr` alone, and only on git's unambiguous `stale info` wording. Anything else is a genuine failure and reports its actual first line of stderr, with the 403 case named explicitly.

**Verified** against all 33 currently-absorbed branches:

| | Before | After |
|---|---|---|
| Report | `33 skipped (moved)` | `33 failed (HTTP 403 — this environment forbids ref deletion)` |
| Branches deleted | 0 | 0 |
| Branches on origin | 298 | 298 |

No data was ever at risk — git exits 1 and the refs survive. The bug was a misleading message, not a destructive one.

Docs-only + tooling; `ci/check-cachebust.mjs` confirms no served-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1NkkzJpXhd7hS3ZWVstBs

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1NkkzJpXhd7hS3ZWVstBs)_