### PR TITLE
Wrangler fix: GPS picker names a lapsed provider link instead of blaming the connection

### DIFF
--- a/app.js
+++ b/app.js
@@ -23592,6 +23592,31 @@ async function gpsProviderDevices(provider) {
   }
 }
 
+/* Is ONE provider's own account link live on the GPS backend? Deere/Yanmar/Bouncie each
+   authenticate against the PROVIDER (Deere/Bouncie OAuth, Yanmar a session login — backend
+   handoff §1) and expose an `/api/<p>/status` probe carrying `authenticated`; Hapn is
+   server-to-server client-credentials with no such probe, so it answers null = unknown.
+   This is the same probe gpsFleetStatus already makes before its phase-2 machine lists —
+   pulled out here so the connect-wizard picker can tell a LAPSED PROVIDER LINK apart from
+   an unreachable backend instead of blaming both on the connection.
+   Returns true = linked · false = link lapsed · null = couldn't tell. */
+async function gpsProviderAuthed(provider) {
+  const p = String(provider || '').toLowerCase();
+  if (p !== 'deere' && p !== 'yanmar' && p !== 'bouncie') return null;
+  try { return (await gpsFetch(`/api/${p}/status`))?.authenticated === true; }
+  catch { return null; }   // the probe itself failed → genuinely a reachability problem
+}
+/* Pick the honest picker-load error off that probe (PURE — exposed on window.__rw). A
+   provider whose account link has lapsed IS reachable; saying "check the connection"
+   sends the operator to their router when the real fix is relinking that account on the
+   GPS service. Anything else (probe unknown, provider linked but the list call failed)
+   keeps the original reachability wording. */
+function gpsPickerError(provider, linked) {
+  return linked === false
+    ? `${provider} isn’t linked to the GPS backend right now — that account needs reconnecting on the GPS service. Not a connection problem on your end.`
+    : 'Couldn’t reach the GPS backend — check the connection and try again.';
+}
+
 /* ── BOUNCIE TRUCKS → UNITS (design note docs/superpowers/specs/2026-07-09-bouncie-
    truck-units-design.md) ─────────────────────────────────────────────────────────
    Trucks are just units of a 'Truck' category — no new entity, no fleetStatus trick,
@@ -23824,11 +23849,19 @@ function gpsRawDeviceSub(provider, raw) {
    popup state. */
 async function gpsConnectLoadDevices(o) {
   o.devicesLoading = true; o.devicesError = ''; o.devices = null; renderOverlay();
+  const p = String(o.provider || '').toLowerCase();
   let list = [];
-  try { list = await gpsProviderDevices(String(o.provider || '').toLowerCase()); }
+  try { list = await gpsProviderDevices(p); }
   catch (e) {
     if (state.overlay !== o) return;
-    o.devicesLoading = false; o.devicesError = 'Couldn’t reach the GPS backend — check the connection and try again.';
+    // §two-phase — gpsFleetStatus probes /api/<p>/status and only pulls a machine list once
+    // it reports `authenticated`; this picker skipped that probe, so a provider whose OWN
+    // account link had lapsed (Yanmar's parked SmartAssist re-auth) surfaced as "couldn't
+    // reach the GPS backend" even while the very same gpsFetch was serving Hapn's list in
+    // this dialog. Ask the probe what actually broke before naming a cause.
+    const linked = await gpsProviderAuthed(p);
+    if (state.overlay !== o) return;
+    o.devicesLoading = false; o.devicesError = gpsPickerError(o.provider, linked);
     return renderOverlay();
   }
   if (state.overlay !== o) return;
@@ -26774,7 +26807,7 @@ function exposeTestApi() {
       dataCache, cacheValid, cacheDeviceOk, cacheTokenTag, cacheAppVer, cacheSnapshotEnvelope, CACHE_SCHEMA_VER, FEATURES,   // §instant-cache (spec 2026-07-16)
       recordDateMatch, dateTermHits, rowMatches,
       kpiFor, kpiRaw, kpiEval, legacyKpiPct, legacyKpiRaw, KPI_DEFAULTS, wrValidateKpi, roleRings,
-      companyRevenueGoal, companyName, companyTagline, membershipPricing, membershipFee, membershipStatus, isActiveMember, rentalPrice, pickFunnelStage, toggleFunnelMembership, rentalFunnelStage, funnelStageOf, inFunnel, inRental, hasRentalActivity, funnelTrackA, funnelTrackEquip, ensureFunnels, funnelMenuHtml, reachFunnelStage, toggleMemberLead, funnelCurrentStage, funnelLayerDate, funnelLayerNote, ensureFunnelLog, markMembershipSigned, funnelLayerAction, funnelScope, naUrgency, naOpenList, rentalProtectionRate, rentalProtectionAmount, protectionLineItems, syncProtectionLine, membershipEconomics, membershipFeeRevenue, membershipMetaHtml, membershipActionsHtml, funnelSectionHtml, membershipCancel, membershipReactivate, membershipCancellationInvoice, agreementSignCommit, addMonthsISO, rentalRuleBlock, dueForCustomer, customFieldsFor, checklistFor, checklistRequired, inspFamilyKey, inspKeyOfCat, inspItemFails, inspItemUnanswered, inspItemType, inspEvidenceMissing, applySettings, getStatus, pageDefaultSlice, previewOverlayFor, WINDOW_CATALOG, unitCoverage, fleetInsuredValue, fleetPremiumMonthly, insuranceTypeCatalog, invoiceCollectionsActive, collectionsHasOtherActive, getEntityColor, getEntityFlags, isEmptyMockDraft, sweepEmptyDrafts, createInvoiceForRental, syncRentalLines, rentalLineItems, salePriceSuggest, salePricingCfg, categoryCostBasis, driverRoster, driverName, legDriverField, dispatchEvents, applyRoleLanding, topServiceForUnit, snoozeService, svcSnoozedUntil, unitServiceRows, recordServiceCompletion, sellUnit, categoryStats, gpsMatchFleet, gpsMatchScore, gpsMakeFamily, gpsDeviceFamily, gpsApplyMappings, gpsUndoMappings, gpsRoundupRows, gpsCanonProvider, gpsUtilRollup, gpsBounciePlan, gpsApplyBouncieTrucks, reindex, logAction, setRole: (r) => { currentRole = r || ''; render(); }, histText, canMoney,
+      companyRevenueGoal, companyName, companyTagline, membershipPricing, membershipFee, membershipStatus, isActiveMember, rentalPrice, pickFunnelStage, toggleFunnelMembership, rentalFunnelStage, funnelStageOf, inFunnel, inRental, hasRentalActivity, funnelTrackA, funnelTrackEquip, ensureFunnels, funnelMenuHtml, reachFunnelStage, toggleMemberLead, funnelCurrentStage, funnelLayerDate, funnelLayerNote, ensureFunnelLog, markMembershipSigned, funnelLayerAction, funnelScope, naUrgency, naOpenList, rentalProtectionRate, rentalProtectionAmount, protectionLineItems, syncProtectionLine, membershipEconomics, membershipFeeRevenue, membershipMetaHtml, membershipActionsHtml, funnelSectionHtml, membershipCancel, membershipReactivate, membershipCancellationInvoice, agreementSignCommit, addMonthsISO, rentalRuleBlock, dueForCustomer, customFieldsFor, checklistFor, checklistRequired, inspFamilyKey, inspKeyOfCat, inspItemFails, inspItemUnanswered, inspItemType, inspEvidenceMissing, applySettings, getStatus, pageDefaultSlice, previewOverlayFor, WINDOW_CATALOG, unitCoverage, fleetInsuredValue, fleetPremiumMonthly, insuranceTypeCatalog, invoiceCollectionsActive, collectionsHasOtherActive, getEntityColor, getEntityFlags, isEmptyMockDraft, sweepEmptyDrafts, createInvoiceForRental, syncRentalLines, rentalLineItems, salePriceSuggest, salePricingCfg, categoryCostBasis, driverRoster, driverName, legDriverField, dispatchEvents, applyRoleLanding, topServiceForUnit, snoozeService, svcSnoozedUntil, unitServiceRows, recordServiceCompletion, sellUnit, categoryStats, gpsMatchFleet, gpsMatchScore, gpsMakeFamily, gpsDeviceFamily, gpsApplyMappings, gpsUndoMappings, gpsRoundupRows, gpsCanonProvider, gpsPickerError, gpsUtilRollup, gpsBounciePlan, gpsApplyBouncieTrucks, reindex, logAction, setRole: (r) => { currentRole = r || ''; render(); }, histText, canMoney,
       tripsFor, tripTown, telHref, tripMatches, tripSort, stopDone, dispatchStopId, tripRowHTML: (t) => ROWS.calendar(t), yardCapture, openYardCamera, commitYardCapture, nextCategoryId, nextUnitId,
       tripsLS, tripMerge, tripSplit, assignTripDriver, tripLabel, assignStopDriver, tripSetTime,
       tripPushSoon, tripPushNow, loadTripsFromBackend, tripsSyncFooter, setBackendPassword: (pw) => { backendPassword = pw || ''; },   // §2.3 Phase 4 sync — the setter is test-only (mirrors setRole), letting logic-test.mjs exercise the online path via a mocked window.fetch, never a real backend

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -1903,6 +1903,20 @@ try {
         ok(r6.results[0].ok === true && uOpen.gpsProvider === 'Hapn' && uOpen.gpsDeviceId === 'ru-dev-6', 'gps M5: a real matcher proposal applies end-to-end with the canonical-cased provider');
       }
 
+      // === Connect-wizard picker error — a LAPSED PROVIDER LINK is not an unreachable
+      // backend (#803). The picker used to collapse every gpsProviderDevices() throw into
+      // "check the connection", which sent the operator to their router while Hapn loaded
+      // fine in the same dialog. gpsPickerError is the pure branch off the /api/<p>/status
+      // `authenticated` probe gpsFleetStatus already makes. ===
+      {
+        const lapsed = T.gpsPickerError('Yanmar', false);
+        ok(/isn’t linked to the GPS backend/.test(lapsed), 'gps #803: authenticated:false → names the lapsed account link');
+        ok(!/check the connection/.test(lapsed), 'gps #803: a lapsed link never blames the connection');
+        ok(/Yanmar/.test(lapsed) && /Deere/.test(T.gpsPickerError('Deere', false)), 'gps #803: the message names the provider that lapsed');
+        ok(T.gpsPickerError('Yanmar', null) === 'Couldn’t reach the GPS backend — check the connection and try again.', 'gps #803: an unknown probe keeps the original reachability wording');
+        ok(T.gpsPickerError('Yanmar', true) === T.gpsPickerError('Yanmar', null), 'gps #803: linked-but-list-failed also stays on the reachability wording');
+      }
+
       // cleanup — the suite mutates shared DATA
       ['U-RU1', 'U-RU2', 'U-RU3'].forEach((id) => T.IDX.unit.delete(id));
       ['U-RU1', 'U-RU2', 'U-RU3'].forEach((id) => { const i = T.DATA.units.findIndex((u) => u.unitId === id); if (i >= 0) T.DATA.units.splice(i, 1); });

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27655 lines, 41 chapters
+## app.js — 27688 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -44,11 +44,11 @@
 | APP-34 | 21324–22857 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+97) |
 | APP-35 | 22858–23340 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
 | APP-36 | 23341–23343 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23344–24568 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+85) |
