### PR TITLE
docs: refresh the Codex handoff kit against current canon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,19 @@ Before reading application code, open `docs/CODE-MAP.md` and navigate by its `fi
 
 For design work, use the design canon and current specs as the source of truth, not reverse-engineering from the current implementation:
 
-- `docs/superpowers/specs/2026-07-20-decisions-ledger.md`
-- `docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md`
-- `docs/superpowers/specs/2026-07-20-mockup-critique-log.md`
+- `docs/superpowers/specs/2026-07-20-decisions-ledger.md` — **read it to the END.** Rows #1–100 are a
+  2026-07-20 snapshot; rows #101+ supersede some of them. A decision is not made until it is a row in
+  that table, so **add a row** when something is settled.
+- `docs/design/HANDOFF-2026-08-05.md` — the most recent design-session handoff: what is built, what
+  is blocked on Jac's Figma work, and what not to try to fix in CSS.
+- `.claude/skills/art-pipeline/SKILL.md` — how illustrated UI gets out of Figma into running code.
+  Mandatory before touching any Halo/V2 artwork: **export, never recreate**; 9-slice via
+  `border-image`; structure `stretch`, countable rhythm `round`.
+- `docs/design/SLICE-SPEC.md` — the measured, adversarially verified 9-slice bands per panel. Do not
+  re-derive these numbers.
+- `docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md` and
+  `2026-07-20-mockup-critique-log.md` — the inline-expand model. **Shipped and landed on `trunk`;**
+  read as background, not as the active build target.
 - `DESIGN.md` and `docs/design/` when applicable
 
 ## Safety and product constraints
@@ -63,7 +73,11 @@ Before any new or reshaped UI, read both authorities in full:
 
 Also read the relevant current feature spec and decisions ledger. Never derive a new
 design decision by reverse-engineering `app.js` or `style.css`. `jactec-ui` is
-retired and must not be used.
+**deleted** (2026-07-26, ledger #26/#91) and must not be resurrected — it taught a
+superseded language (`#ff7a1a`, Saira Condensed, hazard stripes, one chip radius) that
+current canon contradicts. Four of its capabilities survive as read-only reference in
+`docs/design/reference/legacy-jactec-ui/`: the role audit, mobile reflow/touch,
+anti-slop, and the DESIGN.md guides. Reference only — not canon.
 
 Non-negotiables:
 
@@ -89,6 +103,12 @@ Non-negotiables:
   distinct.
 - Keep the voice industrial rental yard first, with restrained wrangler/ranch
   seasoning in copy rather than decorative chrome.
