### PR TITLE
Wrangler fix: stop the instant-cache boot window silently eating saves

### DIFF
--- a/app.js
+++ b/app.js
@@ -23721,6 +23721,12 @@ function mergeInvoiceInto(keepId, absorbId) {
    Single shared password (sent with every call; the URL alone is useless). */
 const BACKEND_URL = 'https://script.google.com/macros/s/AKfycbzHahzgJqOYe9o4GKlRVGh-A7USRn1k4Dvyy4ajLh8EYCqVxofouM28qs8trNlObZw/exec';
 const PERSIST_KEYS = ['categories', 'units', 'customers', 'invoices', 'rentals', 'workOrders', 'inspections', 'vendors', 'parts', 'companyFiles', 'expenses', 'models'];
+/* #829 — a bare fetch() to GAS can stall indefinitely (cellular handoff, iOS suspending a
+   home-screen app mid-request, a wedged cold container): it neither resolves nor rejects.
+   Applied to the BOOT load/resume and the live poll ONLY — never blanket-wrapped inside
+   backendCall(), because timing out a card/charge/auth round-trip that the server actually
+   completed would report a real payment as failed. Same 30s budget gpsFetch already uses. */
+const BACKEND_TIMEOUT_MS = 30000;
 let backendPassword = sessionStorage.getItem('jactec.pw') || '';
 let booting = true;                       // suppresses saves during initial load
 let saveTimer = null, saving = false, savePending = false;
@@ -24969,7 +24975,7 @@ function applyLoadResponse(r) {
     applySettings(r.settings);
   }
 }
-async function loadFromBackend() { applyLoadResponse(await backendCall('load')); }
+async function loadFromBackend() { applyLoadResponse(await withTimeout(backendCall('load'), BACKEND_TIMEOUT_MS, 'Backend load')); }   // #829 — a stalled load must reject, not hang the boot forever
 
 /* ══════════════ INSTANT CACHE — on-device data snapshot (spec 2026-07-16) ══════════════
    A DISPLAY-ONLY photograph of the last confirmed backend load, so a PERSONAL (trusted)
@@ -25068,6 +25074,7 @@ function cachePersistSnapshot() {
 // The confirmed backend load replaces this the moment it lands.
 function paintFromCache(env) {
   try {
+    _bootWriteWarned = false;                  // #829 — re-arm the "not saving yet" warning for THIS window (a logout/relogin gets its own)
     if (env.role) currentRole = env.role;
     if (env.user) currentUser = env.user;
     applyLoadResponse({ ok: true, data: env.payload.data, settings: env.payload.settings });
@@ -25093,6 +25100,30 @@ function mountRefreshCue() {
 function cacheRefreshing(on) {
   _cacheRefreshing = !!on;
   try { mountRefreshCue(); document.body.classList.toggle('rw-refreshing', _cacheRefreshing); } catch (e) {}
+}
+/* #829 — the boot write-guard, shared by every debounced writer below.
+   `booting` was only ever meant to suppress saves while boot painted a SPLASH, where no
+   edit was possible (see `let booting = true` — "suppresses saves during initial load").
+   The instant cache changed that: paintFromCache renders the REAL, fully-interactive app
+   while `booting` stays true (spec 2026-07-16 — "The app is fully interactive from cache
+   the whole time — this is a cue, not a gate"), so every `if (booting) return` became a
+   SILENT write drop. An operator could key in inspections, services and hours, see them
+   listed, and lose the lot when applyLoadResponse() replaced DATA — or on refresh. The
+   spec's safety note ("writes are gated on a live backendPassword") does not hold: phoneBoot
+   sets backendPassword BEFORE the paint, so `booting` was the only gate.
+   We do NOT queue the edit — an offline write buffer is an explicit spec non-goal (the
+   rejected "Option B"; it re-opens the corruption surface) and the cache must never become
+   a save baseline. We refuse it OUT LOUD instead, once per window, so nobody keeps working
+   into a screen that isn't recording anything. The window itself is now bounded by
+   BACKEND_TIMEOUT_MS, so this is a seconds-long "hold on", not a silent black hole. */
+let _bootWriteWarned = false;
+function bootWriteBlocked() {
+  if (!booting) return false;
+  if (_cacheRefreshing && !_bootWriteWarned) {
+    _bootWriteWarned = true;
+    toast('Still catching up with the yard — hold on a second. Anything changed right now is NOT saved.');
+  }
+  return true;
 }
 
 // ── Incremental persistence (diff-based sync) ──────────────────────────────