-| APP-38 | 24569–25708 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25709–25715 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25716–26027 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26028–27655 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-37 | 23344–24601 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+87) |
+| APP-38 | 24602–25741 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25742–25748 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25749–26060 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26061–27688 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260803a" />
+  <link rel="stylesheet" href="style.css?v=20260807a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260803a"></script>
-  <script type="module" src="app.js?v=20260803a"></script>
+  <script src="rule-usage.js?v=20260807a"></script>
+  <script type="module" src="app.js?v=20260807a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Refs #803 — **does not close it**: the reported symptom (no Yanmar devices) needs a
credential op only Jac can do. See "What this does NOT fix" below.

## Verdict on the report

**Correct on the symptom, wrong on the cause — and the app is what told it wrong.**

Yanmar genuinely returns no device list. But the wizard's message
("Couldn't reach the GPS backend — check the connection and try again.")
is false: the backend is demonstrably reachable, because **Hapn's list loads from the
same dialog, over the same `gpsFetch`, same `x-auth-token`, same origin**
(`gpsProviderDevices`, `app.js:23585-23593` — all four providers, one transport).

Real cause, cited: **Yanmar's SmartAssist account link is not authenticated on the
WranglerGPS backend** — `docs/specs/gps-tracking.md:99-108` ("Yanmar's account shows
`authenticated: false` on the GPS backend (0 devices vs. 25 across the other three
providers) — needs a re-auth on the GPS backend's Yanmar OAuth"), deliberately parked by
Jac 2026-07-08 and reconfirmed still not started at `:172-173`. Yanmar is a **session
login** (id+password), not OAuth-persisted like Deere/Bouncie —
`docs/handoffs/wrangler-gps-backend-handoff.md:75,81,114`.

## The in-repo defect this exposed

`gpsFetch` (`app.js:23412-23427`) throws `gps-http-<status>` on **any** non-2xx.
`gpsConnectLoadDevices` collapsed every one of those — lapsed provider link, 404, 500,
a real network drop — into one "check the connection" string.

The app already knows how to tell these apart. `gpsFleetStatus`
(`app.js:23547-23553`) probes `/api/<p>/status` and only pulls a phase-2 machine list
once it reports `authenticated`, marking an un-authenticated provider `down` rather than
failed (`:23550`; the comment at `:23522-23523` calls it "useFleet's two-phase pattern").
**The connect-wizard picker was the one Deere/Yanmar/Bouncie list-fetch in the app that
skipped that probe.** That divergence is the bug.

## What changed (minimal)

- **`gpsProviderAuthed(p)`** — the probe, extracted next to `gpsProviderDevices`.
  `true` linked · `false` lapsed · `null` unknown. Hapn is client-credentials with no
  `/status` probe, so it answers `null`.
- **`gpsPickerError(provider, linked)`** — pure, on `window.__rw`. Only
  `linked === false` gets the new wording; an unknown probe or a linked-but-failed list
  keeps the original reachability string **verbatim**.
- `gpsConnectLoadDevices` makes the probe on failure, re-checking `state.overlay === o`
  after the extra round-trip (same self-guard as every other async step there).

Pattern pass: `gpsProviderDevices`' other callers (`gpsUnitStatus:23577`, the Bouncie
truck import `:23654/:24524`) already `.catch(() => [])` and surface no cause string —
no sibling of this bug, so nothing else touched.

