### PR TITLE
Field notes: what building this app taught us, plus a day-one starter kit

### DIFF
--- a/docs/field-notes/README.md
+++ b/docs/field-notes/README.md
@@ -1,0 +1,37 @@
+# Field notes — what building this app actually taught us
+
+Written 2026-08-20, reconstructed from this repo's own record: `MEMORY.md`, 68 design specs, the
+178-row decisions ledger, ~40 handoff notes in `docs/handoffs/`, and the git history underneath.
+Nothing here is generic best practice — every claim traces to something that happened on this
+project, and most of them cost real time to learn.
+
+The audience is **the next app**, not this one. None of it changes how Rental Wrangler works.
+
+| File | What it is | Read it when |
+|---|---|---|
+| [`scaffolding-before-features.md`](./scaffolding-before-features.md) | The playbook — 14 sections on builder tooling, the code map, labelling, skills, UI/UX, disposable jigs, audits, agents, tokens, loops and local organisation. | Starting a new app, or deciding what to build before the first feature. |
+| [`integration-field-report.md`](./integration-field-report.md) | What each external system actually cost — Stripe, texting, Google Maps, Gmail, GPS/telematics, Figma, and Apps Script itself. The specific traps, not the quickstarts. | Before wiring up any external service. |
+| [`scaffolding-card.md`](./scaffolding-card.md) | The whole playbook on one page. | Pinning up, or pasting into a short prompt. |
+| [`starter-kit/`](./starter-kit/) | Runnable scaffolding — two dependency-free scripts and seven templates. Start with its own README. | Day one of the next repo. |
+
+Rendered PDF and self-contained HTML copies of these documents exist but are deliberately not
+committed — they're build outputs, and the font-embedded HTML is ~265KB apiece. The Markdown here
+is the source of truth.
+
+## The two ideas everything else hangs off
+
+**1. An AI-built app has two codebases** — the source, and the context needed to safely change it.
+A person carries the second one in their head; a model rebuilds it from scratch every session,
+every subagent, every audit. The machinery that makes that context cheap to load and impossible to
+lose is worth more than any single feature. That machinery is most of what `CLAUDE.md`,
+`MEMORY.md`, `docs/CODE-MAP.md` and the `ci/*-check` guards actually are.
+
+**2. Anything enforced by remembering is already broken** — it just hasn't cost you yet. Every
+rule worth having is a script that fails without it. This repo learned that twice: once with the
+cache-bust bump, and once with the code map.
+
+## What's deliberately not here
+
+A fifth document — a candid retrospective on how the collaboration itself worked — was written at
+the same time and kept out of this public repo on purpose. It's a named personal assessment, and
+git history is permanent.