@@ -25161,7 +25192,11 @@ async function refreshFromBackend() {
   if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return;              // mid-typing
   refreshing = true;
   try {
-    const r = await backendCall('load');
+    // #829 — a stalled poll used to leave `refreshing = true` forever, permanently killing the
+    // live multi-user refresh: from then on the ONLY way to see someone else's edit was a full
+    // page reload (the reporter's "we have to refresh the whole app" complaint). The timeout
+    // rejects, `finally` clears the flag, and the next 18s tick tries again.
+    const r = await withTimeout(backendCall('load'), BACKEND_TIMEOUT_MS, 'Live refresh');
     if (!r || !r.ok || !r.data) return;
     const data = r.data; let applied = 0;
     PERSIST_KEYS.forEach((k) => {
@@ -25277,7 +25312,7 @@ async function pushChats() {
   if (js === lastChatsJson) return;                 // nothing new since the last successful push
   try { const r = await backendCall('setChats', { chats: state.chat.chats, ...chatSyncIdentity() }); if (r && r.ok) lastChatsJson = js; } catch (e) { /* offline → retries on next change/poll */ }
 }
-function pushChatsSoon() { if (booting || !backendPassword) return; clearTimeout(chatPushTimer); chatPushTimer = setTimeout(pushChats, 1200); }
+function pushChatsSoon() { if (bootWriteBlocked() || !backendPassword) return; clearTimeout(chatPushTimer); chatPushTimer = setTimeout(pushChats, 1200); }   // #829 — same silent-drop class as saveSoon
 async function loadChats() {
   if (!backendPassword) return;
   try {
@@ -25311,7 +25346,7 @@ function mergeWranglerRails(local, remote) {
   const merged = [...byId.values()].sort((a, b) => (b.ts || 0) - (a.ts || 0));
   return { merged, changed, localAhead };
 }
-function pushWranglerRailSoon() { if (booting || !backendPassword) return; clearTimeout(railPushTimer); railPushTimer = setTimeout(pushWranglerRail, 1200); }
+function pushWranglerRailSoon() { if (bootWriteBlocked() || !backendPassword) return; clearTimeout(railPushTimer); railPushTimer = setTimeout(pushWranglerRail, 1200); }   // #829 — the reporter lost Mr. Wrangler entries to exactly this guard
 async function pushWranglerRail() {
   if (!backendPassword) return;
   for (const c of state.wranglerRail) { try { await wrOffloadChatImages(c); } catch (e) {} }   // full fidelity: images → Drive URLs before they ride the sync
@@ -25411,7 +25446,7 @@ function syncMirrorGuard() {
 // ── debounced writer (mirrors pushChatsSoon / pushWranglerRailSoon: 1200ms, boot-guarded) ──
 let _userPrefsTimer = null, _userPrefsDirty = {};
 function flushUserPrefs(section) {
-  if (booting || !syncOn()) return;                                   // device-local only; never push during boot/reset
+  if (bootWriteBlocked() || !syncOn()) return;                        // device-local only; never push during boot/reset (#829 — refuse out loud, not silently)
   if (section) _userPrefsDirty[section] = true;
   else ['prefs', 'views', 'dispatch', 'comms', 'session'].forEach((s) => { _userPrefsDirty[s] = true; });
   clearTimeout(_userPrefsTimer); _userPrefsTimer = setTimeout(pushUserPrefs, 1200);
@@ -25533,7 +25568,7 @@ function upSyncCollapsed() { const up = state.userPrefs; if (!up) return; (up.pr
 function upSyncViews() { const up = state.userPrefs; if (!up) return; up.views = _viewsMap(); flushUserPrefs('views'); }
 function upSyncDispatch() { const up = state.userPrefs; if (!up) return; up.dispatch = { order: _lsJSON('jactec.dispatchOrder'), schedule: _lsJSON('jactec.dispatchSchedule'), lanes: _lsJSON('jactec.dispatchLanes'), times: _lsJSON('jactec.dispatchTimes') }; flushUserPrefs('dispatch'); }
 function upSyncComms() { const up = state.userPrefs; if (!up) return; up.comms = { ended: commsEndedMap(), rail: { sessions: (state.commsRail && state.commsRail.sessions) || {} } }; flushUserPrefs('comms'); }
-function upSyncSession() { const up = state.userPrefs; if (!up || booting) return; up.session = { col: state.mobileCol, mobileCol: state.mobileCol }; flushUserPrefs('session'); }
+function upSyncSession() { const up = state.userPrefs; if (!up || bootWriteBlocked()) return; up.session = { col: state.mobileCol, mobileCol: state.mobileCol }; flushUserPrefs('session'); }
 /* ── §18h Wrangler Ops — the developer live-chat bridge (from-spec re-implementation,
    2026-07-09, of the stale claude/mirror-wrangler-chats-l8pjfd branch). A Developer-tier
    operator (roleTier(currentRole) >= tierRank('developer') — the SAME gate as Design
@@ -25713,7 +25748,7 @@ function wranglerOpsBody(o) {
   const pane = o.openId ? wranglerOpsDetail(o) : '<div class="wrops-empty">Pick a chat to read it — or jump in.</div>';
   return `<div class="wrops-wrap"><div class="wrops-list">${list}</div><div class="wrops-pane">${pane}</div></div>`;
 }
-function saveSoon(ms) { if (booting || !backendPassword) return; clearTimeout(saveTimer); saveTimer = setTimeout(flushSave, ms || 1200); }
+function saveSoon(ms) { if (bootWriteBlocked() || !backendPassword) return; clearTimeout(saveTimer); saveTimer = setTimeout(flushSave, ms || 1200); }   // #829 — bootWriteBlocked() replaces a bare `booting` test: it still refuses the write, but says so
 // #247 — sync-health. A failing backend sync used to be SILENT (savePending → flat
 // 1.2s retry, no signal), so writes vanished with no warning. Now: track consecutive
 // failures, retry with EXPONENTIAL BACKOFF, and once an outage is confirmed (≥2 in a
@@ -26085,7 +26120,7 @@ async function attemptLogin() {
     // password server-side and neither's response feeds the other's request, so they
     // don't need to run back to back — firing 'load' immediately, before awaiting
     // 'auth', turns two serial GAS round-trips (the slow part of login) into one.
-    const loadPromise = backendCall('load');
+    const loadPromise = withTimeout(backendCall('load'), BACKEND_TIMEOUT_MS, 'Backend load');   // #829 — bounded, so "Wrangling the herd…" can't spin forever
     loadPromise.catch(() => {});   // a network-level rejection here is handled where loadPromise is awaited below; this just keeps it from surfacing as an unhandled rejection if an early 'auth' throw skips that await
     // Ask the backend for the role. The role-aware backend returns it; an older
     // backend (pre-roles) replies "unknown action" → we proceed without a role
@@ -26182,7 +26217,12 @@ function phoneBoot() {
   // to the serial path, in roughly half the wall-clock.
   renderBootSplash();
   backendPassword = tok;                       // backendCall sends it as sessionToken on both calls
-  const loadP = backendCall('load');
+  // #829 — BOTH calls are time-boxed. A stalled request here used to neither resolve nor
+  // reject, so the cache-painted app below stayed live and interactive INDEFINITELY with
+  // `booting` still true: every edit silently dropped, no banner, nothing saved, and the lot
+  // erased on the next load or refresh. Bounded, a dead network now falls to the honest
+  // failure paths below within BACKEND_TIMEOUT_MS instead of becoming a zombie app.
+  const loadP = withTimeout(backendCall('load'), BACKEND_TIMEOUT_MS, 'Backend load');
   loadP.catch(() => {});                       // may settle before pidEnter attaches the real handler — silence the interim rejection (the chain below still sees it)
   // §instant-cache: while the two backend calls run, paint the last snapshot as the REAL
   // app (personal device + flag + a valid snapshot) so the reopen shows data, not a
@@ -26197,10 +26237,10 @@ function phoneBoot() {
       else if (env) dataCache.wipe();          // a stale / foreign / malformed snapshot → discard, keep the splash
     }).catch(() => {});
   }
-  backendCall('authResume', { token: tok }).then((r) => {
+  withTimeout(backendCall('authResume', { token: tok }), BACKEND_TIMEOUT_MS, 'Sign-in resume').then((r) => {
     if (r && r.ok) { resumeSettled = true; pidAdopt(r, tok, !!(function () { try { return localStorage.getItem('jactec.pidToken'); } catch (e) { return null; } })()); pidEnter(loadP.then(applyLoadResponse)); }
     else { resumeSettled = true; cacheRefreshing(false); pidTokenClear(); backendPassword = ''; warmBackend(); renderPhoneLogin(); }   // rejected resume: pidTokenClear wipes the snapshot too
-  }).catch(() => { resumeSettled = true; cacheRefreshing(false); backendPassword = ''; warmBackend(); renderPhoneLogin(); });   // network blip: keep the token (+ its cache) for the next try
+  }).catch(() => { resumeSettled = true; cacheRefreshing(false); backendPassword = ''; warmBackend(); renderPhoneLogin("Couldn't reach the database. Try again."); });   // network blip / timeout: keep the token (+ its cache) for the next try — but SAY so (#829: a blank re-login read as "the app just forgot me")
 }
 function pidErr(msg) { pidUI.err = msg || ''; const e = document.getElementById('pid-err'); if (e) e.textContent = pidUI.err; return null; }
 async function pidCall(btnId, fn) {

--- a/docs/code-map.generated.md
+++ b/docs/code-map.generated.md
@@ -4,7 +4,7 @@
 
 # Code Atlas — generated chapter index (Part I · The Frontend)
 
-## app.js — 28061 lines, 41 chapters
+## app.js — 28101 lines, 41 chapters
 
 | ID | Lines | Anchors | Chapter title | Key symbols |
 |----|------:|---------|---------------|-------------|
@@ -44,11 +44,11 @@
 | APP-34 | 21636–23187 | §17 | §17 STRIPE / PAYMENTS — card-on-file + invoice charging (client side). | _stripe, _pubKey, ensurePubKey, getStripe, canMoney, brandName, hasCardOnFile, commitAction, cardOneLabel, cardLabel, friendlyPayErr, openAddCard, …(+98) |
 | APP-35 | 23188–23712 | §5.4d | §5.4d — DATE SEARCH PICKER. A standalone calendar that REUSES the rental | openDateSearch, closeDateSearch, dsMonth, dsToday, dsClear, dsPickDay, dsDone, dateSearchEl, positionDateSearch, setInspWash, setInspResult, recordServiceCompletion, …(+24) |
 | APP-36 | 23713–23715 | §18 | §18 PERSISTENCE & BOOT | — |
-| APP-37 | 23716–24973 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, gpsRelogin, …(+87) |
-| APP-38 | 24974–26113 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+93) |
-| APP-39 | 26114–26120 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
-| APP-40 | 26121–26432 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
-| APP-41 | 26433–28061 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
+| APP-37 | 23716–24979 | §18b | §18b BACKEND SYNC — Google Sheets via the Apps Script web app | BACKEND_URL, PERSIST_KEYS, BACKEND_TIMEOUT_MS, backendPassword, booting, saveTimer, driveViewUrl, backendCall, gpsToken, gpsBase, gpsConfigured, _gpsReloginInflight, …(+88) |
+| APP-38 | 24980–26148 | — | INSTANT CACHE — on-device data snapshot (spec 2026-07-16) | DC_DB, CACHE_SCHEMA_VER, _dcDbPromise, dcDbOpen, dcTx, dataCache, cacheAppVer, pidLocalToken, cacheTokenTag, cacheDeviceOk, cacheValid, cacheSnapshotEnvelope, …(+95) |
+| APP-39 | 26149–26155 | — | PHONE-VERIFIED DEVICE IDENTITY — login flow (Phase 2) | — |
+| APP-40 | 26156–26472 | — | const pidUI = { step: 'identify', personId: '', name: '', masked: '', kind: '', err: '', _phone: '', _tok: '', | pidUI, pidTokenGet, pidTokenSet, pidTokenClear, pidRosterCache, pidAdopt, pidLoadFail, pidEnter, renderBootSplash, phoneBoot, pidErr, pidCall, …(+14) |
+| APP-41 | 26473–28101 | — | SCAN-TO-LOG (QR DECAL → VIDEO) — standalone capture (FEATURES.qrScanLog) | pendingScan, scanActive, scanUI, scanEnabled, scanPreviewOn, scanTokenGet, scanTokenSet, scanTokenClear, maybeReplayScan, scanCall, scanPreviewResponse, renderScanCapture, …(+80) |
 
 ## config.js — 697 lines, 0 chapters
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <!-- Cache-busting: bump ?v= on EVERY deploy so a new release loads immediately on
        desktop + mobile instead of serving a stale cached app.js/style.css (GitHub Pages
        sends max-age=600 with no per-file hashing). See CLAUDE.md → Deploy & gates. -->
-  <link rel="stylesheet" href="style.css?v=20260826a" />
+  <link rel="stylesheet" href="style.css?v=20260827a" />
   <!-- Stripe.js (must load from js.stripe.com for PCI SAQ-A; card data stays in Stripe's iframe) -->
   <script src="https://js.stripe.com/v3/"></script>
 </head>
@@ -48,8 +48,8 @@
   </script>
 
   <!-- Static catalog of which fields/elements use each design rule (rulebook index). -->
-  <script src="rule-usage.js?v=20260826a"></script>
-  <script type="module" src="app.js?v=20260826a"></script>
+  <script src="rule-usage.js?v=20260827a"></script>
+  <script type="module" src="app.js?v=20260827a"></script>
   <!-- DEV ONLY (localhost): reload when Claude bumps dev-version.txt — i.e. only
        when a FINISHED, verified edit batch lands (Jac: no mid-edit reloads).
        Never runs on app.jacrentals.com. Pauses while typing in a field. -->


### PR DESCRIPTION
Closes #829

## Verdict — the report is CORRECT, and it's a real data-loss defect

The reporter is right on every point: edits showed as saved, never reached the backend, and a refresh wiped them. Reproduced and traced to the root cause.

## Root cause

The instant-cache paint (spec `docs/superpowers/specs/2026-07-16-instant-cache-design.md`) renders the **real, fully interactive app** while `booting` is still `true` — the spec says so verbatim: *"The app is **fully interactive** from cache the whole time — this is a cue, not a gate."* `paintFromCache()` deliberately leaves `booting = true` so the cache can never become a save baseline.

But every debounced writer was guarded by a bare `if (booting) return` — `saveSoon()` (`app.js:25716`), and the comment on `let booting = true` (`app.js:23725`) says what that guard was *for*: *"suppresses saves during initial load"*, written when boot painted only a splash and **no edit was possible**. Once the window became interactive, that guard turned into a **silent write drop**: no save, no R25 banner, no `beforeunload` prompt. The work is then erased when `applyLoadResponse()` (`app.js:24956`) does `DATA[k].length = 0` and re-pushes the server rows — or on refresh.

The spec's own safety argument for this window is **factually wrong against the shipped code**. §"Auth ordering note" claims *"no write ever happened against it (writes are gated on a live `backendPassword`, which a rejected resume never sets)"* — but `phoneBoot()` sets `backendPassword = tok` **before** the paint and before `authResume`. `booting` was the only gate.

And the window was **unbounded**: `backendCall()` (`app.js:23735`) uses a bare `fetch` with no timeout, unlike `gpsFetch()` which wraps `withTimeout(…, 30000)`. A stalled `load`/`authResume` — cellular handoff, iOS suspending a home-screen app mid-request, a wedged cold GAS container — neither resolves nor rejects, so the zombie interactive app stays up indefinitely.

## The fix (minimal, at the cause)

The spec's Non-goals explicitly forbid the obvious "just queue it" fix — *"No offline editing / write buffer / conflict resolution … the rejected Option B — it re-opens the corruption surface the app deliberately closed"* — and the load-bearing invariant forbids the cache ever becoming a save baseline. Both are preserved. Instead the window is made **short** and **honest**, which is what the spec assumed it already was:

- **Bound it.** `withTimeout(…, BACKEND_TIMEOUT_MS)` on the boot `load` + `authResume` and on the 18s live poll. Deliberately **not** blanket-applied inside `backendCall()` — timing out a card/charge round-trip the server actually completed would report a real payment as failed.
- **Stop the silence.** `bootWriteBlocked()` replaces the bare `booting` test in `saveSoon`, `pushChatsSoon`, `pushWranglerRailSoon`, `flushUserPrefs` and `upSyncSession`. It still refuses the write, but says so once per window instead of discarding it without a word.
- A timed-out / blipped resume now re-renders the phone login **with a reason** instead of a blank screen that read as "the app just forgot me".

## Pattern sweep (same bug class)

The silent `if (booting) return` sat on every debounced writer reachable in that window — including `pushWranglerRailSoon`, which is why the reporter *"lost all the info I put into wrangler"*. All five are swept.

The stalled-poll case is the reporter's second complaint too: a hung `refreshFromBackend` left `refreshing = true` forever, permanently killing live multi-user refresh so the only way to see someone else's edit was a full page reload — *"it's annoying how sometimes we have to refresh our entire app for changes someone else made to appear"*. The timeout unwedges it via the existing `finally`.

## Verification

Playwright repro driving the **real** `phoneBoot()` path on a trusted device with a valid on-device snapshot, editing through the actual UI (customer quick-add):

| | before | after |
|---|---|---|
| **A — hung backend**: `sync` POSTs | 0 | 0 |
| **A**: warning shown | *(none)* | "Still catching up with the yard — … NOT saved." |
| **A**: still a live zombie app at 40s | yes | no — closes to an honest login |
| **B — healthy backend (control)**: `sync` POSTs | 3 | 3 |
| **B**: spurious warning | none | none |

Gates: `smoke` ✓ · `logic-test` 859/859 ✓ · `gen-rule-usage --check` ✓ · `check-window-catalog` ✓ · `gen-code-map --check` ✓ (regenerated) · `cachebust-test` 23/23 ✓ · `check-cachebust` ✓ · `lease` 77/77 ✓ · `lease-deploy` 42/42 ✓ · `promote-freshness` 23/23 ✓

Staging: `fix-829-sync-1` — https://operations-jacrentals.github.io/rental-wrangler-staging/d/fix-829-sync-1/ (verified serving `?v=20260827a`)

No money / card / auth / WO-completion logic weakened — the money path was specifically excluded from the timeout for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)