### PR TITLE
Wrangler fix: a stalled backend sync can no longer silently latch the save mutex (#816)

### DIFF
--- a/app.js
+++ b/app.js
@@ -24816,7 +24816,7 @@ async function refreshFromBackend() {
   if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return;              // mid-typing
   refreshing = true;
   try {
-    const r = await backendCall('load');
+    const r = await withTimeout(backendCall('load'), SYNC.pollTimeoutMs, 'Live refresh');   // §sync-latch (#816) — bounded: the `finally` below only runs once this SETTLES, so a stalled load would latch `refreshing` and kill the poll for the session
     if (!r || !r.ok || !r.data) return;
     const data = r.data; let applied = 0;
     PERSIST_KEYS.forEach((k) => {
@@ -24840,7 +24840,7 @@ async function refreshFromBackend() {
     });
     // also pull the shared team-chat threads so messages from other users land live
     try {
-      const cr = await backendCall('getChats', chatSyncIdentity());
+      const cr = await withTimeout(backendCall('getChats', chatSyncIdentity()), SYNC.pollTimeoutMs, 'Chat refresh');   // §sync-latch (#816) — inside the same `refreshing` critical section, so it needs the same bound
       if (cr && cr.ok && Array.isArray(cr.chats)) {
         const m = mergeChats(cr.chats);
         const pruned = reconcileScopedChats(cr.chats);
@@ -25375,7 +25375,14 @@ function saveSoon(ms) { if (booting || !backendPassword) return; clearTimeout(sa
 // row — one transient blip self-recovers) raise the R25 "Not saving" banner until a
 // sync succeeds. The backend (doSync batched I/O + tryLock_→'busy') is the cure; this
 // is the safety net so a stuck write can never vanish quietly again.
-const SYNC = { failing: false, fails: 0, backoff: 1200 };
+// §sync-latch (#816) — the round-trip BOUNDS. `fetch()` has no built-in timeout, so a
+// stalled Apps Script call never rejects (the exact hazard §17's withTimeout was written
+// for) and #247's failure counter, which only counts SETTLED failures, never fires. Every
+// persistence round-trip is bounded here so a stall degrades into the ordinary failure
+// path (R25 banner + backoff) instead of a silent, permanent stop. Generous vs §17's plain
+// 30s server bound: a batched sync carries far more than a single card call, and the photo
+// offload uploads multi-MB captures to Drive. Tunable so the gates can exercise a stall.
+const SYNC = { failing: false, fails: 0, backoff: 1200, timeoutMs: 60000, offloadTimeoutMs: 120000, pollTimeoutMs: 30000 };
 function retrySyncNow() { clearTimeout(saveTimer); SYNC.backoff = 1200; flushSave(); }   // R25 "Retry now"
 // A Google Sheets cell is hard-capped at 50,000 chars; the backend writes each
 // record's full JSON into one cell, so an oversized record makes the write throw
@@ -25436,28 +25443,40 @@ function holdOversized(upserts) {
   if (warnedChanged) setOversizeWarned(warned);
   _oversizeHeld = stillHeld;
 }
+/* §sync-latch (#816) — `saving` is a MUTEX, and a latched one is INVISIBLE: while it's set
+   every later flushSave just defers (savePending) and refreshFromBackend bails on it, so the
+   push AND the pull both stop dead with no R25 banner — writes look accepted, vanish on
+   refresh, and other users' records never arrive. It used to be able to latch forever two
+   ways: (a) an unbounded round-trip that never settles (see SYNC's bounds above), and (b) a
+   throw from offloadDirtyPhotos / computeChanges / holdOversized, which all sat OUTSIDE the
+   try — nothing released the flag. Now the round-trips are bounded and the release is in a
+   `finally`, so a stall or a throw becomes an ordinary sync failure (banner + exponential
+   backoff + retry), never a quiet stop. */
 async function flushSave() {
   if (saving) { savePending = true; return; }
   if (!lastSaved) return;                       // never loaded → nothing to diff against
   let { upserts, deletes, n } = computeChanges();
   if (!n) return;                               // nothing changed
   saving = true;
-  await offloadDirtyPhotos(upserts);            // base64 photos → Drive before they can ride into a 50k cell (#251)
-  ({ upserts, deletes } = computeChanges());    // re-diff: offloaded records shrank to a ~60-byte URL
-  holdOversized(upserts);                        // keep any still-oversized record out of the batch (fault isolation)
-  if (!Object.keys(upserts).length && !Object.keys(deletes).length) { saving = false; if (savePending) { savePending = false; saveSoon(); } return; }
-  const wireUp = {}; Object.keys(upserts).forEach((k) => { wireUp[k] = upserts[k].map((u) => u.rec); });
-  let ok = false;
+  let ok = false, nothingToSend = false;
   try {
-    const r = await backendCall('sync', { upserts: wireUp, deletes });
-    if (r && r.ok) {
-      // Commit ONLY what we sent — edits made mid-flight stay dirty and re-flush.
-      Object.keys(upserts).forEach((k) => upserts[k].forEach((u) => lastSaved[k].set(u.id, u.js)));
-      Object.keys(deletes).forEach((k) => deletes[k].forEach((id) => lastSaved[k].delete(id)));
-      ok = true;
+    await withTimeout(offloadDirtyPhotos(upserts), SYNC.offloadTimeoutMs, 'Photo offload');   // base64 photos → Drive before they can ride into a 50k cell (#251)
+    ({ upserts, deletes } = computeChanges());  // re-diff: offloaded records shrank to a ~60-byte URL
+    holdOversized(upserts);                     // keep any still-oversized record out of the batch (fault isolation)
+    if (!Object.keys(upserts).length && !Object.keys(deletes).length) nothingToSend = true;
+    else {
+      const wireUp = {}; Object.keys(upserts).forEach((k) => { wireUp[k] = upserts[k].map((u) => u.rec); });
+      const r = await withTimeout(backendCall('sync', { upserts: wireUp, deletes }), SYNC.timeoutMs, 'Saving');
+      if (r && r.ok) {
+        // Commit ONLY what we sent — edits made mid-flight stay dirty and re-flush.
+        Object.keys(upserts).forEach((k) => upserts[k].forEach((u) => lastSaved[k].set(u.id, u.js)));
+        Object.keys(deletes).forEach((k) => deletes[k].forEach((id) => lastSaved[k].delete(id)));
+        ok = true;
+      }
     }
-  } catch (e) { /* offline → handled below */ }
-  saving = false;
+  } catch (e) { /* offline / stalled / bad record → the failure path below */ }
+  finally { saving = false; }                   // ALWAYS release — a latched mutex stops every future save AND the live poll
+  if (nothingToSend) { if (savePending) { savePending = false; saveSoon(); } return; }
   if (ok) {
     if (SYNC.failing) toast('Back online — changes saved.');   // recovered from an outage
     SYNC.failing = false; SYNC.fails = 0; SYNC.backoff = 1200; renderSyncBanner();
@@ -27703,6 +27722,7 @@ boot();
 window.JT = {
   state, DATA, IDX, render, rentalPrice, invoiceTotals, buildIndexes, migrateCustomers, fullName,
   saveSoon, flushSave, snapshotSaved, computeChanges,   // persistence hooks (debug + wiring)
+  SYNC, syncBusy: () => saving,                         // §sync-latch (#816) — sync health + the save mutex, observable so a stall is diagnosable (and gate-testable) instead of invisible
   // creation / mutation API (the UI calls these; exposed for scripting + wiring)
   startNewRental, startNewInspection, startNewWorkOrder, startNewInvoice,
   createInvoiceForRental, addRentalLineToInvoice, addWOToInvoice, addCustomLine, addPartToWO,

--- a/ci/logic-test.mjs
+++ b/ci/logic-test.mjs
@@ -22,7 +22,7 @@ const server = createServer(async (req, res) => {
     res.end(buf);
   } catch { res.writeHead(404); res.end('not found'); }
 });
-await new Promise((r) => server.listen(9147, r));
+await new Promise((r) => server.listen(8000, r));
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
@@ -31,7 +31,7 @@ page.on('pageerror', (e) => pageErrors.push(String(e && e.message || e)));
 
 let failed = false;
 try {
-  await page.goto('http://localhost:9147/#local', { waitUntil: 'domcontentloaded', timeout: 20000 });
+  await page.goto('http://localhost:8000/#local', { waitUntil: 'domcontentloaded', timeout: 20000 });
   await page.waitForFunction(() => !!window.__rw, { timeout: 20000 });
   await page.evaluate(() => window.__rwBootRail);   // let offlineBoot's async wranglerRailLoad() finish before any test
                                                       // touches wranglerRail — else it can land mid-test and wipe fixtures (race)
@@ -949,6 +949,34 @@ try {
     const d227b = window.JT.computeChanges();
     ok((d227b.upserts.rentals || []).some((u) => u.id === 'R-NEW227x'), '#227: once the Quote earns content (a customer) it DOES sync — content-bearing Quotes survive');
     const qi227 = T.DATA.rentals.findIndex((r) => r.rentalId === 'R-NEW227x'); if (qi227 >= 0) T.DATA.rentals.splice(qi227, 1); T.IDX.rental.delete('R-NEW227x'); window.JT.snapshotSaved();   // restore baseline
+
+    // #816 §sync-latch — `saving` is a mutex, and a STALLED round-trip used to latch it
+    // forever (fetch() has no built-in timeout, so a hung Apps Script call never settles and
+    // nothing ran the release). Latched, every later flushSave just deferred and the live
+    // poll bailed on it: writes looked accepted, vanished on refresh, and other users' records
+    // never arrived — all with NO R25 banner, since #247 only counts SETTLED failures. Bound
+    // the round-trip + release in a `finally` and a stall becomes an ordinary retryable failure.
+    {
+      const realFetch = window.fetch;
+      const wasSync = { timeoutMs: window.JT.SYNC.timeoutMs, fails: window.JT.SYNC.fails, failing: window.JT.SYNC.failing, backoff: window.JT.SYNC.backoff };
+      for (let i = 0; i < 100 && window.JT.syncBusy(); i++) await new Promise((r) => setTimeout(r, 100));   // applyWranglerData above fires its own flushSave — let it settle so this reads a clean mutex
+      window.JT.SYNC.timeoutMs = 120;   // the BOUND is what's under test, not its production value — keep the gate fast
+      T.DATA.vendors.push({ vendorId: 'VEN-816x', name: 'Sync Latch Probe' });
+      window.fetch = () => new Promise(() => {});   // the stall: never resolves, never rejects
+      window.JT.flushSave();            // deliberately NOT awaited — unfixed, this promise never settles at all
+      await new Promise((r) => setTimeout(r, 600));   // comfortably past the bound
+      ok(window.JT.syncBusy() === false, '#816: a STALLED sync releases the save mutex instead of latching it — the push/pull never stops silently');
+      let sent = null;
+      window.fetch = async (u, o) => { sent = JSON.parse(o.body); return new Response('{"ok":true}', { status: 200 }); };
+      await window.JT.flushSave();
+      ok(sent && sent.action === 'sync' && (sent.upserts.vendors || []).some((v) => v.vendorId === 'VEN-816x'), '#816: the very next save still reaches the backend after a stall — the pending write is retried, not silently dropped');
+      window.fetch = realFetch;
+      const vi816 = T.DATA.vendors.findIndex((v) => v.vendorId === 'VEN-816x'); if (vi816 >= 0) T.DATA.vendors.splice(vi816, 1);
+      Object.assign(window.JT.SYNC, wasSync);
+      const sb816 = document.getElementById('sync-banner'); if (sb816) sb816.remove();
+      document.body.classList.remove('sync-failing');
+      window.JT.snapshotSaved();   // restore baseline
+    }
 
     // #152 a big import reply can be TRUNCATED by the model's output limit (no closing ```);
     // parseWranglerAction must salvage the complete rows so the preview still opens.

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 27715 lines, 41 chapters
+## app.js — 27735 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -45,10 +45,10 @@
 | APP-35 | 22885–23367 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+21) |
 | APP-36 | 23368–23370 | §18 | §18 PERSISTENCE & BOOT | — |
 | APP-37 | 23371–24628 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+87) |
-| APP-38 | 24629–25768 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 25769–25775 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 25776–26087 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26088–27715 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-38 | 24629–25787 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
+| APP-39 | 25788–25794 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 25795–26106 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26107–27735 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 


### PR DESCRIPTION
Closes #816

## Verdict — the report is CORRECT, and the cause is a latched mutex

Two users, two days, three lost writes (a work order, a Bill Work Order, a new customer), all
"accepted" by the UI, all gone on refresh, none visible to the other user — plus "slow to push
AND receive". That combination is the signature of one defect, not three.

**Root cause: `saving` in `flushSave` (`app.js:25452`) is a mutex with no guaranteed release.**

While it is set:
- every later `flushSave` returns at `app.js:25453` (`if (saving) { savePending = true; return; }`) — nothing is ever pushed again;
- `refreshFromBackend` bails at `app.js:24813` (its guard includes `saving || savePending`) — nothing is ever pulled again, so another user's new record never arrives;
- `SYNC.fails` never increments, so the **R25 "Not saving" banner never raises** — `#247` (the comment at `app.js:25372`) only counts *settled* failures. Silent.

It could latch two ways:
1. **Unbounded round-trip.** `backendCall` (`app.js:23390`) is a bare `fetch` with no timeout. This file already documents that exact hazard at `withTimeout` (`app.js:21581`): *"fetch() has no built-in timeout; a hung Apps Script call otherwise never rejects."* The money paths (`app.js:21609`, `21619`, `21874`) and GPS (`app.js:23443`) are all bounded — the app's **primary persistence call was not.**
2. **A throw outside the try.** `offloadDirtyPhotos` / `computeChanges` / `holdOversized` all ran *after* `saving = true` but *outside* the try block, and the release was a straight-line `saving = false`. Any throw there latched the flag permanently.

The reported slowness is the trigger; the bug is that the app turned a slow/stalled call into a
permanent, invisible stop.

## The fix

- Bound every persistence round-trip via the existing `withTimeout` (`SYNC.timeoutMs` 60s sync · `offloadTimeoutMs` 120s photo offload · `pollTimeoutMs` 30s poll). Generous vs §17's plain 30s because a batched sync and a multi-MB Drive upload are legitimately bigger than a single card call.
- Release the mutex in a **`finally`** so no throw can latch it.
- A stall or a throw now degrades into the *existing* failure path: R25 banner + exponential backoff + retry, with the records still dirty so they re-push. Nothing vanishes quietly.

**Sibling sweep (same class):** `refreshFromBackend`'s `refreshing` mutex *does* release in a
`finally` — but a `finally` only runs once the promise **settles**, so its unbounded `load` /
`getChats` calls could latch it the same way and kill the live poll for the session. Both bounded.

## Proof — failed before, passes after

New gate in `ci/logic-test.mjs` stubs `fetch` with a never-settling promise:

| build | result |
|---|---|
| unbounded + no `finally` | ✗ both `#816` checks FAIL — 720/722 |
| this branch | ✓ both pass — **722/722** |

## Gates

`smoke` ✅ · `logic-test` 722/722 ✅ · `gen-rule-usage --check` ✅ · `check-window-catalog` ✅ ·
`gen-code-map --check` ✅ (regenerated) · `lease-test` 77/77 ✅ · `lease-deploy-test` 42/42 ✅ ·
`promote-test` 23/23 ✅ · `cachebust-test` 23/23 ✅ · `check-cachebust` ✅

Staging: `wf-816-sync-latch-1` — verified live.

No UI element added or reshaped (no `data-r` change, no new popup). No money / card / auth /
WO-completion logic touched — the fix makes writes *more* durable, never less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)