--- a/docs/field-notes/integration-field-report.md
+++ b/docs/field-notes/integration-field-report.md
@@ -1,0 +1,263 @@
+# What the *integrations* actually cost
+
+**Seven external systems, reconstructed from this project's own handoff notes. Not "how to integrate Stripe" — the specific traps that were expensive here, the ones no quickstart mentions, and what to do first next time.**
+
+*Field report · Rental Wrangler · 2026-08-20*
+
+Payments: **Stripe** · Texting: **Twilio · Mocean** · Location: **Google Maps** · Email: **Gmail / GmailApp** · Telematics: **4 GPS providers** · Design: **Figma** · Runtime: **Apps Script**
+
+---
+
+## §01 — The pattern behind all seven
+
+Every expensive integration surprise in this project was one of the same handful of mistakes wearing a different vendor's logo. Before the vendor-by-vendor detail, these are the transferable ones — they'd have caught most of what follows.
+
+- **Decide who owns the record before you write a line.** The single most expensive integration bug here was memberships being billed inside Stripe while the app had no link to those subscriptions and wasn't reconciling them. Not a bug in anyone's code — an unmade decision. Write down which system is the source of truth for every object that exists on both sides.
+- **Verify from the far side.** `ok:true` is not proof. The email backend returns success even when it silently drops a malformed attachment — the only real evidence was opening the Sent copy and seeing the file. Check the provider dashboard, the receiving inbox, the actual charge.
+- **Spike before you design.** Twenty lines proving the API behaves as documented, before a feature is designed on top of that assumption. Nearly every entry below would have been cheaper as a spike.
+- **Asynchronous verification breaks synchronous assumptions.** Cards attach immediately; bank accounts take days. Any code written on "saved means attached means verified" fails the moment a slower method arrives.
+- **Know which keys are secrets and which are restricted-public.** Both exist, they look identical, and treating one like the other either leaks a credential or breaks a working page. Write down which is which, by name.
+- **Never put heavy work in a boot path.** An account-level API quota is a hard ceiling — retries and backoff cannot fix it, they just spend it faster.
+- **Ship behind a flag, off, until a real round-trip is verified live.** Non-negotiable for anything touching money.
+
+---
+
+## §02 — Stripe — the one that hid a real problem behind a harmless symptom
+
+> **The symptom · 2026-07-13**  
+> Stripe emailed that it couldn't deliver live-mode events to the webhook endpoint. Chasing that email uncovered that membership billing was running entirely inside Stripe, on subscriptions the app had no link to and wasn't reconciling.
+
+### Trap 1 — a redirect-answering endpoint can't receive webhooks
+
+Every POST to an Apps Script `/exec` URL answers with an HTTP **302 redirect**. Stripe doesn't follow redirects, so it logged every delivery as failed — even though the handler behind the redirect always returned 200 when reached. This is a platform limitation upstream of your code; there is nothing to fix in the handler.
+
+**Generalize it:** before choosing a webhook receiver, check what the *first hop* returns. Any host that answers with a redirect — Apps Script, some serverless proxies, anything behind an auth bounce — is incompatible with senders that don't follow them.
+
+### Trap 2 — dual-source-of-truth billing, discovered by accident
+
+The read-only audit that followed found the real problem:
+
+| Checked | Found |
+|---|---|
+| Customers carrying a Stripe subscription id | **0** of ~2,257 |
+| Customers carrying a membership status | **0** |
+| Live Stripe subscriptions actively billing cards | yes — renewals, failures, a cancellation |
+| Invoices produced by the app's own billing engine | **0** (nobody was enrolled) |
+
+The daily reconciliation sweep looked healthy — it ran on schedule with a 0% error rate. It was also a complete no-op, because it only reconciles customers that carry a subscription id, and none did. **A green cron proves the cron ran, not that it did anything.** The failure mode this produced is the worst kind: cards charged after a membership had lapsed, with nothing in the app aware of it.
+
+> **Worth noting about the note itself**  
+> The first version of that handoff concluded "billing is not affected." It was wrong, and it was corrected in place with the reasoning shown. A retrospective that can't record its own wrong first answer isn't much use — leave the correction visible.
+
+### The migration recipe (reusable)
+
+Moving a live subscription from vendor-owned to app-owned billing without a double charge or a gap:
+
+**01. Confirm the two prices match, exactly**
+Base plus tax, to the cent, before anything moves. Ours: $299 monthly + 10.75% tax = $331.14.
+
+**02. Enrol app-side with a start date equal to the subscription's period end**
+A future start date takes the deferred path: member fields land now, $0 is charged today, and the daily cron makes the first charge on that day.
+
+**03. Cancel the vendor subscription "at period end" — never immediately**
+The vendor covers the customer through that date and never charges again; the app picks up the same day. Deleting a webhook does *not* cancel a subscription — that catches people.
+
+### Trap 3 — the deferred path left an orphan invoice
+
+The enrolment function created its cycle invoice *before* branching, so the deferred path returned an invoice it never charged — and the cron later minted its own on the start day. Every future-dated enrolment left a dangling unpaid invoice that had to be voided by hand. **Branch first, then create the artifact.**
+
+### Trap 4 — ACH is not a card, and one ownership check blocked it entirely
+
+The best single example in this repo of an assumption quietly generalising:
+
+- Bank accounts verify by microdeposit, which takes **1–2 business days**. The setup intent therefore sits in `requires_action`, not `succeeded`.
+- The provider attaches a payment method to the customer only on *successful* setup — so on a fresh bank add, the method's customer field is still `null`.
+- The save handler's ownership check — written for cards — compared that null against the customer id and rejected it. **Every ACH add failed, categorically**, and the user saw card-worded copy: "That card isn't linked to this customer."
+
+Three correct, defensible pieces of code producing a feature that could never work. **When you add a second payment method type, re-read every check written for the first one** — and make error copy name what the user actually did.
+
+### Refunds
+
+- Do the math in **integer cents**, and clamp the request to what's actually left: `min(requested, paid − alreadyRefunded)`.
+- **The server owns the totals; the client owns the per-line split.** The server never needs to know how a refund was allocated across lines, so don't teach it.
+- Treat "fully refunded" as *within a cent*, not exact equality.
+- Keep the original paid amount. Don't rewrite history to make a balance come out.
+
+---
+
+## §03 — Texting — approval, quiet hours, and codes that can't cross over
+
+### Build the provider seam before you need it
+
+Carrier registration for business texting takes real calendar time and can be rejected. The thing that saved this project was a **provider selector**: the backend auto-picks the primary provider when its three credentials are all present in the secret store, and falls back to a secondary otherwise. That let the feature ship and be used while approval was pending, and go-live was a credential change, not a code change.
+
+### Credentials: set them through an allowlisted action, not the console
+
+- Secrets live only in the platform's property store. Never in the repo, never echoed.
+- They were set through a **name-allowlisted, set-only admin action**, so the value passes through once and can never be read back out.
+- The status endpoint reports **names and booleans only** — "is a token present", never the token. Build that endpoint; you'll use it constantly.
+- Validate against the provider on save — confirm the number is actually SMS-capable — then send one real end-to-end test before believing it.
+
+### Quiet hours are a product decision, and it will move
+
+The send window started at 8am–8pm and was widened to **6am–8pm** once staff actually used it — crews start early. Two rules that survived:
+
+- Quiet hours apply to **every** send.
+- An admin may override, but **only on a manual send — never on an automated sweep**. That single carve-out is what keeps a 3am cron from texting customers.
+
+### One-time codes: separate the namespaces
+
+SMS codes replaced shared passwords entirely — login codes for identity, approval codes for authorising a single privileged action. The design rule worth stealing:
+
+> **Two code types, zero overlap**  
+> A **login code can never approve**, and an **approval code can never mint a session** — they live in separate storage namespaces with separate rate buckets. Approval verification returns `{ok, approver}` and **never a token**. Single-use, 5-try cap, 10-minute expiry, tier checked at mint *and* again at verify.
+
+> **The one that's still open**  
+> Approval codes take a client-supplied "required tier" string. The server enforces the approver against it but never learns *which action* is being approved. Not independently exploitable here — verification hands back no capability — but the right shape is a **server-known action → tier-floor table**. Never let the client name the authority it needs.
+
+---
+
+## §04 — Google Maps — a public key, and a meter that runs on keystrokes
+
+### The key is public on purpose — but only if you actually lock it
+
+The browser key is committed to a public repo *by design*. That's safe only because it is **HTTP-referrer-locked** to the production domain (plus localhost for dev) *and* **API-restricted** to just the three APIs in use. It is not in the secrets class. The server-side copy of the same key *is*, and must never reach a log or the UI.
+
+Write this distinction down explicitly, because both a well-meaning security sweep (moving a restricted key into a secret store and breaking the page) and a genuine leak look the same from a distance.
+
+### The meter runs per keystroke
+
+- **Autocomplete bills per request.** Without session tokens, every keystroke is a billable call. With them, a whole lookup is one session. Ours also carries a **180ms debounce**.
+- **Cache every geocode result permanently.** Write the resolved pin back onto the record the first time you geocode it — an address doesn't move. This was adopted as an explicit decision, not an optimisation.
+- **A referrer lock limits abuse, not your own bugs.** A runaway autocomplete loop burns your quota from your own domain, which is exactly where the lock says traffic should come from.
+
+### The APIs move under you
+
+Distance work moved to a newer Routes library; place lookup moved to new classes. Most tutorials you'll find describe the previous generation. **Check the migration notice before copying any example** — this is a recurring tax on Google APIs specifically.
+
+### Free win worth taking
+
+A plain "open in Google Maps" deep link costs nothing — no key, no quota — and hands a route straight to the driver's phone navigation. Not every map problem needs an embedded map.
+
+---
+
+## §05 — Email — the integration that lies to you politely
+
+### The failure that shaped everything else
+
+> **The rule**  
+> The send handler **returns success even when it silently drops a malformed attachment** — deliberately, so a bad image can never fail a real message. Which means `ok:true` proves nothing about the attachment. **The only proof is opening the Sent copy and seeing the file on it.**
+
+That's the generalisable lesson for every send-shaped integration: if your handler is designed to degrade gracefully, then its success response cannot be your test. Verify on the receiving side.
+
+### What made it safe
+
+- **The recipient is resolved server-side from the record** — the client names an invoice, never an address. An isolation gate like this means a client bug can't email one customer's document to another.
+- **MIME-whitelisted and size-capped** (png/jpeg, ~3MB) before decode.
+- **Consent, quiet hours, rate caps and deduplication all run first**, unchanged by the attachment work. New capability rides behind existing gates.
+- **Fail-safe while undeployed:** the client sent the attachment field before the backend understood it, and the old backend simply ignored it — emails kept sending, text-only. Design the client-ahead-of-server window to be a no-op, not an error.
+
+### Two practical notes
+
+- The backend sends as one account; the "from" addresses available to it are that account's **send-as aliases**, enumerated at runtime. Adding a sending address is a mail-account action, not a code change.
+- **A cloud sandbox can't prove visual fidelity.** Rendering an invoice to an image needs real fonts and a real browser; the automated test proved the *transport*, and a separate real-device check proved the *picture*. Know which half your test actually covers.
+
+---
+
+## §06 — GPS & telematics — four providers, and the boot-path quota fire
+
+The heaviest integration by far: four hardware vendors, each with its own OAuth dance, pagination quirks and refresh-token behaviour.
+
+### Fork and run it — don't port it
+
+We inherited a working backend from its author, whose integration guide assumed we'd port its database and token-management code into our own stack. We didn't. We forked it, deployed it unchanged as a standalone service, and called it over HTTPS.
+
+The reason is the whole lesson: **porting means re-implementing and re-verifying every already-debugged edge case** — one vendor's broken pagination cursor, two vendors' rotating refresh tokens, the ignition-session pairing logic. None of that is interesting work, all of it is load-bearing, and rewriting it converts solved problems back into open ones.
+
+> **The incident worth memorising**  
+> A historical backfill job ran **in full on every server restart**, on top of its hourly schedule. It exhausted the vendor's **account-level** API quota and units vanished from the dashboard. An account ceiling is not a rate limit — retries and backoff don't help, they spend it faster. The fix was simply not running the backfill at boot; the trap is that any future restart-time call reintroduces it.
+
+### The OAuth deployment loop nobody warns you about
+
+### CORS: staging is an origin too
+
+---
+
+## §07 — Figma → code — eight measured traps
+
+### First, the framing that saves the most time
+
+**In a normal product team, nobody pulls artwork out of Figma.** Three things cross the boundary, and none of them is pixels:
+
+| What crosses | How | Consumed as |
+|---|---|---|
+| Tokens | Figma variables exported to JSON | a CSS variable, never a literal hex |
+| Component identity | a name mapped to a code component | you *call* it — you never redraw it |
+| Art assets | exported SVG/PNG | referenced, never recreated |
+
+Fidelity comes from **not diverging** — the designer composes from a kit whose parts already exist in code. It does not come from matching afterwards. If you find yourself recreating a component by eye, stop: either export it as art, or build it as a real component and have the design use that. The exception is UI that genuinely *is* artwork — and there the answer is the game-industry one: **export the art, don't rebuild it.**
+
+### The eight traps, all measured here
+
+**01. The metadata lies about overridden instances**
+The API reports the *un-overridden component* position, not the instance's actual one. One channel read 149px from metadata and was really at 108px. For anything instanced, read the instance's own transform.
+
+**02. Frame bounds are not the painted extent**
+Children routinely sit outside their frame; one node's frame was 487×97 while its paint covered 683×97, offset ~194px left. One pass built an entire component from a 41×158 sliver believing it was the whole part. **Render the node and look at it** before building from numbers.
+
+**03. Mask layers don't pair one-to-one with background layers**
+Masks union rather than pairing, so only the topmost background ever shows. Use one z-ordered image or separate elements.
+
+**04. The sub-1% paths are the bevels**
+Dropping about forty "negligible" paths collapsed a panel from nine tones to six and made the metal read flat. On another part, **32 of 33** sub-1% runs had a measurable visible cost. Low area is not low value.
+
+**05. PNG export quantizes translucent washes**
+It bands them into values one channel apart. Counting those as distinct design tones fails an asset for not reproducing a rasteriser artifact. Compare tones by *distance*, not identity — and cast to a signed integer before subtracting, or byte overflow turns a difference of 1 into 36. That produced two false failures here.
+
+**06. Paint order is load-bearing**
+Draw an accent ring before the opaque plate it sits on and it disappears. It looks like a missing asset; it's z-order.
+
+**07. Baked text doubles with live text**
+Export art *without* glyphs and let the DOM supply the words — but strip only the glyphs, since the surrounding outline usually lives in the same layer group.
+
+**08. Layer names go stale**
+A layer named for one thing frequently renders another. **Trust the render, not the name.**
+
+Two closing notes from the same work: animate **transform and opacity only** — an animated drop-shadow glow cost about 12fps across many instances and was cut, while a static one was fine. And tint art per state with a mask plus a token fill rather than exporting a copy per state.
+
+---
+
+## §08 — The runtime itself — the integration you forget to count
+
+The backend platform was as expensive as any vendor on this list, and its lessons are the most transferable, because every platform has some version of them.
+
+- **An auth path can be blocked by policy, not by configuration.** The standard CLI login is refused by an organisation-level re-authentication policy — confirmed with a brand-new token minted fresh, which failed immediately. No amount of re-logging-in fixes a server-side policy. The working path is a service account with delegated authority, impersonating a real user. **When an auth failure repeats identically on a clean credential, stop debugging the credential.**
+- **The programmatic deploy is not equivalent to the console deploy.** Deploying through the API breaks the web app's anonymous access and takes the live backend down — confirmed the hard way. Go-live is now deliberately a human click, and the script's deploy subcommand is guarded against being used. If two deploy paths exist, prove they're equivalent before trusting the convenient one.
+- **Have one post-deploy check that proves the thing you're most afraid of.** Ours: an anonymous request with a deliberately wrong password must come back as a clean "unauthorized" at HTTP 200. That single call proves the endpoint is still reachable anonymously *and* still rejecting bad credentials.
+- **Know when every environment shares one backend.** Local, staging and production all hit the same backend and the same payment account here. That's a legitimate choice, but it means "just testing" touches real records — and it has to be stated out loud, repeatedly, or someone will assume otherwise.
+
+---
+
+## §09 — Pre-flight checklist for the next integration
+
+Half a day before the build, against every one of these.
+
+> **Before you design anything**  
+> - **Ownership.** For every object existing on both sides, which system is the source of truth? Write it down. What reconciles them, and how would you know it did nothing?
+> - **Spike it.** Twenty lines against the real API. Does it behave the way the docs claim?
+> - **Slow paths.** Which operations are asynchronous or take days? What does your code assume finishes immediately?
+> - **Second variants.** When a second type arrives — another payment method, another provider, another channel — which checks written for the first will wrongly reject it?
+
+> **Before you ship it**  
+> - **Credentials** in the platform's secret store only; a status endpoint that reports presence, never values.
+> - **Every origin** that will call it is allowed — including staging.
+> - **No heavy work in a boot path.** Quotas are ceilings, not limits.
+> - **Behind a flag, off**, with the un-flagged path a safe no-op.
+> - **One real round-trip verified from the far side** — the Sent copy, the provider dashboard, the actual charge — before the flag flips.
+> - **The error copy names what the user actually did**, not what the first version of the feature assumed they did.
+
+---
+
+Every trap above was found by something breaking in production, and every one of them is written down here because writing it down is cheaper than finding it twice. That is the entire method: **the notes are the deliverable, and the working code is the by-product.**
+
+---