## What this does NOT fix

**Yanmar device results still won't load.** Restoring them means relinking that account
on the WranglerGPS service (`PUT /api/yanmar/credentials`, or `YANMAR_ID`/`YANMAR_PASSWORD`
on Railway — handoff §1/§2). That's a credential operation and Jac's call; nothing here
touches it. This change only stops the app pointing at the wrong culprit meanwhile.

No money / card / auth / WO-completion logic touched — the new probe is a read-only
`GET /api/<p>/status` the fleet snapshot already makes on every refresh.

## Gates

`smoke` ✅ · `logic-test` 716/716 ✅ (**5 new #803 checks**) · `gen-rule-usage --check` ✅ ·
`check-window-catalog` ✅ · `gen-code-map --check` ✅ (regenerated) · `lease-*` ✅ ·
`promote-test` ✅ · `cachebust-test` ✅ · `check-cachebust` ✅ (`?v=` 20260803a → 20260807a).

Bracket: the new checks **fail on trunk** (`TypeError: T.gpsPickerError is not a function`)
and pass here.

Staging: `gps-yanmar-picker-error-1` —
https://operations-jacrentals.github.io/rental-wrangler-staging/d/gps-yanmar-picker-error-1/

🤖 Generated with [Claude Code](https://claude.com/claude-code)