+- **"Matte — no glow" is a STEEL rule, not a ban** (ledger #251 — the shorthand in
+  `CLAUDE.md` and `wrangler-style` §28 keeps being over-read). The operative rule is
+  #146: light is emitted **by glass, never applied to steel**. Ask what material is
+  glowing. Glass emitting (terminal text, carets, an interactive control's lit state)
+  is correct and sometimes required; steel emitting (decks, housings, the card frame,
+  grip-rack ticks) is the actual violation. Cite #146 before removing a glow.
 
 ## Working rules
 
@@ -98,9 +118,17 @@ Non-negotiables:
   reference.
 - Do not invent UI pieces. Every element is a Signal, Gate, Stamp, Ref, or Door.
   If a new pill or button seems necessary, stop and ask rather than creating one.
-- Everything new rides behind `FEATURES.designV2` and remains additive. With that
-  flag off, the app must look and behave byte-for-byte as it does today. Back out any
-  change that alters the flag-off app.
+- Big *replacements* ride behind a `FEATURES` flag in `config.js` (read it with
+  `flagOn()`), landing the new path alongside the old one. Flag off = the old path is
+  still live and byte-identical; flipping it on is the rollout switch and flipping it
+  back is the instant rollback. Delete the old path only once the new one has proven
+  out. Small, low-risk changes skip the flag entirely and merge plainly.
+  A flag disables **execution, not visibility** on a public Pages site — never gate a
+  secret or a security/auth check on one.
+  Current flags: `cardGlobalSearch`, `phoneIdentity`, `qrScanLog`, `qrScanPreview`,
+  `instantCache`, `userSync`. **`designV2` no longer exists** — the `dv2` inline-expand
+  redesign landed on `trunk` and the flag was retired. Read `config.js` for live state
+  rather than trusting any flag name quoted in a document, including this one.
 - Colour is never decoration. Use the colour the state calls for, never one chosen
   merely because it looks nicer.
 - Done is factual, not aesthetic: green = genuinely finished; blue = waiting/on
@@ -117,27 +145,33 @@ Non-negotiables:
 **Design authority — decides what is correct:**
 
 - `.claude/skills/style/SKILL.md` and `.claude/skills/wrangler-style/SKILL.md` —
-  the canon.
-- `docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md` — the
-  current feature spec, including the mockups and Jac's ETA ledger in words.
-- `docs/superpowers/specs/2026-07-20-decisions-ledger.md` — locked decisions;
-  newer entries win.
-- `docs/superpowers/specs/2026-07-20-mockup-critique-log.md` — known flaws and
-  their fixes.
-- `docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md` — build plan
-  and running shipped-work log.
+  the canon. Read both, always, before any new or reshaped UI.
+- `docs/superpowers/specs/2026-07-20-decisions-ledger.md` — locked decisions; newer
+  entries win. Read to the end (currently ~#261) and add a row when something settles.
+- `.claude/skills/art-pipeline/SKILL.md` — the Figma→code method for illustrated UI.
+- `docs/design/SLICE-SPEC.md` — measured 9-slice bands; do not re-derive.
+- `docs/design/HANDOFF-2026-08-05.md` — the latest design-session state and its
+  explicit "blocked on Jac's Figma work — do not fix these in CSS" list.
+
+**Background — shipped, read for history, not as a build target:**
+
+- `docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md`,
+  `2026-07-20-mockup-critique-log.md`, and
+  `docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md` — the
+  inline-expand model. Landed on `trunk`; its `designV2` flag is retired.
 
 **Where the current build lives — read to continue work, not to decide design:**
 
-- `config.js` — `FEATURES.designV2`; `app.js` sets the `html.dv2` class.
-- `style.css` — the `html.dv2` redesign blocks.
-- `app.js` — inline-expand code: `rowEl`, `cardEl`, `openStandard`, `dv2On`, and
-  `INLINE_EXPAND_CARDS`.
+- `config.js` — the live `FEATURES` set.
+- `docs/design/v2-card/` — the Figma V2 card (`438:274`) running as live HTML/CSS.
+  Serve the folder and open `card.html`.
+- `docs/design/tier-01-card/` — the Tier-01 card the V2 assembly is built on.
+- `app.js` / `style.css` — navigate via `docs/CODE-MAP.md`, never by scanning.
 
-Reading those `dv2` implementation areas to extend them is expected. What is
-off-limits is deciding what the design should be by copying the current app. The
-visual mockups, hand-drawn sketches, and design artifacts are not in the repository;
-do not hunt for them. Use the specs and the live staging build instead.
+Reading implementation to extend it is expected. What is off-limits is deciding what
+the design should be by copying the current app. Most visual mockups and hand-drawn
+sketches are not in the repository; do not hunt for them. Use the canon, the ledger,
+the design docs, and the live staging build instead.
 
 ## Working conventions
 

--- a/docs/CODEX-HANDOFF.md
+++ b/docs/CODEX-HANDOFF.md
@@ -9,13 +9,19 @@ so it works wherever Codex reads it.
 > what's next.
 
 ## TL;DR — most of this is agent-agnostic and already travels
-The project is mostly portable Node + markdown on a GitHub repo. There are **three real work
-items**, everything else just works if Codex runs on the same repo:
+The project is mostly portable Node + markdown on a GitHub repo. Most of the setup is **already
+done** — what remains is short:
 
-1. **Create `AGENTS.md`** — Codex's instruction file (it does not read `CLAUDE.md`).
-2. **Re-provision secrets** in Codex's environment — *you* do this, never through chat or the repo.
-3. **Swap the two LLM-calling GitHub Actions** to OpenAI (`wrangler-fix.yml`, check `auto-promote.yml`).
-4. **If Claude + Codex run at once:** namespace branches (`codex/*`) + a `docs/WIP.md` ledger +
+1. ~~**Create `AGENTS.md`**~~ — ✅ done (#762/#765, refreshed 2026-08-10). Codex reads `AGENTS.md`,
+   not `CLAUDE.md`.
+2. ~~**Wrap the ship flow in npm scripts**~~ — ✅ done: `gates`, `deploy:staging`, `promote`,
+   `cachebust`. ~~**Build the Codex plugin**~~ — ✅ done, 12 commands.
+3. **Re-provision secrets** in Codex's environment — *you* do this, never through chat or the repo.
+   **Still open.**
+4. **Swap `wrangler-fix.yml` to OpenAI** (or disable it). **Still open** — it is the only workflow
+   that actually calls an LLM.
+5. **Split `app.js`** by CODE-MAP chapters — **still open**, and the largest single token win (§5).
+6. **If Claude + Codex run at once:** namespace branches (`codex/*`) + a `docs/WIP.md` ledger +
    a cross-review skill (§8). The staging deck already isolates deploys for free.
 
 ---
@@ -48,11 +54,19 @@ Every skill is a markdown file under `.claude/skills/<name>/SKILL.md`. Point `AG
 | `style` · `wrangler-style` | **PORT (critical)** | the design canon (palette, type voices, Signal·Gate·Stamp·Ref·Door, and the measurable spec — control height, size ladder, contrast floors). The reason the UI is one family. |
 | `wrangler-fix` | **PORT** | "prove the root cause with citations before changing code" — the debugging methodology. |
 | `atlas` | **PORT (as instruction)** | CODE-MAP-first navigation → the #2 token lever (§5). |
-| `start` | **ADAPT** | session orientation — keep the branch-flow parts, drop Claude-session bits. |
+| `art-pipeline` | **PORT (critical, added 2026-08-05)** | the Figma→code method for illustrated UI: export never recreate, 9-slice, stretch-vs-round, and eight measured traps. This is the *active* design method — not yet wrapped as a Codex command. |
+| `startup` | **ADAPT** | session orientation. **Renamed from `start` on 2026-07-28 (#802)** to end a plugin name collision; the Codex plugin command is still `start`. Keep the branch-flow parts, drop Claude-session bits. |
 | `run-live` · `lazy-audit` · `webapp-testing` | **ADAPT** | Playwright-based test/audit flows — portable, useful. |
+| `paint` | **ADAPT** | the guided design pipeline (inspiration → Canva critique → Figma → gated code). Depends on Canva/Figma MCP connectors, so port only what Codex can actually reach. |
+| `prompt-a` · `prompt-b` · `promptai` | **ADAPT** | the external-model audit handoff. Ironically useful in reverse: Codex can use these to hand a prototype to *another* model. |
 | `brainstorming` | **ADAPT** | the spec-first design dialogue — a useful pattern, not Claude-specific. |
 | `audit` | **DROP** | Claude token-efficiency audit — harness-specific. |
 | `end` · `skill-creator` | **DROP** | Claude session/skill management. |
+
+**Not yet wrapped as Codex commands:** `art-pipeline`, `paint`, `lazy-audit`, `run-live`,
+`prompt-a`/`prompt-b`. The plugin currently ships 12: `start`, `style`, `wrangler-style`, `atlas`,
+`wrangler-fix`, `gates`, `build`, `deploy`, `merge`, `promote`, `live`, `clasp`. Codex can still
+**read** the unwrapped ones as plain markdown under `.claude/skills/<name>/SKILL.md`.
 
 ## 3. Secrets — YOU re-provision, never through the agent or the repo
 **Hard rule (unchanged): the repo is PUBLIC via Pages. No secret value ever goes in the repo, a
@@ -111,13 +125,22 @@ Two homes for secrets:
    required check.
 
 ## 7. First-week Codex checklist
-- [ ] Confirm Codex on the **same** GitHub repo (inherits CI + branch protection + Actions secrets).
-- [ ] Create `AGENTS.md` (seed from `CLAUDE.md`; graft in `build`/`deploy`/`promote`/`clasp`/
-      `style`/`wrangler-style` runbooks; point it at `docs/CODE-MAP.md` as the nav entrypoint).
-- [ ] Add the §6 npm scripts so the ship flow is agent-agnostic.
-- [ ] Re-provision agent-env secrets from your vault (§3) — never via chat/repo.
-- [ ] Swap `wrangler-fix.yml` (and check `auto-promote.yml`) to OpenAI, or disable.
-- [ ] Split `app.js` by CODE-MAP chapters, re-running the full gate suite after each move.
+*Status as of 2026-08-10.*
+- [x] Confirm Codex on the **same** GitHub repo (inherits CI + branch protection + Actions secrets).
+- [x] Create `AGENTS.md` — **done** (#762/#765, refreshed 2026-08-10). It carries the ship flow,
+      the backend runbook, the design canon, and the Codex command list.
+- [x] Add the §6 npm scripts — **done**: `gates`, `deploy:staging`, `promote`, `cachebust`.
+- [x] Build the Codex plugin — **done**: `plugins/rental-wrangler-commands` (12 commands) with its
+      marketplace manifest at `.agents/plugins/marketplace.json`.
+- [ ] **Re-provision agent-env secrets from your vault (§3) — YOURS to do, never via chat/repo.**
+- [ ] **Swap `wrangler-fix.yml` to OpenAI, or disable it.** Still open: it calls Claude to triage
+      auto-fix issues. `branch-janitor.yml` also mentions Claude but only to recognise `claude/*`
+      branch names — no LLM call, so it needs a `codex/*` pattern, not a model swap.
+      `auto-promote.yml` and `ci.yml` are LLM-free.
+- [ ] **Split `app.js` (27,687 lines) by CODE-MAP chapters**, re-running the full gate suite after
+      each move. Still open — the #1 token lever (§5).
+- [ ] Wrap the unwrapped skills as Codex commands (§2b) — `art-pipeline` first, since it is the
+      active design method.
 
 ## 8. Running Claude + Codex on one repo — collisions & cross-review
 Both agents on one repo is safe *if* each stays in its own lane and the shared integration point
@@ -154,12 +177,29 @@ on demand — never a gate, never a merge block, never a required check.**
   run it whenever you want a second opinion, and it never touches the merge.
 
 ## 9. Current work-in-flight (context for whoever picks up the UI)
-The active branch `claude/rental-wrangler-ui-research-rhd74v` (PR #752) holds the **Phase-2
-`dv2` redesign**, gated behind `FEATURES.designV2` (off in production; auto-on on staging/local
-via the `html.dv2` class). Steps 1–2 of the inline-expand model are built: a single-click reveals
-a record **in the list** (row expands, height-capped to the column), reshaped to the section
-**plate-stack** (header-as-close, collapsed Inspection + History, swipe-easing reveal). Remaining:
-carry the reshape into Rentals + Customers, the History-search footer, links-land-on-section,
-mobile paged sections + To-Do, and retiring the legacy card-swap detail. Full plan:
-`docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md` and
-`docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md`.
+*Refreshed 2026-08-10. The earlier version of this section described the `dv2` inline-expand branch
+as in-flight; that work **landed on `trunk` as #766** and its `FEATURES.designV2` flag was retired.*
+
+The live frontier is the **design system / V2 card**, landed as **#798** (`def4a15`). It is a
+Figma-sourced, illustrated UI — the interface *is* artwork — so the working method is the
+**`art-pipeline`** skill: **export from Figma, never recreate in CSS**; bake static art as one
+z-ordered `background-image`; carry anything state-coloured as a white-silhouette `mask-image`
+filled with `var(--row-hue)`; make panels resize with `border-image` 9-slice using the measured
+bands in `docs/design/SLICE-SPEC.md` (structure `stretch`, countable rhythm `round`).
+
+**Read `docs/design/HANDOFF-2026-08-05.md` before touching any of this.** Two things it settles
+that will otherwise cost you a day:
+
+- **The V2 card is "a start," not at fidelity.** It still uses fixed-size scaled art, not
+  `border-image` 9-slice. The spec exists; nothing is wired to it yet.
+- **Four panels are blocked on Jac redrawing the artwork — do not try to fix them in CSS.**
+  `asm-deck` cannot slice below 1316px (its chips and nameplate are frozen in a 1100px corner);
+  `asm-housing`'s interior staircase is a near-rhythm that can neither `stretch` nor `round`;
+  `asm-headboard`/`asm-rowboard` need text-free re-exports; the rail export has three defects
+  (#259). **`asm-headboard`, `asm-rowboard` and `asm-channel` slice cleanly today** — start there.
+
+Ledger rows **#238–#261** cover everything settled in that run, including two errors that were
+scoped back rather than deleted. Read them; re-deriving them is what made the last session slow.
+
+Also live but unrelated to the redesign: `docs/handoffs/audit-2026-07-19-rentals-dispatcher-remaining-work.md`
+carries the parked Bucket-B dispatcher findings from the RENTALS audit.

--- a/docs/CODEX-ONBOARDING.md
+++ b/docs/CODEX-ONBOARDING.md
@@ -6,11 +6,14 @@ the project *on your own*, then confirm your understanding with Jac before writi
 ---
 
 ## Phase A — set up (walk Jac through it)
-Follow **`docs/CODEX-HANDOFF.md`** end to end: same GitHub repo, create `AGENTS.md`, add the npm
-scripts, and re-provision secrets. **Walk Jac through each secret** — he provisions the values from
-his own vault; you never handle or echo a secret value, and nothing secret ever enters the repo or
-chat. Swap the two LLM-calling GitHub Actions to OpenAI. **Do not touch feature code until
-`npm run gates` (the full CI suite) is green.**
+Follow **`docs/CODEX-HANDOFF.md`** end to end. **Most of it is already done:** same GitHub repo,
+`AGENTS.md`, the npm scripts (`gates`, `deploy:staging`, `promote`, `cachebust`), and the Codex
+plugin all exist. What is still open is the §7 checklist tail — **re-provision the secrets**, **swap
+`wrangler-fix.yml`** off Claude, and **split `app.js`**.
+
+**Walk Jac through each secret** — he provisions the values from his own vault; you never handle or
+echo a secret value, and nothing secret ever enters the repo or chat. **Do not touch feature code
+until `npm run gates` (the full CI suite) is green.**
 
 ## Phase B — study & understand (before any feature code)
 Read the sources below **in order**, then **write Jac a short "here's my understanding of where the
@@ -25,7 +28,10 @@ single-file frontend: `app.js` (~27.8k lines), `style.css`, `index.html`, `confi
 Ships on a **trunk → staging → production** flow. Currently mid a **Phase-2 UI redesign**.
 
 ### 2. The brain (read first)
-- **`CLAUDE.md`** — the project operating rules (seed your `AGENTS.md` from it).
+- **`AGENTS.md`** — **your instruction file, and the one to trust.** It already carries the ship
+  flow, the backend runbook, the design canon and the Codex command list.
+- **`CLAUDE.md`** — the Claude-side equivalent. Useful as a cross-check, but where the two disagree,
+  `AGENTS.md` and the decisions ledger win. Do not seed anything from it — it is already seeded.
 - **`MEMORY.md`** (repo root) — cross-session memory / durable context.
 - **`.claude/rules/`** — path-scoped rules (e.g. icons: never hand-draw, source from Lucide).
 - **`docs/CODE-MAP.md`** — the navigation map. **Open this FIRST before any code dive** and jump to
@@ -39,7 +45,15 @@ Ships on a **trunk → staging → production** flow. Currently mid a **Phase-2 
   voices, the button taxonomy, the **Signal · Gate · Stamp · Ref · Door** component vocabulary, and
   the restrained wrangler/ranch voice.
 - **`docs/superpowers/specs/2026-07-20-decisions-ledger.md`** — the running ledger of locked design
-  decisions (what was decided and why; newer decisions supersede older ones).
+  decisions (what was decided and why; newer decisions supersede older ones). **Read it to the
+  END** — rows #1–100 are a 2026-07-20 snapshot and #101+ supersede some of them. Rows **#238–#261**
+  are the current design-system run. A decision is not made until it is a row here, so **add one**
+  when something is settled.
+- **A canon trap worth knowing before you trip it:** `CLAUDE.md` and `wrangler-style` compress the
+  rule to "**Matte — no glow**," which reads as a total ban and is not what canon says. Ledger #251
+  is operative: light is emitted **by glass, never applied to steel**. Glass emitting (terminal
+  text, carets, a lit interactive control) is correct; steel emitting (decks, housings, the card
+  frame) is the violation. Check the material before removing a glow.
 - **CRITICAL sourcing rule:** design comes from the **canon + specs + mockups + research** —
   **never reverse-engineered from the live `app.js`/`style.css`.** This is a hard rule from Jac
   (a controlled design environment); honor it.
@@ -55,66 +69,87 @@ Ships on a **trunk → staging → production** flow. Currently mid a **Phase-2 
   session*; its conclusions are folded into the specs in §5. The raw inventory is **not in the
   repo** — see §9.
 
-### 5. The CURRENT redesign (what we're building now) — read closely
-- **`docs/superpowers/specs/2026-07-20-list-views-inline-expand-design.md`** — **THE current spec.**
-  The whole Phase-2 model: inline-expand (detail is a reveal *in the list*, not a card-swap), the
-  section **plate-stack**, the Rentals calendar-anchor exception, links-land-on-section, mobile
-  paged sections, Comms/Inbox (§7), the **Trips ETA-Tracker ledger** (§8 — includes Jac's
-  hand-drawn ledger, described in detail at §8.5), and the role **Dashboard** (§5). Jac's ideas are
-  captured throughout; the §2.0 block records the plate-stack-vs-paging decision.
-- **`docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md`** — the build plan for the
-  list + detail views: the shared element layer, the phases, and a **running build log** of what's
-  been shipped slice by slice.
+### 5. The CURRENT design work (what we're building now) — read closely
+*This section was rewritten 2026-08-10. It previously described the `dv2` inline-expand redesign as
+the active build; that shipped and landed on `trunk` (#766), and its `FEATURES.designV2` flag was
+retired. The frontier moved.*
+
+The live work is the **design system / V2 card**, landed as **#798**. This is **illustrated UI** —
+the interface *is* artwork, sourced from Figma — which makes the working method different from
+ordinary component work. Read in this order:
+
+- **`.claude/skills/art-pipeline/SKILL.md`** — **the method, and the most important thing here.**
+  Export from Figma with `exportAsync({format:'SVG_STRING'})`; **never recreate art in CSS**
+  (a hand-rebuilt elbow failed the bar, and the export beat it immediately). Static art bakes as
+  one z-ordered `background-image`; anything state-coloured rides as a white-silhouette
+  `mask-image` filled with `var(--row-hue)`. Panels that must fit any width use `border-image`
+  9-slice. It also carries eight measured traps that have each cost this project real time.
+- **`docs/design/SLICE-SPEC.md`** — the 9-slice bands per panel, measured per-pixel and
+  adversarially re-rendered at six widths. **Do not re-derive these.** Four of five panels failed
+  first-pass verification, which is why the re-render step is mandatory rather than optional.
+- **`docs/design/HANDOFF-2026-08-05.md`** — the latest session state, and the explicit list of what
+  is **blocked on Jac's Figma work and must not be fixed in CSS**.
+- **`docs/design/v2-card/`** — the Figma card `438:274` running as live HTML/CSS. Serve the folder
+  and open `card.html`. **`docs/design/tier-01-card/`** is the card V2 is assembled on.
+
+**Background, not a build target:** `2026-07-20-list-views-inline-expand-design.md`,
+`2026-07-20-mockup-critique-log.md`, and `2026-07-21-list-detail-views-build-plan.md` describe the
+inline-expand model that already shipped. Read for history and for the Trips ETA-Tracker / Comms /
+Dashboard ideas that are still unbuilt — not to decide what to do next.
 
 ### 6. What's been done so far (current build state)
-The Phase-2 **`dv2`** redesign is being built **incrementally on staging**, gated behind
-`FEATURES.designV2` (`config.js`) + the `html.dv2` class (set in `app.js`). It is **additive and
-scoped `html.dv2 …`** — auto-on on staging/local, **production frozen** until the flag flips, so the
-base look is byte-identical when off. On branch **`claude/rental-wrangler-ui-research-rhd74v`
-(PR #752)**:
-- **Palette/voice + element slices** — steel palette under `html.dv2`, section state stripes
-  (left-border, matte), Ref icon plates, unit names routed through the shared `unitPill` builder,
-  mono-tabular numbers, group-count voice.
-- **Inline-expand Step 1** — single-click **reveals a record IN the list** (the row expands),
-  **height-capped to the column** (the item scrolls internally, never blows out), full-width
-  **grid-row breakout**.
-- **Inline-expand Step 2** — reshaped to the **section plate-stack**: the header is the close
-  control (the ✕ was dropped), Inspection collapses to a one-line plate, History collapses to its
-  count chips, a swipe-easing reveal, and it scroll-anchors to the column top. **Units only so far.**
-- **Study the built design two ways:** open the live staging build (the `/d/` launcher → newest
-  deck, or the in-app **Staging ▾** switcher), and read the `html.dv2` blocks in `style.css` +
-  the inline-expand code in `app.js` (`rowEl` / `cardEl` / `openStandard`, and the
-  `INLINE_EXPAND_CARDS` / `dv2On` helpers).
+The V2 card runs as code. Jac's verdict: **"it's a start"** — not at fidelity.
+
+**Working:** measured coordinate composition (a flex approximation was built and *rejected*); the
+assets pass the tone gate; rows are fused to their elbows (#256) and hide behind the group header,
+riding the channel down as it reveals; per-state lasers red/blue/yellow with steel never tinting;
+`LayoutCount: 0` at ~60fps across 96 elbows.
+
+**Not done:** the build still uses fixed-size scaled art, **not** `border-image` 9-slice. The spec
+exists; nothing is wired to it yet.
+
+**Blocked on Jac redrawing artwork — do not attempt these in CSS:**
+- `asm-deck` cannot 9-slice below **1316px** — its chips, nameplate and "PROMISED" are frozen in a
+  1100px fixed corner and the widest uniform corridor in the whole panel is 19px. The fix is to pull
+  those elements out of the art into live DOM.
+- `asm-housing`'s interior staircase is a **near-rhythm** (pitch 460/440/459) — it can neither
+  `stretch` nor `round`.
+- `asm-headboard` / `asm-rowboard` need **text-free** plate re-exports.
+- The conduit rail export has three defects (#259), including an accent that is **red, not the canon
+  `#ff7e1f`**. Author it neutral and tint per state.
+
+**`asm-headboard`, `asm-rowboard` and `asm-channel` slice cleanly today.** Start there.
 
 ### 7. What's next (the roadmap)
-Immediate — finish the inline-expand rollout (agreed build order):
-3. role default landing + drag-resort section order
-4. Rentals calendar-anchor exception (no section tabs)
-5. persistent History-search footer (bring the log back on demand)
-6. single/double-click remap (largely done — single = expand, double = anchor)
-7. links land on the correct **section** (generalize the existing `pillTo`)
-8. mobile full-screen **paged** sections + a **To-Do** landing page
-9. hover-jump popover (lowest priority)
-10. retire the legacy card-swap detail once 1–7 cover all three cards
-Also: **carry the plate-stack reshape into Rentals + Customers** (Units is done).
-Then, per the spec: the **Trips ETA-Tracker ledger** (§8, mockup iterated with Jac), **Comms/Inbox**
-(§7), the role **Dashboard** (§5 — Jac: "after the staging builds"), the **all-cards Sort redesign**,
-and the extra-colour **palette collapse** into the frozen set.
+Immediate, per `docs/design/NEXT-SESSION-PROMPT.md`: **prove the pipeline is fast.** Take ONE
+component (one of the three clean-slicing panels) from Figma all the way to a published,
+interactive, resizable artifact — export → split static/state-coloured → 9-slice → publish — and
+**report the wall-clock time.** If it runs past ~30 minutes, stop and report *which step ate it*;
+Jac wants the diagnosis, not a heroic recovery. The last card took hours, almost all of it rework,
+and `art-pipeline` exists so that does not repeat.
+
+After that: wire the rest of the panels to `SLICE-SPEC.md` as their artwork is redrawn, then carry
+the V2 assembly across the remaining cards. Still unbuilt from the older spec and worth keeping in
+view: the **Trips ETA-Tracker ledger**, **Comms/Inbox**, the role **Dashboard**, the all-cards
+**Sort redesign**, and the extra-colour **palette collapse** into the frozen set.
 
 ### 8. How work ships here
 Feature branch **`codex/<slug>`** → `npm run deploy:staging` (review on the deck URL) → **`/merge`**
 (PR → `trunk`, gates must pass) → **`/promote`** (`trunk` → production — **a human call, the only
-step that goes live**). **Never push to `trunk`/`production` directly** (branch-protected). Keep dv2
-changes additive and `html.dv2`-scoped so production stays byte-identical until Jac flips the flag.
-(If Claude is also running: see `CODEX-HANDOFF.md` §8 for branch namespacing + the `docs/WIP.md`
-work ledger so the two agents don't collide.)
+step that goes live**). **Never push to `trunk`/`production` directly** (branch-protected). Keep a
+big replacement additive behind its own `FEATURES` flag so production stays byte-identical until Jac
+flips it; small changes skip the flag and merge plainly. (If Claude is also running: see
+`CODEX-HANDOFF.md` §8 for branch namespacing + the `docs/WIP.md` work ledger so the two agents don't
+collide.)
 
 ### 9. Gaps to close with Jac (NOT in the repo — you can't see these yet)
-- **The visual mockups + photos + artifacts.** The 3-detail-views mockup, the `list-views` /
-  `detail-views` HTML, Jac's hand-drawn sketches (e.g. the ETA-tracker), and the inspiration images
-  live in the **chat / on claude.ai — not the repo**. `scratchpad/` is empty. If you want them, ask
-  Jac to export the key ones into `docs/design/reference/`. The design is otherwise fully captured
-  in the spec (§5) + the **live staging build** + the canon skills — start there.
+- **Much of this gap has since closed.** `docs/design/reference/` now holds the exported mockups —
+  `list-views.html`, `detail-views.html`, `trips-ledger.html`, `inbox-card.html`, `funnel.html`,
+  `dashboard-card.html` and more, plus `decision-notes.md`. `docs/design/tier-01-card/` and
+  `docs/design/v2-card/` hold the current cards as runnable HTML. Look there before asking.
+- **Still not in the repo:** Jac's hand-drawn sketches and the raw inspiration images, which live in
+  chat. The Figma file (`cc3TcK2F2a8qSbCAstzcA5`) is the source for the V2 artwork and needs a Figma
+  connector to reach. Ask Jac if you need either.
 - **The raw UX-research finding inventory (~171 findings + taxonomy)** was worked in a prior
   session. Its conclusions are folded into the spec + the critique log (§4). Ask Jac whether the raw
   inventory should be committed.
@@ -122,5 +157,5 @@ work ledger so the two agents don't collide.)
 ### 10. Your first deliverable
 After reading the above and skimming the live staging build: **write Jac a short summary — "here's
 my understanding of the current state and what I'd do next" — and confirm it before building.** Then
-pick up the inline-expand rollout (step 3), the Rentals/Customers plate-stack reshape, or whatever
-Jac prioritizes.
+pick up the timed one-component pipeline test (§7), the open §7 handoff-checklist items (the
+`wrangler-fix.yml` swap, the `app.js` split), or whatever Jac prioritizes.

--- a/docs/WIP.md
+++ b/docs/WIP.md
@@ -8,7 +8,11 @@ before starting anything, so the two agents never grab the same work.
 
 ---
 
-- **claude** · `claude/rental-wrangler-ui-research-rhd74v` (PR #752) · `FEATURES.designV2` · dv2
-  inline-expand redesign — Steps 1–2 built (inline-expand rendering seam + section plate-stack,
-  Units done). Pending: land on trunk behind the flag, then carry the plate-stack into Rentals +
-  Customers and finish rollout steps 3–10 (`docs/superpowers/plans/2026-07-21-list-detail-views-build-plan.md`).
+*Nothing in flight as of 2026-08-10.*
+
+Recently cleared:
+- ~~**claude** · `claude/rental-wrangler-ui-research-rhd74v` (PR #752) · `FEATURES.designV2` · dv2
+  inline-expand redesign~~ — **merged as #766**; the `designV2` flag was retired afterwards.
+- ~~**claude** · `claude/design-system-phase-1-vcgald` (PR #798) · design system / V2 card~~ —
+  **merged as `def4a15`**. Follow-on state and blockers:
+  `docs/design/HANDOFF-2026-08-05.md`; next step in `docs/design/NEXT-SESSION-PROMPT.md`.


### PR DESCRIPTION
## What

The Codex handoff kit already existed — `AGENTS.md`, `docs/CODEX-HANDOFF.md`, `docs/CODEX-ONBOARDING.md`, `docs/WIP.md`, and the 12-command plugin at `plugins/rental-wrangler-commands`. It was last touched **2026-07-24 (#765)**. Twenty-nine commits have landed since, and it had drifted into pointing Codex at work that has already shipped.

Docs only — no served file, no code, no config changed.

## The consequential fix

`AGENTS.md` instructed Codex that *"everything new rides behind `FEATURES.designV2`"* and named the 07-20 inline-expand spec as **the current feature spec**.

`FEATURES.designV2` **no longer exists in `config.js`** — the `dv2` redesign landed on `trunk` as #766 and the flag was retired. A fresh Codex session following the guide would have tried to gate new work on a flag it could not find, against a spec describing finished work.

Repointed at the live frontier: the design system / V2 card (#798, `def4a15`) and the **`art-pipeline`** export method, with the four Figma-blocked panels called out explicitly so nobody spends a day trying to fix them in CSS.

## Also corrected

| | |
|---|---|
| Decisions ledger | Must be read **to the end** — rows #101+ supersede #1–100 — and a row added when something settles. Current tip is ~#261. |
| `jactec-ui` | Was described as "retired"; it is **deleted** (#26/#91). Surviving reference now pointed at `docs/design/reference/legacy-jactec-ui/`. |
| "Matte — no glow" | Stated inline as a **steel** rule, not a ban (#251). The shorthand keeps being over-read; the operative test is *what material is glowing* — glass emitting is correct, steel emitting is the violation. |
| `/start` → `/startup` | Renamed in #802. |
| Checklist status | Marked against reality: `AGENTS.md`, the npm scripts and the plugin are **done**; secrets, the `wrangler-fix.yml` swap and the `app.js` split remain **open**. |
| Skill table | Added `art-pipeline` (critical, and the active design method), `paint`, `prompt-a`/`prompt-b`. Named the five skills not yet wrapped as Codex commands. |
| `docs/WIP.md` | Cleared — both branches it listed have merged. |
| Onboarding §9 | The "mockups aren't in the repo" gap has largely closed; `docs/design/reference/` now holds them. |

## Still open for Jac

Three items are outside what a docs pass can close, and are flagged rather than done:

1. **Re-provision secrets** in Codex's environment — yours to do, never through chat or the repo.
2. **`wrangler-fix.yml` still calls Claude** to triage auto-fix issues. Needs an OpenAI swap (and an `OPENAI_API_KEY` you provision) or disabling. Note `branch-janitor.yml` also mentions Claude but makes no LLM call — it only recognises `claude/*` branch names, so it needs a `codex/*` pattern added, not a model swap.
3. **Split `app.js`** (27,687 lines) along CODE-MAP chapter boundaries — still the largest single token win.

Two questions I could not resolve without you, noted here rather than guessed:

- **Is Claude still working this repo alongside Codex?** The dual-agent machinery (`codex/*` vs `claude/*` namespacing, the `WIP.md` ledger, cross-review) is left intact and current. If this is a clean handover, that section can be cut down to a note.
- **Should the unwrapped skills become Codex commands?** `art-pipeline` is the strongest candidate, since it is the method the current design work runs on.

## Testing

`npm run gates` — full suite green (smoke, logic, lease, lease-deploy, promote, cachebust, rule-usage `--check`, window-catalog, code-map `--check`, check-cachebust, design-md). Port swapped to 9147 for the run and `ci/` restored afterwards.

Note for anyone reproducing locally: `playwright` was absent and the version that installs by default does not match this environment's preinstalled Chromium. `playwright@1.56.0` ships chromium rev 1194, which matches `/opt/pw-browsers/chromium-1194`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAJAuLGr5bMmXYM3ydhpFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAJAuLGr5bMmXYM3ydhpFZ)_