--- a/docs/field-notes/scaffolding-before-features.md
+++ b/docs/field-notes/scaffolding-before-features.md
@@ -1,0 +1,413 @@
+# Scaffolding Before Features
+
+**Field notes from building Rental Wrangler with AI — what to install on day one of the next app.**
+
+*Rental Wrangler · 2026-08-20 · engine `app.js` 27,714 lines · chapters `APP-01`…`APP-38` · 11 CI scripts · 14 build tools · 23 project skills*
+
+---
+
+## §01 — The one idea, if you only keep one
+
+An AI-built app has two codebases. There's the source, and there's the **context needed to safely
+change the source** — where things live, what was already decided, what "done" means. Humans carry
+the second one in their heads. A model carries none of it, and rebuilds it from scratch on every
+session, every subagent, every audit.
+
+So the highest-leverage thing you can build is not a feature. It's the machinery that makes that
+second codebase **cheap to load and impossible to lose**. Every hour spent on a map, an index, a
+ledger, or a gate pays back on every single session afterward, forever. Every hour you don't spend
+gets charged back to you as re-derivation, at compounding interest.
+
+Practically: **write the tools that answer questions before you write the code that raises them.**
+
+---
+
+## §02 — The day-one build order
+
+Before the first feature — while the repo is still small enough that all of this takes an afternoon
+rather than a month of retrofitting:
+
+**01. A boot smoke test.**
+Thirty lines: serve the app, load it headless, assert no console errors and one known element
+rendered. Written before feature one, it never has to be retrofitted, and it catches roughly half of
+all "it's broken" reports before a human sees them.
+
+**02. Chapter IDs stamped into the source.**
+Banner comments carrying a stable ID — `APP-01` … `APP-38`. The ID lives *in the code*, not only in
+a doc, so `grep APP-19` lands on the right chapter from a cold start with zero context loaded. Line
+numbers rot; IDs don't.
+
+**03. A code map, in two halves.**
+One hand-written file that tells the *story* (why each chapter exists, how the data flows), and one
+machine-generated index that holds the volatile part — line numbers, symbol lists. A CI `--check`
+keeps the generated half honest. Splitting them is the trick: the story stays stable while the index
+churns.
+
+**04. A regression test for anything that computes money.**
+The day a function first returns a dollar figure, it gets a test. Money bugs are the only bugs that
+cost you customers rather than time, and they're the ones a model is most confident about while
+being wrong.
+
+**05. A dated decisions ledger — starting at row one.**
+Append-only, every row dated, every reversal carrying a pointer both ways. Not a document you write
+later: a table you append to the moment something is settled. A decision that isn't in the table
+hasn't been made.
+
+**06. The `--check` pattern on every registry.**
+Any list a human or model must keep in sync — design rules, routes, feature flags, window catalogs —
+gets a generator with two modes: *write it*, or *fail if writing would change anything*. Same
+script. That single flag is what makes documentation non-optional without anyone having to nag.
+
+**07. Deploy and release as scripts with a preview mode.**
+Anything you'll do the same way twice becomes a script. Anything irreversible gets a bare read-only
+preview and an explicit `--yes`. The script is also where the safety check lives — ours refuses to
+promote unless the reviewed bytes actually match what's about to go live.
+
+**08. A memory file, committed to the repo.**
+Decisions, gotchas, open threads. Read at session start, updated at session end. It's the difference
+between session forty knowing what session three decided and session forty re-litigating it.
+
+> **What skipping it costs.** Every item above was eventually built here — just later, against a
+> codebase that had grown past 15,000 lines. Retrofitting chapter IDs and a map into a file that size
+> is a multi-session job that produces zero visible product. Doing it at 500 lines is an afternoon.
+
+---
+
+## §03 — The map, and making the atlas interactive
+
+The map is the single highest-return artifact in this repo. The arithmetic is blunt: reading a
+27,000-line file to change one function costs roughly 350k tokens. Reading a 450-line map, then one
+600-line chapter, costs about 15k and lands more accurately. That's the whole game — **map before
+grep**, every time.
+
+### What makes a map actually work
+
+- **Narrate, don't list.** A table of function names is a symbol dump. The useful map explains the
+  *one rule that explains the whole app* — for us: render from state, actions mutate state,
+  everything else is derived. With that sentence, a model knows which of four places to look before
+  it opens anything.
+- **Supply a reading order the file doesn't have.** Real codebases accrete — ours has chapters
+  sitting physically out of order because features got bolted in wherever they fit. The map imposes
+  the order the file lacks, and keeps a separate "as it sits on disk" view for when you need the
+  truth.
+- **Never renumber.** Anchors are handles, not addresses. We have a `§13.3` that sits before `§12`
+  and we left it there, because renumbering silently invalidates every reference in every doc, every
+  past decision, and every memory of every prior session.
+
+### Making it interactive — the thing I'd build in week one
+
+The map answers "where does X live" when you can already name X. The expensive case is the opposite:
+you're looking at a screen and something is wrong, and nobody can name it. That gap is where most
+triage tokens die.
+
+So close the loop from pixel back to source. Stamp every UI element with its rule ID in the markup,
+then add a dev-only overlay that prints the coordinates on click:
+
+```
+R14 · APP-19 Header & KPI · app.js:6585 · style.css:1204
+```
+
+That turns a bug report from a paragraph of prose into a coordinate. Instead of "the status chip on
+the rentals card looks wrong," you get three tokens that a model can act on without reading anything.
+Ours has the stamps (`data-r` on every element) but not the overlay — the overlay is the piece I'd
+add first on the next build.
+
+---
+
+## §04 — Labelling and splitting the code
+
+A 27,000-line file is survivable *because* it's chaptered and indexed — but I wouldn't do it again.
+Split at chapter boundaries early, and name the file after the chapter ID so the map and the
+filesystem agree: `app-19-header-kpi.js`. Then the map's index and `ls` tell the same story, and a
+model that has neither loaded can still find its way by filename alone.
+
+- **One concept per file, named for the concept** — not `utils.js`, which is where findability goes
+  to die.
+- **Keep a dead-code report generated, not audited.** AI-built codebases accrete abandoned helpers
+  fast; a script that lists unreferenced symbols weekly beats a human noticing.
+- **Stamp generated files as generated,** in the first line, loudly. Someone will eventually
+  hand-edit one otherwise, and the next regeneration silently eats the edit.
+
+---
+
+## §05 — Skills
+
+Twenty-three of them here, and the pattern that emerged is fairly clean.
+
+- **A skill is a decision that survived being made twice.** Don't write them up front — you'll guess
+  wrong about what recurs. Write one the second time you catch yourself explaining the same thing.
+- **The description is the product.** A skill that never fires is worth zero, and firing is entirely
+  a function of the description. Ours are long on purpose: they list the literal phrasings a person
+  actually uses ("walk the invoices card as an AR clerk"), and — just as important — they end with an
+  explicit boundary pointing at the sibling skill: *NOT for X, that's Y.* The negative half does as
+  much work as the positive half.
+- **Separate decisions from rules.** Our design system is deliberately two skills: one holds the
+  *decisions* (this exact orange, this typeface, these four control shapes) and one holds the
+  *measurable rules* those decisions must satisfy (contrast floors, one control height, the accent
+  budget). Decisions change constantly; rules almost never. Merge them and every brand tweak forces
+  you to rewrite the rulebook.
+- **Publish the precedence rule.** Ours: *when a decision and a rule conflict, the decision moves,
+  not the rule.* One sentence, and an entire category of circular argument disappears.
+- **Make workflow skills chainable and self-backfilling.** `/promote` runs `/merge`, which runs
+  `/deploy` if the work was never deployed. You can enter the pipeline at any station and it repairs
+  the steps behind you. That's what makes it safe to forget the order.
+
+---
+
+## §06 — UI
+
+- **Name the archetypes before you draw anything.** Ours are Signal · Gate · Stamp · Ref · Door ·
+  Pin · Field. Deciding what *kinds* of things exist is what keeps screen two hundred coherent with
+  screen one. Skip it and you get fourteen button variants and no vocabulary to discuss them in.
+- **Shape carries meaning, and there are only a few shapes.** Four here: squared means state, one
+  means opener, rounded means record, pill means action. A user learns that once and then reads every
+  new screen for free.
+- **One accent, budgeted.** One orange, roughly a 60-30-10 split. The discipline isn't picking the
+  colour, it's refusing the second one — and keeping semantic colour (good / warning / critical)
+  strictly separate from brand accent so an alert can never be mistaken for decoration.
+- **Tokens in the code, never hexes.** So a reskin is a variable swap rather than a search-and-replace
+  across thousands of lines.
+- **Read the ledger to the end.** This one cost us real time: our first hundred ledger rows were
+  written as a snapshot after the fact, and later rows supersede some of them. Grepping for a decision
+  and stopping at the first hit is exactly how a dead decision gets confidently cited as canon. Date
+  every row, require a supersedes-pointer both directions, and if you can, add a check that fails when
+  two live rows contradict.
+
+---
+
+## §07 — UX, and the characters that find the bugs
+
+The most productive UX tool we built is a persona audit — walk a screen as a specific person with a
+specific bad day. The counter-intuitive part:
+
+> **A smart, patient persona finds nothing.** The character has to be lazy, distracted, mid-task and
+> not especially interested — because that's the actual user. A charitable reviewer reads the tooltip.
+> A real dispatcher with forty minutes before the yard closes does not.
+
+Give each character four things and keep them in a file the model reads:
+
+| | |
+|---|---|
+| **A job** | dispatcher, AR clerk, shop hand |
+| **A competence level** | how fluent are they, really |
+| **A distraction** | what's actually on their mind right now |
+| **A failure mode** | what they do when confused — guess, tap the biggest button, walk away |
+
+Three to five characters covers most apps.
+
+Two questions catch more than any checklist:
+
+- **"What does this screen tell me to do next?"** If nothing, the screen isn't finished. This is the
+  single most productive question we ask.
+- **"Where is the real emergency, and what is burying it?"** Most bad dashboards aren't missing
+  information — they're weighting it wrong.
+
+Then **verify every finding against the actual shipping code before you believe it**. Personas
+hallucinate problems enthusiastically. An unverified persona audit is a tidy list of plausible
+fiction, and acting on it burns more than the audit saved.
+
+The second use of characters is voice. A product character — ours is "Mr. Wrangler" — plus a fixed
+verb set (six to ten words: *wrangle, round up, corral, brand*) gets you consistent copy across
+hundreds of strings without a style meeting per string.
+
+---
+
+## §08 — Build the jig, not the part
+
+The most avoidable cost in this project was iterating inside the real app when a throwaway would
+have answered the question in a tenth of the time. Changing something in the real app costs a build,
+a deploy, a review pass and a context reload. Changing it in a 200-line scratch page costs a refresh.
+
+So before a big build, spend an hour on a **disposable tool whose only job is to make one decision
+cheap** — then throw it away.
+
+### The five worth building
+
+- **A renderer / explorer.** One page that shows a single visual system — a texture, a palette, a
+  type ramp, every state of one component — side by side with live controls. Turns "which of these
+  six" into a two-minute look instead of six deploy cycles.
+- **An interactive mockup, not a static one.** Real interaction, fake data. A static image can't
+  answer *what happens with four hundred rows, an empty list, or a sixty-character name* — and
+  that's where most designs actually die.
+- **A standalone slice of the real UI.** One card, extracted, with no nav, no auth and no backend.
+  We built exactly this, and the reason is instructive: a hand-inlined copy of a prototype card
+  silently fell behind the real one, because nobody rebuilt it. Making it one command fixed that
+  permanently.
+- **A data-shape probe.** Feed a real export in and print what your parser actually makes of it,
+  *before* designing around an assumed shape. Real data is where assumptions go to die.
+- **An API spike.** Twenty lines proving an integration behaves the way its documentation claims,
+  before you design a feature on top of it. Nearly every entry in the integration report would have
+  been cheaper as a spike first.
+
+### Four rules that keep them cheap
+
+- **Isolate exactly one variable.** A texture explorer that also carries your nav and your auth
+  isn't a jig — it's the app, and it costs what the app costs.
+- **Fake the data, but make it hostile.** Longest plausible name, empty set, four hundred rows, a
+  missing field. Friendly fake data proves nothing.
+- **No tests, no polish, no reuse.** Scratch folder, git-ignored, deleted after. A "temporary" tool
+  that quietly becomes permanent is a second product you now maintain forever.
+- **Decide in the cheapest medium that can hold the decision.** Sketch → published page → standalone
+  slice → design tool → real code. Move up one level only when the current one genuinely can't
+  answer the question — and no further.
+
+The one exception to disposability: **if you rebuild the same throwaway twice, it has earned a
+script.** That's the same rule as skills — the second time is the signal.
+
+> **The counter-example.** Pixel-recreating one card from a flat image cost **103 minutes and
+> roughly two million tokens** — to recover structure that was never in the file to begin with. A jig
+> can make a decision cheap; it cannot recover information that doesn't exist. If an editable
+> source exists anywhere, go get the source first.
+
+---
+
+## §09 — Audits: three kinds, and you need all three
+
+| Kind | Cost | Cadence | Catches |
+|---|---|---|---|
+| **Machine gates** | seconds | every push | Boot failures, money regressions, contract breaks. Non-negotiable, so nobody argues. |
+| **Drift checks** | seconds | every push | The `--check` family — map out of date, registry out of sync, a released file changed without its version bumped. |
+| **Judgment audits** | expensive | on demand | Persona/role sweeps, security and data-exposure passes. Real reasoning, so run them deliberately. |
+
+- **No fix without a cited root cause.** Our triage skill requires the symptom be traced *up* to a
+  cause, with file-and-line citations, before a line changes. This one rule kills the most common AI
+  failure mode: a plausible, confident fix that changes nothing because it addressed a symptom.
+- **Verify adversarially.** Fan out finders, then have *separate* agents try to refute each finding.
+  Majority-refuted dies. Without this, a forty-item audit is about thirty items of fiction and you'll
+  spend a week on it.
+- **Audit the bytes that ship,** not the working tree.
+- **Findings become rows, not prose.** A finding with no home in a tracked list is a finding you'll
+  rediscover in three weeks and pay for twice.
+
+---
+
+## §10 — Agents
+
+The real benefit of a subagent isn't parallelism — it's **context isolation**. An agent that greps
+forty files and hands back eight lines just saved you thirty-nine files of context you'll never have
+to carry.
+
+Two questions decide every delegation: *what does it cost if this is wrong?* and *do I need to see
+the reasoning, or just the answer?* If you need the intermediate thinking to make the next call, keep
+it. If you only need the result, send it away.
+
+| Tier | Send it | Why |
+|---|---|---|
+| **Cheapest** | git plumbing, grep sweeps, file munging, run-a-script-and-report | Being wrong is instantly visible and free to redo. |
+| **Mid** | UI or code from a settled spec, an additive endpoint, PR bodies | Bounded work with a written target to check against. |
+| **Top** | specs, security and data gates, cross-system architecture, ambiguous calls | Wrong here leaks data or money. Keep it on the main thread. |
+
+### Four rules that stop delegation from backfiring
+
+- **Never delegate ambiguity.** An agent handed an under-specified task returns a confident, wrong
+  artifact, and reviewing it costs more than building it. Ambiguity gets resolved *before* the handoff
+  or not at all.
+- **Never delegate the third attempt.** If two fixes already failed, the problem isn't effort — it's
+  a wrong model of the system. A fresh agent with less context will fail faster and more expensively.
+- **Give every agent the coordinates.** An agent without your map re-greps blind and burns more than
+  doing it yourself. Hand it the chapter ID and the file path in the prompt. This is why the map pays
+  twice.
+- **Background by default,** so the main thread stays free for the next question — and say in one line
+  which agent got what, so nobody has to guess where a decision was actually made.
+
+---
+
+## §11 — Tokens
+
+Ranked by what they actually saved here, largest first.
+
+| Habit | Rough saving |
+|---|---|
+| Map before grep — index plus one chapter, never the whole file | ~20× |
+| Delegate the reading; keep the deciding | ~10× on sweeps |
+| Cap every tool output — `\| head -50`, ranges not whole files | large, silent |
+| Never re-read a file you just edited to "verify" | 2 reads/edit |
+| Write decisions down once so session 40 doesn't re-derive session 3 | compounding |
+| Keep stable context stable — churn invalidates cache from that point on | cache-wide |
+
+The biggest silent burn is **oversized tool output**. A single unbounded directory listing or log
+dump can cost more than an hour of careful editing. Cap everything by reflex.
+
+And **build the self-measurement in.** We have an audit that fires automatically roughly every million
+tokens and reports cache hit rate, redundant reads, oversized outputs, and whether the model tier
+actually fit the work. You cannot fix a habit you can't see, and nobody reviews their own transcripts
+voluntarily.
+
+---
+
+## §12 — Looping toward a goal without burning everything
+
+The failure mode is specific and worth naming: an open-ended loop where each pass re-reads the world,
+makes a small change, and re-verifies everything. Cost grows with the square of the number of passes,
+and it does not converge — it just runs out of budget.
+
+Every fix is a variation on the same move: **put the loop's state outside the conversation.**
+
+- **Define "done" as a command before you start.** If the exit condition is "looks good," the loop
+  never exits. If it's *this script exits zero*, it terminates on its own.
+- **Externalize the checklist.** Each pass reads a file, does *one* item, marks it, and stops.
+  Context per pass stays flat instead of growing with history — and the work survives the session
+  ending.
+- **Loop until dry, not until N.** For discovery, keep going until two consecutive passes find
+  nothing new; a fixed count always stops mid-tail or long past it.
+- **Deduplicate against everything *seen*, not everything *accepted*.** Miss this and rejected
+  findings resurface every round forever and the loop can never converge. It's the single most common
+  reason a discovery loop runs away.
+- **Cap the blast radius per pass** — one file, one failure, one item. Large passes fail in ways you
+  can't attribute, which forces a re-read of everything.
+- **Commit each green step.** A loop that checkpoints can be resumed; one that holds its progress in
+  context dies with the session and takes the work with it.
+- **Set the budget explicitly** — stop at N passes or below X remaining, then report what's left
+  rather than silently running dry mid-edit.
+
+---
+
+## §13 — The desk: local and cloud organization
+
+- **One canonical checkout.** Two working copies of the same project is how you end up shipping the
+  wrong one. Parallel work goes in isolated worktrees off the same repo, never a second clone.
+- **Outputs never touch source.** A dated, git-ignored session folder per topic; a known scratch
+  directory for temporary files. Never the repo root, never scattered through the system temp.
+- **Secrets are environment variables, always.** Ours are referenced by name only — never a value,
+  not even in a doc. If the repo is public, a password committed once is a permanent leak, and
+  rotating it doesn't un-publish it.
+- **Write down what each machine can actually do.** Our browser test suite runs in CI and the cloud
+  but has never once installed correctly on the desktop. That fact lives in the startup routine now,
+  which is the only reason we stopped rediscovering it every few weeks.
+- **Have a start ritual and an end ritual.** Start orients: what's installed, what branch, what did
+  we decide last time. End closes: what actually shipped, what's still pending, park every loose idea
+  on its own branch, and write the handoff note. The end ritual is the one that stops good
+  half-finished ideas from dying quietly in a closed tab.
+
+---
+
+## §14 — What I'd genuinely do differently
+
+**01. Chapter IDs and the map on day one, not at 15,000 lines.**
+Everything else in this document depends on being able to find things cheaply. It was built late
+here, and retrofitting it was a multi-session job with nothing visible to show for it.
+
+**02. The decisions ledger starting at row one, live.**
+Ours began as a reconstruction, which is why its first hundred rows are the least trustworthy part of
+it. A ledger written after the fact is a guess about what you used to think.
+
+**03. Click-to-source in dev builds, in week one.**
+The cheapest bug report is a coordinate. Everything else is prose that someone has to translate back
+into a file and a line.
+
+**04. Prefer designs with nothing to arbitrate over designs with good locking.**
+We built a lock-and-lease system so parallel sessions could share three staging slots, then replaced
+it with immutable numbered folders — where contention simply cannot occur, because nothing is shared.
+The second design is smaller, has no failure states, and made an entire class of "staging is busy"
+problems stop existing. Reach for the version with no shared mutable state first.
+
+**05. Make every guard a script, never a habit.**
+We had a rule that a released file needs its version bumped. People and models forgot it, repeatedly,
+until it became a check that fails the build. Anything enforced by remembering is already broken — it
+just hasn't cost you yet.
+
+---
+
+> The through-line: **every piece of knowledge that lives only in a person's head or a past
+> conversation is a recurring bill.** Write it into a file a model reads, or a script that fails
+> without it. Those are the only two places it survives.

--- a/docs/field-notes/scaffolding-card.md
+++ b/docs/field-notes/scaffolding-card.md
@@ -1,0 +1,61 @@
+# Scaffolding before features — the card
+
+An AI-built app has two codebases: the source, and the context needed to safely change it. You carry
+the second in your head; a model rebuilds it from scratch every session. **Build the tools that
+answer questions before the code that raises them.**
+
+## Day one — before feature #1
+1. **Boot smoke test.** Thirty lines. Catches half of all "it's broken" before a human sees it.
+2. **Chapter IDs stamped in the source.** `grep APP-19` works cold. Line numbers rot; IDs don't.
+3. **Code map in two halves.** Hand-written story + generated index, with a CI `--check`.
+4. **A test for anything computing money.** The day it first returns a dollar.
+5. **Dated decisions ledger, from row one.** Written later, it's a guess about what you used to think.
+6. **`--check` on every registry.** Same script, two modes: write, or fail if writing would change anything.
+7. **Deploy/release as scripts with a preview mode.** Bare = read-only; `--yes` to run.
+8. **A memory file in the repo.** So session 40 doesn't re-derive session 3.
+
+## The five I'd redo
+1. **Map and chapter IDs on day one**, not at 15,000 lines. Retrofitting produces nothing visible.
+2. **Ledger live from row one.** Ours was reconstructed — that's why its first 100 rows are the least trustworthy.
+3. **Click-to-source in dev builds, week one.** The cheapest bug report is a coordinate, not a paragraph.
+4. **Nothing to arbitrate beats good locking.** Immutable paths killed a whole class of contention bug by construction.
+5. **Every guard a script, never a habit.** Anything enforced by remembering is already broken.
+
+## Before the next integration
+- **Ownership.** For every object on both sides: which system is the source of truth? What reconciles them — and how would you know it did nothing?
+- **Spike it.** Twenty lines proving the API behaves as documented, before designing on that assumption.
+- **Slow paths.** What's asynchronous or takes days? What assumes it finishes now? (Cards attach instantly; bank accounts take days.)
+- **Second variants.** When a second type arrives, which checks written for the first will wrongly reject it?
+- **Verify from the far side.** `ok:true` is not proof. The Sent copy, the dashboard, the actual charge.
+- **No heavy work in a boot path.** An account quota is a ceiling — backoff spends it faster, not slower.
+
+## Tokens, agents, loops
+- **Map before grep.** Index + one chapter ≈ 15k tokens. Whole file ≈ 350k. That's the 20×.
+- **Cap every tool output.** Oversized output is the biggest silent burn there is.
+- **Delegate the reading, keep the deciding** — and give every agent the coordinates, or it re-greps blind.
+- **Never delegate ambiguity, or the third attempt** at a bug that already beat two fixes.
+- **Make "done" a command,** not a judgement. "Looks good" never exits.
+- **Externalize the loop's checklist.** One item per pass, commit, stop. Flat context per pass.
+- **Dedupe against everything *seen*, not everything *accepted*** — the #1 reason a loop never converges.
+
+## Build the jig, not the part
+- Before a big build, spend an hour on a **throwaway that makes one decision cheap**. Then delete it.
+- **Isolate one variable.** A texture explorer carrying your nav and auth is just the app.
+- **Interactive, not static** — a picture can't answer "400 rows, empty list, 60-character name."
+- **Fake data, but hostile.** Friendly fake data proves nothing.
+- **Cheapest medium that holds the decision.** Sketch → page → slice → design tool → code. One level at a time.
+- **Rebuilt the same throwaway twice? It earned a script.** Same rule as skills.
+
+## UI · UX · characters
+- **Name the archetypes before drawing.** Otherwise: fourteen button variants and no vocabulary.
+- **One accent, budgeted.** Semantic colour stays separate from brand accent.
+- **A smart persona finds nothing.** Make them lazy, distracted, mid-task — that's the real user.
+- **"What does this screen tell me to do next?"** Nothing → it isn't finished.
+- **Verify every finding against shipping code.** Personas hallucinate enthusiastically.
+- **Read the ledger to the END.** Stopping at the first hit is how a dead decision becomes canon.
+
+---
+
+Every piece of knowledge that lives only in a person's head or a past conversation is a **recurring
+bill**. Write it into a file a model reads, or a script that fails without it. Those are the only two
+places it survives.

--- a/docs/field-notes/starter-kit/README.md
+++ b/docs/field-notes/starter-kit/README.md
@@ -1,0 +1,46 @@
+# Day-one starter kit
+
+Drop-in scaffolding for a new app you intend to build with AI. Everything here exists because
+building it *late* on a previous project cost multiples of what building it early would have.
+
+Nothing here is a framework — two small scripts and five templates. Adapt freely.
+
+## Install in this order
+
+| # | Do this | Why first |
+|---|---|---|
+| 1 | Copy `ci/smoke.mjs`, run it. | Written before feature one, it never needs retrofitting. Catches roughly half of all "it's broken" reports. |
+| 2 | Add a chapter banner to your first source file. | `// ═══ APP-01 · Utilities ═══`. IDs stamped in the source mean `grep APP-01` works from a cold start. |
+| 3 | Copy `tools/gen-code-map.mjs`, run it, then wire `--check` into CI. | The `--check` flag is what makes the map impossible to silently drift. |
+| 4 | Copy `templates/CODE-MAP.md` and write the *one rule that explains the whole app*. | That single paragraph saves more model time than everything else in the doc. |
+| 5 | Copy `templates/DECISIONS.md` and add row #1 today. | A ledger reconstructed later is a guess about what you used to think. |
+| 6 | Copy `templates/CLAUDE.md` and `templates/MEMORY.md`. | So session forty knows what session three decided. |
+| 7 | Copy `templates/CHARACTERS.md` when you first build UI someone else will use. | |
+| 8 | Copy `templates/LOOP-CHECKLIST.md` the first time you want a long unattended run. | |
+
+## What's here
+
+```
+ci/smoke.mjs              does it boot? real browser if Playwright is present, HTTP checks if not
+tools/gen-code-map.mjs    scans chapter banners → generated index; --check is the CI drift gate
+templates/CLAUDE.md       project instructions a model reads every session
+templates/MEMORY.md       durable cross-session memory
+templates/DECISIONS.md    the append-only decisions ledger
+templates/CHARACTERS.md   audit personas + the product voice character
+templates/CODE-MAP.md     the hand-written story half of the map
+templates/SKILL.md        a skill, with the description pattern that actually triggers
+templates/LOOP-CHECKLIST.md   externalized loop state, so long runs converge
+```
+
+## The two ideas underneath all of it
+
+**1. Every artifact a human or model must keep in sync gets a generator and a `--check`.**
+Same script, two modes: write it, or fail if writing would change anything. That single flag
+is what makes documentation non-optional without anyone nagging.
+
+**2. Anything enforced by remembering is already broken** — it just hasn't cost you yet.
+
+## Requirements
+
+Node 18+. No dependencies. Playwright is optional and only upgrades `smoke.mjs` from useful
+to strict.

--- a/docs/field-notes/starter-kit/ci/smoke.mjs
+++ b/docs/field-notes/starter-kit/ci/smoke.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * smoke.mjs — "does it boot?" Write this BEFORE feature one.
+ *
+ *   node ci/smoke.mjs
+ *
+ * Serves the project statically, loads it, and asserts the basics. Two modes,
+ * picked automatically:
+ *
+ *   • Playwright installed  → real browser: catches console errors, JS
+ *     exceptions, failed requests, and checks a rendered element.
+ *   • Playwright missing    → HTTP-only fallback: the page serves, is not
+ *     empty, and every local asset it references resolves.
+ *
+ * The fallback exists so this never becomes the test nobody can run. CI
+ * installs Playwright and gets the strict version; a laptop gets the useful
+ * subset. Neither one is allowed to be skipped.
+ *
+ * No dependencies required. Node 18+.
+ */
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { extname, join, normalize } from 'node:path';
+
+// ── configure ────────────────────────────────────────────────────────────────
+const ROOT = process.cwd();
+const PORT = Number(process.env.SMOKE_PORT || 9147);   // NOT 8000 — that's usually taken
+const ENTRY = '/index.html';
+const MUST_RENDER = 'body';        // a selector that proves the app actually drew something
+const MUST_CONTAIN = [];           // optional: strings that must appear in the served HTML
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MIME = {
+  '.html': 'text/html', '.js': 'application/javascript', '.mjs': 'application/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml', '.ico': 'image/x-icon', '.woff2': 'font/woff2', '.woff': 'font/woff',
+};
+
+const fail = (msg) => { console.error('✗ ' + msg); process.exitCode = 1; };
+const pass = (msg) => console.log('✓ ' + msg);
+
+function serve() {
+  return new Promise((resolve) => {
+    const server = createServer(async (req, res) => {
+      try {
+        let p = decodeURIComponent(req.url.split('?')[0]);
+        if (p === '/') p = ENTRY;
+        const safe = normalize(p).replace(/^(\.\.[/\\])+/, '');
+        const data = await readFile(join(ROOT, safe));
+        res.writeHead(200, {
+          'Content-Type': MIME[extname(safe)] || 'application/octet-stream',
+          'Cache-Control': 'no-store',
+        });
+        res.end(data);
+      } catch {
+        res.writeHead(404); res.end('Not found');
+      }
+    });
+    server.listen(PORT, () => resolve(server));
+  });
+}
+
+async function withBrowser(base) {
+  let chromium;
+  try { ({ chromium } = await import('playwright')); }
+  catch { return false; }
+
+  const errors = [];
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', (m) => { if (m.type() === 'error') errors.push('console: ' + m.text()); });
+  page.on('pageerror', (e) => errors.push('exception: ' + e.message));
+  page.on('requestfailed', (r) => errors.push('request failed: ' + r.url()));
+
+  await page.goto(base + ENTRY, { waitUntil: 'networkidle' });
+  const rendered = await page.locator(MUST_RENDER).count();
+  const text = (await page.textContent('body')) || '';
+  await browser.close();
+
+  if (errors.length) errors.forEach((e) => fail(e)); else pass('no console errors, exceptions or failed requests');
+  if (rendered > 0) pass(`rendered ${MUST_RENDER}`); else fail(`nothing matched ${MUST_RENDER}`);
+  if (text.trim().length > 0) pass('page produced visible text'); else fail('page rendered but is empty');
+  return true;
+}
+
+async function withoutBrowser(base) {
+  const res = await fetch(base + ENTRY);
+  if (!res.ok) return fail(`${ENTRY} returned ${res.status}`);
+  const html = await res.text();
+  if (html.trim().length < 50) return fail(`${ENTRY} is suspiciously empty`);
+  pass(`${ENTRY} serves (${html.length} bytes)`);
+
+  for (const needle of MUST_CONTAIN) {
+    if (html.includes(needle)) pass(`contains "${needle}"`);
+    else fail(`missing "${needle}"`);
+  }
+
+  // every local asset the entry references must resolve
+  const refs = [...html.matchAll(/(?:src|href)="([^"#][^"]*)"/g)]
+    .map((m) => m[1])
+    .filter((u) => !/^(https?:)?\/\//.test(u) && !u.startsWith('data:') && !u.startsWith('mailto:'));
+
+  let broken = 0;
+  for (const ref of [...new Set(refs)]) {
+    const url = base + (ref.startsWith('/') ? ref : '/' + ref);
+    const r = await fetch(url.split('?')[0]).catch(() => null);
+    if (!r || !r.ok) { fail(`broken local reference: ${ref}`); broken++; }
+  }
+  if (!broken) pass(`all ${new Set(refs).size} local references resolve`);
+}
+
+// ── run ──────────────────────────────────────────────────────────────────────
+if (!existsSync(join(ROOT, ENTRY.slice(1)))) {
+  console.error(`✗ no ${ENTRY} in ${ROOT} — set ENTRY at the top of ci/smoke.mjs`);
+  process.exit(1);
+}
+
+const server = await serve();
+const base = `http://localhost:${PORT}`;
+console.log(`smoke: serving ${ROOT} on ${base}`);
+
+try {
+  const usedBrowser = await withBrowser(base);
+  if (!usedBrowser) {
+    console.log('  (playwright not installed — running HTTP-only checks)');
+    await withoutBrowser(base);
+  }
+} finally {
+  server.close();
+}
+
+if (process.exitCode) console.error('\nsmoke FAILED');
+else console.log('\nsmoke passed');

--- a/docs/field-notes/starter-kit/templates/CHARACTERS.md
+++ b/docs/field-notes/starter-kit/templates/CHARACTERS.md
@@ -1,0 +1,43 @@
+# Characters
+
+Two kinds live here: **user characters** for auditing, and the **product character** for voice.
+Both exist so a model can apply them without you re-explaining.
+
+---
+
+## User characters — for UX audits
+
+A smart, patient persona finds nothing. Make them **lazy, distracted and mid-task**, because
+that's the real user. Three to five is plenty.
+
+### <Name> — <role>
+
+- **Job:** what they're actually trying to finish today.
+- **Fluency:** how well they know this software, honestly. Usually: not very.
+- **Distraction:** what's on their mind instead of your UI right now.
+- **Failure mode:** what they do when confused — guess, tap the biggest button, call someone,
+  walk away.
+- **Never does:** reads the tooltip / scrolls past the fold / notices the small grey text.
+
+> **Example**
+> **Denny — dispatcher.** Forty minutes before the yard closes, three trucks still out.
+> Fluency: low, uses four screens out of thirty. Distraction: the phone is ringing.
+> Failure mode: taps whatever is biggest and orange, then asks someone. Never reads a tooltip.
+
+### The two questions that catch the most
+
+1. **What does this screen tell me to do next?** If nothing — it isn't finished.
+2. **Where is the real emergency, and what is burying it?**
+
+**And then verify.** Personas hallucinate problems enthusiastically. Every finding gets checked
+against the actual shipping code before anyone acts on it.
+
+---
+
+## Product character — for voice
+
+- **Name:**
+- **Who they are:** one sentence.
+- **Voice:** how they'd say "that didn't work."
+- **The verb set** (6–10 words, use only these):
+- **Never says:**

--- a/docs/field-notes/starter-kit/templates/CLAUDE.md
+++ b/docs/field-notes/starter-kit/templates/CLAUDE.md
@@ -1,0 +1,56 @@
+# <Project> — project notes
+
+<One paragraph: what this is, who it's for, what it's built with. A model reads this first,
+every session. Keep it under a screen.>
+
+**Contents:** [Interaction](#interaction) · [Design](#design) · [Ship flow](#ship-flow) ·
+[Don't](#dont) · [Delegation](#delegation)
+Cross-session memory lives in **`MEMORY.md`**. Path-scoped detail lives in `.claude/rules/`
+(loads only when the relevant files are touched).
+
+## Interaction
+
+- **How to ask me things:** <one format, decided once. Batched? One at a time? Inline?>
+- **Lead with the outcome**, not the process.
+- **Show, don't describe** — a rendered page beats a paragraph for anything visual or
+  comparative.
+- **Don't stop unless there's something to see or know.**
+
+## Design
+
+- Every new or reshaped UI runs through **<your rules skill>** and **<your decisions skill>**.
+- **Every UI decision is indexed in `docs/DECISIONS.md`.** Read it before designing, read to
+  the END, and add a row when something is settled.
+- <The one-line version of the design language: palette, type, one accent.>
+
+## Ship flow
+
+<The exact sequence, with who owns each gate. Name the one step that changes what users see,
+and say plainly that it is a human's call.>
+
+**Gates (must pass before push):**
+```
+node ci/smoke.mjs
+node tools/gen-code-map.mjs --check
+<every other check, one per line, copy-pasteable>
+```
+
+## Don't
+
+- Never commit secrets. <Name the env vars by name; never a value.>
+- Never push directly to `<protected branch>`.
+- <The project-specific rule someone got wrong once and must never get wrong again.>
+
+## Delegation
+
+Push cheap work down, keep the hard calls up. Delegate by **cost-of-being-wrong** and by
+whether the main thread needs the intermediate reasoning.
+
+| Tier | Delegate this |
+|---|---|
+| Mechanical · IO | git plumbing, grep sweeps, file munging, run-a-script-and-report |
+| Scoped build | code from a settled spec, PR bodies, research gathering |
+| Hard reasoning | specs, security/auth/data gates, architecture, ambiguous calls |
+
+**Never delegate:** authoring specs · security, auth or data-exposure calls · irreversible or
+live-deploy operations · any bug that already resisted two fixes.

--- a/docs/field-notes/starter-kit/templates/CODE-MAP.md
+++ b/docs/field-notes/starter-kit/templates/CODE-MAP.md
@@ -1,0 +1,44 @@
+# The code map — the story half
+
+> **What this is.** A narrated table of contents for the codebase. It doesn't change how
+> anything works; it says *where* things live and *why they're there*.
+>
+> **Two files, one map.** This file is the **story** (hand-written, stable). Its companion
+> `code-map.generated.md` is the **index** (machine-owned — live line numbers and symbols,
+> produced by `tools/gen-code-map.mjs`, kept honest by a CI `--check`).
+> When code moves, regenerate the index. **The chapter IDs below never change.**
+
+## The one rule that explains the whole app
+
+<One paragraph. If a reader knows only this, they should be able to guess which of three or
+four places to look for any given change. Example: "UI renders from state; an action mutates
+state; the app re-renders. Records reference each other by ID; everything else is derived,
+never stored." That sentence saves more time than the rest of the document.>
+
+## How to use it
+
+- Find the chapter here → jump to the `file:line` in the generated index.
+- Every chapter ID is **stamped into the source** as a banner comment, so `grep APP-19` lands
+  on it from a cold start with no context loaded.
+- **IDs are handles, not addresses.** Never renumber them, even when chapters end up out of
+  order on disk. Renumbering silently invalidates every reference in every doc and every past
+  decision.
+
+## Chapters
+
+### Act I — <the first grouping, in *reading* order, not file order>
+
+- **`APP-01` — <title>.** What it owns, and the one thing to know before editing it.
+- **`APP-02` — <title>.** …
+
+### Act II — <…>
+
+…
+
+## Where to change what
+
+| I want to change… | Look for a… | Which lives in… |
+|---|---|---|
+| what's shown | builder / renderer | Act … |
+| a number | derivation | Act … |
+| what a click does | action or handler | Act … |

--- a/docs/field-notes/starter-kit/templates/DECISIONS.md
+++ b/docs/field-notes/starter-kit/templates/DECISIONS.md
@@ -1,0 +1,22 @@
+# Decisions ledger
+
+> **Append-only. Every row dated. A decision is not made until it has a row here.**
+>
+> Three rules, learned expensively:
+> 1. **Read this before designing anything.** Don't re-derive what's settled.
+> 2. **Read to the END, and check dates.** A later row may supersede an earlier one.
+>    Grepping and stopping at the first hit is how a dead decision gets cited as canon.
+> 3. **When something is reversed, point both ways** — the old row gets `→ superseded by #N`,
+>    the new row gets `(reverses #M)`. Never delete a row; a struck-through decision is
+>    evidence, a missing one is a mystery.
+
+| # | Date | Area | Decision | Why | Status |
+|---|------|------|----------|-----|--------|
+| 1 | YYYY-MM-DD | example | The thing that was settled, stated as a rule. | The reason, in one clause. | LIVE |
+| 2 | YYYY-MM-DD | example | The replacement rule. (reverses #1) | What changed our mind. | LIVE |
+
+**Status values:** `LIVE` · `SUPERSEDED → #N` · `OPEN` (raised, not settled) ·
+`DEFERRED` (settled to not decide yet) · `PROVISIONAL` (in use, not blessed).
+
+**Areas** are yours — keep the list short enough to scan: `ui`, `data`, `money`, `auth`,
+`process`, `copy`.

--- a/docs/field-notes/starter-kit/templates/LOOP-CHECKLIST.md
+++ b/docs/field-notes/starter-kit/templates/LOOP-CHECKLIST.md
@@ -1,0 +1,32 @@
+# Loop checklist — <goal>
+
+> **How to run this loop.** Each pass: read this file, do **one** unchecked item, check it off,
+> commit, stop. Do not re-read the whole world; do not batch items. Context per pass stays flat,
+> and the work survives the session ending.
+
+**Done means:** `<the exact command that must exit 0>`
+*(If "done" is "looks good", the loop never terminates. Make it a command.)*
+
+**Budget:** stop after `<N>` passes or when remaining budget drops below `<X>`, then report
+what's left rather than running dry mid-edit.
+
+**Blast radius per pass:** one file / one failure / one item. Larger passes fail in ways you
+can't attribute.
+
+## Items
+
+- [ ] …
+- [ ] …
+
+## Seen (do NOT re-add)
+
+> Deduplicate against everything **seen**, not everything **accepted**. Otherwise rejected
+> findings resurface every round and the loop can never converge — the single most common
+> reason a discovery loop runs away.
+
+- …
+
+## Log
+
+| Pass | Item | Result | Commit |
+|---|---|---|---|

--- a/docs/field-notes/starter-kit/templates/MEMORY.md
+++ b/docs/field-notes/starter-kit/templates/MEMORY.md
@@ -1,0 +1,20 @@
+# MEMORY — <project>
+
+> Durable cross-session memory. **Read at session start, updated at session end.**
+> <If the repo is public, say so here and forbid customer data, credentials and pricing.>
+> Keep it lean — the first ~200 lines are what a session actually leans on.
+
+## Decisions
+<!-- Newest first. Dated, attributed, one paragraph each. Link the spec or PR. -->
+- **YYYY-MM-DD — <what was decided>.** <Why, and what it replaced. Where the detail lives.>
+
+## Design prefs
+<!-- The things you'd otherwise re-explain every session. -->
+
+## Gotchas
+<!-- Every "we lost an hour to this" goes here, with the date and the symptom you'd search for.
+     Write the SYMPTOM in the first line — that's what a future session greps for, not the cause. -->
+- **<Symptom as you'd first see it> (YYYY-MM-DD).** <Cause, and the fix.>
+
+## Open threads
+<!-- Half-done work, parked ideas, decisions waiting on someone. Each with a branch or a doc. -->

--- a/docs/field-notes/starter-kit/templates/SKILL.md
+++ b/docs/field-notes/starter-kit/templates/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: <kebab-case-name>
+description: >-
+  <WHAT it does, in one sentence.> Reach for it whenever <the literal phrasings a person
+  actually types — "audit the X card as a dispatcher", "why is Y broken", "make this a proper
+  chip" — three or four real ones, not categories>. <WHEN NOT to use it, naming the sibling
+  skill that covers that instead: "NOT for building UI from a text spec — that's `other-skill`.">
+---
+
+# <Name> — <one-line purpose>
+
+## When this fires
+
+<Two or three sentences on the situation. Be concrete about the trigger, because triggering is
+the whole game: a skill that never fires is worth zero.>
+
+## The method
+
+1. <Step, phrased as an instruction, not a description.>
+2. …
+
+## Rules
+
+- <The non-negotiables. Say why, briefly — a rule with a reason survives; a bare rule gets
+  argued with.>
+
+## What this is NOT for
+
+- <The nearest neighbour, and where to go instead.>

--- a/docs/field-notes/starter-kit/tools/gen-code-map.mjs
+++ b/docs/field-notes/starter-kit/tools/gen-code-map.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * gen-code-map.mjs — the generated half of the two-file code map.
+ *
+ * Scans your source for CHAPTER banners and writes a machine-owned index with
+ * live line numbers. The hand-written half (docs/CODE-MAP.md) tells the story
+ * and never has to be regenerated.
+ *
+ *   node tools/gen-code-map.mjs           # write the index
+ *   node tools/gen-code-map.mjs --check   # exit 1 if writing would change anything
+ *
+ * The --check mode is the whole point: wire it into CI and the map can never
+ * silently drift from the code.
+ *
+ * A chapter banner is any comment line containing an ID and a title:
+ *
+ *   // ═══ <PREFIX>-01 · Utilities & formatting ═══════════════════════
+ *   /* <PREFIX>-02 · State & sessions *\/
+ *   # <PREFIX>-03 · Derivations
+ *
+ * IDs must be unique and must appear in file order — a stray reorder fails
+ * --check, which is how you find out someone moved a chapter without saying so.
+ *
+ * No dependencies. Node 18+.
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── configure these three for your project ───────────────────────────────────
+const ROOT = process.cwd();
+const SOURCE_DIRS = ['.', 'src', 'lib'];          // where to look
+const OUT = 'docs/code-map.generated.md';          // what to write
+const PREFIX = 'APP';                              // your chapter ID prefix
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CODE_EXT = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.py', '.go', '.rb', '.css']);
+const SKIP_DIR = new Set([
+  'node_modules', '.git', 'dist', 'build', 'vendor', 'coverage', '.next',
+  // build tooling is not app source — drop these two if you do want it mapped
+  'tools', 'ci',
+]);
+// never scan this generator itself: its own docs contain example banners
+const SELF = relative(ROOT, fileURLToPath(import.meta.url));
+
+const bannerRe = new RegExp(`\\b(${PREFIX}-\\d+)\\b[^\\S\\n]*[·\\-—:|]?[^\\S\\n]*(.*)$`);
+// A "key symbol" is a top-level declaration — the things you actually jump to.
+const symbolRe = /^(?:export\s+)?(?:async\s+)?(?:function\s+(\w+)|const\s+(\w+)\s*=\s*(?:async\s*)?(?:function|\()|class\s+(\w+)|def\s+(\w+))/;
+
+function walk(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    if (e.name.startsWith('.') && e.name !== '.') continue;
+    const p = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (SKIP_DIR.has(e.name)) continue;
+      walk(p, out);
+    } else if (CODE_EXT.has(extname(e.name))) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function collectFiles() {
+  const seen = new Set();
+  const files = [];
+  for (const d of SOURCE_DIRS) {
+    const abs = join(ROOT, d);
+    if (!existsSync(abs)) continue;
+    for (const f of walk(abs)) {
+      const rel = relative(ROOT, f);
+      if (rel === SELF) continue;
+      if (!seen.has(rel)) { seen.add(rel); files.push(rel); }
+    }
+  }
+  return files.sort();
+}
+
+function scan(files) {
+  const chapters = [];
+  for (const rel of files) {
+    const lines = readFileSync(join(ROOT, rel), 'utf8').split('\n');
+    let current = null;
+    lines.forEach((line, i) => {
+      const m = line.match(bannerRe);
+      // only treat it as a banner if the line is a comment
+      const isComment = /^\s*(\/\/|\/\*|\*|#|<!--)/.test(line);
+      if (m && isComment) {
+        current = {
+          id: m[1],
+          // close the block comment FIRST, then strip the trailing rule characters
+          title: (m[2] || '')
+            .replace(/(\*\/|-->)\s*$/, '')
+            .replace(/[═=\-*\/#\s]+$/, '')
+            .trim() || '(untitled)',
+          file: rel,
+          line: i + 1,
+          symbols: [],
+        };
+        chapters.push(current);
+        return;
+      }
+      if (!current) return;
+      const s = line.match(symbolRe);
+      if (s) {
+        const name = s[1] || s[2] || s[3] || s[4];
+        if (name && current.symbols.length < 12) current.symbols.push(name);
+      }
+    });
+  }
+  return chapters;
+}
+
+function validate(chapters) {
+  const problems = [];
+  const byId = new Map();
+  for (const c of chapters) {
+    if (byId.has(c.id)) {
+      problems.push(`duplicate chapter id ${c.id} — ${byId.get(c.id).file}:${byId.get(c.id).line} and ${c.file}:${c.line}`);
+    } else {
+      byId.set(c.id, c);
+    }
+  }
+  // IDs should ascend within each file — a descending pair means a chapter moved.
+  const byFile = new Map();
+  for (const c of chapters) {
+    if (!byFile.has(c.file)) byFile.set(c.file, []);
+    byFile.get(c.file).push(c);
+  }
+  for (const [file, list] of byFile) {
+    for (let i = 1; i < list.length; i++) {
+      const prev = Number(list[i - 1].id.split('-')[1]);
+      const cur = Number(list[i].id.split('-')[1]);
+      if (cur < prev) {
+        problems.push(`chapter order: ${list[i].id} appears after ${list[i - 1].id} in ${file}:${list[i].line}`);
+      }
+    }
+  }
+  return problems;
+}
+
+function render(chapters) {
+  const stamp = [
+    '<!-- GENERATED FILE — DO NOT EDIT BY HAND.',
+    '     Produced by tools/gen-code-map.mjs. Run `node tools/gen-code-map.mjs` to refresh.',
+    '     The hand-written companion is docs/CODE-MAP.md — edit that one. -->',
+    '',
+    '# Code map — generated index',
+    '',
+    `${chapters.length} chapters across ${new Set(chapters.map(c => c.file)).size} files.`,
+    '',
+    '| Chapter | Title | Location | Key symbols |',
+    '|---|---|---|---|',
+  ];
+  for (const c of chapters) {
+    const syms = c.symbols.length ? c.symbols.map(s => `\`${s}\``).join(', ') : '—';
+    stamp.push(`| \`${c.id}\` | ${c.title} | \`${c.file}:${c.line}\` | ${syms} |`);
+  }
+  stamp.push('');
+  stamp.push('## Found in file order');
+  stamp.push('');
+  let lastFile = null;
+  for (const c of chapters) {
+    if (c.file !== lastFile) { stamp.push(`\n**\`${c.file}\`**`); lastFile = c.file; }
+    stamp.push(`- \`${c.id}\` — ${c.title} (line ${c.line})`);
+  }
+  stamp.push('');
+  return stamp.join('\n');
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+const check = process.argv.includes('--check');
+const chapters = scan(collectFiles());
+
+if (!chapters.length) {
+  console.error(`No ${PREFIX}-NN chapter banners found. Add one to a source file:\n`);
+  console.error(`    // ═══ ${PREFIX}-01 · What this chapter is ═══════════════════\n`);
+  process.exit(check ? 1 : 0);
+}
+
+const problems = validate(chapters);
+if (problems.length) {
+  console.error('Code map problems:');
+  for (const p of problems) console.error('  ✗ ' + p);
+  process.exit(1);
+}
+
+const next = render(chapters);
+const outPath = join(ROOT, OUT);
+const prev = existsSync(outPath) ? readFileSync(outPath, 'utf8') : null;
+
+if (check) {
+  if (prev !== next) {
+    console.error(`✗ ${OUT} is out of date. Run: node tools/gen-code-map.mjs`);
+    process.exit(1);
+  }
+  console.log(`✓ ${OUT} is current (${chapters.length} chapters).`);
+} else {
+  writeFileSync(outPath, next);
+  console.log(`✓ wrote ${OUT} — ${chapters.length} chapters.`);
+}


### PR DESCRIPTION
Adds `docs/field-notes/` — retrospective documentation aimed at **the next app**, reconstructed from this repo's own record (`MEMORY.md`, the decisions ledger, `docs/handoffs/`, git history).

**Nothing here changes how Rental Wrangler works.** No served file is touched; this is docs plus two standalone template scripts that nothing in this repo imports or runs.

## What's in it

| Path | What |
|---|---|
| `scaffolding-before-features.md` | The playbook — 14 sections: builder tooling, the two-file code map, chapter IDs stamped in source, skills, UI/UX and audit personas, disposable jigs, audits, agents, token discipline, loop convergence, local organisation, and what we'd redo. |
| `integration-field-report.md` | What each external system actually cost — Stripe, texting, Google Maps, email, GPS/telematics, Figma, and Apps Script itself. |
| `scaffolding-card.md` | The whole playbook on one page. |
| `starter-kit/` | Runnable, dependency-free scaffolding: `ci/smoke.mjs`, `tools/gen-code-map.mjs`, and seven templates. |

## A few of the traps it records

- **Stripe's "failing webhook" email was a harmless symptom** — Apps Script answers every POST with a 302 and Stripe doesn't follow redirects. Chasing it uncovered the real problem: 0 of ~2,257 customers carried a subscription id while live subscriptions were actively billing cards, and the daily reconciliation sweep ran at 0% error as a complete no-op.
- **ACH was blocked categorically by one card-shaped assumption** — microdeposits leave the setup intent in `requires_action` for days, so the payment method's customer is still null, so an ownership check written for cards rejected every bank add.
- **`ok:true` is not proof** — the email backend returns success even when it silently drops a malformed attachment. The only real evidence is the Sent copy.
- **Figma's eight measured traps**, including metadata lying about overridden instances and sub-1% paths turning out to be the bevels.

## Starter-kit scripts — tested, not just written

- `tools/gen-code-map.mjs` across write / check-passes / check-detects-drift / duplicate-id / out-of-order-id.
- `ci/smoke.mjs` in both browser and no-Playwright modes, each proven to *fail* on a real defect (a thrown exception; a broken local reference).

Two bugs were found and fixed during that testing: the generator scanned its own source (its doc examples contained real-looking chapter banners), and block-comment titles kept their trailing `═══`.

## Scope decisions

- **Markdown only.** The PDF and font-embedded HTML renders are build outputs and stay out of the repo.
- **A fifth document is deliberately not committed** — a retrospective on the collaboration itself. It's a named personal assessment and this repo is public.

## Gates

All ten pure-Node suites pass locally:

```
tools/gen-code-map.mjs --check     PASS      ci/cachebust-test.mjs       PASS
ci/gen-rule-usage.mjs --check      PASS      ci/lease-test.mjs           PASS (77/77)
ci/check-window-catalog.mjs        PASS      ci/lease-deploy-test.mjs    PASS (42/42)
ci/check-cachebust.mjs             PASS      ci/promote-test.mjs         PASS (23/23)
ci/check-design-md.mjs             PASS      ci/deck-test.mjs            PASS (24/24)
```

Browser gates (`ci/smoke.mjs`, `ci/logic-test.mjs`) run in CI and are unaffected — no served file changes, so no cache-bust bump is required.

Draft until reviewed. Config/docs-only, so this ships by `/merge` alone — no deploy, no promote.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnffdZKMmTShhE4ZG6QViV)_